### PR TITLE
🎨 Palette: Improve RelativeTime accessibility

### DIFF
--- a/ultros-frontend/ultros-app/src/components/relative_time.rs
+++ b/ultros-frontend/ultros-app/src/components/relative_time.rs
@@ -19,5 +19,11 @@ pub fn RelativeToNow(timestamp: NaiveDateTime) -> impl IntoView {
             .map(|duration| Formatter::new().convert(duration))
             .unwrap_or("now".to_string())
     });
-    view! { <span>{time_display}</span> }.into_any()
+    let iso_string = timestamp.and_utc().to_rfc3339();
+    view! {
+        <time datetime=iso_string.clone() title=iso_string>
+            {time_display}
+        </time>
+    }
+    .into_any()
 }


### PR DESCRIPTION
💡 What: Replaced the `span` element with a `<time>` element in the `RelativeToNow` component.
🎯 Why: To improve accessibility and usability. The `<time>` element provides semantic meaning, and the `datetime` attribute allows machine readability. The `title` attribute adds a tooltip with the exact timestamp on hover, addressing the ambiguity of relative time displays (e.g., "2 hours ago").
📸 Before/After:
Before: `<span>2 hours ago</span>`
After: `<time datetime="2023-10-27T10:00:00Z" title="2023-10-27T10:00:00Z">2 hours ago</time>`
♿ Accessibility:
- Uses semantic `<time>` element.
- Adds `datetime` attribute with ISO 8601 string.

---
*PR created automatically by Jules for task [1668138526495097125](https://jules.google.com/task/1668138526495097125) started by @akarras*