### PR TITLE
🎨 Palette: Add `aria-label` to "Remove character" icon button

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/settings.rs
+++ b/ultros-frontend/ultros-app/src/routes/settings.rs
@@ -459,6 +459,7 @@ pub fn Profile() -> impl IntoView {
                                                                         text-gray-400 hover:text-red-400
                                                                         opacity-0 group-hover:opacity-100
                                                                         transition-all duration-200"
+                                                                        aria-label="Remove character"
                                                                         on:click=move |_| {
                                                                             let _ = unclaim_character.dispatch(character.id);
                                                                         }


### PR DESCRIPTION
💡 What: Added an `aria-label="Remove character"` attribute to the icon-only trash button in the user profile settings page used to unclaim a character.
🎯 Why: Without an `aria-label`, screen readers would not announce the purpose of the button to the user.
📸 Before/After: Accessibility text string added.
♿ Accessibility: Improves accessibility for visually impaired users relying on screen readers.

---
*PR created automatically by Jules for task [155104368958972514](https://jules.google.com/task/155104368958972514) started by @akarras*