### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2025-01-20 - Icon-Only Button Accessibility
+**Learning:** Icon-only action buttons (such as edit, delete, mark acquired, or close modal) are frequently missing `aria-label`s across various components, relying purely on visual cues which makes them inaccessible to screen readers.
+**Action:** Always check for and enforce descriptive `aria-label`s on any button where the only child is an `<Icon />` component.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save item" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save item" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons in `ListItemRow` and `AddRecipeToCurrentListModal` components.
🎯 Why: Icon-only buttons relying purely on visual cues are inaccessible to screen readers, making it difficult for users with visual impairments to understand what the buttons do.
♿ Accessibility: Improved accessibility for screen readers by providing descriptive text for delete, edit/save, mark acquired, and close actions. Edited the edit/save button's `aria-label` to dynamically update based on the button's current state. Added a journal entry about this pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [658409043947913980](https://jules.google.com/task/658409043947913980) started by @akarras*