### PR TITLE
🎨 Palette: Improve Top Deals empty state

### DIFF
--- a/ultros-frontend/ultros-app/src/components/top_deals.rs
+++ b/ultros-frontend/ultros-app/src/components/top_deals.rs
@@ -93,12 +93,19 @@ pub fn TopDeals() -> impl IntoView {
                     deals.get().flatten().map(|data| {
                         if data.is_empty() {
                             view! {
-                                <div class="text-center py-8 text-[color:var(--color-text-muted)] bg-[color:var(--surface-color-alt)] rounded-xl border border-dashed border-[color:var(--separator-color)]">
+                                <div class="text-center py-8 text-[color:var(--color-text-muted)] bg-[color:var(--surface-color-alt)] rounded-xl border border-dashed border-[color:var(--separator-color)] flex flex-col items-center gap-2">
                                     <div class="mb-2 opacity-50 mx-auto w-8 h-8 flex items-center justify-center">
                                         <Icon icon=i::FaBoxOpenSolid width="2em" height="2em" />
                                     </div>
-                                    <p>"No hot deals found right now."</p>
-                                    <p class="text-sm">"Check back later or try the full Flip Finder."</p>
+                                    <p class="font-medium">"No hot deals found right now."</p>
+                                    <p class="text-sm max-w-xs mx-auto mb-2">"Check back later or try the full Flip Finder for more options."</p>
+                                    <a
+                                        href="/flip-finder"
+                                        class="btn-primary text-sm px-4 py-2 rounded-lg inline-flex items-center gap-2 transition-transform hover:scale-105"
+                                    >
+                                        <Icon icon=i::AiSearchOutlined />
+                                        "Open Flip Finder"
+                                    </a>
                                 </div>
                             }.into_any()
                         } else {


### PR DESCRIPTION
Improved the empty state of the Top Deals component by adding a call-to-action button that directs users to the Flip Finder tool, making the interface more helpful when no deals are immediately available.


---
*PR created automatically by Jules for task [9099764990388104833](https://jules.google.com/task/9099764990388104833) started by @akarras*