### PR TITLE
🎨 Palette: Add aria-label to close button in modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2026-04-12 - Add aria-label to close button
+**Learning:** Found an icon-only close button lacking an `aria-label` in a Leptos modal component (`AddRecipeToCurrentListModal`). This pattern (icon inside a button without screen reader text) is a common accessibility issue.
+**Action:** Always ensure icon-only buttons have an `aria-label` or `title` to provide context for screen readers. Added `aria-label="Close modal"` to the specific button.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,11 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button
+                        class="btn-ghost p-2"
+                        aria-label="Close modal"
+                        on:click=move |_| set_visible(false)
+                    >
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
🎨 Palette: Added `aria-label` to close button in `AddRecipeToCurrentListModal`.

**What**: Added `aria-label="Close modal"` to the icon-only close button in `ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs`.
**Why**: Icon-only buttons without an accessible name are not navigable or understandable by screen reader users.
**Accessibility**: Improves keyboard and screen reader accessibility by providing context for the close action.

---
*PR created automatically by Jules for task [8845118451653254130](https://jules.google.com/task/8845118451653254130) started by @akarras*