### PR TITLE
🎨 Palette: Improve LanguagePicker accessibility and focus state

### DIFF
--- a/ultros-frontend/ultros-app/src/components/language_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/language_picker.rs
@@ -23,8 +23,9 @@ pub fn LanguagePicker() -> impl IntoView {
     view! {
         <button
             on:click=on_switch
-            class="btn-ghost p-2 rounded-full hover:bg-black/20 transition-colors"
+            class="btn-ghost p-2 rounded-full hover:bg-black/20 transition-colors focus-visible:ring-2 focus-visible:ring-[color:var(--brand-ring)] focus:outline-none"
             title=move || t_string!(i18n, switch_language).to_string()
+            aria-label=move || t_string!(i18n, switch_language).to_string()
         >
             <Icon icon=i::IoLanguage width="1.2em" height="1.2em" />
             <span class="ml-1 uppercase text-xs font-bold">{move || i18n.get_locale().as_str()}</span>


### PR DESCRIPTION
🎨 Palette: Improve LanguagePicker accessibility and focus state

**💡 What:** 
Added an `aria-label` and `focus-visible` ring styles to the `LanguagePicker` component button in `ultros-frontend/ultros-app/src/components/language_picker.rs`.

**🎯 Why:** 
The language picker button previously only had a `title` and inner text displaying the current locale (e.g., "EN", "FR"). Adding an explicit `aria-label` ensures screen readers accurately announce the action ("Switch Language"), improving accessibility. Additionally, adding `focus-visible` styles ensures users navigating via keyboard have clear visual feedback of their current focus, while `focus:outline-none` prevents an ugly default focus outline when clicking with a mouse.

**♿ Accessibility:** 
- Improved screen reader accessibility by adding an explicit `aria-label` using the existing localized string.
- Improved keyboard navigation accessibility by adding a custom focus ring (`focus-visible:ring-2`) and hiding the default browser outline (`focus:outline-none`).

---
*PR created automatically by Jules for task [6367672631728770108](https://jules.google.com/task/6367672631728770108) started by @akarras*