### PR TITLE
🎨 Palette: Add ARIA labels to list item action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2026-02-28 - ARIA labels for dynamic list item buttons
+**Learning:** Leptos components with dynamic state (like toggleable edit modes on list items) benefit greatly from reactive closures for ARIA labels (`aria-label=move || if edit() { "Save edit" } else { "Edit item" }`), ensuring screen reader context stays perfectly in sync with the visual icon swap.
+**Action:** Always use reactive closures for accessibility attributes on buttons whose icons or purposes change based on local component state.

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to list item action buttons

💡 What: Added accessible `aria-label` attributes to icon-only buttons (delete, edit/save, mark as acquired) in the `ListItemRow` component.
🎯 Why: To improve screen reader accessibility and provide semantic meaning to visual-only action buttons. Dynamic labels were used for the edit button to correctly reflect its state ("Edit item" vs "Save edit").
♿ Accessibility: Ensures that users navigating via screen readers can understand the function of each list management action.

---
*PR created automatically by Jules for task [6935406531589850354](https://jules.google.com/task/6935406531589850354) started by @akarras*