### PR TITLE
🎨 Palette: Improved accessibility for 'Add to List' buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_to_list.rs
@@ -116,6 +116,7 @@ fn AddToListModal(
                                         let (running, set_running) = signal(false);
                                         let (error, set_error) = signal(Option::<String>::None);
                                         let toasts = use_toast();
+                                        let list_name = list.name.clone();
 
                                         view! {
                                             <div class="space-y-1">
@@ -123,6 +124,7 @@ fn AddToListModal(
                                                     <div class="font-semibold truncate">{list.name}</div>
                                                     <button
                                                         class="btn-primary"
+                                                        aria-label=move || format!("Add to list {}", list_name)
                                                         disabled=running
                                                         on:click=move |_| {
                                                             set_error(None);


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-label` to "Add to list" buttons.
🎯 **Why:** To improve accessibility for screen reader users who would otherwise hear ambiguous "Add" buttons without context.
📸 **Before/After:** No visual change.
♿ **Accessibility:** Screen readers will now announce the specific list name when focusing on the add button (e.g., "Add to list Wishlist").

---
*PR created automatically by Jules for task [11080692086385427576](https://jules.google.com/task/11080692086385427576) started by @akarras*