### PR TITLE
🎨 Palette: Add ARIA labels to list item row buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-01-15 - Table Accessibility Pattern
 **Learning:** Multiple data tables (`ListingsTable`, `SaleHistoryTable`) were missing semantic `<thead>` wrappers and `scope` attributes, relying on browser auto-correction which is insufficient for accessibility.
 **Action:** Enforce `<thead>` and `scope="col"`/`scope="row"` in all table components during creation or refactor.
+## 2025-01-09 - Add ARIA Labels to List Item Row Buttons
+**Learning:** Found multiple icon-only buttons in the `ListItemRow` component that were missing ARIA labels, making them inaccessible to screen readers.
+**Action:** Added `aria-label` attributes to the parent `<button>` elements and `aria_hidden=true` to the inner `<Icon>` components to provide clear context without redundant reading.

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -130,14 +130,16 @@ pub fn ListItemRow(
                                 <div class="flex gap-1">
                                     <button
                                         class="btn"
+                                        aria-label="Delete item"
                                         on:click=move |_| {
                                             let _ = delete_item.dispatch(item.with(|i| i.id));
                                         }
                                     >
-                                        <Icon icon=i::BiTrashSolid />
+                                        <Icon icon=i::BiTrashSolid aria_hidden=true />
                                     </button>
                                     <button
                                         class="btn"
+                                        aria-label=move || if edit() { "Save item" } else { "Edit item" }
                                         on:click=move |_| {
                                             if temp_item() != item() {
                                                 let _ = edit_item.dispatch(temp_item());
@@ -145,13 +147,14 @@ pub fn ListItemRow(
                                             set_edit(!edit())
                                         }
                                     >
-                                        <Icon icon=Signal::derive(move || {
+                                        <Icon aria_hidden=true icon=Signal::derive(move || {
                                             if edit() { i::BsCheck } else { i::BsPencilFill }
                                         }) />
                                     </button>
                                     <Tooltip tooltip_text="Mark as acquired">
                                         <button
                                             class="btn"
+                                            aria-label="Mark as acquired"
                                             on:click=move |_| {
                                                 item.update(|i| {
                                                     i.acquired = i.quantity;
@@ -159,7 +162,7 @@ pub fn ListItemRow(
                                                 let _ = edit_item.dispatch(item());
                                             }
                                         >
-                                            <Icon icon=i::BiCheckRegular />
+                                            <Icon icon=i::BiCheckRegular aria_hidden=true />
                                         </button>
                                     </Tooltip>
                                 </div>
@@ -256,14 +259,16 @@ pub fn ListItemRow(
                             <td>
                                 <button
                                     class="btn"
+                                    aria-label="Delete item"
                                     on:click=move |_| {
                                         let _ = delete_item.dispatch(item.id);
                                     }
                                 >
-                                    <Icon icon=i::BiTrashSolid />
+                                    <Icon icon=i::BiTrashSolid aria_hidden=true />
                                 </button>
                                 <button
                                     class="btn"
+                                    aria-label=move || if edit() { "Save item" } else { "Edit item" }
                                     on:click=move |_| {
                                         if temp_item() != item {
                                             let _ = edit_item.dispatch(temp_item());
@@ -271,7 +276,7 @@ pub fn ListItemRow(
                                         set_edit(!edit())
                                     }
                                 >
-                                    <Icon icon=Signal::derive(move || {
+                                    <Icon aria_hidden=true icon=Signal::derive(move || {
                                         if edit() { i::BsCheck } else { i::BsPencilFill }
                                     }) />
                                 </button>


### PR DESCRIPTION
Added descriptive `aria-label`s to the edit, delete, and mark-as-acquired buttons in `list_item_row.rs`, and set `aria_hidden=true` on their inner `<Icon>` components to ensure they are accessible to screen readers.

---
*PR created automatically by Jules for task [9432397948529059044](https://jules.google.com/task/9432397948529059044) started by @akarras*