### PR TITLE
Improve TopDeals empty state with call-to-action

### DIFF
--- a/ultros-frontend/ultros-app/src/components/top_deals.rs
+++ b/ultros-frontend/ultros-app/src/components/top_deals.rs
@@ -93,12 +93,16 @@ pub fn TopDeals() -> impl IntoView {
                     deals.get().flatten().map(|data| {
                         if data.is_empty() {
                             view! {
-                                <div class="text-center py-8 text-[color:var(--color-text-muted)] bg-[color:var(--surface-color-alt)] rounded-xl border border-dashed border-[color:var(--separator-color)]">
+                                <div class="text-center py-8 text-[color:var(--color-text-muted)] bg-[color:var(--surface-color-alt)] rounded-xl border border-dashed border-[color:var(--separator-color)] flex flex-col items-center gap-2">
                                     <div class="mb-2 opacity-50 mx-auto w-8 h-8 flex items-center justify-center">
                                         <Icon icon=i::FaBoxOpenSolid width="2em" height="2em" />
                                     </div>
-                                    <p>"No hot deals found right now."</p>
-                                    <p class="text-sm">"Check back later or try the full Flip Finder."</p>
+                                    <p class="font-bold">"No hot deals found right now."</p>
+                                    <p class="text-sm max-w-xs mx-auto mb-2">"Check back later or try the full Flip Finder for more options."</p>
+                                    <a href="/flip-finder" class="btn-primary text-sm px-4 py-2 rounded-lg inline-flex items-center gap-2 transition-transform hover:scale-105">
+                                        <Icon icon=i::AiSearchOutlined />
+                                        "Open Flip Finder"
+                                    </a>
                                 </div>
                             }.into_any()
                         } else {


### PR DESCRIPTION
Improved the empty state of the `TopDeals` component to provide a clear call-to-action for users when no deals are found. This directs them to the "Flip Finder" tool, making the empty state more useful and actionable. This follows the Palette philosophy of adding helpful micro-UX improvements.

---
*PR created automatically by Jules for task [6494400520655185717](https://jules.google.com/task/6494400520655185717) started by @akarras*