### PR TITLE
⚡ Bolt: Replace manual N+1 fetching with single query JOIN

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-12 - SeaORM Join Optimization
+**Learning:** In SeaORM, fetching a model and mapping it manually to another table creates N+1 query patterns or 2-query manual joins which can be slow and use more memory.
+**Action:** Use `.find_also_related()` on `Entity::find()` to let the database handle the `LEFT JOIN` and map the result to a `Vec<(Model, Option<RelatedModel>)>` in a single round-trip. This simplifies code and improves execution speed significantly.

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -116,27 +116,14 @@ impl UltrosDb {
         item: ItemId,
     ) -> Result<Vec<(active_listing::Model, Option<retainer::Model>)>> {
         let instant = Instant::now();
-        // OPTIMIZATION: Fetch all listings in one query
-        let listings = active_listing::Entity::find()
+        // OPTIMIZATION: Fetch listings and their associated retainers in one query
+        let data = active_listing::Entity::find()
             .filter(active_listing::Column::ItemId.eq(item.0))
             .filter(active_listing::Column::WorldId.is_in(worlds.to_vec()))
+            .find_also_related(retainer::Entity)
             .all(&self.db)
             .await?;
 
-        let retainers = retainer::Entity::find()
-            .filter(retainer::Column::Id.is_in(listings.iter().map(|l| l.retainer_id).unique()))
-            .all(&self.db)
-            .await?
-            .into_iter()
-            .map(|r| (r.id, r))
-            .collect::<HashMap<_, _>>();
-        let data = listings
-            .into_iter()
-            .map(|l| {
-                let retainer = retainers.get(&l.retainer_id).cloned();
-                (l, retainer)
-            })
-            .collect();
         histogram!("ultros_db_query_listings_all_world_with_retainers_duration_seconds")
             .record(instant.elapsed());
         Ok(data)


### PR DESCRIPTION
⚡ Bolt: Replace manual N+1 fetching with single query JOIN

💡 What: Used SeaORM's `.find_also_related()` to eagerly load retainers alongside their listings.
🎯 Why: The previous implementation performed an initial DB query for listings, collected unique retainer IDs via a map operation, and executed a secondary query for retainers, joining them together manually in the application layer. By shifting this work to the database engine (via a standard `LEFT JOIN`), we avoid two network round-trips to the database and eliminate manual allocations for mappings.
📊 Impact: Considerably faster querying due to one database trip rather than two, plus reduced memory footprint (no need to allocate temporary HashMaps).
🔬 Measurement: Can be verified by running `cargo bench` or looking at profiling for `ultros_db_query_listings_all_world_with_retainers_duration_seconds`.

---
*PR created automatically by Jules for task [7967798535820129564](https://jules.google.com/task/7967798535820129564) started by @akarras*