### PR TITLE
🎨 Palette: Improve accessibility of Add Recipe To List inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Accessibilty for Dynamic Input Lists]
+**Learning:** When using iterating lists of inputs (like ingredients), standard `label for` doesn't scale well without unique ID generation. `aria-label` is a cleaner solution for list items where context (visual proximity to item name) implies meaning but screen readers need explicit association.
+**Action:** Use `aria-label` with dynamic text (e.g. `format!("Quantity for {}", item_name)`) for inputs in repeating lists to ensure accessibility without complex ID management.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -131,8 +131,11 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]">"Number of crafts"</label>
+                    <label class="text-sm text-[color:var(--color-text-muted)]" attr:for="craft-qty">
+                        "Number of crafts"
+                    </label>
                     <input
+                        id="craft-qty"
                         type="number"
                         min="1"
                         class="input w-24"
@@ -169,6 +172,7 @@ fn AddRecipeToListModal(
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"
+                                        aria-label=move || format!("Quantity for {}", ingredient.item.name)
                                         prop:value=move || ingredient.quantity.get()
                                         on:input=move |e| {
                                             let Ok(q) = event_target_value(&e).parse::<i32>() else {


### PR DESCRIPTION
💡 What: Added `for`/`id` association to the "Number of crafts" input and `aria-label` to ingredient quantity inputs in `AddRecipeToList` component.
🎯 Why: Screen reader users could not identify the purpose of these inputs.
📸 Before/After: N/A (Attribute changes only)
♿ Accessibility: Ensures inputs have accessible names.

---
*PR created automatically by Jules for task [13188254493225981716](https://jules.google.com/task/13188254493225981716) started by @akarras*