### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to icon-only buttons in ListItemRow

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -128,30 +128,37 @@ pub fn ListItemRow(
                             </td>
                             <td class:hidden=edit_list_mode>
                                 <div class="flex gap-1">
-                                    <button
-                                        class="btn"
-                                        on:click=move |_| {
-                                            let _ = delete_item.dispatch(item.with(|i| i.id));
-                                        }
-                                    >
-                                        <Icon icon=i::BiTrashSolid />
-                                    </button>
-                                    <button
-                                        class="btn"
-                                        on:click=move |_| {
-                                            if temp_item() != item() {
-                                                let _ = edit_item.dispatch(temp_item());
+                                    <Tooltip tooltip_text="Delete item">
+                                        <button
+                                            class="btn"
+                                            aria-label="Delete item"
+                                            on:click=move |_| {
+                                                let _ = delete_item.dispatch(item.with(|i| i.id));
                                             }
-                                            set_edit(!edit())
-                                        }
-                                    >
-                                        <Icon icon=Signal::derive(move || {
-                                            if edit() { i::BsCheck } else { i::BsPencilFill }
-                                        }) />
-                                    </button>
+                                        >
+                                            <Icon icon=i::BiTrashSolid />
+                                        </button>
+                                    </Tooltip>
+                                    <Tooltip tooltip_text=Signal::derive(move || if edit() { "Save item".to_string() } else { "Edit item".to_string() })>
+                                        <button
+                                            class="btn"
+                                            aria-label=move || if edit() { "Save item" } else { "Edit item" }
+                                            on:click=move |_| {
+                                                if temp_item() != item() {
+                                                    let _ = edit_item.dispatch(temp_item());
+                                                }
+                                                set_edit(!edit())
+                                            }
+                                        >
+                                            <Icon icon=Signal::derive(move || {
+                                                if edit() { i::BsCheck } else { i::BsPencilFill }
+                                            }) />
+                                        </button>
+                                    </Tooltip>
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark item as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -167,7 +174,6 @@ pub fn ListItemRow(
                         },
                     )
                 } else {
-                    let item = item();
                     Either::Right(
                         view! {
                             <td>
@@ -182,16 +188,16 @@ pub fn ListItemRow(
                             </td>
                             <td>
                                 <div class="flex-row">
-                                    <ItemIcon item_id=item.item_id icon_size=IconSize::Small />
+                                    <ItemIcon item_id=item.with(|i| i.item_id) icon_size=IconSize::Small />
                                     {game_items
-                                        .get(&ItemId(item.item_id))
+                                        .get(&ItemId(item.with(|i| i.item_id)))
                                         .map(|item| item.name.as_str())}
                                     <Clipboard clipboard_text=game_items
-                                        .get(&ItemId(item.item_id))
+                                        .get(&ItemId(item.with(|i| i.item_id)))
                                         .map(|item| item.name.to_string())
                                         .unwrap_or_default() />
                                     {game_items
-                                        .get(&ItemId(item.item_id))
+                                        .get(&ItemId(item.with(|i| i.item_id)))
                                         .map(|item| item.item_search_category <= 1)
                                         .unwrap_or_default()
                                         .then(move || {
@@ -240,6 +246,7 @@ pub fn ListItemRow(
                             </td>
                             <td>
                                 {move || {
+                                    let item = item.get();
                                     let q = item.quantity.unwrap_or(1);
                                     let a = item.acquired.unwrap_or(0);
                                     let remaining = q.saturating_sub(a);
@@ -253,28 +260,36 @@ pub fn ListItemRow(
                                 }}
 
                             </td>
-                            <td>
-                                <button
-                                    class="btn"
-                                    on:click=move |_| {
-                                        let _ = delete_item.dispatch(item.id);
-                                    }
-                                >
-                                    <Icon icon=i::BiTrashSolid />
-                                </button>
-                                <button
-                                    class="btn"
-                                    on:click=move |_| {
-                                        if temp_item() != item {
-                                            let _ = edit_item.dispatch(temp_item());
-                                        }
-                                        set_edit(!edit())
-                                    }
-                                >
-                                    <Icon icon=Signal::derive(move || {
-                                        if edit() { i::BsCheck } else { i::BsPencilFill }
-                                    }) />
-                                </button>
+                            <td colspan="2">
+                                <div class="flex flex-row justify-center gap-1">
+                                    <Tooltip tooltip_text="Delete item">
+                                        <button
+                                            class="btn"
+                                            aria-label="Delete item"
+                                            on:click=move |_| {
+                                                let _ = delete_item.dispatch(item.with(|i| i.id));
+                                            }
+                                        >
+                                            <Icon icon=i::BiTrashSolid />
+                                        </button>
+                                    </Tooltip>
+                                    <Tooltip tooltip_text=Signal::derive(move || if edit() { "Save item".to_string() } else { "Edit item".to_string() })>
+                                        <button
+                                            class="btn"
+                                            aria-label=move || if edit() { "Save item" } else { "Edit item" }
+                                            on:click=move |_| {
+                                                if temp_item() != item() {
+                                                    let _ = edit_item.dispatch(temp_item());
+                                                }
+                                                set_edit(!edit())
+                                            }
+                                        >
+                                            <Icon icon=Signal::derive(move || {
+                                                if edit() { i::BsCheck } else { i::BsPencilFill }
+                                            }) />
+                                        </button>
+                                    </Tooltip>
+                                </div>
                             </td>
                         },
                     )


### PR DESCRIPTION
🎨 Palette: Add tooltips and ARIA labels to icon-only buttons in ListItemRow

💡 What: Added `aria-label`s and `Tooltip` components to the icon-only buttons (Delete, Edit, Save, Mark as acquired) in the list item rows.
🎯 Why: To make the actions of these buttons clear to all users, including those relying on screen readers or needing more context.
♿ Accessibility: Improved accessibility for screen readers by adding descriptive labels, ensuring users know exactly what action each button performs without relying solely on visual icons.

---
*PR created automatically by Jules for task [7238242802256324865](https://jules.google.com/task/7238242802256324865) started by @akarras*