### PR TITLE
⚡ Bolt: Use `sort_by_cached_key` for retainer listings

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-02 - Replace sort_by_key with sort_by_cached_key
+**Learning:** In Rust, `.sort_by_key()` calls the key extraction function `O(N log N)` times. For keys that involve expensive operations like map lookups (`ItemSortKey::from`), this can cause a noticeable performance hit.
+**Action:** Use `.sort_by_cached_key()` instead when the sort key extraction is non-trivial, reducing lookups from `O(N log N)` to `O(N)`. Ensure to add comments explaining the performance benefit as required by Bolt's boundaries.

--- a/ultros-frontend/ultros-app/src/routes/retainers.rs
+++ b/ultros-frontend/ultros-app/src/routes/retainers.rs
@@ -47,7 +47,9 @@ fn RetainerUndercutTable(retainer: Retainer, listings: Vec<UndercutData>) -> imp
     let mut listings = listings;
     let data = xiv_gen_db::data();
     let items = &data.items;
-    listings.sort_by_key(|u| ItemSortKey::from(&u.current));
+    // ⚡ Bolt: Use `sort_by_cached_key` to avoid evaluating `ItemSortKey::from` `O(N log N)` times,
+    // reducing expensive lookups from `O(N log N)` to `O(N)`.
+    listings.sort_by_cached_key(|u| ItemSortKey::from(&u.current));
     let worlds = use_context::<LocalWorldData>().unwrap().0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
     let world_name = world.as_ref().map(|w| w.get_name()).unwrap_or_default();
@@ -129,7 +131,9 @@ fn RetainerTable(retainer: Retainer, listings: Vec<ActiveListing>) -> impl IntoV
     let data = xiv_gen_db::data();
     let items = &data.items;
     let mut listings = listings;
-    listings.sort_by_key(|u| ItemSortKey::from(u));
+    // ⚡ Bolt: Use `sort_by_cached_key` to avoid evaluating `ItemSortKey::from` `O(N log N)` times,
+    // reducing expensive lookups from `O(N log N)` to `O(N)`.
+    listings.sort_by_cached_key(|u| ItemSortKey::from(u));
     let world_data = use_context::<LocalWorldData>().unwrap();
     let worlds = world_data.0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
@@ -488,7 +492,7 @@ mod test {
             })
             .collect();
         let original = item_vec.clone();
-        item_vec.sort_by_key(|i| ItemSortKey::from(i));
+        item_vec.sort_by_cached_key(|i| ItemSortKey::from(i));
         assert_eq!(original, item_vec);
     }
 
@@ -503,7 +507,7 @@ mod test {
             41517,
         ]; // rainbow corsage
         let mut rearranged = vec![41516, 41517, 41509];
-        rearranged.sort_by_key(|id| ItemSortKey::from((ItemId(*id), true)));
+        rearranged.sort_by_cached_key(|id| ItemSortKey::from((ItemId(*id), true)));
         assert_eq!(expected_order, rearranged);
     }
 }


### PR DESCRIPTION
💡 **What**: Replaced `.sort_by_key()` with `.sort_by_cached_key()` for sorting `listings` and `rearranged` arrays in `ultros-frontend/ultros-app/src/routes/retainers.rs`.

🎯 **Why**: The key extraction function `ItemSortKey::from` performs dictionary lookups (`xiv_gen_db::data()`, `sort_category.get()`). `sort_by_key` evaluates the key mapping `O(N log N)` times during the sorting algorithm. Using `sort_by_cached_key` calculates the key mappings upfront and exactly once per item (`O(N)`).

📊 **Impact**: Faster evaluation when sorting large amounts of retainer items. By limiting the expensive lookups to `O(N)` times, it reduces the load time for retainer tables.

🔬 **Measurement**: Run the app locally and verify the time it takes to render the listings within the `Retainers` table (it will now be noticeably faster). The test suite also passes successfully to ensure no behavior changes.

---
*PR created automatically by Jules for task [17048048975277849652](https://jules.google.com/task/17048048975277849652) started by @akarras*