### PR TITLE
🎨 Palette: Add ARIA label to AddRecipeToCurrentListModal close button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Close modal"` to the icon-only close button in `AddRecipeToCurrentListModal`.
🎯 **Why:** Icon-only buttons without labels are inaccessible to screen readers. This ensures users relying on assistive technologies can understand the button's purpose.
♿ **Accessibility:** Improved screen reader support by providing an explicit label.

---
*PR created automatically by Jules for task [10982438363525626432](https://jules.google.com/task/10982438363525626432) started by @akarras*