### PR TITLE
⚡ Bolt: [performance improvement] optimize sale history median calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-10 - [Optimize Median Selection]
+**Learning:** Found a performance bottleneck calculating medians in `sale_history_table.rs`. The code was using `sort_unstable()` to fully sort the `unit_prices` and `stack_sizes` arrays `O(N log N)` just to extract the median, max, and min. We can replace this with `select_nth_unstable()` which finds the median in `O(N)` average time.
+**Action:** Always prefer `select_nth_unstable` when only a median (or arbitrary k-th element) is needed rather than fully sorting large datasets. Precompute max and min using `.iter().max()` and `.iter().min()` before partition mutation occurs.

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -170,12 +170,15 @@ impl SalesWindow {
             })
             .ok()?;
 
-        unit_prices.sort_unstable();
-        let median_unit_price = unit_prices[count / 2];
+        // Optimization: Find min/max before finding median, because select_nth_unstable alters the slice order.
+        let min_unit_price = *unit_prices.iter().min()?;
+        let max_unit_price = *unit_prices.iter().max()?;
+
+        // Optimization: Replace sort_unstable (O(N log N)) with select_nth_unstable (O(N)) for finding medians
+        let (_, &mut median_unit_price, _) = unit_prices.select_nth_unstable(count / 2);
         let avg_sale_price = total_sale_price as f64 / count as f64;
 
-        stack_sizes.sort_unstable();
-        let median_stack_size = stack_sizes[count / 2];
+        let (_, &mut median_stack_size, _) = stack_sizes.select_nth_unstable(count / 2);
 
         let duration = *date_range.start() - *date_range.end();
         let avg_duration = duration / count as i32;
@@ -197,8 +200,8 @@ impl SalesWindow {
         Some(Self {
             total_gil,
             average_unit_price: avg_sale_price,
-            max_unit_price: *unit_prices.last()?,
-            min_unit_price: *unit_prices.first()?,
+            max_unit_price,
+            min_unit_price,
             median_stack_size,
             hq_percent: ((hq_count as f64 / count as f64) * 100.0).round() as i32,
             guessed_next_sale_price: next,


### PR DESCRIPTION
💡 What: Replaced `sort_unstable` (O(N log N)) with `select_nth_unstable` (O(N)) for finding medians (`median_unit_price` and `median_stack_size`) within the `SalesWindow::try_new` calculation. Extracted the maximum and minimum unit prices efficiently prior to mutation using iterators.

🎯 Why: Full sorting is completely unnecessary simply to find the middle (median) element. This approach speeds up median lookups without altering program semantics.

📊 Impact: Reduces time complexity from O(N log N) to average case O(N) when evaluating `SalesSummaryData::new(sales)`. Especially noticeable for highly-traded items on populous servers with extremely long sale histories.

🔬 Measurement: Verifiable by testing large `Vec<SaleHistory>` inputs or by profiling Axum route latency in `try_new()`. Ensure output matches previously sorted indices correctly.

---
*PR created automatically by Jules for task [11918096930811636369](https://jules.google.com/task/11918096930811636369) started by @akarras*