### PR TITLE
⚡ Bolt: Optimize get_cheapest_listing to filter before sorting

### DIFF
--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -8,18 +8,17 @@ fn get_cheapest_listing(
     quantity: i32,
     hq: Option<bool>,
 ) -> Vec<ActiveListing> {
+    // Optimization: Filter out unwanted quality types *before* sorting.
+    // This significantly reduces the N in O(N log N) sorting time when filtering by HQ/NQ.
+    if let Some(hq) = hq {
+        listings.retain(|listing| listing.hq == hq);
+    }
     listings.sort_by_key(|listing| listing.price_per_unit);
+
     let quantity_needed = quantity;
     let mut current_quantity = 0;
     listings
         .into_iter()
-        .filter(|listing| {
-            if let Some(hq) = hq {
-                listing.hq == hq
-            } else {
-                true
-            }
-        })
         .take_while(|listings| {
             current_quantity += listings.quantity;
             current_quantity <= quantity_needed


### PR DESCRIPTION
💡 What: Optimize `get_cheapest_listing` by filtering `listings` by `hq` before sorting instead of after sorting.
🎯 Why: Sorting is an $O(N \log N)$ operation. If we filter out unwanted items (e.g. half of the items if `hq` is specified) before sorting, it drastically reduces the number of items that need to be sorted.
📊 Impact: Faster `get_cheapest_listing` rendering, minimizing CPU overhead and time.
🔬 Measurement: Run the application and observe rendering speed.

---
*PR created automatically by Jules for task [1146545580628886068](https://jules.google.com/task/1146545580628886068) started by @akarras*