### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/server_output.log
+++ b/server_output.log
@@ -1,0 +1,4 @@
+error: no such command: `leptos`
+
+help: view all installed commands with `cargo --list`
+help: find a package to install `leptos` with `cargo search cargo-leptos`

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -125,7 +125,7 @@ fn AddRecipeToListModal(
                             {move || result_item().map(|i| i.name.as_str()).unwrap_or("unknown item")}
                         </div>
                     </div>
-                    <button class="btn-secondary" on:click=move |_| set_visible(false)>
+                    <button class="btn-secondary" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         "close"
                     </button>
                 </div>
@@ -211,6 +211,7 @@ fn AddRecipeToListModal(
                                                     <div class="font-semibold truncate">{list.name}</div>
                                                     <button
                                                         class="btn-primary"
+                                                        aria-label="Add this recipe to the list"
                                                         disabled=add_bulk_action.pending()
                                                         on:click=move |_| {
                                                             let list_id = list.id;

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -616,7 +616,7 @@ fn AnalyzerTable(
                             chips.push(view! {
                                 <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
                                     "Profit ≥ " <Gil amount=p />
-                                    <button class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_minimum_profit(None)>
+                                    <button class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" aria-label="Remove minimum profit filter" on:click=move |_| set_minimum_profit(None)>
                                         <Icon icon=icondata::MdiClose />
                                     </button>
                                 </span>

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -645,6 +645,7 @@ pub fn ChartWrapper(
                                                     if days_range() == 7 { "bg-brand-600/25 text-brand-100" } else { "bg-brand-900/30 text-[color:var(--color-text)]" },
                                                 ].join(" ")
                                                 on:click=move |_| set_days_range(7)
+                                                aria-label="View last 7 days"
                                             >
                                                 "7d"
                                             </button>
@@ -654,6 +655,7 @@ pub fn ChartWrapper(
                                                     if days_range() == 30 { "bg-brand-600/25 text-brand-100" } else { "bg-brand-900/30 text-[color:var(--color-text)]" },
                                                 ].join(" ")
                                                 on:click=move |_| set_days_range(30)
+                                                aria-label="View last 30 days"
                                             >
                                                 "30d"
                                             </button>
@@ -663,6 +665,7 @@ pub fn ChartWrapper(
                                                     if days_range() == 90 { "bg-brand-600/25 text-brand-100" } else { "bg-brand-900/30 text-[color:var(--color-text)]" },
                                                 ].join(" ")
                                                 on:click=move |_| set_days_range(90)
+                                                aria-label="View last 90 days"
                                             >
                                                 "90d"
                                             </button>
@@ -672,6 +675,7 @@ pub fn ChartWrapper(
                                                     if days_range() == 0 { "bg-brand-600/25 text-brand-100" } else { "bg-brand-900/30 text-[color:var(--color-text)]" },
                                                 ].join(" ")
                                                 on:click=move |_| set_days_range(0)
+                                                aria-label="View all time"
                                             >
                                                 "All"
                                             </button>


### PR DESCRIPTION
Add aria-labels to the remove profit filter button in analyzer.rs, the time range selection buttons in item_view.rs, and the add and close buttons in the add_recipe_to_list.rs modal for improved accessibility.

---
*PR created automatically by Jules for task [3113806505367121316](https://jules.google.com/task/3113806505367121316) started by @akarras*