### PR TITLE
🎨 Palette: [a11y] Add aria-label to icon-only close button in AddRecipeToCurrentListModal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button aria-label="Close modal" class="btn-ghost p-2" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
🎨 Palette: Add aria-label to icon-only close button

💡 **What**: Added an `aria-label="Close modal"` to the close button in `AddRecipeToCurrentListModal`.
🎯 **Why**: The close button previously only contained an `X` icon, meaning it lacked an accessible name for screen readers, violating WCAG guidelines for interactive elements.
♿ **Accessibility**: Improved keyboard and screen reader accessibility by providing a clear name for an essential interactive control.

---
*PR created automatically by Jules for task [17645196106171877003](https://jules.google.com/task/17645196106171877003) started by @akarras*