### PR TITLE
🎨 Palette: Improve accessibility of modal forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2024-05-19 - Modal Forms Accessibility Pattern
+**Learning:** Multiple custom modal forms, such as `AddRecipeToCurrentListModal` and `AddToListModal`, were missing `aria-label`s on icon-only close buttons, and their internal input fields (like search and quantity) lacked proper association with descriptive labels or `aria-label`s.
+**Action:** Enforce `aria-label`s on all icon-only buttons (like `BsX`), and always associate `<label>` elements with their corresponding `<input>` using `id` and `for` attributes, or use `aria-label` on `<input>` fields that lack a visible label.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,8 +100,12 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
-                        <Icon icon=i::BsX width="24" height="24" />
+                    <button
+                        class="btn-ghost p-2"
+                        on:click=move |_| set_visible(false)
+                        aria-label="Close"
+                    >
+                        <Icon icon=i::BsX width="24" height="24" aria_hidden=true />
                     </button>
                 </div>
 
@@ -109,6 +113,7 @@ pub fn AddRecipeToCurrentListModal(
                     <input
                         class="input w-full"
                         placeholder="Search for a recipe..."
+                        aria-label="Search for a recipe"
                         autofocus
                         prop:value=search
                         on:input=move |e| set_search(event_target_value(&e))
@@ -138,8 +143,14 @@ pub fn AddRecipeToCurrentListModal(
 
                                     <div class="flex flex-wrap items-center gap-4 shrink-0">
                                         <div class="flex items-center gap-2">
-                                            <label class="text-xs text-[color:var(--color-text-muted)]">"Count"</label>
+                                            <label
+                                                class="text-xs text-[color:var(--color-text-muted)]"
+                                                for=move || format!("add-recipe-qty-{}", item.key_id.0)
+                                            >
+                                                "Count"
+                                            </label>
                                             <input
+                                                id=move || format!("add-recipe-qty-{}", item.key_id.0)
                                                 type="number"
                                                 class="input w-16 h-8 text-sm"
                                                 min="1"


### PR DESCRIPTION
💡 What: Added `aria-label` to the close button, `aria_hidden` to its icon, `aria-label` to the search input, and associated the quantity label with its input using `for` and `id` attributes in the Add Recipe to List modal. Also logged this pattern in the Palette journal.
🎯 Why: Enhances keyboard and screen reader accessibility by ensuring interactive elements and inputs are properly described.
♿ Accessibility: Improved screen reader support for icon-only buttons and form inputs.

---
*PR created automatically by Jules for task [4248718780064372542](https://jules.google.com/task/4248718780064372542) started by @akarras*