### PR TITLE
⚡ Bolt: Optimize get_trends memory allocation

### DIFF
--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -664,15 +664,16 @@ impl AnalyzerService {
             }
 
             // Filter out sales older than 30 days to keep "trends" relevant
-            let recent_sales: Vec<_> = sales
+            let count = sales
                 .iter()
-                .filter(|s| (now - s.sale_date).num_days() < 30)
-                .collect();
+                .take_while(|s| (now - s.sale_date).num_days() < 30)
+                .count();
 
-            if recent_sales.len() < 2 {
+            if count < 2 {
                 continue;
             }
 
+            let recent_sales = &sales[0..count];
             let newest = recent_sales.first()?;
             let oldest = recent_sales.last()?;
             let days_diff = (newest.sale_date - oldest.sale_date).num_days().max(1) as f32;


### PR DESCRIPTION
💡 **What:** Optimized `get_trends` in `ultros/src/analyzer_service.rs` by removing a `Vec` allocation inside the main item loop.
🎯 **Why:** The function iterates over all items (thousands). Allocating a `Vec` for "recent sales" for every item creates unnecessary heap pressure and CPU overhead.
📊 **Impact:** Reduces memory allocations from O(Items) to 0 for this operation. Speeds up the analyzer service loop.
🔬 **Measurement:** Verified correctness via code review and `cargo check`. The logic is equivalent as `sales` is sorted descending by date.

---
*PR created automatically by Jules for task [9297646915191284333](https://jules.google.com/task/9297646915191284333) started by @akarras*