### PR TITLE
🎨 Palette: Improve CrafterSettings accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Iterated Input Labeling
+**Learning:** Iterated inputs often lack unique IDs, breaking label association.
+**Action:** Always generate unique IDs (e.g., using item code or index) when mapping over a list to create form fields.

--- a/ultros-frontend/ultros-app/src/components/crafter_settings.rs
+++ b/ultros-frontend/ultros-app/src/components/crafter_settings.rs
@@ -40,13 +40,15 @@ pub fn CrafterSettings() -> impl IntoView {
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                 {jobs.into_iter()
                     .map(|(code, name, getter)| {
+                        let id = format!("crafter-level-{}", code);
                         view! {
                             <div class="space-y-1">
-                                <label class="text-sm font-medium text-[color:var(--color-text-muted)]">
+                                <label class="text-sm font-medium text-[color:var(--color-text-muted)]" for={id.clone()}>
                                     {name}
                                 </label>
                                 <div class="relative">
                                     <input
+                                        id={id}
                                         type="number"
                                         min="0"
                                         max="100"


### PR DESCRIPTION
💡 What: Added `id` and `for` attributes to associate labels with inputs in the `CrafterSettings` component.
🎯 Why: Without explicit association, screen readers cannot identify the purpose of the input fields, and mouse users cannot click the label to focus the input.
📸 Before/After: Visual appearance is unchanged, but interaction and accessibility semantics are improved.
♿ Accessibility: Ensures WCAG compliance for form labels (SC 3.3.2).


---
*PR created automatically by Jules for task [10057030015190306809](https://jules.google.com/task/10057030015190306809) started by @akarras*