### PR TITLE
⚡ Bolt: Optimize sale history date range filter

### DIFF
--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -220,16 +220,23 @@ fn find_date_range(
     date_range: RangeInclusive<NaiveDateTime>,
     sales: &[SaleHistory],
 ) -> Option<&[SaleHistory]> {
-    let (start, _) = sales
-        .iter()
-        .enumerate()
-        .find(|(_, sale)| date_range.contains(&sale.sold_date))?;
-    let (end, _) = sales
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, sale)| date_range.contains(&sale.sold_date))?;
-    Some(&sales[start..=end])
+    if sales.is_empty() {
+        return None;
+    }
+    // Optimization: Use binary search (partition_point) for O(log N) lookup instead of O(N) linear scan.
+    // Relies on sales being sorted by date descending (Newest -> Oldest).
+
+    // Find first sale that is <= end_date (i.e. skip newer sales)
+    let start_idx = sales.partition_point(|s| s.sold_date > *date_range.end());
+
+    // Find first sale that is < start_date (i.e. this is the exclusive end index of sales >= start_date)
+    let end_idx = sales.partition_point(|s| s.sold_date >= *date_range.start());
+
+    if start_idx >= end_idx {
+        return None;
+    }
+
+    Some(&sales[start_idx..end_idx])
 }
 
 impl SalesSummaryData {


### PR DESCRIPTION
💡 What: Replaced O(N) linear scan with O(log N) binary search in `find_date_range` function using `partition_point`.
🎯 Why: `SalesSummaryData` calculation filters sales by date range (Day, Month) on every render. Linear scan becomes expensive for items with long sale history.
📊 Impact: Faster filtering for large datasets. Reduces complexity from O(N) to O(log N).
🔬 Measurement: Verified logic with test cases covering various scenarios (start of list, end of list, middle, no match). Assumes sales are sorted descending by date (Newest -> Oldest), which is standard for sale history.

---
*PR created automatically by Jules for task [7674970866663873220](https://jules.google.com/task/7674970866663873220) started by @akarras*