### PR TITLE
🎨 Palette: Fix unassociated labels in CrafterSettings

### DIFF
--- a/ultros-frontend/ultros-app/src/components/crafter_settings.rs
+++ b/ultros-frontend/ultros-app/src/components/crafter_settings.rs
@@ -40,13 +40,18 @@ pub fn CrafterSettings() -> impl IntoView {
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                 {jobs.into_iter()
                     .map(|(code, name, getter)| {
+                        let id = format!("crafter-level-{}", code);
                         view! {
                             <div class="space-y-1">
-                                <label class="text-sm font-medium text-[color:var(--color-text-muted)]">
+                                <label
+                                    class="text-sm font-medium text-[color:var(--color-text-muted)]"
+                                    for=id.clone()
+                                >
                                     {name}
                                 </label>
                                 <div class="relative">
                                     <input
+                                        id=id
                                         type="number"
                                         min="0"
                                         max="100"


### PR DESCRIPTION
💡 What: Added `id` and `for` attributes to the crafter level inputs and labels in `CrafterSettings`.
🎯 Why: Screen readers could not associate the labels ("Carpenter", etc.) with the inputs.
📸 Before/After: No visual change, but functionality is improved for assistive technology.
♿ Accessibility: Ensures WCAG compliance for form labels.

---
*PR created automatically by Jules for task [8829872358791307236](https://jules.google.com/task/8829872358791307236) started by @akarras*