### PR TITLE
Add Purchasing View for Lists

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -1,0 +1,215 @@
+use crate::components::gil::*;
+use crate::components::icon::Icon;
+use crate::components::item_icon::*;
+use crate::global_state::LocalWorldData;
+use icondata as i;
+use leptos::either::Either;
+use leptos::prelude::*;
+use std::collections::HashMap;
+use ultros_api_types::{
+    ActiveListing, list::ListItem,
+    world_helper::{AnyResult, AnySelector},
+};
+use xiv_gen::ItemId;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct GroupedListing {
+    item_id: i32,
+    item_name: String,
+    price: i32,
+    quantity: i32,
+    list_item: ListItem,
+    hq: bool,
+    listing_id: i32,
+}
+
+#[component]
+pub fn BuyingView(
+    items: Vec<(ListItem, Vec<ActiveListing>)>,
+    edit_item: Action<ListItem, Result<(), crate::error::AppError>>,
+) -> impl IntoView {
+    let world_data = use_context::<LocalWorldData>()
+        .expect("LocalWorldData should be available")
+        .0
+        .expect("LocalWorldData should be loaded");
+    let data = xiv_gen_db::data();
+    let game_items = &data.items;
+
+    let mut selected_listings: Vec<(i32, GroupedListing)> = Vec::new();
+
+    for (list_item, mut listings) in items {
+        let quantity = list_item.quantity.unwrap_or(1);
+        let acquired = list_item.acquired.unwrap_or(0);
+        let needed = quantity.saturating_sub(acquired);
+        if needed <= 0 {
+            continue;
+        }
+
+        listings.sort_by_key(|l| l.price_per_unit);
+        let mut remaining = needed;
+        for listing in listings {
+            if remaining <= 0 {
+                break;
+            }
+            if matches!(list_item.hq, Some(hq) if listing.hq != hq) {
+                continue;
+            }
+            let buy_quantity = remaining.min(listing.quantity);
+            let item_name = game_items
+                .get(&ItemId(list_item.item_id))
+                .map(|i| i.name.to_string())
+                .unwrap_or_else(|| "Unknown Item".to_string());
+
+            selected_listings.push((
+                listing.world_id,
+                GroupedListing {
+                    item_id: list_item.item_id,
+                    item_name,
+                    price: listing.price_per_unit,
+                    quantity: buy_quantity,
+                    list_item: list_item.clone(),
+                    hq: listing.hq,
+                    listing_id: listing.id,
+                },
+            ));
+            remaining -= buy_quantity;
+        }
+    }
+
+    // Group by Datacenter -> World -> Listing
+    type WorldMap = HashMap<i32, (String, Vec<GroupedListing>)>;
+    let mut dc_groups: HashMap<i32, (String, WorldMap)> = HashMap::new();
+
+    for (world_id, listing) in selected_listings {
+        let world_res = world_data.lookup_selector(AnySelector::World(world_id));
+        if let Some(AnyResult::World(world)) = world_res {
+            let dc_res = world_data.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
+            if let Some(AnyResult::Datacenter(dc)) = dc_res {
+                let dc_entry = dc_groups
+                    .entry(dc.id)
+                    .or_insert_with(|| (dc.name.clone(), HashMap::new()));
+                let world_entry = dc_entry
+                    .1
+                    .entry(world.id)
+                    .or_insert_with(|| (world.name.clone(), Vec::new()));
+                world_entry.1.push(listing);
+            }
+        }
+    }
+
+    // Convert to sorted vectors for display
+    type WorldList = Vec<(i32, String, Vec<GroupedListing>)>;
+    let mut sorted_dcs: Vec<(i32, String, WorldList)> = dc_groups
+        .into_iter()
+        .map(|(dc_id, (dc_name, worlds))| {
+            let mut sorted_worlds: WorldList = worlds
+                .into_iter()
+                .map(|(world_id, (world_name, listings))| (world_id, world_name, listings))
+                .collect();
+            sorted_worlds.sort_by(|a, b| a.1.cmp(&b.1));
+            (dc_id, dc_name, sorted_worlds)
+        })
+        .collect();
+    sorted_dcs.sort_by(|a, b| a.1.cmp(&b.1));
+
+    view! {
+        <div class="flex flex-col gap-6">
+            {if sorted_dcs.is_empty() {
+                Either::Left(
+                    view! {
+                        <div class="text-center py-8 text-[color:var(--color-text-muted)] italic">
+                            "No items left to buy! 🎉"
+                        </div>
+                    },
+                )
+            } else {
+                Either::Right(
+                    view! {
+                        <For
+                            each=move || sorted_dcs.clone()
+                            key=|(dc_id, _, _)| *dc_id
+                            children=move |(_dc_id, dc_name, worlds)| {
+                                view! {
+                                    <div class="flex flex-col gap-4">
+                                        <div class="text-2xl font-bold text-brand-400 border-b-2 border-brand-900/50 pb-1">
+                                            {dc_name}
+                                        </div>
+                                        <div class="flex flex-col gap-6 pl-2">
+                                            <For
+                                                each=move || worlds.clone()
+                                                key=|(world_id, _, _)| *world_id
+                                                children=move |(_world_id, world_name, listings)| {
+                                                    view! {
+                                                        <div class="flex flex-col gap-2">
+                                                            <div class="text-xl font-semibold text-brand-200 flex items-center gap-2">
+                                                                <Icon icon=i::BiMapRegular />
+                                                                {world_name}
+                                                            </div>
+                                                            <div class="flex flex-col gap-1 pl-6">
+                                                                <For
+                                                                    each=move || listings.clone()
+                                                                    key=|listing| listing.listing_id
+                                                                    children=move |listing| {
+                                                                        let edit_item = edit_item;
+                                                                        let mut list_item = listing.list_item.clone();
+                                                                        let quantity_to_add = listing.quantity;
+                                                                        view! {
+                                                                            <div class="flex flex-row items-center gap-3 py-2 hover:bg-brand-900/20 rounded-lg px-3 group transition-colors">
+                                                                                <ItemIcon
+                                                                                    item_id=listing.item_id
+                                                                                    icon_size=IconSize::Medium
+                                                                                />
+                                                                                <div class="flex-1 flex flex-col">
+                                                                                    <div class="flex items-center gap-2">
+                                                                                        <span class="font-bold text-lg">
+                                                                                            {listing.quantity}
+                                                                                        </span>
+                                                                                        <span class="text-[color:var(--color-text)]">
+                                                                                            {listing.item_name}
+                                                                                        </span>
+                                                                                        {listing
+                                                                                            .hq
+                                                                                            .then(|| {
+                                                                                                view! {
+                                                                                                    <span class="text-brand-400">"HQ"</span>
+                                                                                                }
+                                                                                            })}
+                                                                                    </div>
+                                                                                    <div class="flex items-center gap-1 text-sm text-[color:var(--color-text-muted)]">
+                                                                                        "@"
+                                                                                        <Gil amount=Signal::derive(move || listing.price) />
+                                                                                        "each"
+                                                                                    </div>
+                                                                                </div>
+                                                                                <button
+                                                                                    class="btn btn-primary opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-2"
+                                                                                    on:click=move |_| {
+                                                                                        list_item.acquired = Some(
+                                                                                            list_item.acquired.unwrap_or(0) + quantity_to_add,
+                                                                                        );
+                                                                                        let _ = edit_item.dispatch(list_item.clone());
+                                                                                    }
+                                                                                >
+                                                                                    <Icon icon=i::BiCheckRegular />
+                                                                                    <span>"Mark Purchased"</span>
+                                                                                </button>
+                                                                            </div>
+                                                                        }
+                                                                    }
+                                                                />
+                                                            </div>
+                                                        </div>
+                                                    }
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                }
+                            }
+                        />
+                    },
+                )
+            }}
+        </div>
+    }
+}

--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -7,7 +7,8 @@ use leptos::either::Either;
 use leptos::prelude::*;
 use std::collections::HashMap;
 use ultros_api_types::{
-    ActiveListing, list::ListItem,
+    ActiveListing,
+    list::ListItem,
     world_helper::{AnyResult, AnySelector},
 };
 use xiv_gen::ItemId;

--- a/ultros-frontend/ultros-app/src/components/list/mod.rs
+++ b/ultros-frontend/ultros-app/src/components/list/mod.rs
@@ -1,3 +1,4 @@
 pub mod auto_mark_purchases;
+pub mod buying_view;
 pub mod list_item_row;
 pub mod list_summary;

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -15,7 +15,10 @@ use crate::api::{
 use crate::components::{
     add_recipe_to_current_list::AddRecipeToCurrentListModal,
     item_icon::*,
-    list::{auto_mark_purchases::AutoMarkPurchases, list_item_row::ListItemRow, list_summary::*},
+    list::{
+        auto_mark_purchases::AutoMarkPurchases, buying_view::BuyingView,
+        list_item_row::ListItemRow, list_summary::*,
+    },
     loading::*,
     make_place_importer::*,
     tooltip::*,
@@ -73,6 +76,7 @@ pub fn ListView() -> impl IntoView {
 
     let (menu, set_menu) = signal(MenuState::None);
     let (recipe_modal_open, set_recipe_modal_open) = signal(false);
+    let (buying_view, set_buying_view) = signal(false);
 
     let edit_list_mode = RwSignal::new(false);
     let selected_items = RwSignal::new(HashSet::new());
@@ -123,6 +127,18 @@ pub fn ListView() -> impl IntoView {
                 >
 
                     "Make Place"
+                </button>
+            </Tooltip>
+            <Tooltip tooltip_text="Toggle purchasing view">
+                <button
+                    class="btn-secondary"
+                    class:active=buying_view
+                    on:click=move |_| set_buying_view.update(|v| *v = !*v)
+                >
+                    <i class="pr-1.5">
+                        <Icon icon=i::BiCartRegular />
+                    </i>
+                    <span>"Purchasing View"</span>
                 </button>
             </Tooltip>
 
@@ -287,99 +303,126 @@ pub fn ListView() -> impl IntoView {
                     .map(move |list| match list {
                         Ok((list, items)) => {
                             let items = StoredValue::new(items);
-                            Either::Left(
-                                view! {
-                                    <table></table>
-                                    <div class="content-well">
-                                        <div class="sticky top-0 flex-row justify-between">
-                                            <span class="content-title">{list.name}</span>
-                                            <div class="flex flex-row">
-                                                <button
-                                                    class="btn"
-                                                    class:bg-brand-950=edit_list_mode
-                                                    on:click=move |_| {
-                                                        edit_list_mode
-                                                            .update(|u| {
-                                                                *u = !*u;
-                                                            })
-                                                    }
-                                                >
-
-                                                    "bulk edit"
-                                                </button>
-                                                <div class:hidden=move || !edit_list_mode()>
-                                                    <button
-                                                        class="btn"
-                                                        on:click=move |_| {
-                                                            let items = selected_items
-                                                                .with_untracked(|s| s.iter().copied().collect::<Vec<_>>());
-                                                            selected_items.update(|i| i.clear());
-                                                            delete_items.dispatch(items);
-                                                        }
-                                                    >
-
-                                                        "DELETE"
-                                                    </button>
+                            Either::Left(move || {
+                                if buying_view() {
+                                    Either::Left(
+                                        view! {
+                                            <div class="content-well">
+                                                <div class="sticky top-0 flex-row justify-between">
+                                                    <span class="content-title">{list.name.clone()}</span>
                                                 </div>
-                                                <button
-                                                    class="btn"
-                                                    on:click=move |_| {
-                                                        selected_items
-                                                            .update(|i| {
-                                                                for (item, _) in items.get_value() {
-                                                                    i.insert(item.id);
-                                                                }
-                                                            })
-                                                    }
-                                                >
-
-                                                    "SELECT ALL"
-                                                </button>
-                                                <button
-                                                    class="btn"
-                                                    on:click=move |_| {
-                                                        selected_items.update(|i| i.clear());
-                                                    }
-                                                >
-
-                                                    "DESLECT ALL"
-                                                </button>
+                                                <BuyingView items=items.get_value() edit_item=edit_item />
                                             </div>
-                                        </div>
-                                        <table class="w-full">
-                                            <thead>
-                                                <tr>
-                                                    <th class="text-left p-2" class:hidden=move || !edit_list_mode()>"✅"</th>
-                                                    <th class="text-left p-2">"HQ"</th>
-                                                    <th class="text-left p-2">"Item"</th>
-                                                    <th class="text-left p-2">"Quantity"</th>
-                                                    <th class="text-left p-2">"Price"</th>
-                                                    <th class="text-left p-2" class:hidden=edit_list_mode>"Options"</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <For
-                                                    each=move || items.get_value()
-                                                    key=|(item, _)| item.id
-                                                    children=move |(item, listings)| {
-                                                        view! {
-                                                            <ListItemRow
-                                                                item=item
-                                                                listings=listings
-                                                                edit_list_mode=edit_list_mode.into()
-                                                                selected_items=selected_items
-                                                                delete_item=delete_item
-                                                                edit_item=edit_item
-                                                            />
-                                                        }
-                                                    }
-                                                />
-                                            </tbody>
-                                        </table>
-                                        <ListSummary items=items.get_value() />
-                                    </div>
-                                },
-                            )
+                                        },
+                                    )
+                                } else {
+                                    Either::Right(
+                                        view! {
+                                            <div class="content-well">
+                                                <div class="sticky top-0 flex-row justify-between">
+                                                    <span class="content-title">{list.name.clone()}</span>
+                                                    <div class="flex flex-row">
+                                                        <button
+                                                            class="btn"
+                                                            class:bg-brand-950=edit_list_mode
+                                                            on:click=move |_| {
+                                                                edit_list_mode
+                                                                    .update(|u| {
+                                                                        *u = !*u;
+                                                                    })
+                                                            }
+                                                        >
+
+                                                            "bulk edit"
+                                                        </button>
+                                                        <div class:hidden=move || !edit_list_mode()>
+                                                            <button
+                                                                class="btn"
+                                                                on:click=move |_| {
+                                                                    let items = selected_items
+                                                                        .with_untracked(|s| {
+                                                                            s.iter().copied().collect::<Vec<_>>()
+                                                                        });
+                                                                    selected_items.update(|i| i.clear());
+                                                                    delete_items.dispatch(items);
+                                                                }
+                                                            >
+
+                                                                "DELETE"
+                                                            </button>
+                                                        </div>
+                                                        <button
+                                                            class="btn"
+                                                            on:click=move |_| {
+                                                                selected_items
+                                                                    .update(|i| {
+                                                                        for (item, _) in items.get_value() {
+                                                                            i.insert(item.id);
+                                                                        }
+                                                                    })
+                                                            }
+                                                        >
+
+                                                            "SELECT ALL"
+                                                        </button>
+                                                        <button
+                                                            class="btn"
+                                                            on:click=move |_| {
+                                                                selected_items.update(|i| i.clear());
+                                                            }
+                                                        >
+
+                                                            "DESLECT ALL"
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                                <table class="w-full">
+                                                    <thead>
+                                                        <tr>
+                                                            <th
+                                                                class="text-left p-2"
+                                                                class:hidden=move || !edit_list_mode()
+                                                            >
+                                                                "✅"
+                                                            </th>
+                                                            <th class="text-left p-2">"HQ"</th>
+                                                            <th class="text-left p-2">"Item"</th>
+                                                            <th class="text-left p-2">"Quantity"</th>
+                                                            <th class="text-left p-2">"Price"</th>
+                                                            <th
+                                                                class="text-left p-2"
+                                                                class:hidden=edit_list_mode
+                                                            >
+                                                                "Options"
+                                                            </th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <For
+                                                            each=move || items.get_value()
+                                                            key=|(item, _)| item.id
+                                                            children=move |(item, listings)| {
+                                                                view! {
+                                                                    <ListItemRow
+                                                                        item=item
+                                                                        listings=listings
+                                                                        edit_list_mode=edit_list_mode.into()
+                                                                        selected_items=selected_items
+                                                                        delete_item=delete_item
+                                                                        edit_item=edit_item
+                                                                    />
+                                                                }
+                                                            }
+                                                        />
+
+                                                    </tbody>
+                                                </table>
+                                                <ListSummary items=items.get_value() />
+                                            </div>
+                                        },
+                                    )
+                                }
+                            })
                         }
                         Err(e) => {
                             Either::Right(


### PR DESCRIPTION
Implemented a new "Purchasing View" for user lists. This view helps users purchase items efficiently by showing the cheapest listings grouped by world and datacenter. Users can mark items as purchased directly from this view, which updates the list's acquired count.

Key changes:
- New `BuyingView.rs` component with grouping logic.
- Integration of `BuyingView` into `list_view.rs` with a toggle button.
- Alphabetical sorting by datacenter and world.
- "Mark Purchased" buttons for each item-listing entry.

Fixes #20

---
*PR created automatically by Jules for task [5539075176807191151](https://jules.google.com/task/5539075176807191151) started by @akarras*