### PR TITLE
🎨 Palette: Add ARIA labels to Recipe List modal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>
@@ -109,6 +109,7 @@ pub fn AddRecipeToCurrentListModal(
                     <input
                         class="input w-full"
                         placeholder="Search for a recipe..."
+                        aria-label="Search for a recipe"
                         autofocus
                         prop:value=search
                         on:input=move |e| set_search(event_target_value(&e))


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the close button and search input in the "Add Recipe to List" modal.
🎯 Why: To improve accessibility for screen readers navigating the modal. Icon-only buttons and unlabelled inputs rely on visual cues, which are inaccessible.
♿ Accessibility:
- Added `aria-label="Close"` to the modal's `X` button.
- Added `aria-label="Search for a recipe"` to the search input field.

---
*PR created automatically by Jules for task [11111562439784513001](https://jules.google.com/task/11111562439784513001) started by @akarras*