### PR TITLE
⚡ Bolt: [performance improvement] avoid cloning vector in currency exchange view

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -600,10 +600,10 @@ pub fn ExchangeItem() -> impl IntoView {
                                 let s = s_res.as_ref().and_then(|r| r.as_ref().ok());
                                 let l = l_res.as_ref().and_then(|r| r.as_ref().ok());
                                 let q = currency_quantity.get();
-                                compute_prices(s, l, q).map(|p: Vec<CurrencyTrade>| {
-                                    let mut rows = p.clone();
+                                compute_prices(s, l, q).map(|mut rows: Vec<CurrencyTrade>| {
                                     rows.sort_by(|a, b| b.total_profit.cmp(&a.total_profit));
-                                    let top = rows.into_iter().take(5).collect::<Vec<_>>();
+                                    rows.truncate(5);
+                                    let top = rows;
                                     view! {
                                         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5 gap-3 mb-4 items-stretch">
                                             {top.into_iter().map(|t| view! {


### PR DESCRIPTION
💡 **What:** The optimization implemented removes a `.clone()` on `Vec<CurrencyTrade>` and replaces `.into_iter().take(5).collect::<Vec<_>>()` with `.truncate(5)` for an in-place mutation.
🎯 **Why:** The vector was being passed by value into the closure, so cloning it was entirely redundant and resulted in an unnecessary allocation. The `into_iter().take(5).collect` approach also resulted in a second unnecessary memory allocation. By consuming the variable and sorting/truncating in place, we drastically reduce memory usage and CPU cycles spent on allocation overhead when users compute currency exchange prices.
📊 **Impact:** Reduces memory allocations by 2 large vectors when viewing currency exchanges.
🔬 **Measurement:** Verify by running `cargo test -p ultros-app` and visually confirming the Currency Exchange page continues to render the top 5 rows correctly.

---
*PR created automatically by Jules for task [12740880016201469814](https://jules.google.com/task/12740880016201469814) started by @akarras*