### PR TITLE
🎨 Palette: Improve accessibility of Select component

### DIFF
--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -122,6 +122,7 @@ where
                 role="combobox"
                 aria-autocomplete="list"
                 aria-expanded={
+                    #[cfg(not(feature = "hydrate"))]
                     let hovered = hovered.clone();
                     move || (has_focus() || hovered()).to_string()
                 }
@@ -146,12 +147,11 @@ where
                 <For each=final_result key=move |(l, _)| *l let:data>
                     {
                         let is_selected_selector = is_selected_selector.clone();
-                        let is_selected_selector_aria = is_selected_selector.clone();
                         view! {
                     <button
                         class="w-full text-left"
                         role="option"
-                        aria-selected=move || is_selected_selector_aria.selected(&Some(data.0)).to_string()
+                        aria-selected=move || is_selected_selector.selected(&Some(data.0)).to_string()
                         on:click=move |_| {
                             if let Some(item) = items.with(|i| i.get(data.0).cloned()) {
                                 set_choice(Some(item));
@@ -166,12 +166,15 @@ where
                             }
                         }
                     >
-                        <div class=move || {
-                            let is_selected = is_selected_selector.selected(&Some(data.0));
-                            if is_selected {
-                                "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)]"
-                            } else {
-                                "flex items-center rounded-lg p-2 transition-colors duration-200 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]"
+                        <div class={
+                            let is_selected_selector = is_selected_selector.clone();
+                            move || {
+                                let is_selected = is_selected_selector.selected(&Some(data.0));
+                                if is_selected {
+                                    "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)]"
+                                } else {
+                                    "flex items-center rounded-lg p-2 transition-colors duration-200 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]"
+                                }
                             }
                         }>
                             {move || items

--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -119,6 +119,12 @@ where
                 }
                 on:keydown=keydown
                 prop:value=current_input
+                role="combobox"
+                aria-autocomplete="list"
+                aria-expanded={
+                    let hovered = hovered.clone();
+                    move || (has_focus() || hovered()).to_string()
+                }
             />
             <div
                 class="absolute top-1 left-1 select-none cursor flex items-center"
@@ -135,13 +141,17 @@ where
                 node_ref=dropdown
                 class=move || format!("{} {}", default_dropdown_class, dropdown_class.unwrap_or(""))
                 class:hidden=move || !has_focus() && !hovered()
+                role="listbox"
             >
                 <For each=final_result key=move |(l, _)| *l let:data>
                     {
                         let is_selected_selector = is_selected_selector.clone();
+                        let is_selected_selector_aria = is_selected_selector.clone();
                         view! {
                     <button
                         class="w-full text-left"
+                        role="option"
+                        aria-selected=move || is_selected_selector_aria.selected(&Some(data.0)).to_string()
                         on:click=move |_| {
                             if let Some(item) = items.with(|i| i.get(data.0).cloned()) {
                                 set_choice(Some(item));


### PR DESCRIPTION
Improved the accessibility of the `Select` component by adding standard ARIA attributes.
- The input now has `role="combobox"`, `aria-autocomplete="list"`, and `aria-expanded`.
- The dropdown container has `role="listbox"`.
- The option buttons have `role="option"` and `aria-selected` to indicate selection state.
- Fixed borrow checker errors by properly cloning signals for closures.

---
*PR created automatically by Jules for task [13707476957142951296](https://jules.google.com/task/13707476957142951296) started by @akarras*