### PR TITLE
🎨 Palette: Add ARIA label and ID binding to AddRecipeToListModal inputs

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -110,6 +110,8 @@ fn AddRecipeToListModal(
         });
     });
 
+    let craft_quantity_id = move || format!("add-recipe-craft-qty-{}", recipe.item_result);
+
     view! {
         <Modal set_visible>
             <div class="panel p-6 rounded-xl space-y-4">
@@ -131,8 +133,14 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]">"Number of crafts"</label>
+                    <label
+                        class="text-sm text-[color:var(--color-text-muted)]"
+                        for=craft_quantity_id
+                    >
+                        "Number of crafts"
+                    </label>
                     <input
+                        id=craft_quantity_id
                         type="number"
                         min="1"
                         class="input w-24"
@@ -169,6 +177,7 @@ fn AddRecipeToListModal(
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"
+                                        attr:aria-label=format!("Quantity for {}", ingredient.item.name)
                                         prop:value=move || ingredient.quantity.get()
                                         on:input=move |e| {
                                             let Ok(q) = event_target_value(&e).parse::<i32>() else {


### PR DESCRIPTION
💡 What: Added an ID binding (`for` and `id`) to the "Number of crafts" label and input, and added an `aria-label` to the quantity input for each ingredient.
🎯 Why: Screen readers would previously read the ingredient quantity inputs simply as generic number inputs without any context. Furthermore, the "Number of crafts" text was not programmatically linked to its input, preventing users from clicking the text to focus the input.
♿ Accessibility: Improves form field accessibility by explicitly linking labels and providing aria-labels for fields that lack a visible label.

---
*PR created automatically by Jules for task [11118279723249822058](https://jules.google.com/task/11118279723249822058) started by @akarras*