### PR TITLE
Shared Lists - Axum Endpoints

### DIFF
--- a/ultros-api-types/src/list.rs
+++ b/ultros-api-types/src/list.rs
@@ -58,3 +58,37 @@ pub struct ListInvite {
     pub max_uses: Option<i32>,
     pub uses: i32,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ListSharedUser {
+    pub list_id: i32,
+    pub user_id: i64,
+    pub username: String,
+    pub permission: ListPermission,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ListSharedGroup {
+    pub list_id: i32,
+    pub group_id: i32,
+    pub group_name: String,
+    pub permission: ListPermission,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShareListUser {
+    pub user_id: i64,
+    pub permission: ListPermission,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShareListGroup {
+    pub group_id: i32,
+    pub permission: ListPermission,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateInvite {
+    pub permission: ListPermission,
+    pub max_uses: Option<i32>,
+}

--- a/ultros-api-types/src/user/group.rs
+++ b/ultros-api-types/src/user/group.rs
@@ -11,4 +11,10 @@ pub struct UserGroup {
 pub struct UserGroupMember {
     pub group_id: i32,
     pub user_id: i64,
+    pub username: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CreateGroup {
+    pub name: String,
 }

--- a/ultros-api-types/src/user/mod.rs
+++ b/ultros-api-types/src/user/mod.rs
@@ -1,4 +1,4 @@
-mod group;
+pub mod group;
 mod user_data;
 mod user_retainers;
 

--- a/ultros-db/src/common_type_conversions.rs
+++ b/ultros-db/src/common_type_conversions.rs
@@ -1,16 +1,18 @@
 use crate::{
     entity::{
-        self, datacenter, final_fantasy_character, list, list_item, owned_retainers, region,
-        unknown_final_fantasy_character,
+        self, datacenter, discord_user, final_fantasy_character, list, list_invite, list_item,
+        list_shared_group, list_shared_user, owned_retainers, region,
+        unknown_final_fantasy_character, user_group, user_group_member,
     },
     world_data::world_cache::WorldCache,
 };
 use thiserror::Error;
 use ultros_api_types::{
     ActiveListing, FfxivCharacter, SaleHistory, UnknownCharacter,
-    list::{List, ListItem},
+    list::{List, ListInvite, ListItem, ListSharedGroup, ListSharedUser},
     retainer::Retainer,
     user::OwnedRetainer,
+    user::{UserGroup, UserGroupMember},
     world::{Datacenter, Region, World, WorldData},
     world_helper::AnySelector,
 };
@@ -42,6 +44,70 @@ impl From<entity::active_listing::Model> for ActiveListing {
             quantity,
             hq,
             timestamp,
+        }
+    }
+}
+
+impl From<list_invite::Model> for ListInvite {
+    fn from(value: list_invite::Model) -> Self {
+        let list_invite::Model {
+            id,
+            list_id,
+            permission,
+            max_uses,
+            uses,
+        } = value;
+        Self {
+            id,
+            list_id,
+            permission: permission.into(),
+            max_uses,
+            uses,
+        }
+    }
+}
+
+pub struct ListSharedUserReturn(pub list_shared_user::Model, pub discord_user::Model);
+
+impl From<ListSharedUserReturn> for ListSharedUser {
+    fn from(ListSharedUserReturn(shared, user): ListSharedUserReturn) -> Self {
+        Self {
+            list_id: shared.list_id,
+            user_id: shared.user_id,
+            username: user.username,
+            permission: shared.permission.into(),
+        }
+    }
+}
+
+pub struct ListSharedGroupReturn(pub list_shared_group::Model, pub user_group::Model);
+
+impl From<ListSharedGroupReturn> for ListSharedGroup {
+    fn from(ListSharedGroupReturn(shared, group): ListSharedGroupReturn) -> Self {
+        Self {
+            list_id: shared.list_id,
+            group_id: shared.group_id,
+            group_name: group.name,
+            permission: shared.permission.into(),
+        }
+    }
+}
+
+impl From<user_group::Model> for UserGroup {
+    fn from(value: user_group::Model) -> Self {
+        let user_group::Model { id, name, owner_id } = value;
+        Self { id, name, owner_id }
+    }
+}
+
+pub struct UserGroupMemberReturn(pub user_group_member::Model, pub discord_user::Model);
+
+impl From<UserGroupMemberReturn> for UserGroupMember {
+    fn from(UserGroupMemberReturn(member, user): UserGroupMemberReturn) -> Self {
+        Self {
+            group_id: member.group_id,
+            user_id: member.user_id,
+            username: user.username,
         }
     }
 }

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -1,9 +1,7 @@
 use crate::{
     UltrosDb,
     common::try_update_value::ActiveValueCmpSet,
-    common_type_conversions::{
-        ListSharedGroupReturn, ListSharedUserReturn, UserGroupMemberReturn,
-    },
+    common_type_conversions::{ListSharedGroupReturn, ListSharedUserReturn, UserGroupMemberReturn},
     entity::{
         active_listing, discord_user, list, list_invite, list_item, list_shared_group,
         list_shared_user, retainer, user_group, user_group_member,

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -1,6 +1,9 @@
 use crate::{
     UltrosDb,
     common::try_update_value::ActiveValueCmpSet,
+    common_type_conversions::{
+        ListSharedGroupReturn, ListSharedUserReturn, UserGroupMemberReturn,
+    },
     entity::{
         active_listing, discord_user, list, list_invite, list_item, list_shared_group,
         list_shared_user, retainer, user_group, user_group_member,
@@ -508,12 +511,20 @@ impl UltrosDb {
         if current_perm < ListPermission::Owner {
             return Err(anyhow!("Only the owner can share the list"));
         }
-        list_shared_user::ActiveModel {
+        list_shared_user::Entity::insert(list_shared_user::ActiveModel {
             list_id: ActiveValue::Set(list_id),
             user_id: ActiveValue::Set(user_id),
             permission: ActiveValue::Set(permission as i16),
-        }
-        .insert(&self.db)
+        })
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::columns([
+                list_shared_user::Column::ListId,
+                list_shared_user::Column::UserId,
+            ])
+            .update_column(list_shared_user::Column::Permission)
+            .to_owned(),
+        )
+        .exec(&self.db)
         .await?;
         Ok(())
     }
@@ -529,12 +540,20 @@ impl UltrosDb {
         if current_perm < ListPermission::Owner {
             return Err(anyhow!("Only the owner can share the list"));
         }
-        list_shared_group::ActiveModel {
+        list_shared_group::Entity::insert(list_shared_group::ActiveModel {
             list_id: ActiveValue::Set(list_id),
             group_id: ActiveValue::Set(group_id),
             permission: ActiveValue::Set(permission as i16),
-        }
-        .insert(&self.db)
+        })
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::columns([
+                list_shared_group::Column::ListId,
+                list_shared_group::Column::GroupId,
+            ])
+            .update_column(list_shared_group::Column::Permission)
+            .to_owned(),
+        )
+        .exec(&self.db)
         .await?;
         Ok(())
     }
@@ -648,5 +667,92 @@ impl UltrosDb {
         }
         invite.delete(&self.db).await?;
         Ok(())
+    }
+
+    pub async fn get_list_invites(
+        &self,
+        list_id: i32,
+        user_id: i64,
+    ) -> Result<Vec<list_invite::Model>> {
+        let permission = self.get_permission(list_id, user_id).await?;
+        if permission < ListPermission::Owner {
+            return Err(anyhow!("Only the owner can view invites"));
+        }
+        Ok(list_invite::Entity::find()
+            .filter(list_invite::Column::ListId.eq(list_id))
+            .all(&self.db)
+            .await?)
+    }
+
+    pub async fn get_list_shared_users(
+        &self,
+        list_id: i32,
+        user_id: i64,
+    ) -> Result<Vec<ListSharedUserReturn>> {
+        let permission = self.get_permission(list_id, user_id).await?;
+        if permission < ListPermission::Owner {
+            return Err(anyhow!("Only the owner can view shares"));
+        }
+        Ok(list_shared_user::Entity::find()
+            .filter(list_shared_user::Column::ListId.eq(list_id))
+            .find_also_related(discord_user::Entity)
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|(shared, user)| ListSharedUserReturn(shared, user.unwrap()))
+            .collect())
+    }
+
+    pub async fn get_list_shared_groups(
+        &self,
+        list_id: i32,
+        user_id: i64,
+    ) -> Result<Vec<ListSharedGroupReturn>> {
+        let permission = self.get_permission(list_id, user_id).await?;
+        if permission < ListPermission::Owner {
+            return Err(anyhow!("Only the owner can view shares"));
+        }
+        Ok(list_shared_group::Entity::find()
+            .filter(list_shared_group::Column::ListId.eq(list_id))
+            .find_also_related(user_group::Entity)
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|(shared, group)| ListSharedGroupReturn(shared, group.unwrap()))
+            .collect())
+    }
+
+    pub async fn get_group_members(
+        &self,
+        group_id: i32,
+        user_id: i64,
+    ) -> Result<Vec<UserGroupMemberReturn>> {
+        let group = user_group::Entity::find_by_id(group_id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("Group not found"))?;
+
+        // check if user is member or owner
+        let is_member = user_group_member::Entity::find()
+            .filter(user_group_member::Column::GroupId.eq(group_id))
+            .filter(user_group_member::Column::UserId.eq(user_id))
+            .one(&self.db)
+            .await?
+            .is_some();
+
+        if group.owner_id != user_id && !is_member {
+            return Err(anyhow!(
+                "You must be a member of the group to see other members"
+            ));
+        }
+
+        Ok(user_group_member::Entity::find()
+            .filter(user_group_member::Column::GroupId.eq(group_id))
+            .find_also_related(discord_user::Entity)
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|(member, user)| UserGroupMemberReturn(member, user.unwrap()))
+            .collect())
     }
 }

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -883,7 +883,9 @@ pub(crate) async fn get_group_members(
     Path(id): Path<i32>,
 ) -> Result<Json<Vec<UserGroupMember>>, ApiError> {
     let members = db.get_group_members(id, user.id as i64).await?;
-    Ok(Json(members.into_iter().map(UserGroupMember::from).collect()))
+    Ok(Json(
+        members.into_iter().map(UserGroupMember::from).collect(),
+    ))
 }
 
 pub(crate) async fn add_group_member(
@@ -949,7 +951,8 @@ pub(crate) async fn unshare_list_user(
     user: AuthDiscordUser,
     Path((id, user_id)): Path<(i32, i64)>,
 ) -> Result<Json<()>, ApiError> {
-    db.unshare_list_from_user(id, user.id as i64, user_id).await?;
+    db.unshare_list_from_user(id, user.id as i64, user_id)
+        .await?;
     Ok(Json(()))
 }
 
@@ -1095,7 +1098,10 @@ pub(crate) async fn start_web(state: WebState) {
         )
         .route("/api/v1/list/{id}/invites", get(get_list_invites))
         .route("/api/v1/list/{id}/invite/create", post(create_list_invite))
-        .route("/api/v1/list/invite/{invite_id}", delete(delete_list_invite))
+        .route(
+            "/api/v1/list/invite/{invite_id}",
+            delete(delete_list_invite),
+        )
         .route("/api/v1/list/invite/use/{invite_id}", post(use_list_invite))
         .route("/api/v1/list/item/{id}/delete", delete(delete_list_item))
         .route("/api/v1/list/item/delete", post(delete_multiple_list_items))

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -38,8 +38,12 @@ use tower_http::compression::{CompressionLayer, Predicate};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, warn};
 use ultros_api_types::icon_size::IconSize;
-use ultros_api_types::list::{CreateList, List, ListItem};
+use ultros_api_types::list::{
+    CreateInvite, CreateList, List, ListInvite, ListItem, ListSharedGroup, ListSharedUser,
+    ShareListGroup, ShareListUser,
+};
 use ultros_api_types::retainer::RetainerListings;
+use ultros_api_types::user::group::{CreateGroup, UserGroup, UserGroupMember};
 use ultros_api_types::user::{OwnedRetainer, UserData, UserRetainerListings, UserRetainers};
 use ultros_api_types::websocket::ListingEventData;
 use ultros_api_types::world::WorldData;
@@ -847,6 +851,157 @@ async fn reorder_retainer(
     Ok(Json(()))
 }
 
+pub(crate) async fn get_groups(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+) -> Result<Json<Vec<UserGroup>>, ApiError> {
+    let groups = db.get_groups_for_user(user.id as i64).await?;
+    Ok(Json(groups.into_iter().map(UserGroup::from).collect()))
+}
+
+pub(crate) async fn create_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Json(group): Json<CreateGroup>,
+) -> Result<Json<UserGroup>, ApiError> {
+    let group = db.create_group(group.name, user.id as i64).await?;
+    Ok(Json(UserGroup::from(group)))
+}
+
+pub(crate) async fn delete_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+) -> Result<Json<()>, ApiError> {
+    db.delete_group(id, user.id as i64).await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn get_group_members(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+) -> Result<Json<Vec<UserGroupMember>>, ApiError> {
+    let members = db.get_group_members(id, user.id as i64).await?;
+    Ok(Json(members.into_iter().map(UserGroupMember::from).collect()))
+}
+
+pub(crate) async fn add_group_member(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((group_id, member_id)): Path<(i32, i64)>,
+) -> Result<Json<()>, ApiError> {
+    db.add_group_member(group_id, user.id as i64, member_id)
+        .await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn remove_group_member(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((group_id, member_id)): Path<(i32, i64)>,
+) -> Result<Json<()>, ApiError> {
+    db.remove_group_member(group_id, user.id as i64, member_id)
+        .await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn get_list_shares(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+) -> Result<Json<(Vec<ListSharedUser>, Vec<ListSharedGroup>)>, ApiError> {
+    let (users, groups) = futures::future::try_join(
+        db.get_list_shared_users(id, user.id as i64),
+        db.get_list_shared_groups(id, user.id as i64),
+    )
+    .await?;
+    Ok(Json((
+        users.into_iter().map(ListSharedUser::from).collect(),
+        groups.into_iter().map(ListSharedGroup::from).collect(),
+    )))
+}
+
+pub(crate) async fn share_list_user(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(share): Json<ShareListUser>,
+) -> Result<Json<()>, ApiError> {
+    db.share_list_with_user(id, user.id as i64, share.user_id, share.permission)
+        .await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn share_list_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(share): Json<ShareListGroup>,
+) -> Result<Json<()>, ApiError> {
+    db.share_list_with_group(id, user.id as i64, share.group_id, share.permission)
+        .await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn unshare_list_user(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((id, user_id)): Path<(i32, i64)>,
+) -> Result<Json<()>, ApiError> {
+    db.unshare_list_from_user(id, user.id as i64, user_id).await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn unshare_list_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((id, group_id)): Path<(i32, i32)>,
+) -> Result<Json<()>, ApiError> {
+    db.unshare_list_from_group(id, user.id as i64, group_id)
+        .await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn get_list_invites(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+) -> Result<Json<Vec<ListInvite>>, ApiError> {
+    let invites = db.get_list_invites(id, user.id as i64).await?;
+    Ok(Json(invites.into_iter().map(ListInvite::from).collect()))
+}
+
+pub(crate) async fn create_list_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(invite): Json<CreateInvite>,
+) -> Result<Json<ListInvite>, ApiError> {
+    let invite = db
+        .create_invite(id, user.id as i64, invite.permission, invite.max_uses)
+        .await?;
+    Ok(Json(ListInvite::from(invite)))
+}
+
+pub(crate) async fn delete_list_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(invite_id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    db.delete_invite(invite_id, user.id as i64).await?;
+    Ok(Json(()))
+}
+
+pub(crate) async fn use_list_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(invite_id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    db.use_invite(invite_id, user.id as i64).await?;
+    Ok(Json(()))
+}
+
 async fn delete_user(
     user: AuthDiscordUser,
     State(cache): State<AuthUserCache>,
@@ -927,10 +1082,37 @@ pub(crate) async fn start_web(state: WebState) {
         .route("/api/v1/list/{id}/add/item", post(post_item_to_list))
         .route("/api/v1/list/{id}/add/items", post(post_items_to_list))
         .route("/api/v1/list/{id}/delete", delete(delete_list))
+        .route("/api/v1/list/{id}/shares", get(get_list_shares))
+        .route("/api/v1/list/{id}/share/user", post(share_list_user))
+        .route("/api/v1/list/{id}/share/group", post(share_list_group))
+        .route(
+            "/api/v1/list/{id}/share/user/{user_id}",
+            delete(unshare_list_user),
+        )
+        .route(
+            "/api/v1/list/{id}/share/group/{group_id}",
+            delete(unshare_list_group),
+        )
+        .route("/api/v1/list/{id}/invites", get(get_list_invites))
+        .route("/api/v1/list/{id}/invite/create", post(create_list_invite))
+        .route("/api/v1/list/invite/{invite_id}", delete(delete_list_invite))
+        .route("/api/v1/list/invite/use/{invite_id}", post(use_list_invite))
         .route("/api/v1/list/item/{id}/delete", delete(delete_list_item))
         .route("/api/v1/list/item/delete", post(delete_multiple_list_items))
         .route("/api/v1/world_data", get(world_data))
         .route("/api/v1/current_user", get(current_user))
+        .route("/api/v1/group", get(get_groups))
+        .route("/api/v1/group/create", post(create_group))
+        .route("/api/v1/group/{id}", delete(delete_group))
+        .route("/api/v1/group/{id}/members", get(get_group_members))
+        .route(
+            "/api/v1/group/{group_id}/member/add/{member_id}",
+            post(add_group_member),
+        )
+        .route(
+            "/api/v1/group/{group_id}/member/remove/{member_id}",
+            delete(remove_group_member),
+        )
         .route("/api/v1/user/retainer", get(user_retainers))
         .route("/api/v1/retainer/reorder", post(reorder_retainer))
         .route(


### PR DESCRIPTION
This PR exposes shared list and group management functionality to the Axum API. It allows users to:
- Create and manage groups of users.
- Share lists with specific users or entire groups with defined permissions.
- Create and manage invite links for lists.
- Synchronize list items (buying) via existing write-access permissions.

All necessary database functions and API types were added and verified with `cargo check`.

Fixes #484

---
*PR created automatically by Jules for task [15258616965403222242](https://jules.google.com/task/15258616965403222242) started by @akarras*