### PR TITLE
🎨 Palette: Enhance accessibility in ListItemRow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,9 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2026-05-04 - Added ARIA labels to list item row action buttons
+**Learning:** Found that the action buttons in the list item row component (delete, edit, mark as acquired) lacked ARIA labels, making them inaccessible to screen readers since they only contained icons.
+**Action:** Always verify that icon-only buttons have descriptive  attributes to ensure they are accessible. For buttons that toggle state (like edit/save), the aria-label should also dynamically reflect the current action.
+## 2025-05-04 - Added ARIA labels to list item row action buttons
+**Learning:** Found that the action buttons in the list item row component (delete, edit, mark as acquired) lacked ARIA labels, making them inaccessible to screen readers since they only contained icons.
+**Action:** Always verify that icon-only buttons have descriptive `aria-label` attributes to ensure they are accessible. For buttons that toggle state (like edit/save), the aria-label should also dynamically reflect the current action.

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,6 +130,7 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
@@ -138,6 +139,7 @@ pub fn ListItemRow(
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -152,6 +154,7 @@ pub fn ListItemRow(
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -256,6 +259,7 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
@@ -264,6 +268,7 @@ pub fn ListItemRow(
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save edit" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());


### PR DESCRIPTION
💡 What: Added ARIA labels to the icon-only buttons in the `ListItemRow` component (Delete, Edit, Mark as acquired).
🎯 Why: To make the list management actions accessible to screen reader users. Before this change, the buttons lacked accessible text since they only contained icons.
♿ Accessibility: The Edit button's aria-label is dynamic, communicating "Edit item" or "Save edit" depending on the component's state.

---
*PR created automatically by Jules for task [14718974135027265797](https://jules.google.com/task/14718974135027265797) started by @akarras*