### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons in list item rows

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        attr:aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        attr:aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            attr:aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    attr:aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    attr:aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only buttons (Delete, Edit, and Mark as Acquired) in the `list_item_row.rs` component.
🎯 Why: To improve accessibility for screen readers navigating the lists, as these buttons previously only contained icons without any text description.
📸 Before/After: Visuals are unchanged as this is purely an accessibility enhancement.
♿ Accessibility: Screen readers will now announce "Delete item", "Edit item", "Save edit", and "Mark as acquired" appropriately for these buttons instead of ignoring them or reading out raw icon markup.

---
*PR created automatically by Jules for task [16551952984956011495](https://jules.google.com/task/16551952984956011495) started by @akarras*