### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons in ListItemRow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,8 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+
+## 2024-05-18 - Missing Accessibility on Icon-only Buttons in Lists
+**Learning:** Common list components using icon-only buttons (like delete, edit, save) often miss proper `aria-labels` and visual hints (tooltips), reducing accessibility and clarity.
+**Action:** Always wrap icon-only action buttons in a `Tooltip` and provide a descriptive `aria-label` attribute (or a dynamically derived one when the functionality toggles) to ensure robust screen-reader and visual support.

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -128,30 +128,37 @@ pub fn ListItemRow(
                             </td>
                             <td class:hidden=edit_list_mode>
                                 <div class="flex gap-1">
-                                    <button
-                                        class="btn"
-                                        on:click=move |_| {
-                                            let _ = delete_item.dispatch(item.with(|i| i.id));
-                                        }
-                                    >
-                                        <Icon icon=i::BiTrashSolid />
-                                    </button>
-                                    <button
-                                        class="btn"
-                                        on:click=move |_| {
-                                            if temp_item() != item() {
-                                                let _ = edit_item.dispatch(temp_item());
+                                    <Tooltip tooltip_text="Delete item">
+                                        <button
+                                            class="btn"
+                                            aria-label="Delete item"
+                                            on:click=move |_| {
+                                                let _ = delete_item.dispatch(item.with(|i| i.id));
                                             }
-                                            set_edit(!edit())
-                                        }
-                                    >
-                                        <Icon icon=Signal::derive(move || {
-                                            if edit() { i::BsCheck } else { i::BsPencilFill }
-                                        }) />
-                                    </button>
+                                        >
+                                            <Icon icon=i::BiTrashSolid />
+                                        </button>
+                                    </Tooltip>
+                                    <Tooltip tooltip_text=Signal::derive(move || if edit() { "Save item".to_string() } else { "Edit item".to_string() })>
+                                        <button
+                                            class="btn"
+                                            aria-label=move || if edit() { "Save item".to_string() } else { "Edit item".to_string() }
+                                            on:click=move |_| {
+                                                if temp_item() != item() {
+                                                    let _ = edit_item.dispatch(temp_item());
+                                                }
+                                                set_edit(!edit())
+                                            }
+                                        >
+                                            <Icon icon=Signal::derive(move || {
+                                                if edit() { i::BsCheck } else { i::BsPencilFill }
+                                            }) />
+                                        </button>
+                                    </Tooltip>
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark item as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -254,27 +261,33 @@ pub fn ListItemRow(
 
                             </td>
                             <td>
-                                <button
-                                    class="btn"
-                                    on:click=move |_| {
-                                        let _ = delete_item.dispatch(item.id);
-                                    }
-                                >
-                                    <Icon icon=i::BiTrashSolid />
-                                </button>
-                                <button
-                                    class="btn"
-                                    on:click=move |_| {
-                                        if temp_item() != item {
-                                            let _ = edit_item.dispatch(temp_item());
+                                <Tooltip tooltip_text="Delete item">
+                                    <button
+                                        class="btn"
+                                        aria-label="Delete item"
+                                        on:click=move |_| {
+                                            let _ = delete_item.dispatch(item.id);
                                         }
-                                        set_edit(!edit())
-                                    }
-                                >
-                                    <Icon icon=Signal::derive(move || {
-                                        if edit() { i::BsCheck } else { i::BsPencilFill }
-                                    }) />
-                                </button>
+                                    >
+                                        <Icon icon=i::BiTrashSolid />
+                                    </button>
+                                </Tooltip>
+                                <Tooltip tooltip_text=Signal::derive(move || if edit() { "Save item".to_string() } else { "Edit item".to_string() })>
+                                    <button
+                                        class="btn"
+                                        aria-label=move || if edit() { "Save item".to_string() } else { "Edit item".to_string() }
+                                        on:click=move |_| {
+                                            if temp_item() != item {
+                                                let _ = edit_item.dispatch(temp_item());
+                                            }
+                                            set_edit(!edit())
+                                        }
+                                    >
+                                        <Icon icon=Signal::derive(move || {
+                                            if edit() { i::BsCheck } else { i::BsPencilFill }
+                                        }) />
+                                    </button>
+                                </Tooltip>
                             </td>
                         },
                     )

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -265,8 +265,11 @@ pub fn ListItemRow(
                                     <button
                                         class="btn"
                                         aria-label="Delete item"
-                                        on:click=move |_| {
-                                            let _ = delete_item.dispatch(item.id);
+                                        on:click={
+                                            let item_id = item.id;
+                                            move |_| {
+                                                let _ = delete_item.dispatch(item_id);
+                                            }
                                         }
                                     >
                                         <Icon icon=i::BiTrashSolid />
@@ -276,11 +279,14 @@ pub fn ListItemRow(
                                     <button
                                         class="btn"
                                         aria-label=move || if edit() { "Save item".to_string() } else { "Edit item".to_string() }
-                                        on:click=move |_| {
-                                            if temp_item() != item {
-                                                let _ = edit_item.dispatch(temp_item());
+                                        on:click={
+                                            let item = item.clone();
+                                            move |_| {
+                                                if temp_item.get_untracked() != item {
+                                                    let _ = edit_item.dispatch(temp_item.get_untracked());
+                                                }
+                                                set_edit(!edit.get_untracked())
                                             }
-                                            set_edit(!edit())
                                         }
                                     >
                                         <Icon icon=Signal::derive(move || {


### PR DESCRIPTION
* 💡 What: Added ARIA labels and Tooltip wrappers to icon-only buttons (Delete, Edit/Save, Mark as Acquired) in the `ListItemRow` component.
* 🎯 Why: To make the list interaction actions more accessible to screen-reader users and obvious via hover tooltips for visual users.
* ♿ Accessibility: Improved screen reader support by ensuring icon-only buttons announce their respective actions accurately.

---
*PR created automatically by Jules for task [7843525623369498753](https://jules.google.com/task/7843525623369498753) started by @akarras*