### PR TITLE
🎨 Palette: Add 'No results found' state to SearchBox

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2026-02-17 - Empty Search State Feedback
+**Learning:** Virtualized lists (like `VirtualScroller`) often render nothing when empty, leaving users without confirmation that a search completed with zero results. This is confusing for all users and especially problematic for screen reader users who may think the application is broken or still loading.
+**Action:** Always implement an explicit "No results found" state with `role="status"` whenever filtering or searching results, especially when the result list might be completely hidden when empty.

--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -330,11 +330,24 @@ pub fn SearchBox() -> impl IntoView {
             // Search Results
             <div
                 id="search-results"
-                role="listbox"
                 class="absolute w-full mt-2 z-50 content-visible contain-content forced-layer"
                 class:hidden=move || !active() || search().is_empty()
             >
-                <div class="scroll-panel content-auto contain-layout contain-paint will-change-scroll forced-layer cis-42">
+                <Show when=move || !loading() && search_results.with(|v| v.is_empty())>
+                    <div
+                        role="status"
+                        class="p-4 text-center text-[color:var(--color-text-muted)] bg-[color:var(--color-background-elevated)] border border-[color:var(--color-outline)] rounded-md shadow-lg flex flex-col items-center justify-center gap-2"
+                    >
+                        <Icon icon=i::AiSearchOutlined attr:class="w-8 h-8 opacity-50" aria_hidden=true />
+                        <p>"No results found"</p>
+                    </div>
+                </Show>
+
+                <div
+                    role="listbox"
+                    class="scroll-panel content-auto contain-layout contain-paint will-change-scroll forced-layer cis-42"
+                    class:hidden=move || search_results.with(|v| v.is_empty())
+                >
                     <VirtualScroller
                         each=search_results.into()
                         key={move |result: &Arc<SearchResult>| result.url.clone()}


### PR DESCRIPTION
🎨 Palette: Improved Search Box Empty State

💡 What:
Added a clear "No results found" message when a search returns no items.

🎯 Why:
Previously, searching for a non-existent item resulted in an empty dropdown list, which could be interpreted as a broken search or loading state. This change provides explicit feedback to the user.

♿ Accessibility:
- Added `role="status"` to the "No results" message so screen readers can announce it when it appears.
- Ensured the message is visually distinct and centered.
- Corrected `role="listbox"` placement to ensure valid ARIA structure when results are present vs. empty.

📸 Before/After:
Before: Searching for "giberish" showed nothing (empty dropdown or just input focused).
After: Searching for "giberish" shows a centered "No results found" message with a search icon inside the dropdown area.

---
*PR created automatically by Jules for task [4616470208521503560](https://jules.google.com/task/4616470208521503560) started by @akarras*