### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2026-04-22 - Added missing ARIA labels to icon buttons
+**Learning:** Icon-only buttons using Leptos components often lack accessible names for screen readers. There are several instances in the app (like 'Refresh' in LiveSaleTicker, 'Delete/Edit' in ListItemRow) that only use an inner `<Icon />` component without any text or aria-label attributes.
+**Action:** Always verify that buttons containing only icons have a descriptive `aria-label` added so they are accessible to keyboard and screen reader users.

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label="Edit item"
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -256,6 +258,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +267,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label="Edit item"
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());

--- a/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
+++ b/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
@@ -128,6 +128,7 @@ pub fn LiveSaleTicker() -> impl IntoView {
                     <button
                         class="text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] transition-colors
                         flex items-center gap-2"
+                        aria-label="Refresh live sales"
                         on:click=move |_| {
                             sales.update(|s| s.clear());
                             set_done_loading(false);

--- a/ultros-frontend/ultros-app/src/components/recently_viewed.rs
+++ b/ultros-frontend/ultros-app/src/components/recently_viewed.rs
@@ -73,6 +73,7 @@ pub fn RecentlyViewed() -> impl IntoView {
                         <h4 class="text-xl font-bold text-[color:var(--color-text)]">"Recently Viewed"</h4>
                         <button
                             class="text-sm text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] transition-colors focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-ring)] rounded px-2"
+                            aria-label=move || if confirm_clear.get() { "Confirm clear recently viewed" } else { "Clear all recently viewed" }
                             on:click=move |_| {
                                 if confirm_clear.get_untracked() {
                                     item_data.clear_items();


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to several icon-only buttons across the app.
🎯 **Why:** To improve accessibility for screen reader users by giving interactive, text-less icon buttons an accessible name.
♿ **Accessibility:** Users using assistive technologies will now correctly hear actions like "Delete item", "Edit item", "Close modal", or "Refresh live sales" instead of an unlabelled button announcement.

---
*PR created automatically by Jules for task [964684490572370362](https://jules.google.com/task/964684490572370362) started by @akarras*