### PR TITLE
🎨 Palette: Make Gil Party accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-06 - Handling Click Events for Keyboard Accessibility
+**Learning:** When converting `div` click handlers to `button` for accessibility, keyboard activation (Enter/Space) fires a `click` event with `client_x` and `client_y` as 0. This breaks logic depending on mouse coordinates (like spawning effects).
+**Action:** Always check for (0,0) coordinates in click handlers and provide a fallback (e.g., center of element or screen) for keyboard users.

--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -2,7 +2,24 @@ use leptos::prelude::*;
 use thousands::Separable;
 
 #[cfg(feature = "hydrate")]
-fn spawn_gil_party(x: f64, y: f64) {
+#[allow(clippy::collapsible_if)]
+fn spawn_gil_party(mut x: f64, mut y: f64) {
+    if x == 0.0 && y == 0.0 {
+        if let Some(window) = web_sys::window() {
+            x = window
+                .inner_width()
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                / 2.0;
+            y = window
+                .inner_height()
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                / 2.0;
+        }
+    }
     let document = document();
     let body = document.body().expect("body");
 
@@ -57,22 +74,36 @@ fn spawn_gil_party(x: f64, y: f64) {
 }
 
 #[component]
+fn GilIcon() -> impl IntoView {
+    view! {
+        <button
+            type="button"
+            class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--brand-ring)] rounded-full bg-transparent border-none appearance-none"
+            aria-label="Spawn gil party"
+            on:click=move |ev| {
+                #[cfg(feature = "hydrate")]
+                spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
+                #[cfg(not(feature = "hydrate"))]
+                {
+                    let _ = ev;
+                }
+            }
+        >
+            <img
+                alt=""
+                src="/static/images/gil.webp"
+                aria-hidden="true"
+                class="w-full h-full object-contain pointer-events-none"
+            />
+        </button>
+    }
+}
+
+#[component]
 pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
     view! {
         <div class="flex flex-row items-center">
-            <div
-                class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90"
-                on:click=move |ev| {
-                    #[cfg(feature = "hydrate")]
-                    spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
-                    #[cfg(not(feature = "hydrate"))]
-                    {
-                        let _ = ev;
-                    }
-                }
-            >
-                <img alt="gil" src="/static/images/gil.webp" />
-            </div>
+            <GilIcon />
             <div>{move || amount().separate_with_commas()}</div>
         </div>
     }
@@ -85,19 +116,7 @@ where
 {
     view! {
         <div class="flex flex-row items-center">
-            <div
-                class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90"
-                on:click=move |ev| {
-                    #[cfg(feature = "hydrate")]
-                    spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
-                    #[cfg(not(feature = "hydrate"))]
-                    {
-                        let _ = ev;
-                    }
-                }
-            >
-                <img alt="gil" src="/static/images/gil.webp" />
-            </div>
+            <GilIcon />
             <div>{move || amount().separate_with_commas()}</div>
         </div>
     }


### PR DESCRIPTION
💡 What: Replaced div with button for Gil icon and added keyboard support.
🎯 Why: To make the easter egg accessible to keyboard users and improve semantic HTML.
♿ Accessibility: Added `role="button"`, `aria-label`, focus styles, and keyboard activation support.

---
*PR created automatically by Jules for task [5283906616805465373](https://jules.google.com/task/5283906616805465373) started by @akarras*