### PR TITLE
🎨 Palette: Make Gil Party accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-06 - [Gil Party Accessibility]
+**Learning:** Keyboard-triggered click events often report (0,0) coordinates, which can cause visual effects to appear in the wrong place (top-left corner).
+**Action:** When handling click events that rely on coordinates, always check for (0,0) and provide a sensible fallback (e.g., center of screen or element) for keyboard users.

--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -2,7 +2,23 @@ use leptos::prelude::*;
 use thousands::Separable;
 
 #[cfg(feature = "hydrate")]
-fn spawn_gil_party(x: f64, y: f64) {
+fn spawn_gil_party(mut x: f64, mut y: f64) {
+    if x == 0.0 && y == 0.0 {
+        if let Some(window) = web_sys::window() {
+            x = window
+                .inner_width()
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                / 2.0;
+            y = window
+                .inner_height()
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                / 2.0;
+        }
+    }
     let document = document();
     let body = document.body().expect("body");
 
@@ -57,22 +73,36 @@ fn spawn_gil_party(x: f64, y: f64) {
 }
 
 #[component]
+fn GilIcon() -> impl IntoView {
+    view! {
+        <button
+            type="button"
+            class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-ring)] rounded-full bg-transparent border-none appearance-none flex items-center justify-center"
+            aria-label="Spawn gil party"
+            on:click=move |ev| {
+                #[cfg(feature = "hydrate")]
+                spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
+                #[cfg(not(feature = "hydrate"))]
+                {
+                    let _ = ev;
+                }
+            }
+        >
+            <img
+                alt=""
+                src="/static/images/gil.webp"
+                aria-hidden="true"
+                class="w-full h-full object-contain pointer-events-none"
+            />
+        </button>
+    }
+}
+
+#[component]
 pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
     view! {
         <div class="flex flex-row items-center">
-            <div
-                class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90"
-                on:click=move |ev| {
-                    #[cfg(feature = "hydrate")]
-                    spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
-                    #[cfg(not(feature = "hydrate"))]
-                    {
-                        let _ = ev;
-                    }
-                }
-            >
-                <img alt="gil" src="/static/images/gil.webp" />
-            </div>
+            <GilIcon />
             <div>{move || amount().separate_with_commas()}</div>
         </div>
     }
@@ -85,19 +115,7 @@ where
 {
     view! {
         <div class="flex flex-row items-center">
-            <div
-                class="h-7 w-7 -m-1 aspect-square p-1 cursor-pointer hover:scale-110 transition-transform active:scale-90"
-                on:click=move |ev| {
-                    #[cfg(feature = "hydrate")]
-                    spawn_gil_party(ev.client_x() as f64, ev.client_y() as f64);
-                    #[cfg(not(feature = "hydrate"))]
-                    {
-                        let _ = ev;
-                    }
-                }
-            >
-                <img alt="gil" src="/static/images/gil.webp" />
-            </div>
+            <GilIcon />
             <div>{move || amount().separate_with_commas()}</div>
         </div>
     }

--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -3,6 +3,7 @@ use thousands::Separable;
 
 #[cfg(feature = "hydrate")]
 fn spawn_gil_party(mut x: f64, mut y: f64) {
+    #[allow(clippy::collapsible_if)]
     if x == 0.0 && y == 0.0 {
         if let Some(window) = web_sys::window() {
             x = window


### PR DESCRIPTION
This PR improves the accessibility of the Gil icon (easter egg) by making it keyboard accessible.

### Changes
- Replaced the clickable `div` with a semantic `<button>`.
- Added `aria-label="Spawn gil party"` to ensure screen readers announce the interactive element properly.
- Implemented focus styles (`focus-visible:ring-2`) so keyboard users can see where they are.
- Updated the `spawn_gil_party` function to detect (0,0) coordinates (typical for keyboard activation) and default the effect to the center of the screen, preventing it from spawning in the top-left corner.
- Extracted a reusable `GilIcon` component to avoid duplication between `Gil` and `GenericGil`.

### Why
Previously, the Gil icon was a `div` with a click handler, making it inaccessible to keyboard users and screen readers. This change ensures that everyone can enjoy the delightful "gil party" effect.

### Accessibility
- **Keyboard Support:** Users can now tab to the icon and activate it with Enter/Space.
- **Screen Reader Support:** The button is properly labeled.
- **Visual Feedback:** Focus ring is visible when navigating via keyboard.

---
*PR created automatically by Jules for task [17532634533906192627](https://jules.google.com/task/17532634533906192627) started by @akarras*