### PR TITLE
🎨 Palette: Add empty state to search box

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2024-05-15 - Empty State for SearchBox
+**Learning:** Virtual Scroller components without built-in empty states will simply show a blank box when there are no items to render. This happens silently and can be confusing to users who type a search query and see nothing happen.
+**Action:** Always add an explicit `<Show>` or conditional render below the list or VirtualScroller to handle the `!loading && !query.is_empty() && results.is_empty()` state with a helpful message.

--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -450,6 +450,14 @@ pub fn SearchBox() -> impl IntoView {
                         scroll_to_index=Signal::derive(move || focused_index.get())
 
                     />
+                    <Show when=move || {
+                        let s = search.get();
+                        !s.is_empty() && !loading.get() && search_results.with(|r| r.is_empty())
+                    }>
+                        <div class="p-4 text-center text-sm text-[color:var(--color-text-muted)]">
+                            "No results found for \"" {search} "\""
+                        </div>
+                    </Show>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
💡 **What:** Added an empty state to the search results dropdown in `search_box.rs`.
🎯 **Why:** Previously, if a user searched for something with no results, the dropdown would just appear empty or the scroller would be blank, offering no feedback that the search had actually completed. Now, users receive a clear message confirming their search yielded no results.
♿ **Accessibility:** Provides clear text feedback that the search finished without results, avoiding confusing blank spaces.

*Journal updated in `.Jules/palette.md`.*

---
*PR created automatically by Jules for task [17180147579864784787](https://jules.google.com/task/17180147579864784787) started by @akarras*