### PR TITLE
🎨 Palette: Add ARIA label to icon-only modal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2026-04-07 - Icon-Only Button Accessibility
+**Learning:** Some custom modal implementations (e.g., `AddRecipeToCurrentListModal`) were using icon-only close buttons lacking an `aria-label`.
+**Action:** Consistently add `aria-label="Close"` to all icon-only close buttons. Avoid adding `aria_hidden=true` on leptos `<Icon>` components as it's not a supported prop and breaks compilation.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
UX: Add ARIA label to icon-only close button

Adds `aria-label="Close"` to the icon-only modal close button in
`add_recipe_to_current_list.rs` to improve accessibility for screen readers.
Also added a corresponding journal entry to `palette.md`.

---
*PR created automatically by Jules for task [6134143160479731994](https://jules.google.com/task/6134143160479731994) started by @akarras*