### PR TITLE
feat(search-box): Add accessible "No results" state

### DIFF
--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -330,11 +330,27 @@ pub fn SearchBox() -> impl IntoView {
             // Search Results
             <div
                 id="search-results"
-                role="listbox"
+                role=move || {
+                    if !loading.get() && search_results.with(|v| v.is_empty()) && !search.get().is_empty() {
+                        "status"
+                    } else {
+                        "listbox"
+                    }
+                }
                 class="absolute w-full mt-2 z-50 content-visible contain-content forced-layer"
                 class:hidden=move || !active() || search().is_empty()
             >
-                <div class="scroll-panel content-auto contain-layout contain-paint will-change-scroll forced-layer cis-42">
+                <Show when=move || !loading.get() && search_results.with(|v| v.is_empty()) && !search.get().is_empty()>
+                    <div class="p-8 text-center text-[color:var(--color-text-muted)] flex flex-col items-center gap-2 bg-[color:var(--color-background-elevated)] border border-[color:var(--color-outline)] rounded-md shadow-lg">
+                        <Icon icon=i::AiSearchOutlined attr:class="w-8 h-8 opacity-50" />
+                        <span>"No results found"</span>
+                    </div>
+                </Show>
+
+                <div
+                    class="scroll-panel content-auto contain-layout contain-paint will-change-scroll forced-layer cis-42"
+                    class:hidden=move || search_results.with(|v| v.is_empty())
+                >
                     <VirtualScroller
                         each=search_results.into()
                         key={move |result: &Arc<SearchResult>| result.url.clone()}


### PR DESCRIPTION
This PR improves the UX of the search box by adding a clear "No results found" state when a search yields no matches.

Previously, the search results dropdown would simply be empty or hidden, leaving users unsure if the search failed or if there were truly no results. Now, a friendly message with an icon is displayed.

Accessibility improvements:
- The container's ARIA role dynamically switches between `listbox` (when results exist) and `status` (when no results), ensuring screen readers announce the "No results found" message immediately.
- The message is visually distinct and centered.

Implementation details:
- Used `Show` component for conditional rendering.
- Reused existing `Icon` component and styles.
- Ensured proper hiding of the results list when empty.


---
*PR created automatically by Jules for task [2351569205513832847](https://jules.google.com/task/2351569205513832847) started by @akarras*