### PR TITLE
🎨 Palette: Add aria-labels to modal close buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -125,7 +125,7 @@ fn AddRecipeToListModal(
                             {move || result_item().map(|i| i.name.as_str()).unwrap_or("unknown item")}
                         </div>
                     </div>
-                    <button class="btn-secondary" on:click=move |_| set_visible(false)>
+                    <button class="btn-secondary" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         "close"
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/add_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_to_list.rs
@@ -69,7 +69,7 @@ fn AddToListModal(
                             {move || item().map(|i| i.name.as_str()).unwrap_or("unknown item")}
                         </div>
                     </div>
-                    <button class="btn-secondary" on:click=move |_| set_visible(false)>"close"</button>
+                    <button class="btn-secondary" aria-label="Close modal" on:click=move |_| set_visible(false)>"close"</button>
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
💡 What: Added `aria-label="Close modal"` to modal close buttons across three components (`add_recipe_to_current_list.rs`, `add_to_list.rs`, `add_recipe_to_list.rs`).
🎯 Why: To improve accessibility, particularly for the close button in `add_recipe_to_current_list.rs` which previously only contained an icon without any descriptive text.
♿ Accessibility: Provides clear context for screen readers when encountering these close buttons.

---
*PR created automatically by Jules for task [8982268198997724630](https://jules.google.com/task/8982268198997724630) started by @akarras*