### PR TITLE
🎨 Palette: Add accessible labels to inputs in AddRecipeToListModal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -131,8 +131,9 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]">"Number of crafts"</label>
+                    <label class="text-sm text-[color:var(--color-text-muted)]" for=move || format!("craft-qty-{}", recipe.key_id.0)>"Number of crafts"</label>
                     <input
+                        id=move || format!("craft-qty-{}", recipe.key_id.0)
                         type="number"
                         min="1"
                         class="input w-24"
@@ -164,8 +165,11 @@ fn AddRecipeToListModal(
                         children=move |ingredient| {
                             view! {
                                 <div class="flex items-center gap-2">
-                                    <SmallItemDisplay item=ingredient.item />
+                                    <label for=move || format!("ingredient-qty-{}", ingredient.item_id.0) class="flex-1">
+                                        <SmallItemDisplay item=ingredient.item />
+                                    </label>
                                     <input
+                                        id=move || format!("ingredient-qty-{}", ingredient.item_id.0)
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"


### PR DESCRIPTION
🎨 Palette: Add accessible labels to inputs in AddRecipeToListModal

💡 What: Added `for` and `id` attributes to connect labels with their respective number inputs in the Add Recipe to List modal. Also wrapped the individual ingredient displays in labels to increase the clickable area for focusing the input.
🎯 Why: Improves keyboard accessibility and usability. Screen readers can now properly announce the purpose of the number inputs, and clicking an ingredient now focuses its quantity input.
♿ Accessibility: Ensures WCAG compliance by associating form controls with their textual descriptions.

---
*PR created automatically by Jules for task [18315910287164268035](https://jules.google.com/task/18315910287164268035) started by @akarras*