### PR TITLE
🎨 Palette: Add accessibility labels to AddRecipeToListModal inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2024-05-15 - [Add missing input labels in AddRecipeToListModal]
+**Learning:** Found an accessibility issue pattern where inputs inside loops (`<For>`) or inputs linked to preceding labels lacked `for`/`id` pairings or `aria-label` attributes in Leptos views. When fixing this, `format!` should be evaluated outside of `move ||` closures unless reactivity is needed. If used multiple times in a macro, string `.clone()` should be utilized to avoid `use of moved value` build errors in `view!` macro.
+**Action:** When adding IDs or ARIA attributes in Leptos `view!` macros, assign the formatted string to a variable outside the closure (using `.clone()` when used multiple times) rather than inlining it inside a reactive `move ||` closure unless it genuinely needs to be reactive.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -62,6 +62,7 @@ fn AddRecipeToListModal(
     let (hq, set_hq) = signal(false);
     let (craft_quantity, set_craft_quantity) = signal(1);
     let (ignore_crystals, set_ignore_crystals) = signal(false);
+    let quantity_id = format!("add-recipe-qty-{:?}", recipe.key_id);
 
     let ingredients = StoredValue::new(
         IngredientsIter::new(recipe)
@@ -131,8 +132,11 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]">"Number of crafts"</label>
+                    <label class="text-sm text-[color:var(--color-text-muted)]" for=quantity_id.clone()>
+                        "Number of crafts"
+                    </label>
                     <input
+                        id=quantity_id.clone()
                         type="number"
                         min="1"
                         class="input w-24"
@@ -166,6 +170,7 @@ fn AddRecipeToListModal(
                                 <div class="flex items-center gap-2">
                                     <SmallItemDisplay item=ingredient.item />
                                     <input
+                                        aria-label=format!("{} quantity", ingredient.item.name)
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"


### PR DESCRIPTION
🎨 Palette: Add accessibility labels to AddRecipeToListModal inputs

💡 What:
Added missing `for` and `id` attributes to associate the "Number of crafts" label with its `<input>` field. Also added an `aria-label` to the quantity inputs for individual ingredients in the loop.

🎯 Why:
To make the component more accessible for screen readers and improve keyboard usability by allowing users to click the "Number of crafts" label to focus the input field.

♿ Accessibility:
- Screen readers can now properly identify the purpose of the number of crafts input field.
- Screen readers can now properly identify what ingredient the user is editing the quantity for in the list.

---
*PR created automatically by Jules for task [17705426444423071861](https://jules.google.com/task/17705426444423071861) started by @akarras*