### PR TITLE
Add Sales Velocity to Flip Finder

### DIFF
--- a/.jules/tataru/FlipFinderMasterPlan.md
+++ b/.jules/tataru/FlipFinderMasterPlan.md
@@ -1,0 +1,42 @@
+# Flip Finder Master Plan (Project "Shiny Coin")
+
+The current Flip Finder is... acceptable. But it can be GREATER!
+
+## Current State
+- Finds price differences between worlds.
+- Basic filtering (Profit, ROI).
+- Basic outlier filtering.
+
+## Improvements Needed
+
+### 1. Velocity-Based Sorting (High Priority)
+**Problem:** Users see items with 1000% ROI but don't realize they haven't sold in a year.
+**Solution:**
+- Calculate `SalesPerDay` based on `avg_sale_duration`.
+- Add a column "Daily Sales" to the table.
+- Allow sorting by "Daily Sales".
+- **Formula:** `Daily Sales = 86,400,000 / avg_sale_duration_ms`
+
+### 2. Supply/Demand Warning (Medium Priority)
+**Problem:** Users buy items to flip, but the destination market is flooded.
+**Solution:**
+- Fetch the *number of current listings* on the destination world.
+- Calculate `DaysToSell = Current Listings / Daily Sales`.
+- If `DaysToSell` > 30, show a warning icon (⚠️).
+
+### 3. Bulk Profit Calculator (Medium Priority)
+**Problem:** Buying 1 item is boring. I want to buy 99!
+**Solution:**
+- Show "Stack Profit": Profit if you buy all available cheap stock (up to a limit) and sell it.
+- Requires checking the *quantity* of cheap listings, not just the price.
+
+### 4. Teleport Cost Adjustment (Low Priority)
+**Problem:** Teleporting costs ~1000 gil round trip.
+**Solution:**
+- Add a "Transport Cost" input field (default 1000 gil).
+- Subtract this from the profit of the *first* sale (or amortize it).
+
+## Implementation Specs (for my minions)
+- **File:** `ultros-frontend/ultros-app/src/routes/analyzer.rs`
+- **Struct:** `SaleSummary` needs a `daily_sales` field.
+- **UI:** Add "Daily Sales" column to `AnalyzerTable`.

--- a/.jules/tataru/InvestmentMaths.md
+++ b/.jules/tataru/InvestmentMaths.md
@@ -1,0 +1,47 @@
+# Tataru's Guide to Gillionaire Math
+
+Listen up, minions! If you want to be as rich as me, you need to understand the numbers! It's not just about "buy low, sell high". It's about *how fast* and *how much*!
+
+## 1. Velocity (Sales per Day)
+Time is money! A 100% ROI is useless if it takes a year to sell.
+We need to calculate **Sales Velocity**.
+
+$$ Velocity = \frac{Total Sales}{Time Period (Days)} $$
+
+If an item sold 10 times in the last 2 days, Velocity = 5 sales/day.
+
+## 2. Risk Assessment (Volatility)
+Don't put all your eggs in one basket, especially if that basket is full of holes!
+We measure risk by the **Standard Deviation** of the price.
+
+$$ \sigma = \sqrt{\frac{\sum(x - \mu)^2}{N}} $$
+
+Where:
+- $x$ = Sale Price
+- $\mu$ = Average Price
+- $N$ = Number of Sales
+
+High $\sigma$ means the price jumps around a lot. Risky!
+
+## 3. Return on Effort (ROE)
+Teleporting takes time! Walking takes time! Clicking takes time!
+We need to factor in the cost of our time.
+
+$$ ROE = \frac{Expected Profit}{Estimated Time to Acquire & Sell} $$
+
+If you make 100k gil but it takes 1 hour of running around, your ROE is 100k/hr.
+If you make 50k gil but it takes 1 minute, your ROE is 3m/hr!
+
+## 4. Market Saturation
+If there are 100 people selling the same item, you'll be undercut instantly.
+We need to check the **Supply/Demand Ratio**.
+
+$$ Ratio = \frac{Current Listings}{Daily Sales} $$
+
+If Ratio > 10, the market is flooded. Avoid!
+If Ratio < 1, the market is starving. Gold mine!
+
+## 5. Tax Efficiency
+Never forget the tax man! (Unless you are the tax man, like me!)
+Market board takes 5% (usually).
+$$ Real Profit = (Sell Price \times 0.95) - Buy Price - Teleport Fees $$

--- a/.jules/tataru/VendorResaleMasterPlan.md
+++ b/.jules/tataru/VendorResaleMasterPlan.md
@@ -1,0 +1,33 @@
+# Vendor Resale Master Plan (Project "Easy Gil")
+
+Buying from NPCs and selling to players? That's free real estate!
+
+## Current State
+- Identifies vendor items sold on market board.
+- Basic profit calculation.
+
+## Improvements Needed
+
+### 1. Vendor Location (High Priority)
+**Problem:** Users know *what* to buy, but not *where*.
+**Solution:**
+- Integrate `xiv-gen-db` map data.
+- Display "Zone Name (X, Y)" for the vendor.
+- Link to a map website (e.g., Garland Tools or Teamcraft) if possible.
+
+### 2. Restricted Vendor Warning (High Priority)
+**Problem:** Some vendors are locked behind quests (Beast Tribes, etc.). Users waste time traveling.
+**Solution:**
+- Check `Shop` data for unlock requirements.
+- Add a "Restricted" tag if the vendor is not default.
+
+### 3. "Safe Bet" Score (Medium Priority)
+**Problem:** Is it worth the walk?
+**Solution:**
+- Calculate a score based on ROI * Sales Velocity.
+- `Score = log(ROI) * DailySales`.
+- Highlight high-score items.
+
+## Implementation Specs
+- **File:** `ultros-frontend/ultros-app/src/routes/vendor_resale.rs`
+- **Data Source:** Need to check if `xiv_gen` exposes vendor locations and requirements.

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -39,6 +39,8 @@ struct SaleSummary {
     num_sold: usize,
     /// Represents the average time between sales within the `num_sold`
     avg_sale_duration: Option<Duration>,
+    /// Calculated sales per day
+    daily_sales: f32,
     max_price: i32,
     avg_price: i32,
     min_price: i32,
@@ -69,6 +71,7 @@ struct CalculatedProfitData {
 enum SortMode {
     Roi,
     Profit,
+    Velocity,
 }
 
 #[derive(Clone, Debug)]
@@ -131,11 +134,21 @@ fn compute_summary(
         .last()
         .map(|last| (last.sale_date - now).num_milliseconds().abs() / sales.len() as i64);
     let avg_sale_duration = t.map(Duration::milliseconds);
+
+    let duration_millis = sales
+        .last()
+        .map(|last| (now - last.sale_date).num_milliseconds().abs())
+        .unwrap_or(0);
+    // Clamp to at least 1 second to prevent huge numbers
+    let duration_days = (duration_millis as f64 / 86_400_000.0).max(0.00001);
+    let daily_sales = (sales.len() as f64 / duration_days) as f32;
+
     SaleSummary {
         item_id,
         hq,
         num_sold: sales.len(),
         avg_sale_duration,
+        daily_sales,
         max_price,
         avg_price,
         min_price,
@@ -150,6 +163,7 @@ impl FromStr for SortMode {
         match s {
             "roi" => Ok(SortMode::Roi),
             "profit" => Ok(SortMode::Profit),
+            "velocity" => Ok(SortMode::Velocity),
             _ => Err(()),
         }
     }
@@ -160,6 +174,7 @@ impl std::fmt::Display for SortMode {
         let val = match self {
             SortMode::Roi => "roi",
             SortMode::Profit => "profit",
+            SortMode::Velocity => "velocity",
         };
         f.write_str(val)
     }
@@ -276,6 +291,7 @@ fn AnalyzerTable(
     let (datacenter_filter, set_datacenter_filter) = query_signal::<String>("datacenter");
     let (tax_enabled, set_tax_enabled) = query_signal::<bool>("tax");
     let (minimum_sales, set_minimum_sales) = query_signal::<usize>("sales");
+    let (min_daily_sales, set_min_daily_sales) = query_signal::<f32>("min-sales");
     let (category_filter, set_category_filter) = query_signal::<i32>("category");
 
     let world_clone = worlds.clone();
@@ -343,6 +359,11 @@ fn AnalyzerTable(
                     .unwrap_or(true)
             })
             .filter(move |data| {
+                min_daily_sales()
+                    .map(|sales| data.inner.sale_summary.daily_sales >= sales)
+                    .unwrap_or(true)
+            })
+            .filter(move |data| {
                 category_filter()
                     .map(|cat_id| {
                         items
@@ -379,6 +400,13 @@ fn AnalyzerTable(
         match sort_mode().unwrap_or(SortMode::Roi) {
             SortMode::Roi => sorted_data.sort_by_key(|data| Reverse(data.return_on_investment)),
             SortMode::Profit => sorted_data.sort_by_key(|data| Reverse(data.profit)),
+            SortMode::Velocity => sorted_data.sort_by(|a, b| {
+                b.inner
+                    .sale_summary
+                    .daily_sales
+                    .partial_cmp(&a.inner.sale_summary.daily_sales)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            }),
         }
         sorted_data
             .into_iter()
@@ -414,6 +442,37 @@ fn AnalyzerTable(
                                     set_minimum_profit(Some(profit))
                                 } else if value.is_empty() {
                                     set_minimum_profit(None);
+                                }
+                            }
+                        />
+                    </div>
+                </FilterCard>
+
+                <FilterCard
+                    title="Minimum Daily Sales"
+                    description="Filter items by sales velocity (sales/day)"
+                >
+                    <div class="flex flex-col gap-2">
+                        <div class="text-brand-300">
+                             {move || {
+                                min_daily_sales()
+                                    .map(|s| format!("{:.1} / day", s))
+                                    .unwrap_or("---".to_string())
+                            }}
+                        </div>
+                        <input
+                            class="input"
+                            type="number"
+                            min="0"
+                            step="0.1"
+                            placeholder="e.g. 1.0"
+                            prop:value=min_daily_sales
+                            on:input=move |input| {
+                                let value = event_target_value(&input);
+                                if let Ok(s) = value.parse::<f32>() {
+                                    set_min_daily_sales(Some(s));
+                                } else if value.is_empty() {
+                                    set_min_daily_sales(None);
                                 }
                             }
                         />
@@ -594,6 +653,16 @@ fn AnalyzerTable(
                                 </span>
                             }.into_any());
                         }
+                        if let Some(sales) = min_daily_sales() {
+                            chips.push(view! {
+                                <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
+                                    "Daily Sales ≥ " {format!("{:.1}", sales)}
+                                    <button class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_min_daily_sales(None)>
+                                        <Icon icon=icondata::MdiClose />
+                                    </button>
+                                </span>
+                            }.into_any());
+                        }
                         if let Some(roi) = minimum_roi() {
                             chips.push(view! {
                                 <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
@@ -648,6 +717,7 @@ fn AnalyzerTable(
                     set_world_filter(None);
                     set_datacenter_filter(None);
                     set_minimum_sales(None);
+                    set_min_daily_sales(None);
                     set_category_filter(None);
                 }>
                     "Clear all"
@@ -681,6 +751,22 @@ fn AnalyzerTable(
                                             "Profit"
                                             {move || {
                                                 (sort_mode() == Some(SortMode::Profit))
+                                                    .then(|| view! { <Icon icon=i::BiSortDownRegular /> })
+                                            }}
+                                        </div>
+                                    </QueryButton>
+                                </div>
+                                <div role="columnheader" class="w-30 p-4">
+                                    <QueryButton
+                                        class="!text-brand-300 hover:text-brand-200"
+                                        active_classes="!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
+                                        key="sort"
+                                        value="velocity"
+                                    >
+                                        <div class="flex items-center gap-2">
+                                            "Daily Sales"
+                                            {move || {
+                                                (sort_mode() == Some(SortMode::Velocity))
                                                     .then(|| view! { <Icon icon=i::BiSortDownRegular /> })
                                             }}
                                         </div>
@@ -837,6 +923,9 @@ fn AnalyzerTable(
                                         }>
                                             {format!("{}%", data.return_on_investment)}
                                         </span>
+                                    </div>
+                                    <div role="cell" class="px-4 py-2 w-30 text-right flex items-center justify-end">
+                                        {format!("{:.1}", data.inner.sale_summary.daily_sales)}
                                     </div>
                                     <div role="cell" class="px-4 py-2 w-30 text-right flex items-center justify-end">
                                         <Gil amount=data.inner.cheapest_price />


### PR DESCRIPTION
Implemented Sales Velocity (Daily Sales) tracking for the Flip Finder tool (`analyzer.rs`). This allows users to filter and sort items by how quickly they sell, not just by profit margin. Also documented master plans for future improvements to investment tools.

---
*PR created automatically by Jules for task [10420849102735181676](https://jules.google.com/task/10420849102735181676) started by @akarras*