### PR TITLE
⚡ Bolt: Optimize eager cloning in iterators

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-05 - Optimize eager cloning before take/filter
+**Learning:** Found instances where large `Vec`s were completely cloned before an `.into_iter().take()` or `.filter()`, causing O(n) memory allocation and copy overhead when only a subset was needed.
+**Action:** When filtering or taking from a slice/Vec that is owned by a closure and needs to be returned as an iterator, prefer `.iter().take().cloned().collect()` or `.iter().filter().cloned().collect()` instead of `.clone().into_iter().take()` to minimize allocation and copying overhead.

--- a/ultros-frontend/ultros-app/src/components/top_deals.rs
+++ b/ultros-frontend/ultros-app/src/components/top_deals.rs
@@ -106,7 +106,10 @@ pub fn TopDeals() -> impl IntoView {
                             view! {
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <For
-                                        each=move || data.clone().into_iter().take(6)
+                                        each=move || {
+                                            let top: Vec<_> = data.iter().take(6).cloned().collect();
+                                            top.into_iter()
+                                        }
                                         key=|deal| deal.item_id
                                         children=move |deal| {
                                             view! { <DealItem deal=deal home_world_name=world_name.clone() /> }

--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -657,9 +657,8 @@ pub fn ExchangeItem() -> impl IntoView {
                                             let trades = p.len();
                                             let sorted_and_filtered_rows = move || {
                                                 let query = query();
-                                                let mut p = p
-                                                    .clone()
-                                                    .into_iter()
+                                                let mut p: Vec<_> = p
+                                                    .iter()
                                                     .filter(|currency| {
                                                         let query = &query;
                                                         is_in_range(
@@ -683,6 +682,7 @@ pub fn ExchangeItem() -> impl IntoView {
                                                                 query,
                                                             )
                                                     })
+                                                    .cloned()
                                                     .collect::<Vec<_>>();
                                                 // surface best option at top by default (total_profit desc)
                                                 match sort_label.as_deref() {


### PR DESCRIPTION
⚡ Bolt: Optimize eager cloning in iterators

💡 What: Changed `.clone().into_iter().take()` and `.clone().into_iter().filter()` patterns to use `.iter().take().cloned().collect()` and `.iter().filter().cloned().collect()`.
🎯 Why: In `top_deals.rs` and `currency_exchange.rs`, we were cloning entire `Vec`s (potentially hundreds of items) before applying a `take` or `filter` operation.
📊 Impact: Eliminates O(n) memory allocation and copy overhead when only a small subset of items is needed, reducing memory pressure and improving execution speed.
🔬 Measurement: Verify that rendering top deals and filtering currency exchanges still works, but without allocating temporary vectors for discarded items.

---
*PR created automatically by Jules for task [5823883691941899398](https://jules.google.com/task/5823883691941899398) started by @akarras*