### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in list items

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save changes" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save changes" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only "Delete", "Edit/Save", and "Mark as acquired" buttons in `ultros-frontend/ultros-app/src/components/list/list_item_row.rs`.

🎯 Why: Icon-only buttons without accessible names cannot be understood by screen reader users. This small change ensures users navigating with assistive technologies know exactly what actions are available on their list items.

♿ Accessibility:
- Added `aria-label="Delete item"` to the trash icon buttons.
- Added dynamic `aria-label` to the edit button that switches between "Edit item" and "Save changes" depending on the component's state.
- Added `aria-label="Mark as acquired"` to the checkmark button for acquiring items.

---
*PR created automatically by Jules for task [16052738751920723952](https://jules.google.com/task/16052738751920723952) started by @akarras*