### PR TITLE
⚡ Bolt: optimize `get_multiple_listings_for_worlds_hq_sensitive`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-31 - [N+1 Query Issue in `get_multiple_listings_for_worlds_hq_sensitive`]
+**Learning:** `get_multiple_listings_for_worlds_hq_sensitive` previously suffered from an N+1 query issue. It used `futures::future::try_join_all` with a flat map over worlds and items to individually query for listings.
+**Action:** When querying for entities across multiple related IDs (like `WorldId` and `ItemId`), prefer aggregating the IDs and executing a single query utilizing `is_in`. In this case, `Entity::find().filter(Column::ItemId.is_in(items)).filter(Column::WorldId.is_in(worlds))` reduced multiple `SELECT`s down to just one.

--- a/ultros-db/src/lib.rs
+++ b/ultros-db/src/lib.rs
@@ -206,12 +206,17 @@ impl UltrosDb {
         hq: bool,
         limit: u64,
     ) -> Result<Vec<active_listing::Model>> {
-        let join = futures::future::try_join_all(world_id.flat_map(|world| {
-            item.clone()
-                .map(move |i| self.get_listings_for_world(world, i))
-        }))
-        .await?;
-        Ok(join.into_iter().flat_map(|l| l.into_iter()).collect())
+        let worlds: Vec<i32> = world_id.map(|w| w.0).collect();
+        let items: Vec<i32> = item.map(|i| i.0).collect();
+
+        use crate::entity::active_listing::*;
+        let listings = Entity::find()
+            .filter(Column::ItemId.is_in(items))
+            .filter(Column::WorldId.is_in(worlds))
+            .filter(Column::Hq.eq(hq))
+            .all(&self.db)
+            .await?;
+        Ok(listings)
     }
 
     #[instrument(skip(self))]


### PR DESCRIPTION
⚡ Bolt: optimize `get_multiple_listings_for_worlds_hq_sensitive`

* 💡 What: Replaced an N+1 query loop with a single aggregate `is_in` database call. Also fixed the implicit bug where the `hq` argument was previously ignored.
* 🎯 Why: Previously, `get_multiple_listings_for_worlds_hq_sensitive` iterated through every provided `WorldId` and `ItemId` and invoked `get_listings_for_world` for each pair. This resulted in O(W * I) database queries, significantly bottlenecking database performance.
* 📊 Impact: Database roundtrips reduced from N+1 to exactly 1 per method invocation, dramatically saving latency and database load.
* 🔬 Measurement: Observe database connections/queries logged for any path invoking `get_multiple_listings_for_worlds_hq_sensitive`. Query counts and query durations will drop measurably.

---
*PR created automatically by Jules for task [13722344952931195390](https://jules.google.com/task/13722344952931195390) started by @akarras*