### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_current_list.rs
@@ -100,7 +100,7 @@ pub fn AddRecipeToCurrentListModal(
             <div class="space-y-4 h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between shrink-0">
                     <h2 class="text-xl font-bold">"Add Recipe to List"</h2>
-                    <button class="btn-ghost p-2" on:click=move |_| set_visible(false)>
+                    <button class="btn-ghost p-2" aria-label="Close modal" on:click=move |_| set_visible(false)>
                         <Icon icon=i::BsX width="24" height="24" />
                     </button>
                 </div>

--- a/ultros-frontend/ultros-app/src/components/language_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/language_picker.rs
@@ -25,6 +25,7 @@ pub fn LanguagePicker() -> impl IntoView {
             on:click=on_switch
             class="btn-ghost p-2 rounded-full hover:bg-black/20 transition-colors"
             title=move || t_string!(i18n, switch_language).to_string()
+            aria-label=move || t_string!(i18n, switch_language).to_string()
         >
             <Icon icon=i::IoLanguage width="1.2em" height="1.2em" />
             <span class="ml-1 uppercase text-xs font-bold">{move || i18n.get_locale().as_str()}</span>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the language picker toggle button and the close button in the add recipe modal.
🎯 Why: These buttons primarily use icons (`<Icon ... />`) or rely on visual context, which makes them inaccessible or confusing for screen reader users. The language picker did have a `title`, but `aria-label` ensures broader compatibility. 
♿ Accessibility: Improved screen reader support by explicitly defining the purpose of these interactive elements.

---
*PR created automatically by Jules for task [348082182599702078](https://jules.google.com/task/348082182599702078) started by @akarras*