### PR TITLE
🎨 Palette: Improve Select component accessibility

### DIFF
--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -15,6 +15,7 @@ pub fn Select<T, EF, L, ViewOut>(
     children: EF,
     #[prop(optional)] class: Option<&'static str>,
     #[prop(optional)] dropdown_class: Option<&'static str>,
+    #[prop(optional, into)] id: Option<String>,
     // _view_out: PhantomData<ViewOut>,
 ) -> impl IntoView
 where
@@ -119,6 +120,14 @@ where
                 }
                 on:keydown=keydown
                 prop:value=current_input
+                role="combobox"
+                aria-autocomplete="list"
+                aria-expanded={
+                    let hovered = hovered.clone();
+                    move || (has_focus() || hovered()).to_string()
+                }
+                aria-controls=id.clone()
+                aria-label="Filter options"
             />
             <div
                 class="absolute top-1 left-1 select-none cursor flex items-center"
@@ -132,6 +141,8 @@ where
                 {current_choice_view}
             </div>
             <div
+                id=id
+                role="listbox"
                 node_ref=dropdown
                 class=move || format!("{} {}", default_dropdown_class, dropdown_class.unwrap_or(""))
                 class:hidden=move || !has_focus() && !hovered()
@@ -139,8 +150,11 @@ where
                 <For each=final_result key=move |(l, _)| *l let:data>
                     {
                         let is_selected_selector = is_selected_selector.clone();
+                        let is_selected_selector_aria = is_selected_selector.clone();
                         view! {
                     <button
+                        role="option"
+                        aria-selected=move || is_selected_selector_aria.selected(&Some(data.0)).to_string()
                         class="w-full text-left"
                         on:click=move |_| {
                             if let Some(item) = items.with(|i| i.get(data.0).cloned()) {

--- a/ultros-frontend/ultros-app/src/components/world_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/world_picker.rs
@@ -27,6 +27,7 @@ pub fn WorldOnlyPicker(
             let left = view! {
                 <div class="relative">
                     <Select
+                        id="world-only-picker-listbox"
                         items=data.into()
                         as_label=move |w| w.name.clone()
                         choice=current_world
@@ -87,6 +88,7 @@ pub fn WorldPicker(
             Either::Left(view! {
                 <div class="relative">
                     <Select
+                        id="world-picker-listbox"
                         items=data.into()
                         choice=choice
                         set_choice=set_choice


### PR DESCRIPTION
💡 **What**: Added comprehensive ARIA attributes to the `Select` component and its usage in `WorldPicker`.
🎯 **Why**: The custom `Select` component lacked semantic information for screen readers, making it difficult to use for visually impaired users. It behaved like a text input but opened a list of options.
♿ **Accessibility**:
- Added `role="combobox"` to input.
- Added `role="listbox"` to dropdown.
- Added `role="option"` to items with `aria-selected`.
- Linked input and listbox via `aria-controls` using a new `id` prop to ensure SSR/hydration compatibility.


---
*PR created automatically by Jules for task [15265337871089428522](https://jules.google.com/task/15265337871089428522) started by @akarras*