### PR TITLE
🎨 Palette: Add ARIA label to close button in AddRecipeToCurrentListModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2026-03-26 - Add ARIA label to AddRecipeToCurrentListModal close button
+**Learning:** The AddRecipeToCurrentListModal close button had no screen reader text (it only had an X icon), making it difficult for visually impaired users to understand what the button did.
+**Action:** Add `aria-label="Close modal"` to all modal close buttons and icon-only buttons during creation.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 What: Added `aria-label="Close modal"` to the close button in `AddRecipeToCurrentListModal`.
🎯 Why: The close button previously only contained an "X" icon without any text, making it difficult for visually impaired users relying on screen readers to understand the button's purpose.
♿ Accessibility: Ensures that screen readers can accurately announce the purpose of the close button.

---
*PR created automatically by Jules for task [386573245551649958](https://jules.google.com/task/386573245551649958) started by @akarras*