### PR TITLE
🎨 Palette: Add ARIA labels to icon-only list item action buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        attr:aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    attr:aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the icon-only action buttons (Delete, Edit/Save, Mark as acquired) in the `ListItemRow` component.
🎯 Why: To improve accessibility for screen reader users by providing descriptive text for interactive elements that previously only had visual icons.
♿ Accessibility:
- Added static `aria-label="Delete item"` to delete buttons.
- Added dynamic `attr:aria-label=move || if edit() { "Save edit" } else { "Edit item" }` to edit buttons.
- Added static `aria-label="Mark as acquired"` to the mark as acquired button.

---
*PR created automatically by Jules for task [2102828893098136300](https://jules.google.com/task/2102828893098136300) started by @akarras*