### PR TITLE
🎨 Palette: Add `aria-label` to Language Picker button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/language_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/language_picker.rs
@@ -25,6 +25,7 @@ pub fn LanguagePicker() -> impl IntoView {
             on:click=on_switch
             class="btn-ghost p-2 rounded-full hover:bg-black/20 transition-colors"
             title=move || t_string!(i18n, switch_language).to_string()
+            aria-label=move || t_string!(i18n, switch_language).to_string()
         >
             <Icon icon=i::IoLanguage width="1.2em" height="1.2em" />
             <span class="ml-1 uppercase text-xs font-bold">{move || i18n.get_locale().as_str()}</span>


### PR DESCRIPTION
💡 **What:** Added an `aria-label` attribute to the Language Picker button in `language_picker.rs`.
🎯 **Why:** The Language Picker button currently only relies on the `title` attribute and its inner text (e.g., "EN") for conveying its purpose. While visual users see an icon and an abbreviation, screen reader users might not understand that the button switches the application language. Providing a descriptive, localized `aria-label` clarifies the action.
📸 **Before/After:** Not applicable (accessibility change, no visual differences).
♿ **Accessibility:** Screen readers will now announce the button as the localized equivalent of "Switch Language" instead of simply announcing the abbreviation of the currently active language.

---
*PR created automatically by Jules for task [2352141516256159827](https://jules.google.com/task/2352141516256159827) started by @akarras*