### PR TITLE
Shared Lists - WebSocket Data and Permissions

### DIFF
--- a/ultros-api-types/src/websocket.rs
+++ b/ultros-api-types/src/websocket.rs
@@ -131,10 +131,17 @@ pub struct SaleEventData {
     pub sales: Vec<(SaleHistory, UnknownCharacter)>,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum ListEventData {
+    List(crate::list::List),
+    ListItem(crate::list::ListItem),
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub enum ServerClient {
     Sales(EventType<SaleEventData>),
     Listings(EventType<ListingEventData>),
+    ListUpdate(EventType<ListEventData>),
     SubscriptionCreated,
     SocketConnected,
 }
@@ -150,6 +157,9 @@ pub enum ClientMessage {
     AddSubscribe {
         filter: FilterPredicate,
         msg_type: SocketMessageType,
+    },
+    SubscribeList {
+        list_id: i32,
     },
 }
 

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -74,6 +74,22 @@ pub fn ListView() -> impl IntoView {
         move |(id, _)| get_list_items_with_listings(id),
     );
 
+    #[cfg(not(feature = "ssr"))]
+    {
+        use crate::ws::live_data::subscribe_to_list;
+        Effect::new(move |_| {
+            let id = list_id.get();
+            if id != 0 {
+                leptos::task::spawn_local(async move {
+                    let _ = subscribe_to_list(id, move || {
+                        list_view.refetch();
+                    })
+                    .await;
+                });
+            }
+        });
+    }
+
     let (menu, set_menu) = signal(MenuState::None);
     let (recipe_modal_open, set_recipe_modal_open) = signal(false);
     let (buying_view, set_buying_view) = signal(false);

--- a/ultros-frontend/ultros-app/src/ws/live_data.rs
+++ b/ultros-frontend/ultros-app/src/ws/live_data.rs
@@ -90,3 +90,42 @@ pub(crate) async fn live_sales(
     }
     Ok(())
 }
+
+pub(crate) async fn subscribe_to_list(
+    list_id: i32,
+    on_update: impl Fn() + 'static,
+) -> Result<(), AppError> {
+    let window = web_sys::window().unwrap();
+    let location = window.location();
+    let protocol = location.protocol().unwrap();
+    let host = location.host().unwrap();
+    let ws_protocol = if protocol == "https:" { "wss" } else { "ws" };
+    let url = format!("{}://{}/api/v1/realtime/events", ws_protocol, host);
+
+    let socket = WebSocket::open(&url).unwrap();
+    let (mut write, mut read) = socket.split();
+    let client = ClientMessage::SubscribeList { list_id };
+    write
+        .send(Message::Text(serde_json::to_string(&client).unwrap()))
+        .await
+        .unwrap();
+    while let Some(msg) = read.next().await {
+        match msg {
+            Ok(o) => match o {
+                Message::Text(o) => {
+                    if let Ok(val) = serde_json::from_str::<ServerClient>(&o) {
+                        match val {
+                            ServerClient::ListUpdate(_) => {
+                                on_update();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            },
+            Err(_) => break,
+        }
+    }
+    Ok(())
+}

--- a/ultros/src/event.rs
+++ b/ultros/src/event.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast::channel;
 use ultros_api_types::{
     user::OwnedRetainer,
-    websocket::{ListingEventData, SaleEventData},
+    websocket::{ListEventData, ListingEventData, SaleEventData},
 };
 use ultros_db::entity::*;
 
@@ -48,6 +48,7 @@ pub(crate) fn create_event_busses() -> (EventSenders, EventReceivers) {
     let (alert_sender, alert_receiver) = channel(10);
     let (retainer_undercut_sender, retainer_undercut_receiver) = channel(40);
     let (history_sender, history_receiver) = channel(40);
+    let (list_sender, list_receiver) = channel(40);
     (
         EventSenders {
             retainers: retainer_sender,
@@ -55,6 +56,7 @@ pub(crate) fn create_event_busses() -> (EventSenders, EventReceivers) {
             alerts: alert_sender,
             retainer_undercut: retainer_undercut_sender,
             history: history_sender,
+            lists: list_sender,
         },
         EventReceivers {
             retainers: retainer_receiver,
@@ -62,6 +64,7 @@ pub(crate) fn create_event_busses() -> (EventSenders, EventReceivers) {
             alerts: alert_receiver,
             retainer_undercut: retainer_undercut_receiver,
             history: history_receiver,
+            lists: list_receiver,
         },
     )
 }
@@ -73,6 +76,7 @@ pub(crate) struct EventSenders {
     pub(crate) alerts: EventProducer<alert::Model>,
     pub(crate) retainer_undercut: EventProducer<alert_retainer_undercut::Model>,
     pub(crate) history: EventProducer<SaleEventData>,
+    pub(crate) lists: EventProducer<ListEventData>,
 }
 
 /// Base event type for communicating across different parts of the app
@@ -83,6 +87,7 @@ pub(crate) struct EventReceivers {
     pub(crate) alerts: EventBus<alert::Model>,
     pub(crate) retainer_undercut: EventBus<alert_retainer_undercut::Model>,
     pub(crate) history: EventBus<SaleEventData>,
+    pub(crate) lists: EventBus<ListEventData>,
 }
 
 impl Clone for EventReceivers {
@@ -93,6 +98,7 @@ impl Clone for EventReceivers {
             alerts: self.alerts.resubscribe(),
             retainer_undercut: self.retainer_undercut.resubscribe(),
             history: self.history.resubscribe(),
+            lists: self.lists.resubscribe(),
         }
     }
 }

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -38,10 +38,10 @@ use tower_http::compression::{CompressionLayer, Predicate};
 use tower_http::trace::TraceLayer;
 use tracing::{debug, warn};
 use ultros_api_types::icon_size::IconSize;
-use ultros_api_types::list::{CreateList, List, ListItem};
+use ultros_api_types::list::{CreateList, List, ListItem, ListPermission};
 use ultros_api_types::retainer::RetainerListings;
 use ultros_api_types::user::{OwnedRetainer, UserData, UserRetainerListings, UserRetainers};
-use ultros_api_types::websocket::ListingEventData;
+use ultros_api_types::websocket::{ListEventData, ListingEventData};
 use ultros_api_types::world::WorldData;
 use ultros_api_types::world_helper::WorldHelper;
 use ultros_api_types::{
@@ -575,50 +575,70 @@ pub(crate) async fn get_list_with_listings(
 
 pub(crate) async fn delete_list(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     Path(list_id): Path<i32>,
     user: AuthDiscordUser,
 ) -> Result<Json<()>, ApiError> {
+    let list = db.get_list(list_id, user.id as i64).await?;
     db.delete_list(list_id, user.id as i64).await?;
+    let _ = senders
+        .lists
+        .send(EventType::removed(ListEventData::List(List::try_from(
+            list,
+        )?)));
     Ok(Json(()))
 }
 
 pub(crate) async fn create_list(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     user: AuthDiscordUser,
     Json(list): Json<CreateList>,
 ) -> Result<Json<()>, ApiError> {
     let discord_user = db.get_or_create_discord_user(user.id, user.name).await?;
-    db.create_list(discord_user, list.name, Some(list.wdr_filter.into()))
+    let list = db
+        .create_list(discord_user, list.name, Some(list.wdr_filter.into()))
         .await?;
+    let _ = senders
+        .lists
+        .send(EventType::added(ListEventData::List(List::try_from(list)?)));
     Ok(Json(()))
 }
 
 pub(crate) async fn edit_list(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     user: AuthDiscordUser,
     Json(list): Json<List>,
 ) -> Result<Json<()>, ApiError> {
-    db.update_list(list.id, user.id as i64, |ulist| {
-        ulist.datacenter_id = ActiveValue::Set(match list.wdr_filter {
-            ultros_api_types::world_helper::AnySelector::Datacenter(dc) => Some(dc),
-            _ => None,
-        });
-        ulist.region_id = ActiveValue::Set(match list.wdr_filter {
-            ultros_api_types::world_helper::AnySelector::Region(region) => Some(region),
-            _ => None,
-        });
-        ulist.world_id = ActiveValue::Set(match list.wdr_filter {
-            ultros_api_types::world_helper::AnySelector::World(world) => Some(world),
-            _ => None,
-        });
-        ulist.name = ActiveValue::Set(list.name);
-    })
-    .await?;
+    let list = db
+        .update_list(list.id, user.id as i64, |ulist| {
+            ulist.datacenter_id = ActiveValue::Set(match list.wdr_filter {
+                ultros_api_types::world_helper::AnySelector::Datacenter(dc) => Some(dc),
+                _ => None,
+            });
+            ulist.region_id = ActiveValue::Set(match list.wdr_filter {
+                ultros_api_types::world_helper::AnySelector::Region(region) => Some(region),
+                _ => None,
+            });
+            ulist.world_id = ActiveValue::Set(match list.wdr_filter {
+                ultros_api_types::world_helper::AnySelector::World(world) => Some(world),
+                _ => None,
+            });
+            ulist.name = ActiveValue::Set(list.name);
+        })
+        .await?;
+    let _ = senders
+        .lists
+        .send(EventType::updated(ListEventData::List(List::try_from(
+            list,
+        )?)));
     Ok(Json(()))
 }
 
 pub(crate) async fn post_item_to_list(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     Path(id): Path<i32>,
     user: AuthDiscordUser,
     Json(item): Json<ListItem>,
@@ -631,13 +651,18 @@ pub(crate) async fn post_item_to_list(
         acquired,
         ..
     } = item;
-    db.add_item_to_list(&list, user.id as i64, item_id, hq, quantity, acquired)
+    let item = db
+        .add_item_to_list(&list, user.id as i64, item_id, hq, quantity, acquired)
         .await?;
+    let _ = senders
+        .lists
+        .send(EventType::added(ListEventData::ListItem(item.into())));
     Ok(Json(()))
 }
 
 pub(crate) async fn post_items_to_list(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     Path(id): Path<i32>,
     user: AuthDiscordUser,
     Json(items): Json<Vec<ListItem>>,
@@ -647,38 +672,61 @@ pub(crate) async fn post_items_to_list(
     let _list = db
         .add_items_to_list(&list, user.id as i64, items.into_iter().map(|i| i.into()))
         .await?;
+    // For bulk add, we might want to send a "refresh" event or all items.
+    // Given the current structure, maybe just sending a list update is enough if we want to be simple,
+    // but the task says synchronize buying.
+    // For now, let's just trigger a refetch by sending the List update.
+    let _ = senders
+        .lists
+        .send(EventType::updated(ListEventData::List(List::try_from(
+            list,
+        )?)));
     Ok(Json(()))
 }
 
 pub(crate) async fn edit_list_item(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     user: AuthDiscordUser,
     Json(item): Json<ListItem>,
 ) -> Result<Json<()>, ApiError> {
     let item = item.into();
-    db.update_list_item(item, user.id as i64).await?;
+    let item = db.update_list_item(item, user.id as i64).await?;
+    let _ = senders
+        .lists
+        .send(EventType::updated(ListEventData::ListItem(item.into())));
     Ok(Json(()))
 }
 
 pub(crate) async fn delete_list_item(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     Path(id): Path<i32>,
     user: AuthDiscordUser,
 ) -> Result<Json<()>, ApiError> {
-    db.remove_item_from_list(user.id as i64, id).await?;
+    let item = db.remove_item_from_list(user.id as i64, id).await?;
+    let _ = senders
+        .lists
+        .send(EventType::removed(ListEventData::ListItem(item.into())));
     Ok(Json(()))
 }
 
 pub(crate) async fn delete_multiple_list_items(
     State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
     user: AuthDiscordUser,
     Json(ids): Json<Vec<i32>>,
 ) -> Result<Json<()>, ApiError> {
-    try_join_all(
+    let deleted_items = try_join_all(
         ids.into_iter()
             .map(|id| db.remove_item_from_list(user.id as i64, id)),
     )
     .await?;
+    for item in deleted_items {
+        let _ = senders
+            .lists
+            .send(EventType::removed(ListEventData::ListItem(item.into())));
+    }
     Ok(Json(()))
 }
 
@@ -832,6 +880,144 @@ async fn unclaim_character(
     Ok(Json(()))
 }
 
+#[derive(Deserialize)]
+struct CreateInvite {
+    permission: ListPermission,
+    max_uses: Option<i32>,
+}
+
+async fn create_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(data): Json<CreateInvite>,
+) -> Result<Json<String>, ApiError> {
+    let invite = db
+        .create_invite(id, user.id as i64, data.permission, data.max_uses)
+        .await?;
+    Ok(Json(invite.id))
+}
+
+async fn use_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<String>,
+) -> Result<Json<i32>, ApiError> {
+    let shared = db.use_invite(id, user.id as i64).await?;
+    Ok(Json(shared.list_id))
+}
+
+async fn delete_invite(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    db.delete_invite(id, user.id as i64).await?;
+    Ok(Json(()))
+}
+
+#[derive(Deserialize)]
+struct CreateGroup {
+    name: String,
+}
+
+async fn create_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Json(data): Json<CreateGroup>,
+) -> Result<Json<i32>, ApiError> {
+    let group = db.create_group(data.name, user.id as i64).await?;
+    Ok(Json(group.id))
+}
+
+async fn delete_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+) -> Result<Json<()>, ApiError> {
+    db.delete_group(id, user.id as i64).await?;
+    Ok(Json(()))
+}
+
+#[derive(Deserialize)]
+struct AddMember {
+    user_id: i64,
+}
+
+async fn add_group_member(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(data): Json<AddMember>,
+) -> Result<Json<()>, ApiError> {
+    db.add_group_member(id, user.id as i64, data.user_id)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn remove_group_member(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((id, user_id)): Path<(i32, i64)>,
+) -> Result<Json<()>, ApiError> {
+    db.remove_group_member(id, user.id as i64, user_id).await?;
+    Ok(Json(()))
+}
+
+#[derive(Deserialize)]
+struct ShareUser {
+    user_id: i64,
+    permission: ListPermission,
+}
+
+#[derive(Deserialize)]
+struct ShareGroup {
+    group_id: i32,
+    permission: ListPermission,
+}
+
+async fn share_list_with_user(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(data): Json<ShareUser>,
+) -> Result<Json<()>, ApiError> {
+    db.share_list_with_user(id, user.id as i64, data.user_id, data.permission)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn share_list_with_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path(id): Path<i32>,
+    Json(data): Json<ShareGroup>,
+) -> Result<Json<()>, ApiError> {
+    db.share_list_with_group(id, user.id as i64, data.group_id, data.permission)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn unshare_list_from_user(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((id, user_id)): Path<(i32, i64)>,
+) -> Result<Json<()>, ApiError> {
+    db.unshare_list_from_user(id, user.id as i64, user_id)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn unshare_list_from_group(
+    State(db): State<UltrosDb>,
+    user: AuthDiscordUser,
+    Path((id, group_id)): Path<(i32, i32)>,
+) -> Result<Json<()>, ApiError> {
+    db.unshare_list_from_group(id, user.id as i64, group_id)
+        .await?;
+    Ok(Json(()))
+}
+
 async fn reorder_retainer(
     user: AuthDiscordUser,
     State(db): State<UltrosDb>,
@@ -929,6 +1115,26 @@ pub(crate) async fn start_web(state: WebState) {
         .route("/api/v1/list/{id}/delete", delete(delete_list))
         .route("/api/v1/list/item/{id}/delete", delete(delete_list_item))
         .route("/api/v1/list/item/delete", post(delete_multiple_list_items))
+        .route("/api/v1/group/create", post(create_group))
+        .route("/api/v1/group/{id}", delete(delete_group))
+        .route("/api/v1/group/{id}/member/add", post(add_group_member))
+        .route(
+            "/api/v1/group/{id}/member/{user_id}",
+            delete(remove_group_member),
+        )
+        .route("/api/v1/list/{id}/share/user", post(share_list_with_user))
+        .route("/api/v1/list/{id}/share/group", post(share_list_with_group))
+        .route(
+            "/api/v1/list/{id}/share/user/{user_id}",
+            delete(unshare_list_from_user),
+        )
+        .route(
+            "/api/v1/list/{id}/share/group/{group_id}",
+            delete(unshare_list_from_group),
+        )
+        .route("/api/v1/list/{id}/invite/create", post(create_invite))
+        .route("/api/v1/invite/{id}/use", post(use_invite))
+        .route("/api/v1/invite/{id}", delete(delete_invite))
         .route("/api/v1/world_data", get(world_data))
         .route("/api/v1/current_user", get(current_user))
         .route("/api/v1/user/retainer", get(user_retainers))

--- a/ultros/src/web/api/real_time_data.rs
+++ b/ultros/src/web/api/real_time_data.rs
@@ -17,23 +17,29 @@ use futures::{
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{error, info};
 use ultros_api_types::websocket::{
-    ClientMessage, FilterPredicate, ListingEventData, SaleEventData, ServerClient,
+    ClientMessage, FilterPredicate, ListEventData, ListingEventData, SaleEventData, ServerClient,
     SocketMessageType,
 };
 use ultros_api_types::{websocket::EventType as WEvent, world_helper::WorldHelper};
 
 use crate::event::{EventReceivers, EventType};
+use crate::web::error::ApiError;
+use crate::web::oauth::AuthDiscordUser;
+use ultros_api_types::list::ListPermission;
+use ultros_db::UltrosDb;
 
-// #[axum::debug_handler]
 pub(crate) async fn real_time_data(
     ws: WebSocketUpgrade,
+    user: Result<AuthDiscordUser, ApiError>,
     State(events): State<EventReceivers>,
     State(worlds): State<Arc<WorldHelper>>,
+    State(db): State<UltrosDb>,
 ) -> Response {
+    let user = user.ok();
     info!("Handling websocket");
     ws.on_upgrade(move |websocket| async move {
         info!("Upgrading websocket");
-        if let Err(e) = handle_socket(websocket, events, worlds).await {
+        if let Err(e) = handle_socket(websocket, events, worlds, db, user).await {
             error!("{e:?}");
         }
     })
@@ -112,6 +118,8 @@ async fn handle_socket(
     socket: WebSocket,
     events: EventReceivers,
     world_cache: Arc<WorldHelper>,
+    db: UltrosDb,
+    user: Option<AuthDiscordUser>,
 ) -> Result<(), Box<dyn Error>> {
     let EventReceivers {
         retainers: _,
@@ -119,6 +127,7 @@ async fn handle_socket(
         alerts: _,
         retainer_undercut: _,
         history,
+        lists,
     } = events;
     let (mut sender, mut receiver) = socket.split();
     let mut subscriptions = SelectAll::<BoxStream<ServerClient>>::new();
@@ -171,6 +180,43 @@ async fn handle_socket(
 
                                             subscriptions.push(Box::pin(stream));
                                         }
+                                    }
+                                }
+                                ClientMessage::SubscribeList { list_id } => {
+                                    let user_id = user.as_ref().map(|u| u.id as i64).unwrap_or(0);
+                                    let permission = db.get_permission(list_id, user_id).await?;
+                                    if permission >= ListPermission::Read {
+                                        let stream = BroadcastStream::new(lists.resubscribe())
+                                            .filter_map(move |l| async move {
+                                                let l = l.ok()?;
+                                                let id = match &l {
+                                                    crate::event::EventType::Add(inner)
+                                                    | crate::event::EventType::Remove(inner)
+                                                    | crate::event::EventType::Update(inner) => {
+                                                        match inner.as_ref() {
+                                                            ListEventData::List(l) => l.id,
+                                                            ListEventData::ListItem(l) => l.list_id,
+                                                        }
+                                                    }
+                                                };
+                                                if id == list_id {
+                                                    let event = match l {
+                                                        EventType::Add(a) => {
+                                                            WEvent::Added((*a).clone())
+                                                        }
+                                                        EventType::Remove(r) => {
+                                                            WEvent::Removed((*r).clone())
+                                                        }
+                                                        EventType::Update(u) => {
+                                                            WEvent::Updated((*u).clone())
+                                                        }
+                                                    };
+                                                    Some(ServerClient::ListUpdate(event))
+                                                } else {
+                                                    None
+                                                }
+                                            });
+                                        subscriptions.push(Box::pin(stream));
                                     }
                                 }
                             }


### PR DESCRIPTION
This PR implements real-time synchronization for shared lists using WebSockets. 

Key changes:
1. **WebSocket Protocol Updates**: Added `ListEventData` and `SubscribeList` to the shared API types.
2. **Backend Event Bus**: Introduced a new broadcast channel for list-related events.
3. **Mutation Publishing**: All list and list item mutations now publish events to the broadcast channel.
4. **WebSocket Handler**: Updated the real-time data endpoint to allow users to subscribe to specific list updates, provided they have the necessary permissions.
5. **Group & Sharing API**: Implemented missing endpoints for group management and list sharing to support the "Shared Lists" feature.
6. **Frontend Integration**: The `ListView` component now establishes a WebSocket connection to listen for updates and refresh its data automatically.

These changes ensure that multiple users collaborating on a list see updates in real-time.

Fixes #476

---
*PR created automatically by Jules for task [8205394104354282163](https://jules.google.com/task/8205394104354282163) started by @akarras*