### PR TITLE
🎨 Palette: Add ARIA label to Add Recipe modal close button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 What: Added an `aria-label="Close modal"` to the close button in the `AddRecipeToCurrentListModal` component.
🎯 Why: The close button was an icon-only button (`<Icon icon=i::BsX />`) without an accessible label. This makes it impossible for screen reader users to understand what the button does.
♿ Accessibility: Improves accessibility by clearly indicating the button's purpose to screen readers.

---
*PR created automatically by Jules for task [11526852997034202290](https://jules.google.com/task/11526852997034202290) started by @akarras*