### PR TITLE
🎨 Palette: Improve ThemePicker accessibility with proper roles

### DIFF
--- a/ultros-frontend/ultros-app/src/components/theme_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/theme_picker.rs
@@ -19,6 +19,7 @@ pub fn ThemePicker() -> impl IntoView {
         let is_active = Signal::derive(move || mode.get() == val);
         view! {
             <button
+                role="radio"
                 class=move || {
                     if is_active() {
                         "btn-primary"
@@ -26,7 +27,7 @@ pub fn ThemePicker() -> impl IntoView {
                         "btn-secondary"
                     }
                 }
-                aria-pressed=move || is_active().to_string()
+                aria-checked=move || is_active().to_string()
                 on:click=move |_| set_mode(val)
             >
                 {label}
@@ -38,6 +39,7 @@ pub fn ThemePicker() -> impl IntoView {
         let is_active = Signal::derive(move || palette.get() == val);
         view! {
             <button
+                role="radio"
                 class=move || {
                     if is_active() {
                         "btn-primary"
@@ -45,7 +47,7 @@ pub fn ThemePicker() -> impl IntoView {
                         "btn-secondary"
                     }
                 }
-                aria-pressed=move || is_active().to_string()
+                aria-checked=move || is_active().to_string()
                 on:click=move |_| set_palette(val)
             >
                 {label}
@@ -63,7 +65,7 @@ pub fn ThemePicker() -> impl IntoView {
             <div class="space-y-4">
                 <div class="space-y-2">
                     <div class="text-[color:var(--brand-fg)] font-semibold" id="theme-mode-label">"Mode"</div>
-                    <div class="flex flex-wrap gap-2" role="group" aria-labelledby="theme-mode-label">
+                    <div class="flex flex-wrap gap-2" role="radiogroup" aria-labelledby="theme-mode-label">
                         {mode_button("Dark", ThemeMode::Dark)}
                         {mode_button("Light", ThemeMode::Light)}
                         {mode_button("System", ThemeMode::System)}
@@ -72,7 +74,7 @@ pub fn ThemePicker() -> impl IntoView {
 
                 <div class="space-y-2">
                     <div class="text-[color:var(--brand-fg)] font-semibold" id="theme-palette-label">"Palette"</div>
-                    <div class="flex flex-wrap gap-2" role="group" aria-labelledby="theme-palette-label">
+                    <div class="flex flex-wrap gap-2" role="radiogroup" aria-labelledby="theme-palette-label">
                         {palette_button("Ultros", ThemePalette::Ultros)}
                         {palette_button("Maelstrom", ThemePalette::Maelstrom)}
                         {palette_button("Twin Adder", ThemePalette::TwinAdder)}


### PR DESCRIPTION
🎨 Palette: Improve ThemePicker accessibility with proper roles

💡 What:
- Updated the theme mode and palette selection containers to use `role="radiogroup"` instead of `role="group"`.
- Updated individual toggle buttons to use `role="radio"` and `aria-checked` instead of `aria-pressed`.

🎯 Why:
- These options represent mutually exclusive choices. The previous implementation (group + aria-pressed) sounds to screen readers like a collection of independent toggle switches, where multiple could potentially be active.
- Using `radiogroup` and `radio` with `aria-checked` correctly communicates the "one-of-many" selection model, making the interface more intuitive and compliant with ARIA standards.

♿ Accessibility:
- Changed `role="group"` -> `role="radiogroup"` on containers.
- Added `role="radio"` and updated `aria-pressed` -> `aria-checked` on options.

---
*PR created automatically by Jules for task [11393059548703314351](https://jules.google.com/task/11393059548703314351) started by @akarras*