### PR TITLE
🎨 Palette: Add ARIA label to Add Recipe to List modal close button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
* 💡 What: Added an `aria-label="Close"` attribute to the icon-only close button in the "Add Recipe to List" modal.
* 🎯 Why: Icon-only buttons without accessible labels are invisible or confusing to screen reader users, who rely on the `aria-label` to understand the button's purpose.
* 📸 Before/After: No visual changes.
* ♿ Accessibility: Improved screen reader support for the modal's close functionality.

---
*PR created automatically by Jules for task [14696780998429303618](https://jules.google.com/task/14696780998429303618) started by @akarras*