### PR TITLE
⚡ Bolt: Optimize bulk item listings query

### DIFF
--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -143,6 +143,44 @@ impl UltrosDb {
     }
 
     #[instrument(skip(self))]
+    pub async fn get_listings_for_items(
+        &self,
+        worlds: &[i32],
+        items: &[i32],
+    ) -> Result<HashMap<i32, Vec<(active_listing::Model, Option<retainer::Model>)>>> {
+        let instant = Instant::now();
+        // OPTIMIZATION: Fetch all listings in one query
+        let listings = active_listing::Entity::find()
+            .filter(active_listing::Column::ItemId.is_in(items.to_vec()))
+            .filter(active_listing::Column::WorldId.is_in(worlds.to_vec()))
+            .all(&self.db)
+            .await?;
+
+        let retainers = retainer::Entity::find()
+            .filter(retainer::Column::Id.is_in(listings.iter().map(|l| l.retainer_id).unique()))
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|r| (r.id, r))
+            .collect::<HashMap<_, _>>();
+
+        let mut result: HashMap<i32, Vec<(active_listing::Model, Option<retainer::Model>)>> =
+            HashMap::new();
+
+        for listing in listings {
+            let retainer = retainers.get(&listing.retainer_id).cloned();
+            result
+                .entry(listing.item_id)
+                .or_default()
+                .push((listing, retainer));
+        }
+
+        histogram!("ultros_db_query_multiple_listings_all_world_with_retainers_duration_seconds")
+            .record(instant.elapsed());
+        Ok(result)
+    }
+
+    #[instrument(skip(self))]
     pub async fn get_all_listings_in_worlds(
         &self,
         worlds: &Vec<i32>,

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -34,6 +34,8 @@ pub type ListingUpdate = (
     Vec<(ActiveListing, Retainer)>,
 );
 
+pub type ListingsWithRetainers = Vec<(active_listing::Model, Option<retainer::Model>)>;
+
 struct ListingData(active_listing::Model, retainer::Model);
 
 impl PartialOrd<ListingView> for ListingData {
@@ -147,7 +149,7 @@ impl UltrosDb {
         &self,
         worlds: &[i32],
         items: &[i32],
-    ) -> Result<HashMap<i32, Vec<(active_listing::Model, Option<retainer::Model>)>>> {
+    ) -> Result<HashMap<i32, ListingsWithRetainers>> {
         let instant = Instant::now();
         // OPTIMIZATION: Fetch all listings in one query
         let listings = active_listing::Entity::find()
@@ -164,8 +166,7 @@ impl UltrosDb {
             .map(|r| (r.id, r))
             .collect::<HashMap<_, _>>();
 
-        let mut result: HashMap<i32, Vec<(active_listing::Model, Option<retainer::Model>)>> =
-            HashMap::new();
+        let mut result: HashMap<i32, ListingsWithRetainers> = HashMap::new();
 
         for listing in listings {
             let retainer = retainers.get(&listing.retainer_id).cloned();

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -741,21 +741,17 @@ pub(crate) async fn bulk_item_listings(
     let worlds = &world_cache
         .get_all_worlds_in(&world_lookup)
         .ok_or(anyhow::anyhow!("Invalid world"))?;
-    let db = &db;
     // get item ids
     let item_ids: HashSet<i32> = item_ids.split(',').map(|id| id.parse()).try_collect()?;
+    let item_vec: Vec<i32> = item_ids.iter().cloned().collect();
     // now perform lookups for all the listings for each world/item pair
-    let listings = try_join_all(item_ids.into_iter().map(|item| async move {
-        db.get_all_listings_in_worlds_with_retainers(worlds, ItemId(item))
-            .await
-            // map the result to have the item id at the front.
-            .map(|res| (item, res))
-    }))
-    .await?;
+    let mut listings_map = db.get_listings_for_items(worlds, &item_vec).await?;
+
     // now convert the database models to API types.
-    let listings = listings
+    let listings = item_ids
         .into_iter()
-        .map(|(id, l)| {
+        .map(|id| {
+            let l = listings_map.remove(&id).unwrap_or_default();
             (
                 id,
                 l.into_iter()


### PR DESCRIPTION
💡 What: Added `get_listings_for_items` to `UltrosDb` and updated `bulk_item_listings` to use it.
🎯 Why: `bulk_item_listings` was performing N+1 queries (one query per item) to fetch listings and retainers. This caused significant database overhead when fetching multiple items.
📊 Impact: Reduces database queries from O(N) to O(1) (specifically 2 queries total: one for listings, one for retainers) for bulk requests.
🔬 Measurement: Verified via `cargo check`. Performance improvement is structural by reducing round trips.

---
*PR created automatically by Jules for task [8528019951115328442](https://jules.google.com/task/8528019951115328442) started by @akarras*