### PR TITLE
🎨 Palette: Add a11y labels to inputs in AddRecipeToListModal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -131,8 +131,9 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]">"Number of crafts"</label>
+                    <label class="text-sm text-[color:var(--color-text-muted)]" for="number-of-crafts">"Number of crafts"</label>
                     <input
+                        id="number-of-crafts"
                         type="number"
                         min="1"
                         class="input w-24"
@@ -169,6 +170,7 @@ fn AddRecipeToListModal(
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"
+                                        attr:aria-label=move || format!("Quantity of {}", ingredient.item.name.as_str())
                                         prop:value=move || ingredient.quantity.get()
                                         on:input=move |e| {
                                             let Ok(q) = event_target_value(&e).parse::<i32>() else {


### PR DESCRIPTION
**🎨 Palette: Add a11y labels to inputs in AddRecipeToListModal**

💡 **What:**
- Added a `for` attribute to the `<label>` and a matching `id` to the `<input>` for "Number of crafts" to properly associate them.
- Added a dynamic `aria-label` to the inline ingredient quantity `<input>` based on the item's name (`aria-label="Quantity of {item_name}"`).

🎯 **Why:**
To ensure proper accessibility for screen readers navigating the list recipe inputs, making it clear what quantity is being adjusted for each row and where the total number of crafts is configured.

♿ **Accessibility:**
Fixes two instances of orphaned input fields in the recipe modal that lacked programmatic context for screen reader users.

---
*PR created automatically by Jules for task [12120983255708478398](https://jules.google.com/task/12120983255708478398) started by @akarras*