### PR TITLE
🎨 Palette: Add aria-label to close button in AddRecipeToCurrentListModal

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false) aria-label="Close modal">
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` attribute to the icon-only close button in `AddRecipeToCurrentListModal`.
🎯 Why: To improve accessibility, ensuring screen reader users understand the purpose of the close button.
♿ Accessibility: The button was previously an icon-only button without textual description. Added `aria-label="Close modal"` to fix this.

---
*PR created automatically by Jules for task [7820327138732955071](https://jules.google.com/task/7820327138732955071) started by @akarras*