### PR TITLE
⚡ Bolt: Optimize `SaleHistoryTable` key extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-12 - [Leptos For Loop Keys]
+**Learning:** Using computed values like timestamps as keys in Leptos `<For>` components causes unnecessary computation on every render cycle and risks key collision if times overlap.
+**Action:** Always use unique, direct properties like database IDs as keys for list items to avoid reconciliation overhead.

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -42,7 +42,10 @@ pub fn SaleHistoryTable(sales: Signal<Vec<SaleHistory>>) -> impl IntoView {
             <tbody class="divide-y divide-[color:var(--color-outline)]">
                 <For
                     each=sale_history
-                    key=move |sale| sale.sold_date.and_utc().timestamp()
+                    // Optimization: Use `sale.id` as the key instead of computing a timestamp from `sale.sold_date`
+                    // on every iteration. This avoids unnecessary Date conversion overhead during DOM reconciliation
+                    // and ensures strict uniqueness (timestamps can collide if sales happen in the same second).
+                    key=move |sale| sale.id
                     children=move |sale| {
                         let total = sale.price_per_item * sale.quantity;
                         view! {

--- a/ultros-frontend/ultros-app/src/ws/live_data.rs
+++ b/ultros-frontend/ultros-app/src/ws/live_data.rs
@@ -112,19 +112,12 @@ pub(crate) async fn subscribe_to_list(
         .unwrap();
     while let Some(msg) = read.next().await {
         match msg {
-            Ok(o) => match o {
-                Message::Text(o) => {
-                    if let Ok(val) = serde_json::from_str::<ServerClient>(&o) {
-                        match val {
-                            ServerClient::ListUpdate(_) => {
-                                on_update();
-                            }
-                            _ => {}
-                        }
-                    }
+            Ok(Message::Text(o)) => {
+                if let Ok(ServerClient::ListUpdate(_)) = serde_json::from_str::<ServerClient>(&o) {
+                    on_update();
                 }
-                _ => {}
-            },
+            }
+            Ok(_) => {}
             Err(_) => break,
         }
     }


### PR DESCRIPTION
💡 What: Changed the Leptos `<For>` component `key` function in `SaleHistoryTable` to use `sale.id` instead of a computed timestamp. Also refactored clippy warnings in `ws/live_data.rs`.
🎯 Why: `sale.sold_date.and_utc().timestamp()` computes the timestamp on every DOM reconciliation pass, which is unnecessary and could lead to key collisions for sales in the same second. `sale.id` is both unique and essentially zero-cost to access.
📊 Impact: Eliminates unneeded datetime math for lists of up to hundreds of items during UI updates, leading to faster reconciliation.
🔬 Measurement: Verify rendering performance of `SaleHistoryTable` under heavy updates; observe no duplicate key warnings.

---
*PR created automatically by Jules for task [13827493695341997560](https://jules.google.com/task/13827493695341997560) started by @akarras*