### PR TITLE
fix: resolve reactive tracking warnings

### DIFF
--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -103,7 +103,7 @@ pub fn SearchBox() -> impl IntoView {
         })
     };
 
-    let item_search = move || search_results.get();
+    let item_search = move || search_results.get_untracked();
 
     let navigate_keydown = navigate.clone();
 

--- a/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+++ b/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
@@ -141,8 +141,9 @@ where
             row_height + total_delta / len as f64
         }
     });
-    let children_shown =
-        ((effective_viewport / avg_row_height()).ceil() as u32).max(1) + render_ahead;
+    let children_shown = Memo::new(move |_| {
+        ((effective_viewport / avg_row_height()).ceil() as u32).max(1) + render_ahead
+    });
 
     // Scroll target into view when requested (moved after layout signals are defined)
     if let Some(scroll_sig) = scroll_to_index {
@@ -221,7 +222,7 @@ where
             }
             // make sure start + end doesn't go over the length of the vector, and render at least one row
             let start = (child_start() as usize).min(array_size.saturating_sub(1));
-            let end = (start + children_shown as usize).min(array_size);
+            let end = (start + children_shown() as usize).min(array_size);
             children[start..end]
                 .iter()
                 .cloned()

--- a/ultros-frontend/ultros-app/src/global_state/theme.rs
+++ b/ultros-frontend/ultros-app/src/global_state/theme.rs
@@ -166,8 +166,8 @@ pub fn use_theme_settings() -> ThemeSettings {
 }
 
 fn persist_all(settings: ThemeSettings) {
-    let mode_str = settings.mode.get().as_str().to_string();
-    let palette_str = settings.palette.get().as_str().to_string();
+    let mode_str = settings.mode.get_untracked().as_str().to_string();
+    let palette_str = settings.palette.get_untracked().as_str().to_string();
 
     // localStorage
     #[cfg(feature = "hydrate")]


### PR DESCRIPTION
- theme.rs: Use get_untracked() for theme signal persistence since we don't need reactivity
- search_box.rs: Use get_untracked() for search results in item_search closure
- virtual_scroller.rs: Wrap children_shown calculation in Memo to properly track avg_row_height changes
- Updates children_shown call site to use () syntax for Memo access

These changes fix warnings about accessing signals outside of reactive tracking context.