### PR TITLE
⚡ Bolt: Optimized list items fetch

### DIFF
--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -158,6 +158,21 @@ impl UltrosDb {
     }
 
     #[instrument(skip(self))]
+    pub async fn get_listings_for_items_in_worlds(
+        &self,
+        worlds: &[i32],
+        items: &[i32],
+    ) -> Result<Vec<active_listing::Model>> {
+        // OPTIMIZATION: Fetch all listings for all items in one query
+        let listings = active_listing::Entity::find()
+            .filter(active_listing::Column::ItemId.is_in(items.to_vec()))
+            .filter(active_listing::Column::WorldId.is_in(worlds.to_vec()))
+            .all(&self.db)
+            .await?;
+        Ok(listings)
+    }
+
+    #[instrument(skip(self))]
     pub async fn get_listings_for_world(
         &self,
         world: WorldId,

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -19,8 +19,6 @@ use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::{Cookie, Key};
 use axum_extra::headers::{CacheControl, ContentType, HeaderMapExt};
 use futures::future::{try_join, try_join_all};
-use futures::stream::TryStreamExt;
-use futures::{StreamExt, stream};
 use hyper::header;
 use itertools::Itertools;
 use leptos::config::LeptosOptions;
@@ -549,26 +547,25 @@ pub(crate) async fn get_list_with_listings(
     let world_ids = world_cache
         .get_all_worlds_in(&world)
         .ok_or(anyhow::anyhow!("Bad world id"))?;
-    // borrow these for use inside the closure
-    let world_ids = &world_ids;
-    let db = &db;
-    let list_items = stream::iter(list_items.into_iter().map(|list| async move {
-        // get alll the listings that match our item list
-        let listings = db
-            .get_all_listings_in_worlds(world_ids, ItemId(list.item_id))
-            .await;
-        listings.map(|listings| {
-            // return this as a tuple and bring the list that we moved vec
-            (
-                ListItem::from(list),
-                // convert our new active listing to the API types
-                listings.into_iter().map(ActiveListing::from).collect(),
-            )
+    let item_ids: Vec<_> = list_items.iter().map(|i| i.item_id).collect();
+    let listings = db
+        .get_listings_for_items_in_worlds(&world_ids, &item_ids)
+        .await?;
+    let mut listings_map: HashMap<i32, Vec<ActiveListing>> = HashMap::new();
+    for listing in listings {
+        listings_map
+            .entry(listing.item_id)
+            .or_default()
+            .push(listing.into());
+    }
+
+    let list_items = list_items
+        .into_iter()
+        .map(|list| {
+            let listings = listings_map.get(&list.item_id).cloned().unwrap_or_default();
+            (ListItem::from(list), listings)
         })
-    }))
-    .buffered(2)
-    .try_collect()
-    .await?;
+        .collect();
 
     Ok(Json((List::try_from(list)?, list_items)))
 }


### PR DESCRIPTION
💡 What: Optimized `get_list_with_listings` to fetch all listings in a single DB query instead of one query per item.
🎯 Why: The previous implementation had an N+1 query problem, fetching listings for each item in the list individually. This caused performance issues for large lists.
📊 Impact: Reduces the number of DB queries from N+1 to 2 (one for the list items, one for the listings). This significantly reduces latency and DB load for list retrieval.
🔬 Measurement: Verify by checking the number of DB queries executed when loading a list page, or by benchmarking the endpoint latency.

---
*PR created automatically by Jules for task [9451071179841746065](https://jules.google.com/task/9451071179841746065) started by @akarras*