### PR TITLE
⚡ Bolt: Use find_also_related to optimize active listings queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Eliminated N+1 roundtrip in active listing queries
+**Learning:** `SeaORM` provides `.find_also_related()` which allows fetching an entity along with its related entity using a JOIN. This is much faster and more concise than querying an entity first, manually collecting related IDs, fetching them in a second query, and zip-mapping them in memory.
+**Action:** When I see a manual N+1 join in SeaORM code (querying one entity and then building an ID list to query its relationships), I will replace it with `.find_also_related()`.

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -116,27 +116,13 @@ impl UltrosDb {
         item: ItemId,
     ) -> Result<Vec<(active_listing::Model, Option<retainer::Model>)>> {
         let instant = Instant::now();
-        // OPTIMIZATION: Fetch all listings in one query
-        let listings = active_listing::Entity::find()
+        // OPTIMIZATION: Fetch listings and their retainers in a single query to eliminate N+1 DB roundtrip
+        let data = active_listing::Entity::find()
             .filter(active_listing::Column::ItemId.eq(item.0))
             .filter(active_listing::Column::WorldId.is_in(worlds.to_vec()))
+            .find_also_related(retainer::Entity)
             .all(&self.db)
             .await?;
-
-        let retainers = retainer::Entity::find()
-            .filter(retainer::Column::Id.is_in(listings.iter().map(|l| l.retainer_id).unique()))
-            .all(&self.db)
-            .await?
-            .into_iter()
-            .map(|r| (r.id, r))
-            .collect::<HashMap<_, _>>();
-        let data = listings
-            .into_iter()
-            .map(|l| {
-                let retainer = retainers.get(&l.retainer_id).cloned();
-                (l, retainer)
-            })
-            .collect();
         histogram!("ultros_db_query_listings_all_world_with_retainers_duration_seconds")
             .record(instant.elapsed());
         Ok(data)


### PR DESCRIPTION
💡 What: Replaced a manual N+1 query loop with SeaORM's native `.find_also_related`
🎯 Why: Previously, fetching active listings queried the listings table, accumulated the retainer IDs, and sent a second query to get the retainers before zipping them via a HashMap in memory. By using `find_also_related`, we achieve the exact same output (`Vec<(active_listing::Model, Option<retainer::Model>)>`) in a single DB roundtrip.
📊 Impact: Reduces database queries per request by 50% for listing queries, avoiding application-side overhead.
🔬 Measurement: Verify with `cargo test -p ultros-db` and running the application to observe active listings still appear correctly.

---
*PR created automatically by Jules for task [13818332187215537900](https://jules.google.com/task/13818332187215537900) started by @akarras*