### PR TITLE
⚡ Bolt: Replace `sort_by_key` with `sort_unstable_by_key` for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,12 @@
+## 2024-04-28 - Initial entry
+**Learning:** Starting analysis
+**Action:** Profile the application
+## 2024-04-28 - Virtual Scroller Analysis
+**Learning:** Investigating leptos performance
+**Action:** Found virtual scroller, checking if it handles rendering properly
+## 2024-04-28 - Sorting Optimizations
+**Learning:** Found multiple usages of  across the frontend
+**Action:** Replaced  with  which is faster and allocates less memory, as stable sorting is not required for these cases (e.g. price per unit).
+## 2024-04-28 - Sorting Optimizations
+**Learning:** Found multiple usages of `sort_by_key` across the frontend
+**Action:** Replaced `sort_by_key` with `sort_unstable_by_key` which is faster and allocates less memory, as stable sorting is not required for these cases (e.g. price per unit).

--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -43,7 +43,7 @@ pub fn AddRecipeToCurrentListModal(
                     .collect::<Vec<(&Item, &Recipe)>>()
             });
             // Sort by level descending
-            results.sort_by_key(|(i, _)| Reverse(i.level_item));
+            results.sort_unstable_by_key(|(i, _)| Reverse(i.level_item));
             results
         })
     });

--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -46,7 +46,7 @@ pub fn BuyingView(
             continue;
         }
 
-        listings.sort_by_key(|l| l.price_per_unit);
+        listings.sort_unstable_by_key(|l| l.price_per_unit);
         let mut remaining = needed;
         for listing in listings {
             if remaining <= 0 {
@@ -107,11 +107,11 @@ pub fn BuyingView(
                 .into_iter()
                 .map(|(world_id, (world_name, listings))| (world_id, world_name, listings))
                 .collect();
-            sorted_worlds.sort_by(|a, b| a.1.cmp(&b.1));
+            sorted_worlds.sort_unstable_by(|a, b| a.1.cmp(&b.1));
             (dc_id, dc_name, sorted_worlds)
         })
         .collect();
-    sorted_dcs.sort_by(|a, b| a.1.cmp(&b.1));
+    sorted_dcs.sort_unstable_by(|a, b| a.1.cmp(&b.1));
 
     view! {
         <div class="flex flex-col gap-6">

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -24,7 +24,7 @@ fn get_cheapest_listing(
     quantity: i32,
     hq: Option<bool>,
 ) -> Vec<ActiveListing> {
-    listings.sort_by_key(|listing| listing.price_per_unit);
+    listings.sort_unstable_by_key(|listing| listing.price_per_unit);
     let quantity_needed = quantity;
     let mut current_quantity = 0;
     listings
@@ -174,13 +174,13 @@ pub fn ListSummary(items: Vec<(ListItem, Vec<ActiveListing>)>) -> impl IntoView 
 
     // Sort datacenters by total item count (descending)
     let mut sorted_datacenters: Vec<_> = datacenter_totals.into_iter().collect();
-    sorted_datacenters.sort_by(|(_, (_, _, a_item_count)), (_, (_, _, b_item_count))| {
+    sorted_datacenters.sort_unstable_by(|(_, (_, _, a_item_count)), (_, (_, _, b_item_count))| {
         b_item_count.cmp(a_item_count)
     });
 
     // Sort worlds within each datacenter: by item count (descending), then alphabetically
     for worlds in datacenter_groups.values_mut() {
-        worlds.sort_by(|a, b| match b.item_count.cmp(&a.item_count) {
+        worlds.sort_unstable_by(|a, b| match b.item_count.cmp(&a.item_count) {
             std::cmp::Ordering::Equal => a.world_name.cmp(&b.world_name),
             other => other,
         });

--- a/ultros-frontend/ultros-app/src/components/listings_table.rs
+++ b/ultros-frontend/ultros-app/src/components/listings_table.rs
@@ -18,7 +18,7 @@ pub fn ListingsTable(
     // Note: We use Arc<Retainer> to make cloning cheap (pointer copy vs string copy).
     let sorted_listings = Memo::new(move |_| {
         let mut listings = listings();
-        listings.sort_by_key(|(listing, _)| listing.price_per_unit);
+        listings.sort_unstable_by_key(|(listing, _)| listing.price_per_unit);
         listings
     });
     // This memo handles the cheap slicing/view logic.

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -8,7 +8,7 @@ fn get_cheapest_listing(
     quantity: i32,
     hq: Option<bool>,
 ) -> Vec<ActiveListing> {
-    listings.sort_by_key(|listing| listing.price_per_unit);
+    listings.sort_unstable_by_key(|listing| listing.price_per_unit);
     let quantity_needed = quantity;
     let mut current_quantity = 0;
     listings

--- a/ultros-frontend/ultros-app/src/components/stats_display.rs
+++ b/ultros-frontend/ultros-app/src/components/stats_display.rs
@@ -76,7 +76,7 @@ fn get_param_data_for_item(item: ItemId) -> Option<Vec<ParamData>> {
         .into_values()
         .collect::<Vec<_>>();
 
-    params.sort_by_key(|param| param.base_param.order_priority);
+    params.sort_unstable_by_key(|param| param.base_param.order_priority);
     Some(params)
 }
 

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -397,9 +397,13 @@ fn AnalyzerTable(
             .collect::<Vec<_>>();
 
         match sort_mode().unwrap_or(SortMode::Roi) {
-            SortMode::Roi => sorted_data.sort_by_key(|data| Reverse(data.return_on_investment)),
-            SortMode::Profit => sorted_data.sort_by_key(|data| Reverse(data.profit)),
-            SortMode::ProfitPerDay => sorted_data.sort_by_key(|data| Reverse(data.profit_per_day)),
+            SortMode::Roi => {
+                sorted_data.sort_unstable_by_key(|data| Reverse(data.return_on_investment))
+            }
+            SortMode::Profit => sorted_data.sort_unstable_by_key(|data| Reverse(data.profit)),
+            SortMode::ProfitPerDay => {
+                sorted_data.sort_unstable_by_key(|data| Reverse(data.profit_per_day))
+            }
         }
         sorted_data
             .into_iter()
@@ -497,7 +501,7 @@ fn AnalyzerTable(
                                     .filter(|(_, cat)| !cat.name.is_empty())
                                     .map(|(id, cat)| (id.0, cat.name.clone()))
                                     .collect::<Vec<_>>();
-                                categories.sort_by(|a, b| a.1.cmp(&b.1));
+                                categories.sort_unstable_by(|a, b| a.1.cmp(&b.1));
                                 categories.into_iter().map(|(id, name)| {
                                     view! { <option value=id.to_string() selected=move || category_filter() == Some(id)>{name}</option> }
                                 }).collect_view()

--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -602,7 +602,7 @@ pub fn ExchangeItem() -> impl IntoView {
                                 let q = currency_quantity.get();
                                 compute_prices(s, l, q).map(|p: Vec<CurrencyTrade>| {
                                     let mut rows = p.clone();
-                                    rows.sort_by(|a, b| b.total_profit.cmp(&a.total_profit));
+                                    rows.sort_unstable_by(|a, b| b.total_profit.cmp(&a.total_profit));
                                     let top = rows.into_iter().take(5).collect::<Vec<_>>();
                                     view! {
                                         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5 gap-3 mb-4 items-stretch">
@@ -687,10 +687,10 @@ pub fn ExchangeItem() -> impl IntoView {
                                                 // surface best option at top by default (total_profit desc)
                                                 match sort_label.as_deref() {
                                                     None => {
-                                                        p.sort_by(|a, b| b.total_profit.cmp(&a.total_profit));
+                                                        p.sort_unstable_by(|a, b| b.total_profit.cmp(&a.total_profit));
                                                     }
                                                     Some("total_profit") => {
-                                                        p.sort_by(|a, b| b.total_profit.cmp(&a.total_profit));
+                                                        p.sort_unstable_by(|a, b| b.total_profit.cmp(&a.total_profit));
                                                     }
                                                     Some(label) => {
                                                         CurrencyTrade::sort_vec_by_label(&mut p, label, None);

--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -296,9 +296,9 @@ fn FCCraftingAnalyzerTable(
 
         // Sort
         match sort_mode().unwrap_or(SortMode::Profit) {
-            SortMode::Roi => results.sort_by_key(|d| Reverse(d.return_on_investment)),
-            SortMode::Profit => results.sort_by_key(|d| Reverse(d.profit)),
-            SortMode::Velocity => results.sort_by(|a, b| {
+            SortMode::Roi => results.sort_unstable_by_key(|d| Reverse(d.return_on_investment)),
+            SortMode::Profit => results.sort_unstable_by_key(|d| Reverse(d.profit)),
+            SortMode::Velocity => results.sort_unstable_by(|a, b| {
                 b.daily_sales
                     .partial_cmp(&a.daily_sales)
                     .unwrap_or(std::cmp::Ordering::Equal)

--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -59,7 +59,7 @@ fn CategoryView(category: u8) -> impl IntoView {
             (cat.order, &cat.name, id)
         })
         .collect::<Vec<_>>();
-    categories.sort_by_key(|(order, _, _)| *order);
+    categories.sort_unstable_by_key(|(order, _, _)| *order);
     view! {
         <div class="flex flex-col text-xl">
             {categories
@@ -185,7 +185,7 @@ fn job_category_lookup(class_job_category: &ClassJobCategory, job_acronym: &str)
 fn JobsList() -> impl IntoView {
     let jobs = &xiv_gen_db::data().class_jobs;
     let mut jobs: Vec<_> = jobs.iter().collect();
-    jobs.sort_by_key(|(_, job)| job.ui_priority);
+    jobs.sort_unstable_by_key(|(_, job)| job.ui_priority);
     view! {
         <div class="flex flex-col text-xl">
             {jobs

--- a/ultros-frontend/ultros-app/src/routes/leve_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/leve_analyzer.rs
@@ -300,8 +300,8 @@ fn LeveAnalyzerTable(
 
         // Sort
         match sort_mode().unwrap_or(SortMode::Profit) {
-            SortMode::Profit => results.sort_by_key(|d| Reverse(d.profit)),
-            SortMode::Level => results.sort_by_key(|d| Reverse(d.class_job_level)),
+            SortMode::Profit => results.sort_unstable_by_key(|d| Reverse(d.profit)),
+            SortMode::Level => results.sort_unstable_by_key(|d| Reverse(d.class_job_level)),
         }
 
         results

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -194,7 +194,7 @@ pub fn ListView() -> impl IntoView {
                                         })
                                         .collect::<Vec<_>>();
                                     score
-                                        .sort_by_key(|(_, i)| (
+                                        .sort_unstable_by_key(|(_, i)| (
                                             Reverse(i.level_item),
                                         ));
                                     score

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -361,9 +361,9 @@ fn RecipeAnalyzerTable(
 
         // Sort
         match sort_mode().unwrap_or(SortMode::Profit) {
-            SortMode::Roi => results.sort_by_key(|d| Reverse(d.return_on_investment)),
-            SortMode::Profit => results.sort_by_key(|d| Reverse(d.profit)),
-            SortMode::Velocity => results.sort_by(|a, b| {
+            SortMode::Roi => results.sort_unstable_by_key(|d| Reverse(d.return_on_investment)),
+            SortMode::Profit => results.sort_unstable_by_key(|d| Reverse(d.profit)),
+            SortMode::Velocity => results.sort_unstable_by(|a, b| {
                 b.daily_sales
                     .partial_cmp(&a.daily_sales)
                     .unwrap_or(std::cmp::Ordering::Equal)

--- a/ultros-frontend/ultros-app/src/routes/retainers.rs
+++ b/ultros-frontend/ultros-app/src/routes/retainers.rs
@@ -47,7 +47,7 @@ fn RetainerUndercutTable(retainer: Retainer, listings: Vec<UndercutData>) -> imp
     let mut listings = listings;
     let data = xiv_gen_db::data();
     let items = &data.items;
-    listings.sort_by_key(|u| ItemSortKey::from(&u.current));
+    listings.sort_unstable_by_key(|u| ItemSortKey::from(&u.current));
     let worlds = use_context::<LocalWorldData>().unwrap().0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
     let world_name = world.as_ref().map(|w| w.get_name()).unwrap_or_default();
@@ -129,7 +129,7 @@ fn RetainerTable(retainer: Retainer, listings: Vec<ActiveListing>) -> impl IntoV
     let data = xiv_gen_db::data();
     let items = &data.items;
     let mut listings = listings;
-    listings.sort_by_key(|u| ItemSortKey::from(u));
+    listings.sort_unstable_by_key(|u| ItemSortKey::from(u));
     let world_data = use_context::<LocalWorldData>().unwrap();
     let worlds = world_data.0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
@@ -488,7 +488,7 @@ mod test {
             })
             .collect();
         let original = item_vec.clone();
-        item_vec.sort_by_key(|i| ItemSortKey::from(i));
+        item_vec.sort_unstable_by_key(|i| ItemSortKey::from(i));
         assert_eq!(original, item_vec);
     }
 
@@ -503,7 +503,7 @@ mod test {
             41517,
         ]; // rainbow corsage
         let mut rearranged = vec![41516, 41517, 41509];
-        rearranged.sort_by_key(|id| ItemSortKey::from((ItemId(*id), true)));
+        rearranged.sort_unstable_by_key(|id| ItemSortKey::from((ItemId(*id), true)));
         assert_eq!(expected_order, rearranged);
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
+++ b/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
@@ -282,11 +282,10 @@ fn ScripSourceTable(
 
         // Sort
         match sort_mode().unwrap_or(SortMode::CostPerScrip) {
-            SortMode::CostPerScrip => {
-                results.sort_by(|a, b| a.cost_per_scrip.partial_cmp(&b.cost_per_scrip).unwrap())
-            }
-            SortMode::ScripAmount => results.sort_by_key(|d| Reverse(d.scrip_amount)),
-            SortMode::Cost => results.sort_by_key(|d| d.cost),
+            SortMode::CostPerScrip => results
+                .sort_unstable_by(|a, b| a.cost_per_scrip.partial_cmp(&b.cost_per_scrip).unwrap()),
+            SortMode::ScripAmount => results.sort_unstable_by_key(|d| Reverse(d.scrip_amount)),
+            SortMode::Cost => results.sort_unstable_by_key(|d| d.cost),
         }
 
         // Deduplicate by item_id (since item may appear in multiple shop lists)

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -285,8 +285,10 @@ fn VendorResaleTable(
             .collect::<Vec<_>>();
 
         match sort_mode().unwrap_or(SortMode::Roi) {
-            SortMode::Roi => sorted_data.sort_by_key(|data| Reverse(data.return_on_investment)),
-            SortMode::Profit => sorted_data.sort_by_key(|data| Reverse(data.profit)),
+            SortMode::Roi => {
+                sorted_data.sort_unstable_by_key(|data| Reverse(data.return_on_investment))
+            }
+            SortMode::Profit => sorted_data.sort_unstable_by_key(|data| Reverse(data.profit)),
         }
         sorted_data
             .into_iter()
@@ -353,7 +355,7 @@ fn VendorResaleTable(
                                     .filter(|(_, cat)| !cat.name.is_empty())
                                     .map(|(id, cat)| (id.0, cat.name.clone()))
                                     .collect::<Vec<_>>();
-                                categories.sort_by(|a, b| a.1.cmp(&b.1));
+                                categories.sort_unstable_by(|a, b| a.1.cmp(&b.1));
                                 categories.into_iter().map(|(id, name)| {
                                     view! { <option value=id.to_string() selected=move || category_filter() == Some(id)>{name}</option> }
                                 }).collect_view()

--- a/ultros-frontend/ultros-app/src/routes/venture_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/venture_analyzer.rs
@@ -232,8 +232,8 @@ fn VentureAnalyzerTable(
 
         // Sort
         match sort_mode().unwrap_or(SortMode::Profit) {
-            SortMode::Profit => results.sort_by_key(|d| Reverse(d.profit)),
-            SortMode::Level => results.sort_by_key(|d| Reverse(d.task_level)),
+            SortMode::Profit => results.sort_unstable_by_key(|d| Reverse(d.profit)),
+            SortMode::Level => results.sort_unstable_by_key(|d| Reverse(d.task_level)),
         }
 
         results

--- a/ultros-frontend/ultros-app/src/ws/live_data.rs
+++ b/ultros-frontend/ultros-app/src/ws/live_data.rs
@@ -53,7 +53,7 @@ pub(crate) async fn live_sales(
                                                     hq: sale.hq,
                                                 });
                                             }
-                                            sales.make_contiguous().sort_by_key(|sale| {
+                                            sales.make_contiguous().sort_unstable_by_key(|sale| {
                                                 std::cmp::Reverse(sale.sold_date)
                                             });
                                             *sales = sales


### PR DESCRIPTION
💡 What: Replaced instances of `sort_by` and `sort_by_key` with their unstable counterparts (`sort_unstable_by` and `sort_unstable_by_key`) across the frontend application, specifically in cases where a stable sort is not required (e.g. sorting prices).

🎯 Why: In Rust, `sort_unstable_by` is generally faster and allocates O(1) memory, compared to `sort_by` which allocates O(N/2) memory. Since the stable sort wasn't necessary for these specific use cases, this optimization reduces memory overhead and improves sorting speed.

📊 Impact: Improved performance and reduced memory allocations across multiple data sorting components (e.g., list views, tables, analyzers).

🔬 Measurement: Verify by interacting with any sorted table or list in the UI to ensure they correctly sort data and compare the rendering speed visually or with profile tools.

(Also removed the incorrectly staged `clippy_output.txt` artifact and reverted `search_box.rs` to use `sort_by` to maintain search relevance scoring as requested during code review).

---
*PR created automatically by Jules for task [3608539778463385221](https://jules.google.com/task/3608539778463385221) started by @akarras*