### PR TITLE
🎨 Palette: Add ARIA labels to modal and list buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close add recipe to list modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -125,7 +125,7 @@ fn AddRecipeToListModal(
                             {move || result_item().map(|i| i.name.as_str()).unwrap_or("unknown item")}
                         </div>
                     </div>
-                    <button class="btn-secondary" on:click=move |_| set_visible(false)>
+                    <button class="btn-secondary" aria-label="Close add recipe to list modal" on:click=move |_| set_visible(false)>
                         "close"
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/add_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_to_list.rs
@@ -69,7 +69,7 @@ fn AddToListModal(
                             {move || item().map(|i| i.name.as_str()).unwrap_or("unknown item")}
                         </div>
                     </div>
-                    <button class="btn-secondary" on:click=move |_| set_visible(false)>"close"</button>
+                    <button class="btn-secondary" aria-label="Close add to list modal" on:click=move |_| set_visible(false)>"close"</button>
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item from list"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark item as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item from list"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to modal and list buttons

💡 What: Added `aria-label`s to close buttons in `add_to_list.rs`, `add_recipe_to_list.rs`, and `add_recipe_to_current_list.rs`. Added `aria-label`s to edit, delete, and mark acquired buttons in `list_item_row.rs`.
🎯 Why: These buttons were icon-only and generic "close" text, making them difficult for screen readers to understand the actions available for each list item and modal.
♿ Accessibility: Improves screen reader support by giving descriptive labels to icon buttons.

---
*PR created automatically by Jules for task [11257487538831406058](https://jules.google.com/task/11257487538831406058) started by @akarras*