### PR TITLE
⚡ Bolt: Optimize Select component string filtering allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-01-28 - Precomputing strings in UI iterators
+**Learning:** Leptos filters in UI inputs (like dropdown selections) are hot paths that shouldn't do per-keystroke allocations, especially for large game item databases.
+**Action:** Always extract `to_lowercase()` or other string conversions into an upstream `Memo` cache instead of invoking them inside `filter_map` or `filter` on every input update.

--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -36,15 +36,28 @@ where
         ArcSignal::derive(move || false)
     };
 
-    let labels =
-        Memo::new(move |_| items.with(|i| i.iter().map(as_label).enumerate().collect::<Vec<_>>()));
+    // Optimization: Store both the original label and its lowercase version.
+    // This prevents re-allocating strings for `to_lowercase()` on every keystroke,
+    // which is expensive for large lists (e.g. recipes, items).
+    let labels = Memo::new(move |_| {
+        items.with(|i| {
+            i.iter()
+                .map(as_label)
+                .enumerate()
+                .map(|(i, label)| {
+                    let lower = label.to_lowercase();
+                    (i, label, lower)
+                })
+                .collect::<Vec<_>>()
+        })
+    });
     let search_results = Memo::new(move |_| {
         current_input.with(|input| {
             let input_lower = input.to_lowercase();
             labels.with(|s| {
                 s.iter()
-                    .filter_map(|(i, label)| {
-                        if label.to_lowercase().contains(&input_lower) {
+                    .filter_map(|(i, label, label_lower)| {
+                        if label_lower.contains(&input_lower) {
                             Some((*i, label.clone()))
                         } else {
                             None
@@ -57,7 +70,11 @@ where
     let final_result = Memo::new(move |_| {
         let search_results = search_results();
         if search_results.is_empty() {
-            labels()
+            labels.with(|l| {
+                l.iter()
+                    .map(|(i, label, _)| (*i, label.clone()))
+                    .collect::<Vec<_>>()
+            })
         } else {
             search_results
         }


### PR DESCRIPTION
💡 What: Hoists the `label.to_lowercase()` call out of the `filter_map` iterator used during `Select` component filtering. It now precomputes and caches the lowercase version in the upstream `labels` Memo.

🎯 Why: Previously, filtering large selection lists (e.g. game items, recipes) allocated and computed a new lowercase string for every single item on *every keystroke*. This caused significant memory churn and potential UI lag. By caching the lowercase string, we avoid N allocations per keystroke.

📊 Impact: Reduces string allocations during filtering from O(N) to O(1) matching overhead per keystroke. Memory allocations only happen when a match occurs and a string needs to be cloned to return it.

🔬 Measurement: Compile the WASM frontend and type rapidly into a `Select` component populated with thousands of items (e.g., world picker or item search). The input response time should be measurably lower and garbage collection pauses reduced.

---
*PR created automatically by Jules for task [2005204271318485323](https://jules.google.com/task/2005204271318485323) started by @akarras*