### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in list_item_row

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+
+## 2026-04-25 - ARIA Labels for Icon Buttons
+**Learning:** Icon-only buttons for actions like Delete, Edit, and Mark as acquired were missing accessible names, making them unreadable to screen readers.
+**Action:** Always include an `aria-label` attribute on `<button>` elements that only contain an `<Icon>`. If the button state changes (e.g. from Edit to Save), the `aria-label` should be dynamic (`aria-label=move || if state() { ... } else { ... }`).

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -129,6 +129,7 @@ pub fn ListItemRow(
                             <td class:hidden=edit_list_mode>
                                 <div class="flex gap-1">
                                     <button
+                                        aria-label="Delete item"
                                         class="btn"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
@@ -137,6 +138,7 @@ pub fn ListItemRow(
                                         <Icon icon=i::BiTrashSolid />
                                     </button>
                                     <button
+                                        aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         class="btn"
                                         on:click=move |_| {
                                             if temp_item() != item() {
@@ -151,6 +153,7 @@ pub fn ListItemRow(
                                     </button>
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
+                                        aria-label="Mark as acquired"
                                             class="btn"
                                             on:click=move |_| {
                                                 item.update(|i| {
@@ -255,6 +258,7 @@ pub fn ListItemRow(
                             </td>
                             <td>
                                 <button
+                                        aria-label="Delete item"
                                     class="btn"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
@@ -263,6 +267,7 @@ pub fn ListItemRow(
                                     <Icon icon=i::BiTrashSolid />
                                 </button>
                                 <button
+                                        aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     class="btn"
                                     on:click=move |_| {
                                         if temp_item() != item {


### PR DESCRIPTION
💡 What: Added accessible `aria-label` attributes to the icon-only buttons (Delete, Edit/Save, Mark as acquired) within the `ListItemRow` component.
🎯 Why: These buttons lacked accessible names, making it difficult or impossible for screen reader users to understand their purpose.
♿ Accessibility: Improved screen reader accessibility by ensuring all interactive button elements have descriptive labels. The Edit/Save button label updates dynamically based on the component's state.

---
*PR created automatically by Jules for task [16818073239199170451](https://jules.google.com/task/16818073239199170451) started by @akarras*