### PR TITLE
chore: workspace dependency hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,19 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,17 +3905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5633,16 +5609,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
 
 [[package]]
 name = "prettyplease"
@@ -8054,15 +8020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8819,7 +8776,7 @@ dependencies = [
  "smallvec",
  "tantivy",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -9112,14 +9069,14 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "log",
- "pretty_env_logger",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,15 @@ axum-extra = { version = "0.10.3", features = [
     "cookie-private",
     "typed-header",
 ] }
+axum-macros = "0.5.0"
 tokio = { version = "1.48", features = ["full"] }
 tracing = "0.1.43"
 tracing-subscriber = "0.3.22"
 futures = "0.3.31"
 anyhow = "1.0.100"
+thiserror = "2.0.17"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 leptos = { version = "0.8.14", default-features = false, features = ["nightly"] }
 leptos_axum = { version = "0.8.7" }
 leptos_router = { version = "0.8.10", default-features = false, features = [

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "migration"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "MIT"
 
@@ -11,4 +11,4 @@ path = "src/lib.rs"
 
 [dependencies]
 sea-orm-migration.workspace = true
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }

--- a/ultros-api-types/Cargo.toml
+++ b/ultros-api-types/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0.228", features = ["derive", "rc"]}
-chrono = {version = "0.4.42", features = ["serde"]}
-thiserror = "2.0.17"
+serde = { workspace = true, features = ["derive", "rc"] }
+chrono = { workspace = true, features = ["serde"] }
+thiserror = { workspace = true }
 rkyv = { version = "0.7.42", features = ["validation", "size_64", "hashbrown"], default-features = false, optional = true }
 
 [features]
@@ -17,4 +17,4 @@ default = []
 rkyv = ["dep:rkyv", "chrono/rkyv-64", "chrono/rkyv-validation"]
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/ultros-db/Cargo.toml
+++ b/ultros-db/Cargo.toml
@@ -9,16 +9,16 @@ license = "MIT"
 [dependencies]
 sea-orm.workspace = true
 universalis = {path = "../universalis"}
-anyhow = "1.0.100"
-serde = {version = "1.0.228", features = ["derive"]}
-tracing = {workspace = true}
-futures = {workspace = true}
+anyhow = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+futures = { workspace = true }
 migration = {path = "../migration"}
 sea-query.workspace = true
-chrono = "0.4.42"
+chrono = { workspace = true }
 itertools.workspace = true
 yoke.workspace = true
-thiserror = "2.0.17"
+thiserror = { workspace = true }
 ultros-api-types = {path = "../ultros-api-types"}
 metrics = "0.24.3"
 dotenvy = "0.15.7"
@@ -29,4 +29,4 @@ rkyv = { version = "0.7.42", features = ["validation", "size_64", "hashbrown"], 
 rkyv = ["dep:rkyv"]
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()

--- a/ultros-frontend/ultros-app/Cargo.toml
+++ b/ultros-frontend/ultros-app/Cargo.toml
@@ -35,7 +35,7 @@ web-sys = { version = "0.3", optional = true, features = [
 ] }
 ultros-api-types = { path = "../../ultros-api-types" }
 ultros-db = { path = "../../ultros-db", optional = true }
-serde = { version = "1", features = ["rc", "derive"] }
+serde = { workspace = true, features = ["rc"] }
 thousands = "0.2.0"
 timeago = "0.4.0"
 chrono.workspace = true
@@ -43,15 +43,15 @@ itertools.workspace = true
 futures = "0.3"
 humantime = "2.1"
 colorsys = "0.6.6"
-thiserror = "2.0.17"
+thiserror = { workspace = true }
 log = "0.4.29"
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 cookie = { version = "0.18", features = ["percent-encode"] }
 wasm-bindgen = { version = "0.2", optional = true }
 time = "0.3.20"
 js-sys = { version = "0.3.61", optional = true }
 tracing = "0.1"
-serde_json = "1.0.145"
+serde_json = { workspace = true }
 ultros-charts = { path = "../ultros-charts" }
 leptos-chartistry = "0.2"
 icondata.workspace = true

--- a/ultros-frontend/ultros-client/Cargo.toml
+++ b/ultros-frontend/ultros-client/Cargo.toml
@@ -23,10 +23,10 @@ gloo-net.workspace = true
 xiv-gen-db = { path = "../../xiv-gen-db" }
 xiv-gen = { path = "../../xiv-gen" }
 futures = "0.3"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 serde-wasm-bindgen = "0.6.3"
 serde_bytes = "0.11"
-serde_json = "1.0.145"
+serde_json = { workspace = true }
 anyhow.workspace = true
 rexie = "0.5"
 any_spawner = "0.3"

--- a/ultros/Cargo.toml
+++ b/ultros/Cargo.toml
@@ -12,11 +12,11 @@ ultros-db = { path = "../ultros-db", features = ["rkyv"] }
 anyhow = { workspace = true }
 axum.workspace = true
 axum-extra.workspace = true
-axum-macros = "0.5.0"
+axum-macros = { workspace = true }
 cookie = "0.18"
 xiv-gen-db = { path = "../xiv-gen-db", features = ["embed"] }
 poise = { version = "0.6.1" }
-chrono = "0.4.42"
+chrono = { workspace = true }
 lodestone = { git = "https://github.com/akarras/lodestone.git", branch = 'async', default-features = false, features = [
     "rustls-tls",
 ] }
@@ -24,7 +24,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
 ] }
 xiv-gen.workspace = true
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true }
 include_dir = "0.7.2"
 mime_guess = "2.0.4"
 tokio = { workspace = true }
@@ -34,8 +34,8 @@ tracing-subscriber = "0.3"
 futures = { workspace = true }
 oauth2 = "4.1"
 async-trait = '0.1'
-serde_json = "1.0.85"
-thiserror = "1.0.36"
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 dotenvy = { workspace = true }
 metrics = "0.24.3"
 envy = "0.4"

--- a/universalis/Cargo.toml
+++ b/universalis/Cargo.toml
@@ -8,20 +8,20 @@ license = "MIT"
 
 [dependencies]
 reqwest = {version = "0.11.11", default-features = false, features = ["json", "rustls-tls"]}
-serde = {version = "1.0.228", features = ["derive"]}
-serde_json = "1.0.145"
-thiserror = "2.0.17"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 url = "2"
-log = "0.4.17"
+tracing = { workspace = true }
 bson = "2.4.0"
 async-tungstenite = {version = "0.24", default-features = false, features = ["tokio-runtime", "tokio-rustls-webpki-roots"], optional = true}
-tokio = {version = "1", optional = true, features = ["full"]}
-futures = "0.3.23"
+tokio = { workspace = true, optional = true }
+futures = { workspace = true }
 serde_with = {version = "3.3.0", features = ["chrono"]}
-chrono = {version = "0.4.23", features = ["serde"]}
+chrono = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
-pretty_env_logger = "0.5"
+tracing-subscriber = { workspace = true }
 clap = {version = "4.0.18", features = ["derive"]}
 
 [features]

--- a/universalis/examples/websocket.rs
+++ b/universalis/examples/websocket.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use log::info;
+use tracing::info;
 use universalis::websocket::SocketRx;
 use universalis::websocket::event_types::{EventChannel, SubscribeMode};
 use universalis::{ItemId, UniversalisClient, WebsocketClient};
@@ -16,7 +16,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     // subscribe to several items
-    pretty_env_logger::init();
+    tracing_subscriber::fmt::init();
     let universalis_client = UniversalisClient::new("ultros-universalis-examples");
     let worlds = universalis_client.get_worlds().await.unwrap();
     let args = Args::parse();

--- a/universalis/src/lib.rs
+++ b/universalis/src/lib.rs
@@ -6,13 +6,13 @@ extern crate core;
 
 use crate::MarketView::{MultiView, SingleView};
 use chrono::{DateTime, Local};
-use log::info;
 use reqwest::{Client, Method, Request, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::{TimestampMilliSeconds, TimestampSeconds, formats::Flexible, serde_as};
 use std::collections::{BTreeMap, HashMap};
 use thiserror::Error;
+use tracing::info;
 
 #[derive(Hash, Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ItemId(pub i32);

--- a/universalis/src/websocket/mod.rs
+++ b/universalis/src/websocket/mod.rs
@@ -11,7 +11,7 @@ use bson::Document;
 use futures::future::Either;
 
 use futures::{SinkExt, Stream, StreamExt};
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 
 use async_tungstenite::WebSocketStream;
 use futures::stream::FusedStream;

--- a/xiv-gen-db/Cargo.toml
+++ b/xiv-gen-db/Cargo.toml
@@ -20,6 +20,6 @@ anyhow.workspace = true
 
 [build-dependencies]
 xiv-gen = {workspace = true, features = ["csv_to_bincode"]}
-serde = {version = "1.0.143", features = ["derive"]}
+serde = { workspace = true }
 bincode = {version = "2.0.0-rc.3"}
 flate2 = "1.0.24"

--- a/xiv-gen/Cargo.toml
+++ b/xiv-gen/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-serde = {version = "1.0.228", features = ["derive"]}
+serde = { workspace = true }
 bincode = {version = "2.0.1"}
 csv = {version = "1.4.0"}
 derive_more = {version = "1.0.0", features = ["from_str"]}


### PR DESCRIPTION
## Summary

Pulls commonly-shared dependencies (`thiserror`, `serde`, `serde_json`, `axum-macros`) into `[workspace.dependencies]` so per-crate manifests can use `workspace = true`. Eliminates silent version drift between crates.

Reconciliations driven by this:

- **thiserror**: `ultros` was pinning 1.0.36 while everything else used 2.0.17. Both versions were compiling. Unified on 2.0.17 — the existing `#[error]` / `#[from]` derives compiled cleanly against 2.x.
- **chrono**: `universalis` was on 0.4.23 while the rest of the workspace was on 0.4.42. Unified.
- **serde**: `xiv-gen-db` build-dep was on 1.0.143 vs 1.0.228 elsewhere. Unified.

`universalis` is also switched from `log` to `tracing` to match the rest of the workspace — universalis log output was being silently dropped because the server installs a tracing subscriber, not a log one. The example switches to `tracing_subscriber::fmt::init()` so the dev-dep on `pretty_env_logger` is gone too.

`migration` bumps edition 2021 → 2024 to match the rest of the workspace.

## Not in scope

`reqwest` unification (`universalis` + `ultros` on 0.11 vs `ultros-app` on 0.12) is deferred. The 0.11 → 0.12 bump tangles with the `oauth2` crate in `ultros` (which expects reqwest 0.11), so it needs its own focused PR.

## Test plan

- [x] `./check_ci.sh` passes (fmt + clippy on all targets)
- [ ] No runtime behavior change expected; smoke test by running the app locally