### PR TITLE
test: add backend unit tests + refactor pure helpers out of Discord and alerts modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8821,6 +8821,7 @@ dependencies = [
  "chrono",
  "rkyv",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 
@@ -8940,6 +8941,7 @@ dependencies = [
  "sea-orm",
  "sea-query",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "ultros-api-types",

--- a/dumb-csv/src/lib.rs
+++ b/dumb-csv/src/lib.rs
@@ -90,4 +90,69 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn bool_from_str_recognized_truthy_strings() {
+        assert_eq!(bool_from_str("TRUE"), Some(true));
+        assert_eq!(bool_from_str("True"), Some(true));
+        assert_eq!(bool_from_str("1"), Some(true));
+    }
+
+    #[test]
+    fn bool_from_str_recognized_falsy_strings() {
+        assert_eq!(bool_from_str("FALSE"), Some(false));
+        assert_eq!(bool_from_str("False"), Some(false));
+        assert_eq!(bool_from_str("0"), Some(false));
+    }
+
+    #[test]
+    fn bool_from_str_returns_none_for_unknown_values() {
+        assert_eq!(bool_from_str(""), None);
+        assert_eq!(bool_from_str("true"), None); // lowercase not handled
+        assert_eq!(bool_from_str("false"), None);
+        assert_eq!(bool_from_str("yes"), None);
+        assert_eq!(bool_from_str("2"), None);
+        assert_eq!(bool_from_str(" TRUE "), None); // no trimming
+    }
+
+    #[test]
+    fn parse_bool_trait_defaults_to_false_for_unknown() {
+        assert!("TRUE".parse_bool());
+        assert!(!"FALSE".parse_bool());
+        // unknown input becomes default (false)
+        assert!(!"banana".parse_bool());
+        assert!(!"".parse_bool());
+    }
+
+    #[test]
+    fn deserialize_reads_records_via_dumb_csv_deserialize() {
+        let input = "1,2,3,4,5\n6,7,8,9,10\n";
+        let rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(input.as_bytes());
+        let rows: Vec<SomeType> = deserialize(rdr).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                SomeType {
+                    a: 1,
+                    b: vec![2, 3],
+                    c: vec![4, 5]
+                },
+                SomeType {
+                    a: 6,
+                    b: vec![7, 8],
+                    c: vec![9, 10]
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_or_default_uses_default_for_invalid_input() {
+        let v: i32 = <&str as ParseOrDefault>::parse_or_default("abc");
+        assert_eq!(v, 0);
+        let v: i32 = <&str as ParseOrDefault>::parse_or_default("42");
+        assert_eq!(v, 42);
+    }
 }

--- a/field-iterator/src/lib.rs
+++ b/field-iterator/src/lib.rs
@@ -40,4 +40,81 @@ mod test {
             });
         }
     }
+
+    fn sample() -> Vec<SomeType> {
+        vec![
+            SomeType {
+                value: 3,
+                other_value: "b".into(),
+            },
+            SomeType {
+                value: 1,
+                other_value: "c".into(),
+            },
+            SomeType {
+                value: 2,
+                other_value: "a".into(),
+            },
+        ]
+    }
+
+    #[test]
+    fn sort_by_value_ascending() {
+        let mut v = sample();
+        SomeType::sort_vec_by_label(&mut v, "value", None);
+        assert_eq!(v.iter().map(|x| x.value).collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn sort_by_other_value_lexical() {
+        let mut v = sample();
+        SomeType::sort_vec_by_label(&mut v, "other_value", None);
+        let names: Vec<_> = v.iter().map(|x| x.other_value.clone()).collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn sort_by_primary_then_secondary_breaks_ties() {
+        let mut v = vec![
+            SomeType {
+                value: 1,
+                other_value: "z".into(),
+            },
+            SomeType {
+                value: 1,
+                other_value: "a".into(),
+            },
+            SomeType {
+                value: 1,
+                other_value: "m".into(),
+            },
+        ];
+        SomeType::sort_vec_by_label(&mut v, "value", Some("other_value"));
+        let names: Vec<_> = v.iter().map(|x| x.other_value.clone()).collect();
+        assert_eq!(names, vec!["a", "m", "z"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid index")]
+    fn unknown_field_label_panics() {
+        let mut v = sample();
+        SomeType::sort_vec_by_label(&mut v, "nope", None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid index")]
+    fn unknown_then_by_field_panics_when_comparing_tied_keys() {
+        // The closure only evaluates the secondary key on equal primary, so we need a tie.
+        let mut v = vec![
+            SomeType {
+                value: 1,
+                other_value: "x".into(),
+            },
+            SomeType {
+                value: 1,
+                other_value: "y".into(),
+            },
+        ];
+        SomeType::sort_vec_by_label(&mut v, "value", Some("nope"));
+    }
 }

--- a/ultros-api-types/Cargo.toml
+++ b/ultros-api-types/Cargo.toml
@@ -15,3 +15,6 @@ rkyv = { version = "0.7.42", features = ["validation", "size_64", "hashbrown"], 
 [features]
 default = []
 rkyv = ["dep:rkyv", "chrono/rkyv-64", "chrono/rkyv-validation"]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/ultros-api-types/src/cheapest_listings.rs
+++ b/ultros-api-types/src/cheapest_listings.rs
@@ -153,3 +153,202 @@ impl From<CheapestListings> for CheapestListingsMap {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn data(price: i32, world_id: i32) -> CheapestListingData {
+        CheapestListingData { price, world_id }
+    }
+
+    #[test]
+    fn map_key_serializes_to_id_hq_string() {
+        let key = CheapestListingMapKey {
+            item_id: 42,
+            hq: true,
+        };
+        let s = serde_json::to_string(&key).unwrap();
+        assert_eq!(s, "\"42_true\"");
+    }
+
+    #[test]
+    fn map_key_deserializes_from_id_hq_string() {
+        let key: CheapestListingMapKey = serde_json::from_str("\"123_false\"").unwrap();
+        assert_eq!(
+            key,
+            CheapestListingMapKey {
+                item_id: 123,
+                hq: false
+            }
+        );
+    }
+
+    #[test]
+    fn map_key_roundtrip_through_json() {
+        for (item_id, hq) in [(1, true), (-7, false), (i32::MAX, true), (0, false)] {
+            let key = CheapestListingMapKey { item_id, hq };
+            let s = serde_json::to_string(&key).unwrap();
+            let back: CheapestListingMapKey = serde_json::from_str(&s).unwrap();
+            assert_eq!(key, back);
+        }
+    }
+
+    #[test]
+    fn map_key_rejects_missing_separator() {
+        let r: Result<CheapestListingMapKey, _> = serde_json::from_str("\"123true\"");
+        assert!(r.is_err(), "should reject when separator absent");
+    }
+
+    #[test]
+    fn map_key_rejects_invalid_item_id() {
+        let r: Result<CheapestListingMapKey, _> = serde_json::from_str("\"abc_true\"");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn map_key_rejects_invalid_hq() {
+        let r: Result<CheapestListingMapKey, _> = serde_json::from_str("\"123_maybe\"");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn price_summary_lowest_gil_none_when_both_missing() {
+        let summary = PriceSummary { lq: None, hq: None };
+        assert_eq!(summary.lowest_gil(), None);
+    }
+
+    #[test]
+    fn price_summary_lowest_gil_picks_minimum_when_both_present() {
+        let summary = PriceSummary {
+            lq: Some(data(100, 1)),
+            hq: Some(data(80, 1)),
+        };
+        assert_eq!(summary.lowest_gil(), Some(80));
+
+        let summary = PriceSummary {
+            lq: Some(data(100, 1)),
+            hq: Some(data(120, 1)),
+        };
+        assert_eq!(summary.lowest_gil(), Some(100));
+    }
+
+    #[test]
+    fn price_summary_lowest_gil_uses_only_present_side() {
+        let summary = PriceSummary {
+            lq: Some(data(50, 1)),
+            hq: None,
+        };
+        assert_eq!(summary.lowest_gil(), Some(50));
+
+        let summary = PriceSummary {
+            lq: None,
+            hq: Some(data(75, 1)),
+        };
+        assert_eq!(summary.lowest_gil(), Some(75));
+    }
+
+    #[test]
+    fn price_summary_preferring_hq_prefers_hq_even_when_more_expensive() {
+        let summary = PriceSummary {
+            lq: Some(data(50, 1)),
+            hq: Some(data(200, 1)),
+        };
+        assert_eq!(summary.price_preferring_hq(), Some(200));
+    }
+
+    #[test]
+    fn price_summary_preferring_hq_falls_back_to_lq_when_no_hq() {
+        let summary = PriceSummary {
+            lq: Some(data(50, 1)),
+            hq: None,
+        };
+        assert_eq!(summary.price_preferring_hq(), Some(50));
+    }
+
+    #[test]
+    fn price_summary_preferring_hq_none_when_both_missing() {
+        let summary = PriceSummary { lq: None, hq: None };
+        assert_eq!(summary.price_preferring_hq(), None);
+    }
+
+    #[test]
+    fn from_cheapest_listings_builds_map_indexed_by_item_id_and_hq() {
+        let listings = CheapestListings {
+            cheapest_listings: vec![
+                CheapestListingItem {
+                    item_id: 1,
+                    hq: false,
+                    cheapest_price: 100,
+                    world_id: 7,
+                },
+                CheapestListingItem {
+                    item_id: 1,
+                    hq: true,
+                    cheapest_price: 250,
+                    world_id: 9,
+                },
+                CheapestListingItem {
+                    item_id: 2,
+                    hq: false,
+                    cheapest_price: 1,
+                    world_id: 3,
+                },
+            ],
+        };
+        let map: CheapestListingsMap = listings.into();
+        assert_eq!(map.map.len(), 3);
+        let lq = map
+            .map
+            .get(&CheapestListingMapKey {
+                item_id: 1,
+                hq: false,
+            })
+            .unwrap();
+        assert_eq!(lq.price, 100);
+        assert_eq!(lq.world_id, 7);
+        let hq = map
+            .map
+            .get(&CheapestListingMapKey {
+                item_id: 1,
+                hq: true,
+            })
+            .unwrap();
+        assert_eq!(hq.price, 250);
+        assert_eq!(hq.world_id, 9);
+    }
+
+    #[test]
+    fn find_matching_listings_returns_lq_and_hq() {
+        let listings = CheapestListings {
+            cheapest_listings: vec![
+                CheapestListingItem {
+                    item_id: 5,
+                    hq: false,
+                    cheapest_price: 1000,
+                    world_id: 1,
+                },
+                CheapestListingItem {
+                    item_id: 5,
+                    hq: true,
+                    cheapest_price: 2000,
+                    world_id: 1,
+                },
+            ],
+        };
+        let map: CheapestListingsMap = listings.into();
+        let summary = map.find_matching_listings(5);
+        assert_eq!(summary.lq.map(|d| d.price), Some(1000));
+        assert_eq!(summary.hq.map(|d| d.price), Some(2000));
+    }
+
+    #[test]
+    fn find_matching_listings_returns_none_when_item_missing() {
+        let map: CheapestListingsMap = CheapestListings {
+            cheapest_listings: vec![],
+        }
+        .into();
+        let summary = map.find_matching_listings(999);
+        assert!(summary.lq.is_none() && summary.hq.is_none());
+    }
+}

--- a/ultros-api-types/src/icon_size.rs
+++ b/ultros-api-types/src/icon_size.rs
@@ -44,3 +44,51 @@ impl Display for IconSize {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_strings_match_size() {
+        assert_eq!(IconSize::Small.get_class(), "icon-small");
+        assert_eq!(IconSize::Medium.get_class(), "icon-medium");
+        assert_eq!(IconSize::Large.get_class(), "icon-large");
+    }
+
+    #[test]
+    fn px_sizes_are_ordered_ascending() {
+        assert!(IconSize::Small.get_px_size() < IconSize::Medium.get_px_size());
+        assert!(IconSize::Medium.get_px_size() < IconSize::Large.get_px_size());
+    }
+
+    #[test]
+    fn size_px_string_matches_get_px_size() {
+        for size in [IconSize::Small, IconSize::Medium, IconSize::Large] {
+            let expected = format!("{}px", size.get_px_size());
+            assert_eq!(size.get_size_px(), expected);
+        }
+    }
+
+    #[test]
+    fn display_renders_variant_name() {
+        assert_eq!(IconSize::Small.to_string(), "Small");
+        assert_eq!(IconSize::Medium.to_string(), "Medium");
+        assert_eq!(IconSize::Large.to_string(), "Large");
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_value() {
+        for size in [IconSize::Small, IconSize::Medium, IconSize::Large] {
+            let s = serde_json::to_string(&size).unwrap();
+            let back: IconSize = serde_json::from_str(&s).unwrap();
+            assert_eq!(size, back);
+        }
+    }
+
+    #[test]
+    fn ordering_is_small_lt_medium_lt_large() {
+        assert!(IconSize::Small < IconSize::Medium);
+        assert!(IconSize::Medium < IconSize::Large);
+    }
+}

--- a/ultros-api-types/src/list.rs
+++ b/ultros-api-types/src/list.rs
@@ -58,3 +58,57 @@ pub struct ListInvite {
     pub max_uses: Option<i32>,
     pub uses: i32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_permission_from_i16_known_values() {
+        assert_eq!(ListPermission::from(0_i16), ListPermission::None);
+        assert_eq!(ListPermission::from(1_i16), ListPermission::Read);
+        assert_eq!(ListPermission::from(2_i16), ListPermission::Write);
+        assert_eq!(ListPermission::from(3_i16), ListPermission::Owner);
+    }
+
+    #[test]
+    fn list_permission_from_unknown_falls_back_to_none() {
+        assert_eq!(ListPermission::from(-1_i16), ListPermission::None);
+        assert_eq!(ListPermission::from(4_i16), ListPermission::None);
+        assert_eq!(ListPermission::from(i16::MAX), ListPermission::None);
+        assert_eq!(ListPermission::from(i16::MIN), ListPermission::None);
+    }
+
+    #[test]
+    fn list_permission_ord_increases_with_capability() {
+        assert!(ListPermission::None < ListPermission::Read);
+        assert!(ListPermission::Read < ListPermission::Write);
+        assert!(ListPermission::Write < ListPermission::Owner);
+    }
+
+    #[test]
+    fn list_item_default_is_all_zero_and_none() {
+        let item = ListItem::default();
+        assert_eq!(item.id, 0);
+        assert_eq!(item.item_id, 0);
+        assert_eq!(item.list_id, 0);
+        assert!(item.hq.is_none());
+        assert!(item.quantity.is_none());
+        assert!(item.acquired.is_none());
+    }
+
+    #[test]
+    fn list_item_serde_roundtrip() {
+        let item = ListItem {
+            id: 1,
+            item_id: 2,
+            list_id: 3,
+            hq: Some(true),
+            quantity: Some(99),
+            acquired: Some(50),
+        };
+        let s = serde_json::to_string(&item).unwrap();
+        let back: ListItem = serde_json::from_str(&s).unwrap();
+        assert_eq!(item, back);
+    }
+}

--- a/ultros-api-types/src/result.rs
+++ b/ultros-api-types/src/result.rs
@@ -25,3 +25,41 @@ where
         Self::ApiError(ApiError::Message(str_value))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_error_display_messages() {
+        let e = ApiError::Message("boom".into());
+        assert_eq!(e.to_string(), "Generic error: boom");
+        let e = ApiError::NotAuthenticated;
+        assert_eq!(
+            e.to_string(),
+            "Unauthenticated. Please login to use this feature"
+        );
+    }
+
+    #[test]
+    fn api_error_serde_roundtrip() {
+        for e in [
+            ApiError::Message("oops".into()),
+            ApiError::NotAuthenticated,
+        ] {
+            let s = serde_json::to_string(&e).unwrap();
+            let back: ApiError = serde_json::from_str(&s).unwrap();
+            assert_eq!(e, back);
+        }
+    }
+
+    #[test]
+    fn json_error_wrapper_from_std_error_captures_message() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let wrapper: JsonErrorWrapper = io.into();
+        match wrapper {
+            JsonErrorWrapper::ApiError(ApiError::Message(s)) => assert_eq!(s, "missing"),
+            _ => panic!("expected ApiError::Message"),
+        }
+    }
+}

--- a/ultros-api-types/src/result.rs
+++ b/ultros-api-types/src/result.rs
@@ -43,10 +43,7 @@ mod tests {
 
     #[test]
     fn api_error_serde_roundtrip() {
-        for e in [
-            ApiError::Message("oops".into()),
-            ApiError::NotAuthenticated,
-        ] {
+        for e in [ApiError::Message("oops".into()), ApiError::NotAuthenticated] {
             let s = serde_json::to_string(&e).unwrap();
             let back: ApiError = serde_json::from_str(&s).unwrap();
             assert_eq!(e, back);

--- a/ultros-api-types/src/websocket.rs
+++ b/ultros-api-types/src/websocket.rs
@@ -325,7 +325,9 @@ mod tests {
             .and(FilterPredicate::Retainer("Bob".into()));
         assert!(both.filter(&h, &data));
         // and: one false ⇒ false
-        let one = item_miss.clone().and(FilterPredicate::Retainer("Bob".into()));
+        let one = item_miss
+            .clone()
+            .and(FilterPredicate::Retainer("Bob".into()));
         assert!(!one.filter(&h, &data));
         // or: one true ⇒ true
         let or_one = item_miss.clone().or(item_match.clone());
@@ -361,7 +363,7 @@ mod tests {
 
     #[test]
     fn undercut_retainer_orders_by_struct_field_order() {
-        let mut v = vec![
+        let mut v = [
             UndercutRetainer {
                 id: 2,
                 name: "B".into(),

--- a/ultros-api-types/src/websocket.rs
+++ b/ultros-api-types/src/websocket.rs
@@ -189,3 +189,192 @@ pub enum AlertsTx {
         item_id: i32,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::{Datacenter, Region, World, WorldData};
+    use chrono::NaiveDateTime;
+
+    fn helper() -> WorldHelper {
+        WorldData {
+            regions: vec![Region {
+                id: 1,
+                name: "NA".into(),
+                datacenters: vec![Datacenter {
+                    id: 10,
+                    name: "Aether".into(),
+                    region_id: 1,
+                    worlds: vec![
+                        World {
+                            id: 100,
+                            name: "Adamantoise".into(),
+                            datacenter_id: 10,
+                        },
+                        World {
+                            id: 101,
+                            name: "Cactuar".into(),
+                            datacenter_id: 10,
+                        },
+                    ],
+                }],
+            }],
+        }
+        .into()
+    }
+
+    fn listing(world_id: i32, item_id: i32, price: i32) -> (ActiveListing, Retainer) {
+        (
+            ActiveListing {
+                id: 1,
+                world_id,
+                item_id,
+                retainer_id: 7,
+                price_per_unit: price,
+                quantity: 1,
+                hq: false,
+                timestamp: NaiveDateTime::default(),
+            },
+            Retainer {
+                id: 7,
+                world_id,
+                name: "Bob".into(),
+                retainer_city_id: 1,
+            },
+        )
+    }
+
+    #[test]
+    fn predicate_world_matches_same_world() {
+        let h = helper();
+        let data = listing(100, 5, 1000);
+        let pred = FilterPredicate::World(AnySelector::World(100));
+        assert!(pred.filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_world_matches_when_event_world_is_inside_filter_dc() {
+        let h = helper();
+        let data = listing(100, 5, 1000);
+        let pred = FilterPredicate::World(AnySelector::Datacenter(10));
+        assert!(pred.filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_world_misses_for_unknown_event_world() {
+        // Per impl, unknown lookup defaults to `true` (no filtering applied).
+        let h = helper();
+        let data = listing(999, 5, 1000);
+        let pred = FilterPredicate::World(AnySelector::World(100));
+        assert!(pred.filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_item_id_matches_exact() {
+        let h = helper();
+        let data = listing(100, 42, 100);
+        assert!(FilterPredicate::Item(42).filter(&h, &data));
+        assert!(!FilterPredicate::Item(43).filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_retainer_matches_exact_name() {
+        let h = helper();
+        let data = listing(100, 1, 1);
+        assert!(FilterPredicate::Retainer("Bob".into()).filter(&h, &data));
+        assert!(!FilterPredicate::Retainer("Alice".into()).filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_character_defaults_to_true_when_listing_has_no_character() {
+        let h = helper();
+        let data = listing(100, 1, 1);
+        // ActiveListing+Retainer.character() returns None, so filter returns true.
+        assert!(FilterPredicate::Character("anyone".into()).filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_price_at_least_passes_when_price_is_at_or_below_threshold() {
+        let h = helper();
+        let data = listing(100, 1, 100);
+        // PriceAtLeast(threshold) means data.price() <= threshold
+        assert!(FilterPredicate::PriceAtLeast(100).filter(&h, &data));
+        assert!(FilterPredicate::PriceAtLeast(200).filter(&h, &data));
+        assert!(!FilterPredicate::PriceAtLeast(50).filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_price_at_most_passes_when_price_is_at_or_above_threshold() {
+        let h = helper();
+        let data = listing(100, 1, 100);
+        // PriceAtMost(threshold) means data.price() >= threshold
+        assert!(FilterPredicate::PriceAtMost(50).filter(&h, &data));
+        assert!(FilterPredicate::PriceAtMost(100).filter(&h, &data));
+        assert!(!FilterPredicate::PriceAtMost(200).filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_and_or_combinators_short_circuit_correctly() {
+        let h = helper();
+        let data = listing(100, 42, 100);
+        let item_match = FilterPredicate::Item(42);
+        let item_miss = FilterPredicate::Item(99);
+        // and: both true ⇒ true
+        let both = item_match
+            .clone()
+            .and(FilterPredicate::Retainer("Bob".into()));
+        assert!(both.filter(&h, &data));
+        // and: one false ⇒ false
+        let one = item_miss.clone().and(FilterPredicate::Retainer("Bob".into()));
+        assert!(!one.filter(&h, &data));
+        // or: one true ⇒ true
+        let or_one = item_miss.clone().or(item_match.clone());
+        assert!(or_one.filter(&h, &data));
+        // or: none true ⇒ false
+        let or_none = item_miss.or(FilterPredicate::Retainer("Nobody".into()));
+        assert!(!or_none.filter(&h, &data));
+    }
+
+    #[test]
+    fn predicate_serde_roundtrip_through_json() {
+        let pred = FilterPredicate::Item(42)
+            .and(FilterPredicate::PriceAtMost(100))
+            .or(FilterPredicate::Retainer("Bob".into()));
+        let s = serde_json::to_string(&pred).unwrap();
+        let back: FilterPredicate = serde_json::from_str(&s).unwrap();
+        // Round-trip the round-trip to compare structurally via JSON.
+        let s2 = serde_json::to_string(&back).unwrap();
+        assert_eq!(s, s2);
+    }
+
+    #[test]
+    fn predicate_data_sources_for_listing_returns_expected_fields() {
+        let h = helper();
+        let data = listing(100, 7, 1234);
+        let _ = h; // unused, just to mirror call sites
+        assert_eq!(data.world(), AnySelector::World(100));
+        assert_eq!(data.item(), 7);
+        assert_eq!(data.price(), 1234);
+        assert!(data.character().is_none());
+        assert_eq!(data.retainer(), Some("Bob"));
+    }
+
+    #[test]
+    fn undercut_retainer_orders_by_struct_field_order() {
+        let mut v = vec![
+            UndercutRetainer {
+                id: 2,
+                name: "B".into(),
+                undercut_amount: 0,
+            },
+            UndercutRetainer {
+                id: 1,
+                name: "A".into(),
+                undercut_amount: 0,
+            },
+        ];
+        v.sort();
+        assert_eq!(v[0].id, 1);
+        assert_eq!(v[1].id, 2);
+    }
+}

--- a/ultros-api-types/src/world_helper.rs
+++ b/ultros-api-types/src/world_helper.rs
@@ -498,7 +498,11 @@ mod tests {
     fn get_datacenters_for_region_returns_all_datacenters() {
         let helper: WorldHelper = sample_world_data().into();
         let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
-        let ids: Vec<_> = helper.get_datacenters(&region).iter().map(|d| d.id).collect();
+        let ids: Vec<_> = helper
+            .get_datacenters(&region)
+            .iter()
+            .map(|d| d.id)
+            .collect();
         assert_eq!(ids, vec![10, 11]);
     }
 

--- a/ultros-api-types/src/world_helper.rs
+++ b/ultros-api-types/src/world_helper.rs
@@ -276,3 +276,295 @@ impl<'a> WorldHelper {
         self.world_data.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::{Datacenter, Region, World, WorldData};
+
+    fn sample_world_data() -> WorldData {
+        // Region 1 "North-America" → DC 10 "Aether" → Worlds 100 "Adamantoise", 101 "Cactuar"
+        // Region 1 "North-America" → DC 11 "Primal" → World 110 "Behemoth"
+        // Region 2 "Japan" → DC 20 "Elemental" → World 200 "Aegis"
+        WorldData {
+            regions: vec![
+                Region {
+                    id: 1,
+                    name: "North-America".into(),
+                    datacenters: vec![
+                        Datacenter {
+                            id: 10,
+                            name: "Aether".into(),
+                            region_id: 1,
+                            worlds: vec![
+                                World {
+                                    id: 100,
+                                    name: "Adamantoise".into(),
+                                    datacenter_id: 10,
+                                },
+                                World {
+                                    id: 101,
+                                    name: "Cactuar".into(),
+                                    datacenter_id: 10,
+                                },
+                            ],
+                        },
+                        Datacenter {
+                            id: 11,
+                            name: "Primal".into(),
+                            region_id: 1,
+                            worlds: vec![World {
+                                id: 110,
+                                name: "Behemoth".into(),
+                                datacenter_id: 11,
+                            }],
+                        },
+                    ],
+                },
+                Region {
+                    id: 2,
+                    name: "Japan".into(),
+                    datacenters: vec![Datacenter {
+                        id: 20,
+                        name: "Elemental".into(),
+                        region_id: 2,
+                        worlds: vec![World {
+                            id: 200,
+                            name: "Aegis".into(),
+                            datacenter_id: 20,
+                        }],
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn any_selector_as_world_id_only_for_world_variant() {
+        assert_eq!(AnySelector::World(7).as_world_id(), Some(7));
+        assert_eq!(AnySelector::Datacenter(7).as_world_id(), None);
+        assert_eq!(AnySelector::Region(7).as_world_id(), None);
+    }
+
+    #[test]
+    fn any_selector_serde_roundtrip() {
+        for s in [
+            AnySelector::Region(1),
+            AnySelector::Datacenter(10),
+            AnySelector::World(100),
+        ] {
+            let j = serde_json::to_string(&s).unwrap();
+            let back: AnySelector = serde_json::from_str(&j).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn lookup_selector_finds_each_kind() {
+        let helper: WorldHelper = sample_world_data().into();
+        assert!(matches!(
+            helper.lookup_selector(AnySelector::Region(1)),
+            Some(AnyResult::Region(r)) if r.id == 1
+        ));
+        assert!(matches!(
+            helper.lookup_selector(AnySelector::Datacenter(10)),
+            Some(AnyResult::Datacenter(d)) if d.id == 10
+        ));
+        assert!(matches!(
+            helper.lookup_selector(AnySelector::World(100)),
+            Some(AnyResult::World(w)) if w.id == 100
+        ));
+    }
+
+    #[test]
+    fn lookup_selector_returns_none_for_unknown_id() {
+        let helper: WorldHelper = sample_world_data().into();
+        assert!(helper.lookup_selector(AnySelector::World(99999)).is_none());
+        assert!(
+            helper
+                .lookup_selector(AnySelector::Datacenter(99999))
+                .is_none()
+        );
+        assert!(helper.lookup_selector(AnySelector::Region(99999)).is_none());
+    }
+
+    #[test]
+    fn lookup_world_by_name_is_case_insensitive() {
+        let helper: WorldHelper = sample_world_data().into();
+        let r = helper.lookup_world_by_name("adamantoise").unwrap();
+        assert_eq!(r.get_name(), "Adamantoise");
+        let r = helper.lookup_world_by_name("AETHER").unwrap();
+        assert_eq!(r.get_name(), "Aether");
+    }
+
+    #[test]
+    fn lookup_world_by_name_finds_region_dc_or_world() {
+        let helper: WorldHelper = sample_world_data().into();
+        assert!(matches!(
+            helper.lookup_world_by_name("North-America"),
+            Some(AnyResult::Region(_))
+        ));
+        assert!(matches!(
+            helper.lookup_world_by_name("Primal"),
+            Some(AnyResult::Datacenter(_))
+        ));
+        assert!(matches!(
+            helper.lookup_world_by_name("Behemoth"),
+            Some(AnyResult::World(_))
+        ));
+    }
+
+    #[test]
+    fn lookup_world_by_name_missing_returns_none() {
+        let helper: WorldHelper = sample_world_data().into();
+        assert!(helper.lookup_world_by_name("Nowhere").is_none());
+    }
+
+    #[test]
+    fn any_result_is_in_self_is_true() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        assert!(world.is_in(&world));
+    }
+
+    #[test]
+    fn any_result_world_is_in_its_datacenter_and_region() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        let dc = helper.lookup_selector(AnySelector::Datacenter(10)).unwrap();
+        let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
+        assert!(world.is_in(&dc));
+        assert!(world.is_in(&region));
+    }
+
+    #[test]
+    fn any_result_world_not_in_foreign_dc_or_region() {
+        let helper: WorldHelper = sample_world_data().into();
+        let na_world = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        let jp_dc = helper.lookup_selector(AnySelector::Datacenter(20)).unwrap();
+        let jp_region = helper.lookup_selector(AnySelector::Region(2)).unwrap();
+        assert!(!na_world.is_in(&jp_dc));
+        assert!(!na_world.is_in(&jp_region));
+    }
+
+    #[test]
+    fn any_result_datacenter_in_region_match() {
+        let helper: WorldHelper = sample_world_data().into();
+        let dc = helper.lookup_selector(AnySelector::Datacenter(10)).unwrap();
+        let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
+        assert!(dc.is_in(&region));
+        let other_region = helper.lookup_selector(AnySelector::Region(2)).unwrap();
+        assert!(!dc.is_in(&other_region));
+    }
+
+    #[test]
+    fn any_result_dc_never_contains_region_or_world_when_swapped() {
+        // The `is_in` impl has explicit asymmetric cases; the unhandled directions return false.
+        let helper: WorldHelper = sample_world_data().into();
+        let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
+        let dc = helper.lookup_selector(AnySelector::Datacenter(10)).unwrap();
+        let world = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        // Region is_in DC / Region is_in World — explicitly false branch
+        assert!(!region.is_in(&dc));
+        assert!(!region.is_in(&world));
+        assert!(!dc.is_in(&world));
+    }
+
+    #[test]
+    fn all_worlds_for_region_yields_every_world_in_every_dc() {
+        let helper: WorldHelper = sample_world_data().into();
+        let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
+        let ids: Vec<_> = region.all_worlds().map(|w| w.id).collect();
+        assert_eq!(ids, vec![100, 101, 110]);
+    }
+
+    #[test]
+    fn all_worlds_for_datacenter_yields_only_its_worlds() {
+        let helper: WorldHelper = sample_world_data().into();
+        let dc = helper.lookup_selector(AnySelector::Datacenter(10)).unwrap();
+        let ids: Vec<_> = dc.all_worlds().map(|w| w.id).collect();
+        assert_eq!(ids, vec![100, 101]);
+    }
+
+    #[test]
+    fn all_worlds_for_world_yields_only_itself() {
+        let helper: WorldHelper = sample_world_data().into();
+        let w = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        let ids: Vec<_> = w.all_worlds().map(|w| w.id).collect();
+        assert_eq!(ids, vec![100]);
+    }
+
+    #[test]
+    fn get_datacenters_for_region_returns_all_datacenters() {
+        let helper: WorldHelper = sample_world_data().into();
+        let region = helper.lookup_selector(AnySelector::Region(1)).unwrap();
+        let ids: Vec<_> = helper.get_datacenters(&region).iter().map(|d| d.id).collect();
+        assert_eq!(ids, vec![10, 11]);
+    }
+
+    #[test]
+    fn get_datacenters_for_world_returns_owning_dc() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(110)).unwrap();
+        let dcs = helper.get_datacenters(&world);
+        assert_eq!(dcs.len(), 1);
+        assert_eq!(dcs[0].id, 11);
+    }
+
+    #[test]
+    fn get_region_for_world_returns_owning_region() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(200)).unwrap();
+        let region = helper.get_region(world);
+        assert_eq!(region.id, 2);
+    }
+
+    #[test]
+    fn get_region_for_datacenter_returns_owning_region() {
+        let helper: WorldHelper = sample_world_data().into();
+        let dc = helper.lookup_selector(AnySelector::Datacenter(11)).unwrap();
+        let region = helper.get_region(dc);
+        assert_eq!(region.id, 1);
+    }
+
+    #[test]
+    fn iter_yields_regions_datacenters_and_worlds_each() {
+        let helper: WorldHelper = sample_world_data().into();
+        let mut regions = 0;
+        let mut datacenters = 0;
+        let mut worlds = 0;
+        for any in helper.iter() {
+            match any {
+                AnyResult::Region(_) => regions += 1,
+                AnyResult::Datacenter(_) => datacenters += 1,
+                AnyResult::World(_) => worlds += 1,
+            }
+        }
+        assert_eq!(regions, 2);
+        assert_eq!(datacenters, 3);
+        assert_eq!(worlds, 4);
+    }
+
+    #[test]
+    fn any_result_selector_conversion_matches_id() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(101)).unwrap();
+        assert_eq!(AnySelector::from(&world), AnySelector::World(101));
+        let dc = helper.lookup_selector(AnySelector::Datacenter(11)).unwrap();
+        assert_eq!(AnySelector::from(&dc), AnySelector::Datacenter(11));
+        let region = helper.lookup_selector(AnySelector::Region(2)).unwrap();
+        assert_eq!(AnySelector::from(&region), AnySelector::Region(2));
+    }
+
+    #[test]
+    fn owned_result_get_name_matches_inner() {
+        let helper: WorldHelper = sample_world_data().into();
+        let world = helper.lookup_selector(AnySelector::World(100)).unwrap();
+        let owned: OwnedResult = world.into();
+        assert_eq!(owned.get_name(), "Adamantoise");
+        // round-trip ref
+        assert_eq!(owned.as_ref().get_name(), "Adamantoise");
+        // into selector
+        assert_eq!(AnySelector::from(owned), AnySelector::World(100));
+    }
+}

--- a/ultros-db/Cargo.toml
+++ b/ultros-db/Cargo.toml
@@ -27,3 +27,6 @@ rkyv = { version = "0.7.42", features = ["validation", "size_64", "hashbrown"], 
 
 [features]
 rkyv = ["dep:rkyv"]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/ultros-db/src/common/partial_diff_iterator.rs
+++ b/ultros-db/src/common/partial_diff_iterator.rs
@@ -164,4 +164,77 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn empty_inputs_yield_nothing() {
+        let a_set: [TestA; 0] = [];
+        let b_set: [TestB; 0] = [];
+        let iter = PartialDiffIterator::from((a_set.iter(), b_set.iter()));
+        assert_eq!(iter.count(), 0);
+    }
+
+    #[test]
+    fn left_only_emits_all_as_left() {
+        let a_set = [TestA { name: "a", id: 1 }, TestA { name: "b", id: 2 }];
+        let b_set: [TestB; 0] = [];
+        let iter = PartialDiffIterator::from((a_set.iter(), b_set.iter()));
+        let results: Vec<_> = iter.collect();
+        assert_eq!(
+            results,
+            vec![DiffItem::Left(&a_set[0]), DiffItem::Left(&a_set[1])]
+        );
+    }
+
+    #[test]
+    fn right_only_emits_all_as_right() {
+        let a_set: [TestA; 0] = [];
+        let b_set = [TestB { name: "a" }, TestB { name: "b" }];
+        let iter = PartialDiffIterator::from((a_set.iter(), b_set.iter()));
+        let results: Vec<_> = iter.collect();
+        assert_eq!(
+            results,
+            vec![DiffItem::Right(&b_set[0]), DiffItem::Right(&b_set[1])]
+        );
+    }
+
+    #[test]
+    fn identical_sets_collapse_to_all_same() {
+        let a_set = [TestA { name: "x", id: 1 }, TestA { name: "y", id: 2 }];
+        let b_set = [TestB { name: "x" }, TestB { name: "y" }];
+        let iter = PartialDiffIterator::from((a_set.iter(), b_set.iter()));
+        let results: Vec<_> = iter.collect();
+        assert_eq!(
+            results,
+            vec![
+                DiffItem::Same(&a_set[0], &b_set[0]),
+                DiffItem::Same(&a_set[1], &b_set[1]),
+            ]
+        );
+    }
+
+    #[test]
+    fn diff_item_accessors_pick_the_matching_variant() {
+        let a = TestA { name: "x", id: 1 };
+        let b = TestB { name: "x" };
+
+        // Same: only `.same()` returns Some
+        let same: DiffItem<&TestA, &TestB> = DiffItem::Same(&a, &b);
+        assert!(same.left().is_none());
+        let same: DiffItem<&TestA, &TestB> = DiffItem::Same(&a, &b);
+        assert!(same.right().is_none());
+        let same: DiffItem<&TestA, &TestB> = DiffItem::Same(&a, &b);
+        assert_eq!(same.same(), Some((&a, &b)));
+
+        // Left: only `.left()` returns Some
+        let left: DiffItem<&TestA, &TestB> = DiffItem::Left(&a);
+        assert_eq!(left.left(), Some(&a));
+        let left: DiffItem<&TestA, &TestB> = DiffItem::Left(&a);
+        assert!(left.right().is_none());
+
+        // Right: only `.right()` returns Some
+        let right: DiffItem<&TestA, &TestB> = DiffItem::Right(&b);
+        assert_eq!(right.right(), Some(&b));
+        let right: DiffItem<&TestA, &TestB> = DiffItem::Right(&b);
+        assert!(right.left().is_none());
+    }
 }

--- a/ultros-db/src/common/try_update_value.rs
+++ b/ultros-db/src/common/try_update_value.rs
@@ -25,3 +25,44 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::ActiveValue;
+
+    #[test]
+    fn unchanged_stays_unchanged_when_new_value_equals_old() {
+        let mut v: ActiveValue<i32> = ActiveValue::Unchanged(42);
+        v.cmp_set_value(42);
+        assert!(matches!(v, ActiveValue::Unchanged(42)));
+    }
+
+    #[test]
+    fn unchanged_becomes_set_when_new_value_differs() {
+        let mut v: ActiveValue<i32> = ActiveValue::Unchanged(42);
+        v.cmp_set_value(99);
+        assert!(matches!(v, ActiveValue::Set(99)));
+    }
+
+    #[test]
+    fn set_remains_set_with_updated_value() {
+        let mut v: ActiveValue<i32> = ActiveValue::Set(1);
+        v.cmp_set_value(2);
+        assert!(matches!(v, ActiveValue::Set(2)));
+    }
+
+    #[test]
+    fn set_remains_set_with_same_value() {
+        let mut v: ActiveValue<i32> = ActiveValue::Set(7);
+        v.cmp_set_value(7);
+        assert!(matches!(v, ActiveValue::Set(7)));
+    }
+
+    #[test]
+    fn not_set_remains_not_set_after_cmp_set() {
+        let mut v: ActiveValue<i32> = ActiveValue::NotSet;
+        v.cmp_set_value(123);
+        assert!(matches!(v, ActiveValue::NotSet));
+    }
+}

--- a/ultros-db/src/world_data/world_cache.rs
+++ b/ultros-db/src/world_data/world_cache.rs
@@ -416,3 +416,105 @@ impl WorldCache {
             .flat_map(|(_, d)| d.iter().flat_map(|(_, worlds)| worlds.iter()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn world(id: i32, datacenter_id: i32, name: &str) -> world::Model {
+        world::Model {
+            id,
+            name: name.to_string(),
+            datacenter_id,
+        }
+    }
+
+    fn datacenter(id: i32, region_id: i32, name: &str) -> datacenter::Model {
+        datacenter::Model {
+            id,
+            name: name.to_string(),
+            region_id,
+        }
+    }
+
+    fn region(id: i32, name: &str) -> region::Model {
+        region::Model {
+            id,
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn any_selector_serde_roundtrip() {
+        for s in [
+            AnySelector::World(1),
+            AnySelector::Datacenter(2),
+            AnySelector::Region(3),
+        ] {
+            let j = serde_json::to_string(&s).unwrap();
+            let back: AnySelector = serde_json::from_str(&j).unwrap();
+            assert_eq!(s, back);
+        }
+    }
+
+    #[test]
+    fn any_selector_ord_matches_variant_order() {
+        // Per `Ord` derive: variants are ordered by declaration: World < Datacenter < Region.
+        assert!(AnySelector::World(1) < AnySelector::Datacenter(0));
+        assert!(AnySelector::Datacenter(99) < AnySelector::Region(0));
+        // Same variant: ordered by inner id.
+        assert!(AnySelector::World(1) < AnySelector::World(2));
+    }
+
+    #[test]
+    fn any_result_get_name_returns_inner_name() {
+        let r = region(1, "NA");
+        let d = datacenter(10, 1, "Aether");
+        let w = world(100, 10, "Adamantoise");
+        assert_eq!(AnyResult::Region(&r).get_name(), "NA");
+        assert_eq!(AnyResult::Datacenter(&d).get_name(), "Aether");
+        assert_eq!(AnyResult::World(&w).get_name(), "Adamantoise");
+    }
+
+    #[test]
+    fn any_result_as_world_ok_only_for_world_variant() {
+        let r = region(1, "NA");
+        let d = datacenter(10, 1, "Aether");
+        let w = world(100, 10, "Adamantoise");
+        assert!(AnyResult::World(&w).as_world().is_ok());
+        assert!(matches!(
+            AnyResult::Datacenter(&d).as_world(),
+            Err(WorldCacheError::NotWorld)
+        ));
+        assert!(matches!(
+            AnyResult::Region(&r).as_world(),
+            Err(WorldCacheError::NotWorld)
+        ));
+    }
+
+    #[test]
+    fn any_selector_from_any_result_reads_id() {
+        let r = region(1, "NA");
+        let d = datacenter(10, 1, "Aether");
+        let w = world(100, 10, "Adamantoise");
+        let ar = AnyResult::Region(&r);
+        let ad = AnyResult::Datacenter(&d);
+        let aw = AnyResult::World(&w);
+        assert_eq!(AnySelector::from(&ar), AnySelector::Region(1));
+        assert_eq!(AnySelector::from(&ad), AnySelector::Datacenter(10));
+        assert_eq!(AnySelector::from(&aw), AnySelector::World(100));
+    }
+
+    #[test]
+    fn world_cache_error_messages_include_ids() {
+        assert!(WorldCacheError::World(42).to_string().contains("42"));
+        assert!(WorldCacheError::Datacenter(7).to_string().contains("7"));
+        assert!(WorldCacheError::Region(9).to_string().contains("9"));
+        assert_eq!(WorldCacheError::NotWorld.to_string(), "Not a world");
+        assert!(
+            WorldCacheError::NameLookupError("foo".into())
+                .to_string()
+                .contains("foo")
+        );
+    }
+}

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use tracing::error;
 use ultros_db::UltrosDb;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(tag = "method")]
 pub(crate) enum EndpointConfig {
     #[serde(rename = "DiscordChannel")]
@@ -15,6 +15,26 @@ pub(crate) enum EndpointConfig {
     DiscordDm { user_id: i64 },
     #[serde(rename = "Webhook")]
     Webhook { url: String },
+}
+
+/// Parse a notification endpoint row's `(method, config)` pair into a typed [`EndpointConfig`].
+///
+/// The DB stores `method` as a separate column and `config` as a JSON object missing the
+/// discriminator — this helper splices the discriminator in so `serde(tag = "method")` can
+/// deserialize the result.
+pub(crate) fn parse_endpoint_config(
+    method: &str,
+    config: &serde_json::Value,
+) -> Result<EndpointConfig> {
+    let mut config_obj =
+        serde_json::from_value::<serde_json::Map<String, serde_json::Value>>(config.clone())
+            .unwrap_or_default();
+    config_obj.insert(
+        "method".to_string(),
+        serde_json::Value::String(method.to_string()),
+    );
+    serde_json::from_value(serde_json::Value::Object(config_obj))
+        .map_err(|e| anyhow!("bad endpoint config: {e}"))
 }
 
 /// Look up all notification endpoints for an alert and dispatch the message via each.
@@ -36,23 +56,13 @@ pub(crate) async fn dispatch_alert(
     let mut any_ok = false;
 
     for endpoint in endpoints {
-        // Re-construct the tagged enum from the method string + config JSON object.
-        let mut config_obj = serde_json::from_value::<serde_json::Map<String, serde_json::Value>>(
-            endpoint.config.clone(),
-        )
-        .unwrap_or_default();
-        config_obj.insert(
-            "method".to_string(),
-            serde_json::Value::String(endpoint.method.clone()),
-        );
-        let parsed: EndpointConfig =
-            match serde_json::from_value(serde_json::Value::Object(config_obj)) {
-                Ok(p) => p,
-                Err(e) => {
-                    last_err = Some(anyhow!("bad endpoint config for {}: {e}", endpoint.id));
-                    continue;
-                }
-            };
+        let parsed = match parse_endpoint_config(&endpoint.method, &endpoint.config) {
+            Ok(p) => p,
+            Err(e) => {
+                last_err = Some(anyhow!("bad endpoint config for {}: {e}", endpoint.id));
+                continue;
+            }
+        };
 
         let result = match parsed {
             EndpointConfig::DiscordChannel { channel_id } => {
@@ -144,4 +154,77 @@ async fn send_webhook(url: &str, title: &str, body: &str) -> Result<()> {
         return Err(anyhow!("webhook returned {status}: {body}"));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_discord_dm_from_method_plus_config() {
+        let cfg = json!({ "user_id": 1234 });
+        let parsed = parse_endpoint_config("DiscordDm", &cfg).unwrap();
+        assert_eq!(parsed, EndpointConfig::DiscordDm { user_id: 1234 });
+    }
+
+    #[test]
+    fn parses_discord_channel_from_method_plus_config() {
+        let cfg = json!({ "channel_id": 99 });
+        let parsed = parse_endpoint_config("DiscordChannel", &cfg).unwrap();
+        assert_eq!(parsed, EndpointConfig::DiscordChannel { channel_id: 99 });
+    }
+
+    #[test]
+    fn parses_webhook_from_method_plus_config() {
+        let cfg = json!({ "url": "https://discord.com/api/webhooks/1/abc" });
+        let parsed = parse_endpoint_config("Webhook", &cfg).unwrap();
+        assert_eq!(
+            parsed,
+            EndpointConfig::Webhook {
+                url: "https://discord.com/api/webhooks/1/abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_endpoint_ignores_method_field_already_present_in_config() {
+        // The splicing overwrites any existing "method" key in the config object —
+        // protects against double-tagged rows in the DB.
+        let cfg = json!({ "method": "WrongMethod", "user_id": 7 });
+        let parsed = parse_endpoint_config("DiscordDm", &cfg).unwrap();
+        assert_eq!(parsed, EndpointConfig::DiscordDm { user_id: 7 });
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_unknown_method() {
+        let cfg = json!({ "user_id": 1 });
+        assert!(parse_endpoint_config("Pigeon", &cfg).is_err());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_missing_required_fields() {
+        // DiscordDm requires user_id; missing it is a parse error.
+        let cfg = json!({});
+        assert!(parse_endpoint_config("DiscordDm", &cfg).is_err());
+        // Webhook requires url; missing it is also a parse error.
+        assert!(parse_endpoint_config("Webhook", &cfg).is_err());
+    }
+
+    #[test]
+    fn parse_endpoint_rejects_wrong_type_for_id() {
+        let cfg = json!({ "user_id": "not-a-number" });
+        assert!(parse_endpoint_config("DiscordDm", &cfg).is_err());
+    }
+
+    #[test]
+    fn parse_endpoint_treats_non_object_config_as_empty() {
+        // If the DB stores null/array/string as config, the splicer turns it into an
+        // object with just the method tag, which then fails for missing fields. We
+        // only assert that we don't panic and return an error rather than success.
+        for bad in [json!(null), json!([]), json!("string"), json!(42)] {
+            let r = parse_endpoint_config("DiscordDm", &bad);
+            assert!(r.is_err(), "expected err for config: {bad}");
+        }
+    }
 }

--- a/ultros/src/alerts/price_alert_tracker.rs
+++ b/ultros/src/alerts/price_alert_tracker.rs
@@ -8,7 +8,9 @@ use chrono::{DateTime, Utc};
 use poise::serenity_prelude;
 use tokio::sync::Mutex;
 use tracing::{error, info, instrument, warn};
-use ultros_api_types::{websocket::ListingEventData, world_helper::AnySelector as ApiAnySelector};
+use ultros_api_types::{
+    ActiveListing, websocket::ListingEventData, world_helper::AnySelector as ApiAnySelector,
+};
 use ultros_db::{
     UltrosDb,
     entity::{alert, alert_item_threshold},
@@ -18,23 +20,69 @@ use ultros_db::{
 use crate::alerts::delivery::dispatch_alert;
 use crate::event::{EventBus, EventType};
 
-pub(crate) fn is_off_cooldown(last_fired_at: Option<DateTime<Utc>>, cooldown_seconds: i32) -> bool {
+/// True when an alert with the given `last_fired_at` is free to fire again given `cooldown_seconds`
+/// as of the reference timestamp `now`. `None` (never fired) is always off cooldown.
+pub(crate) fn is_off_cooldown_at(
+    last_fired_at: Option<DateTime<Utc>>,
+    cooldown_seconds: i32,
+    now: DateTime<Utc>,
+) -> bool {
     match last_fired_at {
         None => true,
-        Some(t) => Utc::now().signed_duration_since(t).num_seconds() >= cooldown_seconds as i64,
+        Some(t) => now.signed_duration_since(t).num_seconds() >= cooldown_seconds as i64,
     }
 }
 
-#[derive(Debug, Clone)]
-struct ActiveRule {
-    alert_id: i32,
+/// Returns true if `listing` satisfies every condition of `rule` and the rule is off
+/// cooldown at `now`. Pure: no DB calls, no `Utc::now()`.
+pub(crate) fn rule_matches_listing(
+    rule: &ActiveRule,
+    listing: &ActiveListing,
+    now: DateTime<Utc>,
+) -> bool {
+    if !rule.world_id_set.contains(&listing.world_id) {
+        return false;
+    }
+    if rule.hq_only && !listing.hq {
+        return false;
+    }
+    if listing.price_per_unit > rule.price_threshold {
+        return false;
+    }
+    is_off_cooldown_at(rule.last_fired_at, rule.cooldown_seconds, now)
+}
+
+/// Build the Discord embed title + body for a threshold-alert firing. Pure.
+pub(crate) fn format_threshold_alert_message(
+    item_name: &str,
     item_id: i32,
+    matched_price: i32,
     price_threshold: i32,
-    hq_only: bool,
-    cooldown_seconds: i32,
-    last_fired_at: Option<DateTime<Utc>>,
+) -> (String, String) {
+    let title = format!("🎯 {item_name} dropped to {matched_price} gil");
+    let body = format!("Threshold: {price_threshold} gil\nhttps://ultros.app/item/{item_id}");
+    (title, body)
+}
+
+/// Look up an item's name in the embedded xiv-gen data, falling back to `"Item {id}"` if missing.
+fn resolve_item_name(item_id: i32) -> String {
+    xiv_gen_db::data()
+        .items
+        .get(&xiv_gen::ItemId(item_id))
+        .map(|i| i.name.as_str().to_string())
+        .unwrap_or_else(|| format!("Item {item_id}"))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ActiveRule {
+    pub(crate) alert_id: i32,
+    pub(crate) item_id: i32,
+    pub(crate) price_threshold: i32,
+    pub(crate) hq_only: bool,
+    pub(crate) cooldown_seconds: i32,
+    pub(crate) last_fired_at: Option<DateTime<Utc>>,
     /// Pre-resolved set of world IDs this rule applies to.
-    world_id_set: HashSet<i32>,
+    pub(crate) world_id_set: HashSet<i32>,
 }
 
 #[derive(Debug, Default)]
@@ -152,6 +200,7 @@ async fn handle_added(
     db: &UltrosDb,
     ctx: &serenity_prelude::Context,
 ) {
+    let now = Utc::now();
     let mut to_fire: Vec<(ActiveRule, i32)> = vec![];
 
     {
@@ -161,34 +210,22 @@ async fn handle_added(
                 continue;
             };
             for rule in rules.iter_mut() {
-                if !rule.world_id_set.contains(&listing.world_id) {
+                if !rule_matches_listing(rule, listing, now) {
                     continue;
                 }
-                if rule.hq_only && !listing.hq {
-                    continue;
-                }
-                if listing.price_per_unit > rule.price_threshold {
-                    continue;
-                }
-                if !is_off_cooldown(rule.last_fired_at, rule.cooldown_seconds) {
-                    continue;
-                }
-                rule.last_fired_at = Some(Utc::now());
+                rule.last_fired_at = Some(now);
                 to_fire.push((rule.clone(), listing.price_per_unit));
             }
         }
     }
 
     for (rule, matched_price) in to_fire {
-        let item_name = xiv_gen_db::data()
-            .items
-            .get(&xiv_gen::ItemId(rule.item_id))
-            .map(|i| i.name.as_str().to_string())
-            .unwrap_or_else(|| format!("Item {}", rule.item_id));
-        let title = format!("🎯 {item_name} dropped to {matched_price} gil");
-        let body = format!(
-            "Threshold: {} gil\nhttps://ultros.app/item/{}",
-            rule.price_threshold, rule.item_id
+        let item_name = resolve_item_name(rule.item_id);
+        let (title, body) = format_threshold_alert_message(
+            &item_name,
+            rule.item_id,
+            matched_price,
+            rule.price_threshold,
         );
 
         let delivery_result = dispatch_alert(rule.alert_id, &title, &body, db, ctx).await;
@@ -223,24 +260,166 @@ async fn handle_added(
 #[cfg(test)]
 mod test {
     use super::*;
-    use chrono::{Duration, Utc};
+    use chrono::{Duration, NaiveDateTime, Utc};
+
+    fn rule(threshold: i32, hq_only: bool, worlds: &[i32]) -> ActiveRule {
+        ActiveRule {
+            alert_id: 1,
+            item_id: 42,
+            price_threshold: threshold,
+            hq_only,
+            cooldown_seconds: 3600,
+            last_fired_at: None,
+            world_id_set: worlds.iter().copied().collect(),
+        }
+    }
+
+    fn listing(world_id: i32, price: i32, hq: bool) -> ActiveListing {
+        ActiveListing {
+            id: 1,
+            world_id,
+            item_id: 42,
+            retainer_id: 1,
+            price_per_unit: price,
+            quantity: 1,
+            hq,
+            timestamp: NaiveDateTime::default(),
+        }
+    }
+
+    // ---------- is_off_cooldown_at ----------
 
     #[test]
     fn cooldown_blocks_recent_fire() {
-        let last = Some(Utc::now() - Duration::seconds(30));
-        let cooldown_s = 3600;
-        assert!(!is_off_cooldown(last, cooldown_s));
+        let now = Utc::now();
+        let last = Some(now - Duration::seconds(30));
+        assert!(!is_off_cooldown_at(last, 3600, now));
     }
 
     #[test]
     fn cooldown_allows_old_fire() {
-        let last = Some(Utc::now() - Duration::seconds(7200));
-        let cooldown_s = 3600;
-        assert!(is_off_cooldown(last, cooldown_s));
+        let now = Utc::now();
+        let last = Some(now - Duration::seconds(7200));
+        assert!(is_off_cooldown_at(last, 3600, now));
     }
 
     #[test]
     fn never_fired_is_off_cooldown() {
-        assert!(is_off_cooldown(None, 3600));
+        assert!(is_off_cooldown_at(None, 3600, Utc::now()));
+    }
+
+    #[test]
+    fn cooldown_boundary_at_exactly_cooldown_seconds_is_off() {
+        // Spec: `>= cooldown_seconds` is off cooldown.
+        let now = Utc::now();
+        let last = Some(now - Duration::seconds(3600));
+        assert!(is_off_cooldown_at(last, 3600, now));
+    }
+
+    #[test]
+    fn cooldown_one_second_before_boundary_is_blocked() {
+        let now = Utc::now();
+        let last = Some(now - Duration::seconds(3599));
+        assert!(!is_off_cooldown_at(last, 3600, now));
+    }
+
+    #[test]
+    fn cooldown_zero_is_always_off() {
+        let now = Utc::now();
+        let last = Some(now);
+        assert!(is_off_cooldown_at(last, 0, now));
+    }
+
+    // ---------- rule_matches_listing ----------
+
+    #[test]
+    fn matches_when_world_price_quality_and_cooldown_all_pass() {
+        let r = rule(100, false, &[1]);
+        let l = listing(1, 50, false);
+        assert!(rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn does_not_match_when_listing_world_not_in_rule_world_set() {
+        let r = rule(100, false, &[1, 2]);
+        let l = listing(999, 50, false);
+        assert!(!rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn does_not_match_when_hq_only_rule_sees_nq_listing() {
+        let r = rule(100, true, &[1]);
+        let l = listing(1, 50, false);
+        assert!(!rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn does_match_when_hq_only_rule_sees_hq_listing() {
+        let r = rule(100, true, &[1]);
+        let l = listing(1, 50, true);
+        assert!(rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn nq_rule_accepts_both_hq_and_nq_listings() {
+        let r = rule(100, false, &[1]);
+        assert!(rule_matches_listing(&r, &listing(1, 50, true), Utc::now()));
+        assert!(rule_matches_listing(&r, &listing(1, 50, false), Utc::now()));
+    }
+
+    #[test]
+    fn does_not_match_when_listing_price_above_threshold() {
+        let r = rule(100, false, &[1]);
+        let l = listing(1, 101, false);
+        assert!(!rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn matches_at_exact_threshold_price() {
+        // "drops to or below" — equal is a match.
+        let r = rule(100, false, &[1]);
+        let l = listing(1, 100, false);
+        assert!(rule_matches_listing(&r, &l, Utc::now()));
+    }
+
+    #[test]
+    fn does_not_match_when_within_cooldown_window() {
+        let now = Utc::now();
+        let mut r = rule(100, false, &[1]);
+        r.last_fired_at = Some(now - Duration::seconds(60));
+        let l = listing(1, 50, false);
+        assert!(!rule_matches_listing(&r, &l, now));
+    }
+
+    #[test]
+    fn matches_after_cooldown_window_passed() {
+        let now = Utc::now();
+        let mut r = rule(100, false, &[1]);
+        r.last_fired_at = Some(now - Duration::seconds(7200));
+        let l = listing(1, 50, false);
+        assert!(rule_matches_listing(&r, &l, now));
+    }
+
+    // ---------- format_threshold_alert_message ----------
+
+    #[test]
+    fn format_message_includes_item_name_and_matched_price_in_title() {
+        let (title, _) = format_threshold_alert_message("Eternity Ring", 36687, 99000, 100000);
+        assert!(title.contains("Eternity Ring"));
+        assert!(title.contains("99000"));
+    }
+
+    #[test]
+    fn format_message_body_includes_threshold_and_universalis_link() {
+        let (_, body) = format_threshold_alert_message("Cordial", 6141, 500, 1000);
+        assert!(body.contains("1000"));
+        assert!(body.contains("ultros.app/item/6141"));
+    }
+
+    #[test]
+    fn format_message_handles_unicode_item_names() {
+        let (title, body) = format_threshold_alert_message("水晶", 100, 50, 60);
+        assert!(title.contains("水晶"));
+        assert!(body.contains("ultros.app/item/100"));
     }
 }

--- a/ultros/src/alerts/undercut_alert.rs
+++ b/ultros/src/alerts/undercut_alert.rs
@@ -489,7 +489,7 @@ mod tests {
     #[test]
     fn undercut_retainer_orders_by_struct_field_declaration_order() {
         // id < name < undercut_amount via derive(Ord) on tuple of fields.
-        let mut v = vec![
+        let mut v = [
             UndercutRetainer {
                 id: 2,
                 name: "A".into(),

--- a/ultros/src/alerts/undercut_alert.rs
+++ b/ultros/src/alerts/undercut_alert.rs
@@ -13,6 +13,22 @@ use ultros_db::UltrosDb;
 
 use crate::event::{EventBus, EventType};
 
+/// Returns true when `competitor_price` undercuts `our_lowest_price` by strictly more than
+/// `margin_percent`%. A `margin_percent` of 0 fires on any undercut; values ≥ 100 collapse the
+/// threshold to 0 or below and effectively disable the alert.
+///
+/// The check matches the legacy formula `(our_lowest * (1 - margin/100)) > competitor` so we can
+/// preserve existing user-visible behavior. Computed in `f64` then truncated to `i32`.
+pub(crate) fn is_undercut_by_more_than_margin(
+    our_lowest_price: i32,
+    competitor_price: i32,
+    margin_percent: i32,
+) -> bool {
+    let factor = 1.0 - (margin_percent as f64 / 100.0);
+    let threshold = (our_lowest_price as f64 * factor) as i32;
+    threshold > competitor_price
+}
+
 pub(crate) struct RetainerAlertListener {
     pub(crate) retainer_alert_id: i32,
     pub(crate) cancellation_sender: tokio::sync::mpsc::Sender<RetainerAlertTx>,
@@ -144,21 +160,6 @@ impl UndercutTracker {
         })
     }
 
-    // pub(crate) fn into_stream<E>(self, listing_events: E) -> impl Stream<Item = Undercut>
-    // where
-    //     E: Stream<Item = Result<EventType<Arc<ListingEventData>>, anyhow::Error>>,
-    // {
-    //     let value = Arc::new(Mutex::new(self));
-    //     listing_events.filter_map(move |s| {
-    //         let value = value.clone();
-    //         async move {
-    //             let value = value.clone();
-    //             let mut lock = value.lock().await;
-    //             lock.handle_listing_event(s).await.ok()?
-    //         }
-    //     })
-    // }
-
     pub(crate) async fn handle_listing_event(
         &mut self,
         listings: Result<EventType<Arc<ListingEventData>>, anyhow::Error>,
@@ -226,49 +227,51 @@ impl UndercutTracker {
                         hq: added.hq,
                     })
                 {
-                    let margin_price =
-                        our_price.lowest_price as f64 * (1.0 - (self.margin as f64 / 100.0));
-                    debug!("comparing our_price {our_price:?} {margin_price} {added:?}");
-                    // we have a listing, make sure they didn't just beat our price
-                    if margin_price as i32 > added.price_per_unit {
-                        // they beat our price, raise the alarms
-                        if !our_price.has_alerted {
-                            our_price.has_alerted = true;
-                            // figure out what retainers have been undercut
-                            let retainers = self
-                                .db
-                                .get_retainer_listings_for_discord_user(self.discord_user_id)
-                                .await
-                                .map(|i| {
-                                    i.into_iter()
-                                        .flat_map(|(_, r, listings)| {
-                                            listings
-                                                .iter()
-                                                .find(|i| {
-                                                    i.item_id == added.item_id
-                                                        && i.hq == added.hq
-                                                        && i.world_id == added.world_id
-                                                        && added.price_per_unit
-                                                            < (i.price_per_unit as f64
-                                                                * (1.0
-                                                                    - (self.margin as f64 / 100.0)))
-                                                                as i32
-                                                })
-                                                .map(|l| (r, l.price_per_unit))
-                                        })
-                                        .map(|(retainer, price)| UndercutRetainer {
-                                            id: retainer.id,
-                                            name: retainer.name,
-                                            undercut_amount: price,
-                                        })
-                                        .collect::<Vec<_>>()
-                                })
-                                .unwrap_or_default();
-                            return Ok(Some(Undercut {
-                                item_id: added.item_id,
-                                undercut_retainers: retainers,
-                            }));
-                        }
+                    debug!(
+                        "comparing our_price {our_price:?} margin={} {added:?}",
+                        self.margin
+                    );
+                    if is_undercut_by_more_than_margin(
+                        our_price.lowest_price,
+                        added.price_per_unit,
+                        self.margin,
+                    ) && !our_price.has_alerted
+                    {
+                        our_price.has_alerted = true;
+                        // figure out what retainers have been undercut
+                        let retainers = self
+                            .db
+                            .get_retainer_listings_for_discord_user(self.discord_user_id)
+                            .await
+                            .map(|i| {
+                                i.into_iter()
+                                    .flat_map(|(_, r, listings)| {
+                                        listings
+                                            .iter()
+                                            .find(|i| {
+                                                i.item_id == added.item_id
+                                                    && i.hq == added.hq
+                                                    && i.world_id == added.world_id
+                                                    && is_undercut_by_more_than_margin(
+                                                        i.price_per_unit,
+                                                        added.price_per_unit,
+                                                        self.margin,
+                                                    )
+                                            })
+                                            .map(|l| (r, l.price_per_unit))
+                                    })
+                                    .map(|(retainer, price)| UndercutRetainer {
+                                        id: retainer.id,
+                                        name: retainer.name,
+                                        undercut_amount: price,
+                                    })
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
+                        return Ok(Some(Undercut {
+                            item_id: added.item_id,
+                            undercut_retainers: retainers,
+                        }));
                     }
                 }
             }
@@ -365,5 +368,141 @@ impl RetainerAlertListener {
             retainer_alert_id,
             cancellation_sender,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------- is_undercut_by_more_than_margin ----------
+
+    #[test]
+    fn margin_zero_fires_on_any_strict_undercut() {
+        assert!(is_undercut_by_more_than_margin(100, 99, 0));
+        assert!(is_undercut_by_more_than_margin(100, 1, 0));
+    }
+
+    #[test]
+    fn margin_zero_does_not_fire_when_competitor_matches_or_exceeds_us() {
+        assert!(!is_undercut_by_more_than_margin(100, 100, 0));
+        assert!(!is_undercut_by_more_than_margin(100, 101, 0));
+        assert!(!is_undercut_by_more_than_margin(100, 9999, 0));
+    }
+
+    #[test]
+    fn margin_ten_requires_competitor_below_ninety_percent_of_our_price() {
+        // our 100, margin 10 → threshold = 90. Competitor must be < 90 to trigger.
+        assert!(!is_undercut_by_more_than_margin(100, 90, 10));
+        assert!(is_undercut_by_more_than_margin(100, 89, 10));
+        assert!(is_undercut_by_more_than_margin(100, 0, 10));
+    }
+
+    #[test]
+    fn margin_fifty_requires_competitor_at_least_half_off() {
+        // our 1000, margin 50 → threshold = 500.
+        assert!(!is_undercut_by_more_than_margin(1000, 500, 50));
+        assert!(is_undercut_by_more_than_margin(1000, 499, 50));
+    }
+
+    #[test]
+    fn margin_100_collapses_threshold_to_zero_and_effectively_disables_alert() {
+        // (1 - 1.0) = 0; threshold = 0; 0 > competitor only when competitor < 0,
+        // which never happens with valid listings.
+        assert!(!is_undercut_by_more_than_margin(1000, 0, 100));
+        assert!(!is_undercut_by_more_than_margin(1000, 100, 100));
+    }
+
+    #[test]
+    fn margin_over_100_yields_negative_threshold_and_disables_alert() {
+        // (1 - 2.0) = -1; threshold = -1000; never triggers for non-negative competitor.
+        assert!(!is_undercut_by_more_than_margin(1000, 0, 200));
+        assert!(!is_undercut_by_more_than_margin(1000, 999, 200));
+    }
+
+    #[test]
+    fn margin_works_against_very_cheap_listings_via_i32_truncation() {
+        // our 5, margin 10 → 5 * 0.9 = 4.5 → truncates to 4. Competitor must be < 4.
+        assert!(!is_undercut_by_more_than_margin(5, 4, 10));
+        assert!(is_undercut_by_more_than_margin(5, 3, 10));
+    }
+
+    // ---------- ListingValue Ord behavior (used by the fold in user-listings aggregation) ----------
+
+    #[test]
+    fn listing_value_orders_by_lowest_price_then_has_alerted() {
+        let cheaper = ListingValue {
+            lowest_price: 100,
+            has_alerted: true,
+        };
+        let pricier = ListingValue {
+            lowest_price: 200,
+            has_alerted: false,
+        };
+        assert!(cheaper < pricier, "lower price should sort first");
+
+        // Same price: has_alerted=false beats has_alerted=true (false < true).
+        let fresh = ListingValue {
+            lowest_price: 100,
+            has_alerted: false,
+        };
+        let stale = ListingValue {
+            lowest_price: 100,
+            has_alerted: true,
+        };
+        assert!(fresh < stale);
+        // Therefore .min() of the two keeps the fresh entry. This is the property the
+        // user-listings aggregation fold relies on.
+        assert_eq!(fresh.min(stale), fresh);
+    }
+
+    #[test]
+    fn listing_key_hash_and_eq_account_for_all_three_dimensions() {
+        let a = ListingKey {
+            item_id: 1,
+            world_id: 1,
+            hq: false,
+        };
+        let b = ListingKey {
+            item_id: 1,
+            world_id: 1,
+            hq: true,
+        };
+        let c = ListingKey {
+            item_id: 1,
+            world_id: 2,
+            hq: false,
+        };
+        let d = ListingKey {
+            item_id: 2,
+            world_id: 1,
+            hq: false,
+        };
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+        assert_eq!(a, a);
+    }
+
+    // ---------- UndercutRetainer ordering ----------
+
+    #[test]
+    fn undercut_retainer_orders_by_struct_field_declaration_order() {
+        // id < name < undercut_amount via derive(Ord) on tuple of fields.
+        let mut v = vec![
+            UndercutRetainer {
+                id: 2,
+                name: "A".into(),
+                undercut_amount: 0,
+            },
+            UndercutRetainer {
+                id: 1,
+                name: "Z".into(),
+                undercut_amount: 1000,
+            },
+        ];
+        v.sort();
+        assert_eq!(v[0].id, 1);
+        assert_eq!(v[1].id, 2);
     }
 }

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -1217,7 +1217,9 @@ mod test {
     use chrono::{Duration, Utc};
     use ultros_db::sales::AbbreviatedSaleData;
 
-    use crate::analyzer_service::ItemKey;
+    use crate::analyzer_service::{
+        CheapestListingValue, CheapestListings, ItemKey, SALE_HISTORY_SIZE,
+    };
 
     use super::{SaleHistory, SaleSummary, SoldAmount, SoldWithin, calculate_valuation};
 
@@ -1414,6 +1416,268 @@ mod test {
             SoldWithin::Today(SoldAmount(1)),
             "Should only count sales within the 'Today' window"
         );
+    }
+
+    #[test]
+    fn sold_amount_display_caps_at_history_size() {
+        // SALE_HISTORY_SIZE is 6 and anything ≥ that should render as "6+".
+        assert_eq!(SoldAmount(0).to_string(), "0");
+        assert_eq!(SoldAmount(5).to_string(), "5");
+        assert_eq!(
+            SoldAmount(SALE_HISTORY_SIZE as u8).to_string(),
+            format!("{}+", SALE_HISTORY_SIZE)
+        );
+        assert_eq!(
+            SoldAmount(SALE_HISTORY_SIZE as u8 + 3).to_string(),
+            format!("{}+", SALE_HISTORY_SIZE)
+        );
+    }
+
+    #[test]
+    fn sold_within_display_describes_bucket() {
+        assert_eq!(SoldWithin::NoSales.to_string(), "No sales");
+        assert_eq!(
+            SoldWithin::Today(SoldAmount(2)).to_string(),
+            "2 sold today"
+        );
+        assert_eq!(
+            SoldWithin::Week(SoldAmount(1)).to_string(),
+            "1 sold this week"
+        );
+        assert_eq!(
+            SoldWithin::Month(SoldAmount(3)).to_string(),
+            "3 sold this month"
+        );
+        assert_eq!(
+            SoldWithin::Year(SoldAmount(4)).to_string(),
+            "4 sold this year"
+        );
+        assert_eq!(
+            SoldWithin::YearsAgo(2, SoldAmount(5)).to_string(),
+            "5 sold 2 years ago"
+        );
+    }
+
+    #[test]
+    fn sold_within_duration_conversion_matches_bucket_size() {
+        assert_eq!(
+            Duration::from(&SoldWithin::NoSales),
+            Duration::days(0)
+        );
+        assert_eq!(
+            Duration::from(&SoldWithin::Today(SoldAmount(0))),
+            Duration::days(1)
+        );
+        assert_eq!(
+            Duration::from(&SoldWithin::Week(SoldAmount(0))),
+            Duration::weeks(1)
+        );
+        assert_eq!(
+            Duration::from(&SoldWithin::Month(SoldAmount(0))),
+            Duration::weeks(4)
+        );
+        assert_eq!(
+            Duration::from(&SoldWithin::Year(SoldAmount(0))),
+            Duration::weeks(52)
+        );
+        assert_eq!(
+            Duration::from(&SoldWithin::YearsAgo(3, SoldAmount(0))),
+            Duration::weeks(3 * 52)
+        );
+    }
+
+    #[test]
+    fn sold_within_partial_ord_orders_smaller_window_as_less() {
+        // Smaller (more recent) window is "less than" a larger window.
+        let today = SoldWithin::Today(SoldAmount(1));
+        let week = SoldWithin::Week(SoldAmount(1));
+        let month = SoldWithin::Month(SoldAmount(1));
+        let year = SoldWithin::Year(SoldAmount(1));
+        let years = SoldWithin::YearsAgo(2, SoldAmount(1));
+
+        assert!(today < week);
+        assert!(week < month);
+        assert!(month < year);
+        assert!(year < years);
+    }
+
+    #[test]
+    fn sold_within_no_sales_compared_to_other_buckets_is_unordered() {
+        let no_sales = SoldWithin::NoSales;
+        let today = SoldWithin::Today(SoldAmount(0));
+        assert_eq!(no_sales.partial_cmp(&today), None);
+        assert_eq!(today.partial_cmp(&no_sales), None);
+        // NoSales == NoSales
+        assert_eq!(no_sales.partial_cmp(&SoldWithin::NoSales), Some(std::cmp::Ordering::Equal));
+    }
+
+    #[test]
+    fn sold_within_within_same_bucket_orders_by_count_desc() {
+        // Per the PartialOrd impl, comparing two Same-bucket variants flips the order
+        // (b.cmp(a)) so a *larger* count is "less" — meaning a fresher market.
+        let a = SoldWithin::Today(SoldAmount(5));
+        let b = SoldWithin::Today(SoldAmount(2));
+        assert!(a < b);
+    }
+
+    #[test]
+    fn cheapest_listing_value_compares_only_by_price() {
+        let a = CheapestListingValue {
+            price: 100,
+            world_id: 1,
+        };
+        let b = CheapestListingValue {
+            price: 100,
+            world_id: 999,
+        };
+        let c = CheapestListingValue {
+            price: 200,
+            world_id: 1,
+        };
+        // Different world_id but same price ⇒ equal under PartialEq + total ordering by price
+        assert_eq!(a, b);
+        assert!(a < c);
+        assert!(c > b);
+    }
+
+    #[test]
+    fn cheapest_listings_add_listing_keeps_cheapest_for_item() {
+        let mut cheapest = CheapestListings::default();
+        let make = |item_id, world_id, price| ultros_db::listings::ListingSummary {
+            item_id,
+            world_id,
+            price_per_unit: price,
+            hq: false,
+        };
+
+        // Insert three listings for the same item, cheapest second.
+        cheapest.add_listing(&make(7, 1, 500));
+        cheapest.add_listing(&make(7, 2, 100));
+        cheapest.add_listing(&make(7, 3, 250));
+
+        let key = ItemKey {
+            item_id: 7,
+            hq: false,
+        };
+        let stored = cheapest.item_map.get(&key).unwrap();
+        assert_eq!(stored.price, 100);
+        assert_eq!(stored.world_id, 2);
+    }
+
+    #[test]
+    fn cheapest_listings_keeps_separate_entries_per_quality() {
+        let mut cheapest = CheapestListings::default();
+        let make = |hq, price| ultros_db::listings::ListingSummary {
+            item_id: 9,
+            world_id: 1,
+            price_per_unit: price,
+            hq,
+        };
+        cheapest.add_listing(&make(false, 50));
+        cheapest.add_listing(&make(true, 75));
+        assert_eq!(cheapest.item_map.len(), 2);
+        assert_eq!(
+            cheapest
+                .item_map
+                .get(&ItemKey {
+                    item_id: 9,
+                    hq: false
+                })
+                .unwrap()
+                .price,
+            50
+        );
+        assert_eq!(
+            cheapest
+                .item_map
+                .get(&ItemKey {
+                    item_id: 9,
+                    hq: true
+                })
+                .unwrap()
+                .price,
+            75
+        );
+    }
+
+    #[test]
+    fn sale_history_replaces_oldest_when_full_and_new_sale_is_newer() {
+        let mut sale_history = SaleHistory::default();
+        let now = Utc::now().naive_utc();
+        // Fill to capacity (SALE_HISTORY_SIZE = 6) with progressively newer sales.
+        for i in 0..SALE_HISTORY_SIZE {
+            sale_history.add_sale(&AbbreviatedSaleData {
+                sold_item_id: 1,
+                hq: false,
+                price_per_item: i as i32,
+                sold_date: now - Duration::hours((SALE_HISTORY_SIZE - i) as i64),
+                world_id: 0,
+            });
+        }
+        let key = ItemKey {
+            item_id: 1,
+            hq: false,
+        };
+        assert_eq!(sale_history.item_map.get(&key).unwrap().len(), SALE_HISTORY_SIZE);
+
+        // Add a sale newer than the newest. Oldest should be dropped.
+        sale_history.add_sale(&AbbreviatedSaleData {
+            sold_item_id: 1,
+            hq: false,
+            price_per_item: 999,
+            sold_date: now + Duration::hours(1),
+            world_id: 0,
+        });
+        let entries = sale_history.item_map.get(&key).unwrap();
+        assert_eq!(entries.len(), SALE_HISTORY_SIZE);
+        // Newest sale should now be at the front.
+        assert_eq!(entries[0].price_per_item, 999);
+        // The slot at the previous tail position should now be the second-newest.
+    }
+
+    #[test]
+    fn sale_history_ignores_older_sale_when_full() {
+        let mut sale_history = SaleHistory::default();
+        let now = Utc::now().naive_utc();
+        for i in 0..SALE_HISTORY_SIZE {
+            // Newer sales (smaller `i` → bigger offset back, so use reversed).
+            sale_history.add_sale(&AbbreviatedSaleData {
+                sold_item_id: 2,
+                hq: true,
+                price_per_item: 10 + i as i32,
+                sold_date: now - Duration::minutes(i as i64),
+                world_id: 0,
+            });
+        }
+        let key = ItemKey {
+            item_id: 2,
+            hq: true,
+        };
+        let snapshot_prices: Vec<i32> = sale_history
+            .item_map
+            .get(&key)
+            .unwrap()
+            .iter()
+            .map(|s| s.price_per_item)
+            .collect();
+
+        // Try to insert a sale older than every existing one — should be ignored.
+        sale_history.add_sale(&AbbreviatedSaleData {
+            sold_item_id: 2,
+            hq: true,
+            price_per_item: 9999,
+            sold_date: now - Duration::days(100),
+            world_id: 0,
+        });
+        let after_prices: Vec<i32> = sale_history
+            .item_map
+            .get(&key)
+            .unwrap()
+            .iter()
+            .map(|s| s.price_per_item)
+            .collect();
+        assert_eq!(snapshot_prices, after_prices);
+        assert!(!after_prices.contains(&9999));
     }
 }
 

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -1436,10 +1436,7 @@ mod test {
     #[test]
     fn sold_within_display_describes_bucket() {
         assert_eq!(SoldWithin::NoSales.to_string(), "No sales");
-        assert_eq!(
-            SoldWithin::Today(SoldAmount(2)).to_string(),
-            "2 sold today"
-        );
+        assert_eq!(SoldWithin::Today(SoldAmount(2)).to_string(), "2 sold today");
         assert_eq!(
             SoldWithin::Week(SoldAmount(1)).to_string(),
             "1 sold this week"
@@ -1460,10 +1457,7 @@ mod test {
 
     #[test]
     fn sold_within_duration_conversion_matches_bucket_size() {
-        assert_eq!(
-            Duration::from(&SoldWithin::NoSales),
-            Duration::days(0)
-        );
+        assert_eq!(Duration::from(&SoldWithin::NoSales), Duration::days(0));
         assert_eq!(
             Duration::from(&SoldWithin::Today(SoldAmount(0))),
             Duration::days(1)
@@ -1508,7 +1502,10 @@ mod test {
         assert_eq!(no_sales.partial_cmp(&today), None);
         assert_eq!(today.partial_cmp(&no_sales), None);
         // NoSales == NoSales
-        assert_eq!(no_sales.partial_cmp(&SoldWithin::NoSales), Some(std::cmp::Ordering::Equal));
+        assert_eq!(
+            no_sales.partial_cmp(&SoldWithin::NoSales),
+            Some(std::cmp::Ordering::Equal)
+        );
     }
 
     #[test]
@@ -1618,7 +1615,10 @@ mod test {
             item_id: 1,
             hq: false,
         };
-        assert_eq!(sale_history.item_map.get(&key).unwrap().len(), SALE_HISTORY_SIZE);
+        assert_eq!(
+            sale_history.item_map.get(&key).unwrap().len(),
+            SALE_HISTORY_SIZE
+        );
 
         // Add a sale newer than the newest. Oldest should be dropped.
         sale_history.add_sale(&AbbreviatedSaleData {

--- a/ultros/src/discord/ffxiv/analyze.rs
+++ b/ultros/src/discord/ffxiv/analyze.rs
@@ -2,7 +2,8 @@ use poise::serenity_prelude::Color;
 use std::fmt::Write;
 use xiv_gen::ItemId;
 
-use crate::analyzer_service::{ResaleOptions, SoldAmount, SoldWithin};
+use crate::analyzer_service::ResaleOptions;
+use crate::discord::ffxiv::helpers::{clamp_sold_amount, threshold_days_to_sold_within};
 
 use super::{Context, Error};
 
@@ -32,18 +33,8 @@ pub(crate) async fn profit(
         .ok_or(anyhow::anyhow!("World not in a region?"))?
         .id;
 
-    let amount = SoldAmount(number_recently_sold.clamp(0, 255) as u8);
-    let filter_sale = if threshold_days <= 1 {
-        SoldWithin::Today(amount)
-    } else if threshold_days <= 7 {
-        SoldWithin::Week(amount)
-    } else if threshold_days <= 30 {
-        SoldWithin::Month(amount)
-    } else if threshold_days <= 365 {
-        SoldWithin::Year(amount)
-    } else {
-        SoldWithin::YearsAgo(((threshold_days / 365).clamp(1, 255)) as u8, amount)
-    };
+    let amount = clamp_sold_amount(number_recently_sold);
+    let filter_sale = threshold_days_to_sold_within(threshold_days, amount);
 
     let xiv_data = xiv_gen_db::data();
     let items = &xiv_data.items;

--- a/ultros/src/discord/ffxiv/helpers.rs
+++ b/ultros/src/discord/ffxiv/helpers.rs
@@ -31,27 +31,16 @@ pub(crate) fn clamp_sold_amount(number_recently_sold: i32) -> SoldAmount {
     SoldAmount(number_recently_sold.clamp(0, 255) as u8)
 }
 
-/// Case-insensitive substring match used by Discord autocomplete handlers.
-///
-/// `partial` is lowered on every call; for tight autocomplete loops over thousands of
-/// items, lower the needle once and call [`name_matches_lowered`] instead.
-/// An empty `partial` matches any haystack. The match is Unicode-aware via `to_lowercase`.
-pub(crate) fn name_matches_partial(haystack: &str, partial: &str) -> bool {
-    name_matches_lowered(haystack, &partial.to_lowercase())
-}
-
-/// Hot-loop variant of [`name_matches_partial`]: caller pre-lowers the needle once.
+/// Case-insensitive substring match used by Discord autocomplete handlers. The caller
+/// is expected to lower `partial_lower` once before iterating so the hot loop doesn't
+/// re-allocate a `String` per item. An empty needle matches any haystack. Unicode-aware
+/// via `to_lowercase`.
 pub(crate) fn name_matches_lowered(haystack: &str, partial_lower: &str) -> bool {
     haystack.to_lowercase().contains(partial_lower)
 }
 
-/// ASCII-only variant of [`name_matches_partial`]. Cheaper for plain-text fields like
-/// retainer names that are guaranteed to be ASCII in practice.
-pub(crate) fn name_matches_partial_ascii(haystack: &str, partial: &str) -> bool {
-    name_matches_lowered_ascii(haystack, &partial.to_ascii_lowercase())
-}
-
-/// Hot-loop variant of [`name_matches_partial_ascii`]: caller pre-lowers the needle.
+/// ASCII-only variant of [`name_matches_lowered`]. Cheaper for plain-text fields like
+/// retainer names that are guaranteed to be ASCII in practice. Caller pre-lowers needle.
 pub(crate) fn name_matches_lowered_ascii(haystack: &str, partial_lower: &str) -> bool {
     haystack.to_ascii_lowercase().contains(partial_lower)
 }
@@ -226,41 +215,6 @@ mod tests {
         assert_eq!(clamp_sold_amount(i32::MAX), SoldAmount(255));
     }
 
-    // ---------- name_matches_partial ----------
-
-    #[test]
-    fn name_matches_partial_empty_partial_matches_anything() {
-        assert!(name_matches_partial("Adamantoise", ""));
-        assert!(name_matches_partial("", ""));
-    }
-
-    #[test]
-    fn name_matches_partial_is_case_insensitive() {
-        assert!(name_matches_partial("Adamantoise", "ada"));
-        assert!(name_matches_partial("Adamantoise", "ADA"));
-        assert!(name_matches_partial("ADAMANTOISE", "ada"));
-    }
-
-    #[test]
-    fn name_matches_partial_substring_anywhere() {
-        assert!(name_matches_partial("Behemoth", "hemo"));
-        assert!(name_matches_partial("Behemoth", "moth"));
-    }
-
-    #[test]
-    fn name_matches_partial_no_match_returns_false() {
-        assert!(!name_matches_partial("Adamantoise", "xyz"));
-        assert!(!name_matches_partial("", "anything"));
-    }
-
-    #[test]
-    fn name_matches_partial_handles_unicode() {
-        // Turkish dotless I lowercases differently than ASCII.
-        assert!(name_matches_partial("İstanbul", "i\u{0307}stan"));
-        // CJK names in the game data should match by exact lowercase identity.
-        assert!(name_matches_partial("中国", "中国"));
-    }
-
     // ---------- name_matches_lowered ----------
 
     #[test]
@@ -283,31 +237,23 @@ mod tests {
     }
 
     #[test]
-    fn name_matches_lowered_agrees_with_partial_when_needle_is_prelowered() {
-        let cases = [("Adamantoise", "ada"), ("Behemoth", "moth"), ("中国", "中国")];
-        for (h, n) in cases {
-            let lower = n.to_lowercase();
-            assert_eq!(name_matches_partial(h, n), name_matches_lowered(h, &lower));
-        }
-    }
-
-    // ---------- name_matches_partial_ascii ----------
-
-    #[test]
-    fn name_matches_partial_ascii_empty_partial_matches_anything() {
-        assert!(name_matches_partial_ascii("Bob", ""));
+    fn name_matches_lowered_substring_anywhere() {
+        assert!(name_matches_lowered("Behemoth", "hemo"));
+        assert!(name_matches_lowered("Behemoth", "moth"));
     }
 
     #[test]
-    fn name_matches_partial_ascii_is_case_insensitive() {
-        assert!(name_matches_partial_ascii("Bob", "BOB"));
-        assert!(name_matches_partial_ascii("BOB", "bob"));
+    fn name_matches_lowered_no_match_returns_false() {
+        assert!(!name_matches_lowered("Adamantoise", "xyz"));
+        assert!(!name_matches_lowered("", "anything"));
     }
 
     #[test]
-    fn name_matches_partial_ascii_does_not_lowercase_non_ascii() {
-        // Uppercase 'İ' is NOT lowercased by to_ascii_lowercase, so it won't match 'i'.
-        assert!(!name_matches_partial_ascii("İstanbul", "i"));
+    fn name_matches_lowered_handles_unicode() {
+        // Turkish dotless I lowercases differently than ASCII.
+        assert!(name_matches_lowered("İstanbul", "i\u{0307}stan"));
+        // CJK names in the game data should match by exact lowercase identity.
+        assert!(name_matches_lowered("中国", "中国"));
     }
 
     // ---------- name_matches_lowered_ascii ----------
@@ -324,14 +270,16 @@ mod tests {
     }
 
     #[test]
-    fn name_matches_lowered_ascii_agrees_with_partial_when_prelowered() {
-        let cases = [("Bob", "bo"), ("Retainer42", "AINER"), ("Cap", "P")];
-        for (h, n) in cases {
-            let lower = n.to_ascii_lowercase();
-            assert_eq!(
-                name_matches_partial_ascii(h, n),
-                name_matches_lowered_ascii(h, &lower)
-            );
+    fn name_matches_lowered_ascii_does_not_lowercase_non_ascii() {
+        // Uppercase 'İ' is NOT lowercased by to_ascii_lowercase, so a lowered-needle
+        // of "i" won't find it in the haystack.
+        assert!(!name_matches_lowered_ascii("İstanbul", "i"));
+    }
+
+    #[test]
+    fn name_matches_lowered_ascii_finds_substring_with_prelowered_needle() {
+        for (h, lower) in [("Bob", "bo"), ("Retainer42", "ainer"), ("Cap", "p")] {
+            assert!(name_matches_lowered_ascii(h, lower));
         }
     }
 

--- a/ultros/src/discord/ffxiv/helpers.rs
+++ b/ultros/src/discord/ffxiv/helpers.rs
@@ -1,0 +1,427 @@
+//! Pure helpers extracted from the Discord command handlers so they can be unit-tested
+//! without spinning up Serenity, Poise, the DB, or the world cache.
+
+use ultros_db::entity::active_listing;
+
+use crate::analyzer_service::{SoldAmount, SoldWithin};
+
+/// Map a user-supplied "threshold in days" into the appropriate `SoldWithin` bucket.
+///
+/// The bucket boundaries match the previous inline ladder in `analyze::profit`:
+/// `≤1` → Today, `≤7` → Week, `≤30` → Month, `≤365` → Year, otherwise → YearsAgo(days/365).
+/// `YearsAgo` clamps the year count to `1..=255` to fit in `u8`.
+pub(crate) fn threshold_days_to_sold_within(threshold_days: i32, amount: SoldAmount) -> SoldWithin {
+    if threshold_days <= 1 {
+        SoldWithin::Today(amount)
+    } else if threshold_days <= 7 {
+        SoldWithin::Week(amount)
+    } else if threshold_days <= 30 {
+        SoldWithin::Month(amount)
+    } else if threshold_days <= 365 {
+        SoldWithin::Year(amount)
+    } else {
+        SoldWithin::YearsAgo(((threshold_days / 365).clamp(1, 255)) as u8, amount)
+    }
+}
+
+/// Clamp a user-supplied "number recently sold" into a `SoldAmount` (`u8`-bounded).
+///
+/// Negative values become 0; values above 255 saturate to 255.
+pub(crate) fn clamp_sold_amount(number_recently_sold: i32) -> SoldAmount {
+    SoldAmount(number_recently_sold.clamp(0, 255) as u8)
+}
+
+/// Case-insensitive substring match used by Discord autocomplete handlers.
+///
+/// `partial` is lowered on every call; for tight autocomplete loops over thousands of
+/// items, lower the needle once and call [`name_matches_lowered`] instead.
+/// An empty `partial` matches any haystack. The match is Unicode-aware via `to_lowercase`.
+pub(crate) fn name_matches_partial(haystack: &str, partial: &str) -> bool {
+    name_matches_lowered(haystack, &partial.to_lowercase())
+}
+
+/// Hot-loop variant of [`name_matches_partial`]: caller pre-lowers the needle once.
+pub(crate) fn name_matches_lowered(haystack: &str, partial_lower: &str) -> bool {
+    haystack.to_lowercase().contains(partial_lower)
+}
+
+/// ASCII-only variant of [`name_matches_partial`]. Cheaper for plain-text fields like
+/// retainer names that are guaranteed to be ASCII in practice.
+pub(crate) fn name_matches_partial_ascii(haystack: &str, partial: &str) -> bool {
+    name_matches_lowered_ascii(haystack, &partial.to_ascii_lowercase())
+}
+
+/// Hot-loop variant of [`name_matches_partial_ascii`]: caller pre-lowers the needle.
+pub(crate) fn name_matches_lowered_ascii(haystack: &str, partial_lower: &str) -> bool {
+    haystack.to_ascii_lowercase().contains(partial_lower)
+}
+
+/// Return the cheapest `limit` listings, optionally filtered by HQ.
+///
+/// Sorts by `price_per_unit` ascending. When `hq_filter` is `Some(true)`, only HQ listings
+/// are kept; `Some(false)` keeps only NQ; `None` keeps both.
+pub(crate) fn top_n_cheapest_listings(
+    mut listings: Vec<active_listing::Model>,
+    hq_filter: Option<bool>,
+    limit: usize,
+) -> Vec<active_listing::Model> {
+    listings.sort_by_key(|l| l.price_per_unit);
+    listings
+        .into_iter()
+        .filter(|l| hq_filter.map(|hq| l.hq == hq).unwrap_or(true))
+        .take(limit)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+
+    fn listing(id: i32, price: i32, hq: bool) -> active_listing::Model {
+        active_listing::Model {
+            id,
+            world_id: 1,
+            item_id: 1,
+            retainer_id: 1,
+            price_per_unit: price,
+            quantity: 1,
+            hq,
+            timestamp: NaiveDateTime::default(),
+        }
+    }
+
+    // ---------- threshold_days_to_sold_within ----------
+
+    #[test]
+    fn threshold_zero_or_negative_falls_into_today() {
+        // The ladder uses `<= 1` for Today, so 0 and negative values land here.
+        assert!(matches!(
+            threshold_days_to_sold_within(0, SoldAmount(1)),
+            SoldWithin::Today(_)
+        ));
+        assert!(matches!(
+            threshold_days_to_sold_within(-5, SoldAmount(1)),
+            SoldWithin::Today(_)
+        ));
+        assert!(matches!(
+            threshold_days_to_sold_within(i32::MIN, SoldAmount(1)),
+            SoldWithin::Today(_)
+        ));
+    }
+
+    #[test]
+    fn threshold_one_is_today() {
+        assert!(matches!(
+            threshold_days_to_sold_within(1, SoldAmount(0)),
+            SoldWithin::Today(_)
+        ));
+    }
+
+    #[test]
+    fn threshold_two_through_seven_is_week() {
+        for d in 2..=7 {
+            assert!(
+                matches!(
+                    threshold_days_to_sold_within(d, SoldAmount(0)),
+                    SoldWithin::Week(_)
+                ),
+                "expected Week for {d} days",
+            );
+        }
+    }
+
+    #[test]
+    fn threshold_eight_through_thirty_is_month() {
+        for d in [8, 15, 30] {
+            assert!(
+                matches!(
+                    threshold_days_to_sold_within(d, SoldAmount(0)),
+                    SoldWithin::Month(_)
+                ),
+                "expected Month for {d} days",
+            );
+        }
+    }
+
+    #[test]
+    fn threshold_thirty_one_through_365_is_year() {
+        for d in [31, 100, 365] {
+            assert!(
+                matches!(
+                    threshold_days_to_sold_within(d, SoldAmount(0)),
+                    SoldWithin::Year(_)
+                ),
+                "expected Year for {d} days",
+            );
+        }
+    }
+
+    #[test]
+    fn threshold_just_over_a_year_is_one_year_ago() {
+        // 366 / 365 = 1
+        assert_eq!(
+            threshold_days_to_sold_within(366, SoldAmount(0)),
+            SoldWithin::YearsAgo(1, SoldAmount(0))
+        );
+    }
+
+    #[test]
+    fn threshold_two_years_floor_division() {
+        // 730 / 365 = 2
+        assert_eq!(
+            threshold_days_to_sold_within(730, SoldAmount(2)),
+            SoldWithin::YearsAgo(2, SoldAmount(2))
+        );
+        // 731 / 365 = 2 (floor)
+        assert_eq!(
+            threshold_days_to_sold_within(731, SoldAmount(0)),
+            SoldWithin::YearsAgo(2, SoldAmount(0))
+        );
+    }
+
+    #[test]
+    fn threshold_extreme_clamps_to_255_years() {
+        // 256 * 365 days would overflow u8 if not clamped.
+        let huge = 256 * 365;
+        assert_eq!(
+            threshold_days_to_sold_within(huge, SoldAmount(1)),
+            SoldWithin::YearsAgo(255, SoldAmount(1))
+        );
+        assert_eq!(
+            threshold_days_to_sold_within(i32::MAX, SoldAmount(1)),
+            SoldWithin::YearsAgo(255, SoldAmount(1))
+        );
+    }
+
+    #[test]
+    fn threshold_passes_amount_through_unchanged() {
+        let amt = SoldAmount(42);
+        if let SoldWithin::Year(a) = threshold_days_to_sold_within(100, amt) {
+            assert_eq!(a, amt);
+        } else {
+            panic!("expected Year bucket");
+        }
+    }
+
+    // ---------- clamp_sold_amount ----------
+
+    #[test]
+    fn clamp_sold_amount_passes_in_range_values_through() {
+        assert_eq!(clamp_sold_amount(0), SoldAmount(0));
+        assert_eq!(clamp_sold_amount(42), SoldAmount(42));
+        assert_eq!(clamp_sold_amount(255), SoldAmount(255));
+    }
+
+    #[test]
+    fn clamp_sold_amount_clamps_negative_to_zero() {
+        assert_eq!(clamp_sold_amount(-1), SoldAmount(0));
+        assert_eq!(clamp_sold_amount(i32::MIN), SoldAmount(0));
+    }
+
+    #[test]
+    fn clamp_sold_amount_saturates_above_255() {
+        assert_eq!(clamp_sold_amount(256), SoldAmount(255));
+        assert_eq!(clamp_sold_amount(10_000), SoldAmount(255));
+        assert_eq!(clamp_sold_amount(i32::MAX), SoldAmount(255));
+    }
+
+    // ---------- name_matches_partial ----------
+
+    #[test]
+    fn name_matches_partial_empty_partial_matches_anything() {
+        assert!(name_matches_partial("Adamantoise", ""));
+        assert!(name_matches_partial("", ""));
+    }
+
+    #[test]
+    fn name_matches_partial_is_case_insensitive() {
+        assert!(name_matches_partial("Adamantoise", "ada"));
+        assert!(name_matches_partial("Adamantoise", "ADA"));
+        assert!(name_matches_partial("ADAMANTOISE", "ada"));
+    }
+
+    #[test]
+    fn name_matches_partial_substring_anywhere() {
+        assert!(name_matches_partial("Behemoth", "hemo"));
+        assert!(name_matches_partial("Behemoth", "moth"));
+    }
+
+    #[test]
+    fn name_matches_partial_no_match_returns_false() {
+        assert!(!name_matches_partial("Adamantoise", "xyz"));
+        assert!(!name_matches_partial("", "anything"));
+    }
+
+    #[test]
+    fn name_matches_partial_handles_unicode() {
+        // Turkish dotless I lowercases differently than ASCII.
+        assert!(name_matches_partial("İstanbul", "i\u{0307}stan"));
+        // CJK names in the game data should match by exact lowercase identity.
+        assert!(name_matches_partial("中国", "中国"));
+    }
+
+    // ---------- name_matches_lowered ----------
+
+    #[test]
+    fn name_matches_lowered_does_not_lower_needle() {
+        // Caller is expected to pass already-lowered needle; uppercase needle won't match.
+        assert!(!name_matches_lowered("Adamantoise", "ADA"));
+        assert!(name_matches_lowered("Adamantoise", "ada"));
+    }
+
+    #[test]
+    fn name_matches_lowered_lowers_haystack_only() {
+        // Haystack is lowered each call; mixed-case haystacks still match lowercase needles.
+        assert!(name_matches_lowered("AdamANToise", "manto"));
+    }
+
+    #[test]
+    fn name_matches_lowered_empty_needle_matches_anything() {
+        assert!(name_matches_lowered("anything", ""));
+        assert!(name_matches_lowered("", ""));
+    }
+
+    #[test]
+    fn name_matches_lowered_agrees_with_partial_when_needle_is_prelowered() {
+        let cases = [("Adamantoise", "ada"), ("Behemoth", "moth"), ("中国", "中国")];
+        for (h, n) in cases {
+            let lower = n.to_lowercase();
+            assert_eq!(name_matches_partial(h, n), name_matches_lowered(h, &lower));
+        }
+    }
+
+    // ---------- name_matches_partial_ascii ----------
+
+    #[test]
+    fn name_matches_partial_ascii_empty_partial_matches_anything() {
+        assert!(name_matches_partial_ascii("Bob", ""));
+    }
+
+    #[test]
+    fn name_matches_partial_ascii_is_case_insensitive() {
+        assert!(name_matches_partial_ascii("Bob", "BOB"));
+        assert!(name_matches_partial_ascii("BOB", "bob"));
+    }
+
+    #[test]
+    fn name_matches_partial_ascii_does_not_lowercase_non_ascii() {
+        // Uppercase 'İ' is NOT lowercased by to_ascii_lowercase, so it won't match 'i'.
+        assert!(!name_matches_partial_ascii("İstanbul", "i"));
+    }
+
+    // ---------- name_matches_lowered_ascii ----------
+
+    #[test]
+    fn name_matches_lowered_ascii_does_not_lower_needle() {
+        assert!(!name_matches_lowered_ascii("Bob", "BOB"));
+        assert!(name_matches_lowered_ascii("Bob", "bob"));
+    }
+
+    #[test]
+    fn name_matches_lowered_ascii_empty_needle_matches_anything() {
+        assert!(name_matches_lowered_ascii("Bob", ""));
+    }
+
+    #[test]
+    fn name_matches_lowered_ascii_agrees_with_partial_when_prelowered() {
+        let cases = [("Bob", "bo"), ("Retainer42", "AINER"), ("Cap", "P")];
+        for (h, n) in cases {
+            let lower = n.to_ascii_lowercase();
+            assert_eq!(
+                name_matches_partial_ascii(h, n),
+                name_matches_lowered_ascii(h, &lower)
+            );
+        }
+    }
+
+    // ---------- top_n_cheapest_listings ----------
+
+    #[test]
+    fn top_n_cheapest_returns_listings_in_ascending_price_order() {
+        let listings = vec![
+            listing(1, 500, false),
+            listing(2, 100, false),
+            listing(3, 250, false),
+        ];
+        let result = top_n_cheapest_listings(listings, None, 10);
+        let prices: Vec<_> = result.iter().map(|l| l.price_per_unit).collect();
+        assert_eq!(prices, vec![100, 250, 500]);
+    }
+
+    #[test]
+    fn top_n_cheapest_truncates_to_limit() {
+        let listings = (1..=20).map(|i| listing(i, i * 10, false)).collect();
+        let result = top_n_cheapest_listings(listings, None, 5);
+        assert_eq!(result.len(), 5);
+        let prices: Vec<_> = result.iter().map(|l| l.price_per_unit).collect();
+        assert_eq!(prices, vec![10, 20, 30, 40, 50]);
+    }
+
+    #[test]
+    fn top_n_cheapest_limit_zero_returns_empty() {
+        let listings = vec![listing(1, 1, false)];
+        assert!(top_n_cheapest_listings(listings, None, 0).is_empty());
+    }
+
+    #[test]
+    fn top_n_cheapest_empty_input_stays_empty() {
+        let result = top_n_cheapest_listings(vec![], None, 10);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn top_n_cheapest_hq_only_filters_to_hq() {
+        let listings = vec![
+            listing(1, 100, false),
+            listing(2, 200, true),
+            listing(3, 50, false),
+            listing(4, 300, true),
+        ];
+        let result = top_n_cheapest_listings(listings, Some(true), 10);
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|l| l.hq));
+        assert_eq!(result[0].price_per_unit, 200);
+        assert_eq!(result[1].price_per_unit, 300);
+    }
+
+    #[test]
+    fn top_n_cheapest_nq_only_filters_to_nq() {
+        let listings = vec![
+            listing(1, 100, false),
+            listing(2, 200, true),
+            listing(3, 50, false),
+        ];
+        let result = top_n_cheapest_listings(listings, Some(false), 10);
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|l| !l.hq));
+        assert_eq!(result[0].price_per_unit, 50);
+    }
+
+    #[test]
+    fn top_n_cheapest_filter_applied_after_sort_so_limit_counts_filtered_results() {
+        // Cheapest 3 are NQ; HQ are 200 and 300. Asking for top 5 HQ should still only return 2.
+        let listings = vec![
+            listing(1, 10, false),
+            listing(2, 20, false),
+            listing(3, 30, false),
+            listing(4, 200, true),
+            listing(5, 300, true),
+        ];
+        let result = top_n_cheapest_listings(listings, Some(true), 5);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].price_per_unit, 200);
+    }
+
+    #[test]
+    fn top_n_cheapest_handles_ties_in_price() {
+        let listings = vec![
+            listing(1, 100, false),
+            listing(2, 100, true),
+            listing(3, 100, false),
+        ];
+        let result = top_n_cheapest_listings(listings, None, 10);
+        assert_eq!(result.len(), 3);
+        assert!(result.iter().all(|l| l.price_per_unit == 100));
+    }
+}

--- a/ultros/src/discord/ffxiv/item_prices.rs
+++ b/ultros/src/discord/ffxiv/item_prices.rs
@@ -5,6 +5,7 @@ use ultros_db::world_data::world_cache::AnySelector;
 use xiv_gen::ItemId;
 
 use crate::discord::ffxiv::ULTROS_COLOR;
+use crate::discord::ffxiv::helpers::{name_matches_lowered, top_n_cheapest_listings};
 use crate::web::item_card::generate_image;
 
 use super::{Context, Error};
@@ -19,10 +20,11 @@ async fn autocomplete_item<'a>(
     _ctx: Context<'_>,
     partial: &'a str,
 ) -> impl Iterator<Item = poise::serenity_prelude::AutocompleteChoice> + 'a {
-    let items = xiv_gen_db::data().items.values();
     let partial = partial.to_lowercase();
-    items
-        .filter(move |item| item.name.to_lowercase().contains(&partial))
+    xiv_gen_db::data()
+        .items
+        .values()
+        .filter(move |item| name_matches_lowered(&item.name, &partial))
         .map(|item| {
             poise::serenity_prelude::AutocompleteChoice::new(item.name.to_string(), item.key_id.0)
         })
@@ -37,7 +39,7 @@ async fn autocomplete_world<'a>(
     ctx.data()
         .world_cache
         .get_all_results()
-        .filter(move |w| w.get_name().to_lowercase().contains(&partial))
+        .filter(move |w| name_matches_lowered(w.get_name(), &partial))
         .map(|w| w.get_name().to_string())
         .take(99)
 }
@@ -60,16 +62,13 @@ async fn current(
         .items
         .get(&ItemId(item))
         .ok_or(anyhow!("bad item id"))?;
-    let mut listings = ctx
+    let listings = ctx
         .data()
         .db
         .get_all_listings_in_worlds(&world_ids, universalis::ItemId(item))
         .await?;
-    listings.sort_by_key(|l| l.price_per_unit);
-    let listings = listings
+    let listings = top_n_cheapest_listings(listings, hq_only, 10)
         .into_iter()
-        .filter(|w| hq_only.map(|hq| w.hq == hq).unwrap_or(true))
-        .take(10)
         .format_with("\n", |l, f| {
             f(&format_args!(
                 "{:<10} {:3} {:<7} {}",

--- a/ultros/src/discord/ffxiv/mod.rs
+++ b/ultros/src/discord/ffxiv/mod.rs
@@ -2,6 +2,7 @@ use super::{Context, Error};
 pub mod admin;
 mod analyze;
 mod character;
+mod helpers;
 mod item_prices;
 mod lists;
 mod retainer;

--- a/ultros/src/discord/ffxiv/retainer.rs
+++ b/ultros/src/discord/ffxiv/retainer.rs
@@ -1,4 +1,5 @@
 use crate::EventType;
+use crate::discord::ffxiv::helpers::name_matches_lowered_ascii;
 use itertools::Itertools;
 use poise::serenity_prelude::Color;
 use std::fmt::Write;
@@ -286,7 +287,7 @@ async fn owned_retainer_auto_complete(
     ctx: Context<'_>,
     partial: &str,
 ) -> impl Iterator<Item = poise::serenity_prelude::AutocompleteChoice> {
-    let partial = partial.to_string();
+    let partial = partial.to_ascii_lowercase();
     ctx.data()
         .db
         .get_owned_retainers(ctx.author().id.get(), ctx.author().name.clone())
@@ -294,14 +295,8 @@ async fn owned_retainer_auto_complete(
         .unwrap_or_default()
         .into_iter()
         .filter(move |(_o, r)| {
-            if let Some(retainer) = r {
-                retainer
-                    .name
-                    .to_ascii_lowercase()
-                    .contains(&partial.to_ascii_lowercase())
-            } else {
-                false
-            }
+            r.as_ref()
+                .is_some_and(|retainer| name_matches_lowered_ascii(&retainer.name, &partial))
         })
         .flat_map(|(owned, retainer)| {
             let retainer = retainer?;

--- a/ultros/src/web/api/alerts.rs
+++ b/ultros/src/web/api/alerts.rs
@@ -11,12 +11,38 @@ use ultros_db::UltrosDb;
 use crate::web::error::ApiError;
 use crate::web::oauth::AuthDiscordUser;
 
+/// Default cooldown when the user doesn't supply one (1 hour).
+pub(crate) const DEFAULT_COOLDOWN_SECONDS: i32 = 3600;
+/// Minimum cooldown a user can request (1 minute) — prevents spam.
+pub(crate) const MIN_COOLDOWN_SECONDS: i32 = 60;
+/// Maximum cooldown a user can request (1 day).
+pub(crate) const MAX_COOLDOWN_SECONDS: i32 = 86400;
+
+/// Resolve a user-supplied cooldown into the actual cooldown stored in the DB.
+/// Missing → default (1h). Out-of-range → clamped to [60s, 86400s].
+pub(crate) fn resolve_cooldown_seconds(requested: Option<i32>) -> i32 {
+    requested
+        .unwrap_or(DEFAULT_COOLDOWN_SECONDS)
+        .clamp(MIN_COOLDOWN_SECONDS, MAX_COOLDOWN_SECONDS)
+}
+
+/// Validate a price threshold from a user request. Returns `Err` when zero or negative.
+pub(crate) fn validate_price_threshold(price_threshold: i32) -> Result<(), ApiError> {
+    if price_threshold <= 0 {
+        Err(ApiError::from(anyhow::anyhow!(
+            "price_threshold must be positive"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
 pub(crate) async fn create_alert(
     State(db): State<UltrosDb>,
     user: AuthDiscordUser,
     Json(req): Json<CreateAlertRequest>,
 ) -> Result<Json<Alert>, ApiError> {
-    let cooldown = req.cooldown_seconds.unwrap_or(3600).clamp(60, 86400);
+    let cooldown = resolve_cooldown_seconds(req.cooldown_seconds);
     let owner = user.id as i64;
 
     let AlertTrigger::BelowThreshold {
@@ -26,11 +52,7 @@ pub(crate) async fn create_alert(
         hq_only,
     } = req.trigger;
 
-    if price_threshold <= 0 {
-        return Err(ApiError::from(anyhow::anyhow!(
-            "price_threshold must be positive"
-        )));
-    }
+    validate_price_threshold(price_threshold)?;
 
     let (notification_method, notification_config, notification_name): (&str, _, String) =
         match &req.delivery {
@@ -141,11 +163,7 @@ pub(crate) async fn update_alert(
             .map_err(ApiError::from)?;
     }
     if let Some(price) = req.price_threshold {
-        if price <= 0 {
-            return Err(ApiError::from(anyhow::anyhow!(
-                "price_threshold must be positive"
-            )));
-        }
+        validate_price_threshold(price)?;
         db.update_threshold_alert_price(owner, alert_id, price)
             .await
             .map_err(ApiError::from)?;
@@ -215,4 +233,120 @@ fn validate_discord_webhook_url(url: &str) -> Result<(), ApiError> {
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------- resolve_cooldown_seconds ----------
+
+    #[test]
+    fn cooldown_default_when_unset() {
+        assert_eq!(
+            resolve_cooldown_seconds(None),
+            DEFAULT_COOLDOWN_SECONDS
+        );
+    }
+
+    #[test]
+    fn cooldown_passes_in_range_values_through() {
+        assert_eq!(resolve_cooldown_seconds(Some(60)), 60);
+        assert_eq!(resolve_cooldown_seconds(Some(3600)), 3600);
+        assert_eq!(resolve_cooldown_seconds(Some(86400)), 86400);
+        assert_eq!(resolve_cooldown_seconds(Some(7200)), 7200);
+    }
+
+    #[test]
+    fn cooldown_clamps_to_min_when_below_60() {
+        assert_eq!(resolve_cooldown_seconds(Some(0)), 60);
+        assert_eq!(resolve_cooldown_seconds(Some(59)), 60);
+        assert_eq!(resolve_cooldown_seconds(Some(-1)), 60);
+        assert_eq!(resolve_cooldown_seconds(Some(i32::MIN)), 60);
+    }
+
+    #[test]
+    fn cooldown_clamps_to_max_when_above_86400() {
+        assert_eq!(resolve_cooldown_seconds(Some(86401)), 86400);
+        assert_eq!(resolve_cooldown_seconds(Some(1_000_000)), 86400);
+        assert_eq!(resolve_cooldown_seconds(Some(i32::MAX)), 86400);
+    }
+
+    // ---------- validate_price_threshold ----------
+
+    #[test]
+    fn price_threshold_accepts_positive() {
+        assert!(validate_price_threshold(1).is_ok());
+        assert!(validate_price_threshold(100).is_ok());
+        assert!(validate_price_threshold(i32::MAX).is_ok());
+    }
+
+    #[test]
+    fn price_threshold_rejects_zero_and_negative() {
+        assert!(validate_price_threshold(0).is_err());
+        assert!(validate_price_threshold(-1).is_err());
+        assert!(validate_price_threshold(i32::MIN).is_err());
+    }
+
+    // ---------- validate_discord_webhook_url ----------
+
+    #[test]
+    fn webhook_url_accepts_canonical_discord_host() {
+        assert!(
+            validate_discord_webhook_url("https://discord.com/api/webhooks/1/abc").is_ok()
+        );
+    }
+
+    #[test]
+    fn webhook_url_accepts_all_documented_discord_hosts() {
+        for host in [
+            "discord.com",
+            "discordapp.com",
+            "ptb.discord.com",
+            "canary.discord.com",
+        ] {
+            let url = format!("https://{host}/api/webhooks/1/abc");
+            assert!(
+                validate_discord_webhook_url(&url).is_ok(),
+                "expected ok for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_url_rejects_non_https_scheme() {
+        assert!(
+            validate_discord_webhook_url("http://discord.com/api/webhooks/1/abc").is_err()
+        );
+        assert!(
+            validate_discord_webhook_url("ftp://discord.com/api/webhooks/1/abc").is_err()
+        );
+    }
+
+    #[test]
+    fn webhook_url_rejects_non_discord_host() {
+        assert!(
+            validate_discord_webhook_url("https://evil.com/api/webhooks/1/abc").is_err()
+        );
+        assert!(
+            validate_discord_webhook_url("https://discord.com.evil.com/api/webhooks/1/abc")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn webhook_url_rejects_wrong_path_prefix() {
+        assert!(validate_discord_webhook_url("https://discord.com/").is_err());
+        assert!(validate_discord_webhook_url("https://discord.com/api/").is_err());
+        assert!(
+            validate_discord_webhook_url("https://discord.com/login?next=/api/webhooks/")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn webhook_url_rejects_garbage_string() {
+        assert!(validate_discord_webhook_url("not a url").is_err());
+        assert!(validate_discord_webhook_url("").is_err());
+    }
 }

--- a/ultros/src/web/api/alerts.rs
+++ b/ultros/src/web/api/alerts.rs
@@ -27,6 +27,7 @@ pub(crate) fn resolve_cooldown_seconds(requested: Option<i32>) -> i32 {
 }
 
 /// Validate a price threshold from a user request. Returns `Err` when zero or negative.
+#[allow(clippy::result_large_err)]
 pub(crate) fn validate_price_threshold(price_threshold: i32) -> Result<(), ApiError> {
     if price_threshold <= 0 {
         Err(ApiError::from(anyhow::anyhow!(
@@ -243,10 +244,7 @@ mod tests {
 
     #[test]
     fn cooldown_default_when_unset() {
-        assert_eq!(
-            resolve_cooldown_seconds(None),
-            DEFAULT_COOLDOWN_SECONDS
-        );
+        assert_eq!(resolve_cooldown_seconds(None), DEFAULT_COOLDOWN_SECONDS);
     }
 
     #[test]
@@ -292,9 +290,7 @@ mod tests {
 
     #[test]
     fn webhook_url_accepts_canonical_discord_host() {
-        assert!(
-            validate_discord_webhook_url("https://discord.com/api/webhooks/1/abc").is_ok()
-        );
+        assert!(validate_discord_webhook_url("https://discord.com/api/webhooks/1/abc").is_ok());
     }
 
     #[test]
@@ -315,19 +311,13 @@ mod tests {
 
     #[test]
     fn webhook_url_rejects_non_https_scheme() {
-        assert!(
-            validate_discord_webhook_url("http://discord.com/api/webhooks/1/abc").is_err()
-        );
-        assert!(
-            validate_discord_webhook_url("ftp://discord.com/api/webhooks/1/abc").is_err()
-        );
+        assert!(validate_discord_webhook_url("http://discord.com/api/webhooks/1/abc").is_err());
+        assert!(validate_discord_webhook_url("ftp://discord.com/api/webhooks/1/abc").is_err());
     }
 
     #[test]
     fn webhook_url_rejects_non_discord_host() {
-        assert!(
-            validate_discord_webhook_url("https://evil.com/api/webhooks/1/abc").is_err()
-        );
+        assert!(validate_discord_webhook_url("https://evil.com/api/webhooks/1/abc").is_err());
         assert!(
             validate_discord_webhook_url("https://discord.com.evil.com/api/webhooks/1/abc")
                 .is_err()
@@ -339,8 +329,7 @@ mod tests {
         assert!(validate_discord_webhook_url("https://discord.com/").is_err());
         assert!(validate_discord_webhook_url("https://discord.com/api/").is_err());
         assert!(
-            validate_discord_webhook_url("https://discord.com/login?next=/api/webhooks/")
-                .is_err()
+            validate_discord_webhook_url("https://discord.com/login?next=/api/webhooks/").is_err()
         );
     }
 

--- a/ultros/src/web/country_code_decoder.rs
+++ b/ultros/src/web/country_code_decoder.rs
@@ -117,3 +117,88 @@ impl From<CountryCode> for Region {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_region(country: CountryCode, expected: &str) {
+        let r: Region = country.into();
+        assert_eq!(r.as_str(), expected, "country {country:?}");
+    }
+
+    #[test]
+    fn north_america_countries_map_to_north_america() {
+        for c in [CountryCode::USA, CountryCode::CAN, CountryCode::MEX] {
+            assert_region(c, "North-America");
+        }
+    }
+
+    #[test]
+    fn japan_maps_to_japan() {
+        assert_region(CountryCode::JPN, "Japan");
+    }
+
+    #[test]
+    fn korea_maps_to_korea() {
+        let r: Region = CountryCode::KOR.into();
+        assert!(matches!(r, Region::Korea));
+    }
+
+    #[test]
+    fn china_maps_to_china() {
+        let r: Region = CountryCode::CHN.into();
+        assert!(matches!(r, Region::China));
+    }
+
+    #[test]
+    fn oceania_countries_map_to_oceania() {
+        for c in [
+            CountryCode::AUS,
+            CountryCode::NZL,
+            CountryCode::FJI,
+            CountryCode::GUM,
+            CountryCode::WSM,
+            CountryCode::PNG,
+            CountryCode::TON,
+            CountryCode::PLW,
+            CountryCode::NCL,
+            CountryCode::TUV,
+        ] {
+            assert_region(c, "Oceania");
+        }
+    }
+
+    #[test]
+    fn unknown_country_defaults_to_europe() {
+        // Pick a random European country and a few not handled above.
+        for c in [
+            CountryCode::DEU,
+            CountryCode::FRA,
+            CountryCode::GBR,
+            CountryCode::IND, // India — not in any explicit branch
+            CountryCode::BRA, // Brazil — falls into Europe via the catch-all (documented quirk)
+        ] {
+            assert_region(c, "Europe");
+        }
+    }
+
+    #[test]
+    fn display_renders_region_name() {
+        assert_eq!(Region::Japan.to_string(), "Japan");
+        assert_eq!(Region::NorthAmerica.to_string(), "North-America");
+        assert_eq!(Region::Europe.to_string(), "Europe");
+        assert_eq!(Region::Oceania.to_string(), "Oceania");
+        // The Chinese and Korean display strings are localized.
+        assert_eq!(Region::China.to_string(), "中国");
+        assert_eq!(Region::Korea.to_string(), "한국");
+    }
+
+    #[test]
+    fn as_ref_matches_as_str() {
+        assert_eq!(
+            AsRef::<str>::as_ref(&Region::NorthAmerica),
+            "North-America"
+        );
+    }
+}

--- a/ultros/src/web/country_code_decoder.rs
+++ b/ultros/src/web/country_code_decoder.rs
@@ -196,9 +196,6 @@ mod tests {
 
     #[test]
     fn as_ref_matches_as_str() {
-        assert_eq!(
-            AsRef::<str>::as_ref(&Region::NorthAmerica),
-            "North-America"
-        );
+        assert_eq!(AsRef::<str>::as_ref(&Region::NorthAmerica), "North-America");
     }
 }

--- a/universalis/src/lib.rs
+++ b/universalis/src/lib.rs
@@ -497,3 +497,212 @@ mod test {
         assert_eq!(entries.items.len(), 200);
     }
 }
+
+#[cfg(test)]
+mod pure_tests {
+    //! Network-independent unit tests.
+
+    use super::*;
+
+    fn empty_listing() -> ListingView {
+        ListingView {
+            last_review_time: DateTime::<Local>::from(
+                DateTime::parse_from_rfc3339("2024-01-01T00:00:00+00:00").unwrap(),
+            ),
+            price_per_unit: Some(100),
+            quantity: Some(1),
+            stain_id: None,
+            world_name: None,
+            world_id: None,
+            creator_name: None,
+            creator_id: None,
+            hq: false,
+            is_crafted: false,
+            listing_id: None,
+            materia: vec![],
+            on_mannequin: false,
+            retainer_city: 1,
+            retainer_id: None,
+            retainer_name: "Bob".into(),
+            seller_id: None,
+            total: 100,
+            tax: 0,
+        }
+    }
+
+    #[test]
+    fn ids_to_string_joins_with_commas() {
+        assert_eq!(UniversalisClient::ids_to_string(&[1, 2, 3]), "1,2,3");
+        assert_eq!(UniversalisClient::ids_to_string(&[42]), "42");
+        assert_eq!(UniversalisClient::ids_to_string(&[]), "");
+    }
+
+    #[test]
+    fn single_view_returns_listings_for_matching_id() {
+        let view = MarketView::SingleView(CurrentlyShownSingleView {
+            item_id: 7,
+            listings: vec![empty_listing()],
+            recent_history: vec![],
+        });
+        let listings = view.get_listings_for_item_id(7).unwrap();
+        assert_eq!(listings.len(), 1);
+    }
+
+    #[test]
+    fn single_view_returns_bad_id_for_non_matching_id() {
+        let view = MarketView::SingleView(CurrentlyShownSingleView {
+            item_id: 7,
+            listings: vec![empty_listing()],
+            recent_history: vec![],
+        });
+        let err = view.get_listings_for_item_id(9).unwrap_err();
+        assert!(matches!(err, Error::BadId(7)));
+    }
+
+    #[test]
+    fn multi_view_returns_listings_for_present_id() {
+        let mut items = HashMap::new();
+        items.insert(
+            42,
+            ListingMultiViewData {
+                item_id: 42,
+                last_upload_time: 0,
+                listings: vec![empty_listing()],
+                recent_history: vec![],
+                current_average_price: 0.0,
+                current_average_price_nq: 0.0,
+                current_average_price_hq: 0.0,
+                regular_sale_velocity: 0.0,
+                nq_sale_velocity: 0.0,
+                hq_sale_velocity: 0.0,
+                average_price: 0.0,
+                average_price_nq: 0.0,
+                average_price_hq: 0.0,
+                min_price: 0.0,
+                min_price_nq: 0.0,
+                min_price_hq: 0.0,
+                max_price: 0.0,
+                max_price_nq: 0.0,
+                max_price_hq: 0.0,
+                stack_size_histogram: HashMap::new(),
+                stack_size_histogram_nq: HashMap::new(),
+                stack_size_histogram_hq: HashMap::new(),
+                world_upload_times: None,
+            },
+        );
+        let view = MarketView::MultiView(CurrentlyShownMultiView {
+            item_ids: vec![42],
+            items,
+            unresolved_items: vec![],
+            dc_name: None,
+        });
+        assert_eq!(view.get_listings_for_item_id(42).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn multi_view_returns_bad_id_for_missing_id() {
+        let view = MarketView::MultiView(CurrentlyShownMultiView {
+            item_ids: vec![],
+            items: HashMap::new(),
+            unresolved_items: vec![],
+            dc_name: None,
+        });
+        assert!(matches!(
+            view.get_listings_for_item_id(99).unwrap_err(),
+            Error::BadId(99)
+        ));
+    }
+
+    #[test]
+    fn single_view_items_yields_single_tuple() {
+        let view = MarketView::SingleView(CurrentlyShownSingleView {
+            item_id: 5,
+            listings: vec![empty_listing()],
+            recent_history: vec![],
+        });
+        let items: Vec<_> = view.items().collect();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].0, ItemId(5));
+        assert_eq!(items[0].1.len(), 1);
+    }
+
+    #[test]
+    fn multi_view_items_yields_one_tuple_per_item() {
+        let mut items_map = HashMap::new();
+        for id in [10_u32, 20] {
+            items_map.insert(
+                id,
+                ListingMultiViewData {
+                    item_id: id,
+                    last_upload_time: 0,
+                    listings: vec![],
+                    recent_history: vec![],
+                    current_average_price: 0.0,
+                    current_average_price_nq: 0.0,
+                    current_average_price_hq: 0.0,
+                    regular_sale_velocity: 0.0,
+                    nq_sale_velocity: 0.0,
+                    hq_sale_velocity: 0.0,
+                    average_price: 0.0,
+                    average_price_nq: 0.0,
+                    average_price_hq: 0.0,
+                    min_price: 0.0,
+                    min_price_nq: 0.0,
+                    min_price_hq: 0.0,
+                    max_price: 0.0,
+                    max_price_nq: 0.0,
+                    max_price_hq: 0.0,
+                    stack_size_histogram: HashMap::new(),
+                    stack_size_histogram_nq: HashMap::new(),
+                    stack_size_histogram_hq: HashMap::new(),
+                    world_upload_times: None,
+                },
+            );
+        }
+        let view = MarketView::MultiView(CurrentlyShownMultiView {
+            item_ids: vec![10, 20],
+            items: items_map,
+            unresolved_items: vec![],
+            dc_name: None,
+        });
+        let mut got: Vec<i32> = view.items().map(|(id, _, _)| id.0).collect();
+        got.sort();
+        assert_eq!(got, vec![10, 20]);
+    }
+
+    #[test]
+    fn no_items_error_displays_human_message() {
+        let e = Error::NoItems;
+        assert_eq!(e.to_string(), "No items were suggested");
+    }
+
+    #[test]
+    fn bad_id_error_displays_id_in_message() {
+        let e = Error::BadId(12345);
+        assert!(e.to_string().contains("12345"));
+    }
+
+    #[test]
+    fn item_id_serde_roundtrip() {
+        let id = ItemId(99);
+        let s = serde_json::to_string(&id).unwrap();
+        let back: ItemId = serde_json::from_str(&s).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn world_id_ordering() {
+        assert!(WorldId(1) < WorldId(2));
+        assert_eq!(WorldId(7), WorldId(7));
+    }
+
+    #[tokio::test]
+    async fn marketboard_current_data_with_no_items_returns_no_items_error() {
+        let client = UniversalisClient::new("ultros-test");
+        let err = client
+            .marketboard_current_data("Aether", &[])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::NoItems));
+    }
+}


### PR DESCRIPTION
## Summary

Adds **~190 unit tests** across the backend, plus pulls testable logic out of Discord command bodies and the alerts event loops so the new tests can target it.

### Commit 1: `test: add backend unit tests across workspace` (~110 tests)

Pure-logic coverage for code that previously had ≤3 tests per crate:

- **ultros-api-types** (0 → 63): world_helper (lookup, `is_in`, all_worlds, name search, iter), cheapest_listings (map-key serde format + invalid input, PriceSummary, find_matching_listings), icon_size, ApiError display + serde + `JsonErrorWrapper::from(std::error::Error)`, list (`ListPermission::from(i16)` + ordering), websocket FilterPredicate (world/item/retainer/character/price + And/Or + serde roundtrip).
- **ultros-db** (1 → 17): try_update_value (all four `ActiveValue` state transitions), partial_diff_iterator (empty, left-only, right-only, identical, accessors), world_data::world_cache (`AnySelector` ord, `AnyResult` get_name/as_world, `WorldCacheError` messages).
- **universalis** (0 → 12 pure): `ids_to_string`, `MarketView` single/multi view lookup with `BadId`, `items()` iterator, `ItemId`/`WorldId` ord+serde, empty-input `NoItems` error.
- **dumb-csv** (1 → 7): `bool_from_str` truthy/falsy/unknown, `ParseBool` default, `parse_or_default`, `deserialize` via csv::Reader.
- **field-iterator** (0 → 5): SortableVec ascending + then-by tie break + panic on unknown labels.
- **ultros** (binary): country_code_decoder Region mapping for every documented branch + Display + AsRef; analyzer_service extends existing tests with `SoldAmount` display cap, `SoldWithin` display + duration + `PartialOrd`, `CheapestListingValue` price-only equality, `CheapestListings::add_listing` minimum tracking + LQ/HQ separation, `SaleHistory` full-capacity replace + ignore-older-than-oldest semantics.

`serde_json` added as dev-dep to ultros-api-types and ultros-db for roundtrip assertions.

### Commit 2: `refactor: extract pure helpers from Discord commands` (35 tests)

Move inline ladder / filter / sort logic out of `analyze::profit`, `item_prices::current`, and four autocomplete handlers into a new `discord/ffxiv/helpers.rs`.

- `threshold_days_to_sold_within(days, amount)` — maps user days to `SoldWithin` bucket with `clamp(1, 255)` on `YearsAgo` year count (prevents `i32` overflow).
- `clamp_sold_amount` — saturating cast `i32` → `SoldAmount(u8)`.
- `name_matches_partial` / `name_matches_lowered` (Unicode) + ASCII variants.
- `top_n_cheapest_listings` — sort by price, optional hq filter, take(n).

**Perf side-effect:** old autocompletes called `partial.to_lowercase()` inside the filter closure, allocating one `String` per item for ~5000 xiv-gen items per keystroke. The `*_lowered` helpers force callers to hoist the lowering — one allocation instead of N.

### Commit 3: `refactor: extract pure helpers from alerts module` (41 tests)

Decision logic pulled out of each alerts file:

- `price_alert_tracker`: `is_off_cooldown_at(last, cd, now)` (deterministic), `rule_matches_listing(rule, listing, now)` (the four-way world/hq/price/cooldown predicate), `format_threshold_alert_message`. `handle_added` is now a thin shell over these.
- `delivery`: `parse_endpoint_config(method, config)` — the splice-then-deserialize dance is now testable in isolation. Includes a test for the new `Webhook` variant from Phase 2.
- `undercut_alert`: `is_undercut_by_more_than_margin(our, competitor, margin_pct)` — was inline-duplicated in two places; tests document the margin=100 / margin>100 edge cases that effectively disable the alert. Drops a 14-line commented-out `into_stream` dead code block.
- `web/api/alerts`: `resolve_cooldown_seconds` + `validate_price_threshold` (was inline in `create_alert` and `update_alert`). Also tests `validate_discord_webhook_url` from Phase 2/3 across the 4 allowed hosts, scheme rejection, host spoofing, path prefix.

Behavior preserved end-to-end. None of the changes touch async event loops, DB calls, or the public HTTP API shape.

## Test plan

- [x] `cargo test -p ultros-api-types -p ultros-db -p dumb_csv -p field-iterator` passes locally (104 tests)
- [x] `cargo test -p universalis --lib pure_tests` passes locally (12 tests)
- [x] `cargo check -p ultros --tests` passes locally — full `cargo test` requires CI Linux due to a stale local workspace artifact for `libultros_app`
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)