### PR TITLE
🎨 Palette: Add aria-label to close button in AddRecipeToCurrentListModal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 What: Added an `aria-label="Close"` to the icon-only "X" close button in the `AddRecipeToCurrentListModal`.

🎯 Why: Screen reader users need descriptive text to understand the purpose of icon-only interactive elements.

♿ Accessibility: Ensures the close modal action is explicitly announced by assistive technologies.

---
*PR created automatically by Jules for task [6511038067540629088](https://jules.google.com/task/6511038067540629088) started by @akarras*