### PR TITLE
Fix Edit Retainers drag and drop and refresh logic

### DIFF
--- a/ultros-frontend/ultros-app/Cargo.toml
+++ b/ultros-frontend/ultros-app/Cargo.toml
@@ -29,6 +29,9 @@ web-sys = { version = "0.3", optional = true, features = [
     "HtmlDivElement",
     "HtmlElement",
     "HtmlDocument",
+    "Document",
+    "Element",
+    "PointerEvent",
 ] }
 ultros-api-types = { path = "../../ultros-api-types" }
 ultros-db = { path = "../../ultros-db", optional = true }

--- a/ultros-frontend/ultros-app/src/components/reorderable_list.rs
+++ b/ultros-frontend/ultros-app/src/components/reorderable_list.rs
@@ -1,4 +1,6 @@
 use leptos::prelude::*;
+use web_sys::PointerEvent;
+use web_sys::wasm_bindgen::JsCast;
 
 #[component]
 pub fn ReorderableList<T, V, N>(items: RwSignal<Vec<T>>, item_view: V) -> impl IntoView
@@ -8,48 +10,89 @@ where
     N: IntoView + 'static,
 {
     let (dragging, set_dragging) = signal(None);
-    view! {
-        <For
-            each=move || items().into_iter().enumerate()
-            key=move |(id, _)| *id
-            children=move |(id, child)| {
-                let (hovered, set_hovered) = signal(false);
-                view! {
-                    <div
-                        draggable="true"
-                        on:drop=move |e| {
-                            log::info!("Drop");
-                            e.prevent_default();
-                            let drop_index = id;
-                            if let Some(dragging) = dragging() {
-                                items
-                                    .update(|items| {
-                                        let removed_item = items.remove(dragging);
-                                        items.insert(drop_index, removed_item);
-                                    });
-                                set_dragging(None);
-                            } else {
-                                log::warn!("no item dragging?");
-                            }
-                        }
+    let (over, set_over) = signal(None);
 
-                        on:dragend=move |_| set_dragging(None)
-                        on:dragstart=move |_| set_dragging(Some(id))
-                        on:dragover=move |e| e.prevent_default()
-                        on:dragenter=move |_| { set_hovered(true) }
-                        on:dragleave=move |_| { set_hovered(false) }
-                        class:drop-hint=hovered
-                        class:drag-active=move || {
-                            dragging().map(|drag| drag == id).unwrap_or_default()
-                        }
-                    >
-
-                        // if this is the drag object, leave the view the same, otherwise swap it out.
-                        {item_view(child)}
-                    </div>
-                }
+    let on_pointer_move = move |e: PointerEvent| {
+        if dragging().is_some() {
+            let x = e.client_x();
+            let y = e.client_y();
+            if let Some(index) = web_sys::window()
+                .and_then(|w| w.document())
+                .and_then(|doc| doc.element_from_point(x as f32, y as f32))
+                .and_then(|el| el.closest("[data-index]").ok().flatten())
+                .and_then(|el| el.get_attribute("data-index"))
+                .and_then(|s| s.parse::<usize>().ok())
+            {
+                set_over(Some(index));
+                return;
             }
-        ></For>
+            set_over(None);
+        }
+    };
+
+    let reset = move |_| {
+        set_dragging(None);
+        set_over(None);
+    };
+
+    let on_pointer_up = move |e: PointerEvent| {
+        if let (Some(start), Some(end)) = (dragging(), over()) {
+            #[allow(clippy::collapsible_if)]
+            if start != end {
+                items.update(|items| {
+                    let item = items.remove(start);
+                    items.insert(end, item);
+                });
+            }
+        }
+        if let Some(target) = e
+            .target()
+            .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+        {
+            let _ = target.release_pointer_capture(e.pointer_id());
+        }
+        reset(e);
+    };
+
+    view! {
+        <div
+            class="reorderable-list flex flex-col gap-2"
+            on:pointermove=on_pointer_move
+            on:pointerup=on_pointer_up
+            on:pointercancel=reset
+        >
+            <For
+                each=move || items().into_iter().enumerate()
+                key=move |(id, _)| *id
+                children=move |(id, child)| {
+                    view! {
+                        <div
+                            data-index=id
+                            on:pointerdown=move |e| {
+                                if e.button() == 0 {
+                                    set_dragging(Some(id));
+                                    set_over(Some(id));
+                                    if let Some(target) = e
+                                        .target()
+                                        .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+                                    {
+                                        let _ = target.set_pointer_capture(e.pointer_id());
+                                    }
+                                }
+                            }
+
+                            class:drop-hint=move || {
+                                over() == Some(id) && dragging().is_some() && dragging() != Some(id)
+                            }
+                            class:drag-active=move || dragging() == Some(id)
+                            style="touch-action: none; user-select: none;"
+                        >
+                            {item_view(child)}
+                        </div>
+                    }
+                }
+            />
+        </div>
     }
     .into_any()
 }

--- a/ultros-frontend/ultros-app/src/routes/edit_retainers.rs
+++ b/ultros-frontend/ultros-app/src/routes/edit_retainers.rs
@@ -30,7 +30,7 @@ pub fn EditRetainers() -> impl IntoView {
             (
                 claim.version().get(),
                 remove_retainer.version().get(),
-                // update_retainers.version().get(),
+                update_retainers.version().get(),
             )
         },
         move |key| {


### PR DESCRIPTION
This PR fixes the drag and drop support on the Edit Retainers page to support both pointer and touch events. It also ensures that the retainer list is refreshed automatically after a reorder operation.

Key changes:
- Updated `ReorderableList` component to use Pointer Events instead of the native Drag and Drop API.
- Added `set_pointer_capture` and `on:pointercancel` for better robustness.
- Fixed the `Resource` in `EditRetainers` to track the `update_retainers` action, enabling automatic list refresh.
- Updated `Cargo.toml` with the required `web-sys` features (`PointerEvent`, `Document`, `Element`).

Fixes #30

---
*PR created automatically by Jules for task [12387969204874587859](https://jules.google.com/task/12387969204874587859) started by @akarras*