### PR TITLE
⚡ Bolt: optimize listing deletion with bulk delete

### DIFF
--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -329,12 +329,15 @@ impl UltrosDb {
         });
         let (added, _removed_result) =
             futures::future::join(futures::future::join_all(added), async move {
-                let remove_result = futures::future::try_join_all(
-                    remove_iter
-                        .map(|(l, _)| active_listing::Entity::delete_by_id(l.id).exec(&self.db)),
-                )
-                .await?;
-                Result::<usize>::Ok(remove_result.len())
+                let ids_to_remove: Vec<i32> = remove_iter.map(|(l, _)| l.id).collect();
+                if ids_to_remove.is_empty() {
+                    return Result::<usize>::Ok(0);
+                }
+                let res = active_listing::Entity::delete_many()
+                    .filter(active_listing::Column::Id.is_in(ids_to_remove))
+                    .exec(&self.db)
+                    .await?;
+                Result::<usize>::Ok(res.rows_affected as usize)
             })
             .await;
         let added: Vec<_> = added


### PR DESCRIPTION
💡 What: Optimized `update_listings` in `ultros-db` to use `delete_many` instead of a loop of `delete_by_id`.
🎯 Why: To eliminate N+1 query problem during market board updates when removing listings.
📊 Impact: Reduces N delete queries to 1 delete query per update batch. This reduces database load and network latency.
🔬 Measurement: Verified with `cargo test -p ultros-db` and code review. Logic is standard SeaORM optimization.

---
*PR created automatically by Jules for task [1336034088668028442](https://jules.google.com/task/1336034088668028442) started by @akarras*