### PR TITLE
⚡ Bolt: Optimize database upsert with ON CONFLICT

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-03 - Database Upsert Optimization
+**Learning:** SeaORM supports `ON CONFLICT` clauses which map directly to SQL `INSERT ... ON CONFLICT DO UPDATE`. The previous code was manually handling updates and inserts by cloning the model and executing multiple queries: trying update, then insert, then update again.
+**Action:** Replace multi-query manual update/insert loops with single query `.on_conflict()` inserts to reduce database round-trips from up to 3 down to exactly 1.

--- a/ultros-db/src/recently_updated.rs
+++ b/ultros-db/src/recently_updated.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+    ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, sea_query,
 };
 use universalis::{ItemId, WorldId};
 
@@ -12,25 +12,25 @@ impl UltrosDb {
         world_id: WorldId,
         item_id: ItemId,
     ) -> Result<(), anyhow::Error> {
-        // just assume most items have an update, handle the failure case manually
+        // OPTIMIZATION: Use ON CONFLICT to reduce database round-trips from up to 3 queries down to exactly 1
         let model = listing_last_updated::ActiveModel {
             item_id: ActiveValue::Set(item_id.0),
             world_id: ActiveValue::Set(world_id.0),
             date_time: ActiveValue::Set(Utc::now().naive_utc()),
         };
-        let updated = model.clone().update(&self.db).await;
-        match updated {
-            Ok(_updated) => {}
-            Err(_e) => {
-                match model.clone().insert(&self.db).await {
-                    Ok(_ok) => {}
-                    Err(_e) => {
-                        // ok now can we update?
-                        model.clone().update(&self.db).await?;
-                    }
-                }
-            }
-        }
+
+        listing_last_updated::Entity::insert(model)
+            .on_conflict(
+                sea_query::OnConflict::columns([
+                    listing_last_updated::Column::ItemId,
+                    listing_last_updated::Column::WorldId,
+                ])
+                .update_columns([listing_last_updated::Column::DateTime])
+                .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
💡 What: Replaced a manual 3-query upsert pattern with a single `INSERT ON CONFLICT DO UPDATE` query via SeaORM's `.on_conflict()` builder in `ultros-db/src/recently_updated.rs`.

🎯 Why: The previous manual pattern (update -> on fail, insert -> on fail, update) required up to 3 round-trips to the database for each operation, causing unnecessary latency and database load.

📊 Impact: Reduces database queries from 3 to exactly 1 per recently updated listing record. Should decrease latency for setting last updated times.

🔬 Measurement: Review metrics or tracing histograms to observe reduced time in `set_last_updated`.

---
*PR created automatically by Jules for task [9693924051378324563](https://jules.google.com/task/9693924051378324563) started by @akarras*