### PR TITLE
⚡ Bolt: Optimize top_deals to clone only needed elements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - [Iterate before Cloning for Large Vectors]
+**Learning:** `data.clone().into_iter().take(6)` copies the entire vector before throwing away everything after the 6th element. `data.iter().take(6).cloned()` iterates first, then clones, saving an `O(N)` clone, but must be `.collect::<Vec<_>>()`ed in Leptos to avoid closure lifetime issues.
+**Action:** Be mindful of the order of operations when taking a slice of a larger vector, and ensure `collect()` is used to break lifetimes.

--- a/ultros-frontend/ultros-app/src/components/top_deals.rs
+++ b/ultros-frontend/ultros-app/src/components/top_deals.rs
@@ -106,7 +106,11 @@ pub fn TopDeals() -> impl IntoView {
                             view! {
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <For
-                                        each=move || data.clone().into_iter().take(6)
+                                        each=move || {
+                                            // ⚡ Bolt: Iterate first, then clone only what's needed to avoid cloning the entire array
+                                            // We collect to a Vec to avoid lifetime issues with the iter
+                                            data.iter().take(6).cloned().collect::<Vec<_>>()
+                                        }
                                         key=|deal| deal.item_id
                                         children=move |deal| {
                                             view! { <DealItem deal=deal home_world_name=world_name.clone() /> }


### PR DESCRIPTION
⚡ Bolt: Optimize top_deals to clone only needed elements

💡 What: Changed `data.clone().into_iter().take(6)` to `data.iter().take(6).cloned().collect::<Vec<_>>()`.
🎯 Why: The original code clones the entire `Vec` on every render just to take the first 6 elements. This takes $O(N)$ time instead of $O(k)$ time.
📊 Impact: Reduces array allocations and cloning overhead from $O(N)$ to $O(k)$ for small $k$ limit of 6.
🔬 Measurement: Verified with `cargo clippy`, `cargo test`, and local benchmarker.


---
*PR created automatically by Jules for task [6339199664568282033](https://jules.google.com/task/6339199664568282033) started by @akarras*