### PR TITLE
🎨 Palette: Add ARIA label to Add Recipe modal close button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,11 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button
+                        class="btn-ghost p-2"
+                        on:click=move |_| set_visible(false)
+                        aria-label="Close"
+                    >
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 What: Added an `aria-label="Close"` to the icon-only "close" button in `AddRecipeToCurrentListModal`.
🎯 Why: The button only contained an "X" icon (`BsX`), making its purpose unclear to screen reader users. The ARIA label provides necessary context.
📸 Before/After: No visual changes.
♿ Accessibility: Improved screen reader accessibility for the modal close action.

---
*PR created automatically by Jules for task [16141675342264464120](https://jules.google.com/task/16141675342264464120) started by @akarras*