### PR TITLE
🎨 Palette: Add ARIA labels to Select component and World Pickers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2026-01-15 - ARIA Labels for Generic Select Components
+**Learning:** Generic reusable UI components like `Select` (used in `WorldPicker`) often omit specific `aria-label`s on their inner inputs (`role="combobox"`), breaking accessibility because the wrapper components do not pass down the appropriate context.
+**Action:** Always expose an `aria_label` prop on generic UI components (like `Select`) and pass context-specific labels from the parent components (e.g. `WorldPicker`) so that screen readers correctly announce the purpose of the input.

--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -15,6 +15,7 @@ pub fn Select<T, EF, L, ViewOut>(
     children: EF,
     #[prop(optional)] class: Option<&'static str>,
     #[prop(optional)] dropdown_class: Option<&'static str>,
+    #[prop(optional)] aria_label: Option<&'static str>,
     // _view_out: PhantomData<ViewOut>,
 ) -> impl IntoView
 where
@@ -121,6 +122,7 @@ where
                 prop:value=current_input
                 role="combobox"
                 aria-autocomplete="list"
+                aria-label=aria_label.unwrap_or("Select an option")
                 aria-expanded={
                     #[cfg(not(feature = "hydrate"))]
                     let hovered = hovered.clone();

--- a/ultros-frontend/ultros-app/src/components/world_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/world_picker.rs
@@ -31,6 +31,7 @@ pub fn WorldOnlyPicker(
                         as_label=move |w| w.name.clone()
                         choice=current_world
                         set_choice=set_current_world
+                        aria_label="Select a world"
                         children=move |_w, label| {
                             view! {
                                 <div class="flex items-center px-4 py-2 rounded-lg transition-colors hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]">
@@ -91,6 +92,7 @@ pub fn WorldPicker(
                         choice=choice
                         set_choice=set_choice
                         as_label=move |(d, _)| d.clone()
+                        aria_label="Select a world, region, or datacenter"
                         children=move |(_, s), view| {
                             view! {
                                 <div class="flex justify-between px-4 py-2


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to Select component and World Pickers

💡 What: Added an `aria_label` prop to the generic `Select` component and applied it to the inner combobox input. Passed specific labels ("Select a world", "Select a world, region, or datacenter") from `WorldOnlyPicker` and `WorldPicker`.
🎯 Why: Generic UI components used across the app omitted specific `aria-label`s on their inner `<input role="combobox">`, making it difficult for screen readers to determine the input's purpose. This context is now accurately passed down from the parent components.
♿ Accessibility: Improved screen reader support for comboboxes in World Picker components by providing descriptive, programmatic labels.

---
*PR created automatically by Jules for task [9277940902121156133](https://jules.google.com/task/9277940902121156133) started by @akarras*