### PR TITLE
refactor(ultros-db): collapse N+1 queries and replace hand-rolled upsert

### DIFF
--- a/ultros-db/src/alerts.rs
+++ b/ultros-db/src/alerts.rs
@@ -312,11 +312,12 @@ impl UltrosDb {
         &self,
         alert_id: i32,
     ) -> Result<Option<notification_endpoint::Model>> {
-        let rules = alert_notification_rule::Entity::find()
+        let rule = alert_notification_rule::Entity::find()
             .filter(alert_notification_rule::Column::AlertId.eq(alert_id))
-            .all(&self.db)
+            .limit(1)
+            .one(&self.db)
             .await?;
-        if let Some(rule) = rules.first() {
+        if let Some(rule) = rule {
             Ok(notification_endpoint::Entity::find_by_id(rule.endpoint_id)
                 .one(&self.db)
                 .await?)
@@ -342,18 +343,9 @@ impl UltrosDb {
         owner: i64,
         limit: u64,
     ) -> Result<Vec<alert_event::Model>> {
-        let alert_ids: Vec<i32> = alert::Entity::find()
-            .filter(alert::Column::Owner.eq(owner))
-            .all(&self.db)
-            .await?
-            .into_iter()
-            .map(|a| a.id)
-            .collect();
-        if alert_ids.is_empty() {
-            return Ok(vec![]);
-        }
         Ok(alert_event::Entity::find()
-            .filter(alert_event::Column::AlertId.is_in(alert_ids))
+            .inner_join(alert::Entity)
+            .filter(alert::Column::Owner.eq(owner))
             .order_by_desc(alert_event::Column::FiredAt)
             .limit(limit)
             .all(&self.db)

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()
@@ -168,19 +170,17 @@ impl UltrosDb {
     }
 
     pub async fn get_lists_for_user(&self, discord_user: i64) -> Result<Vec<list::Model>> {
-        // This should probably also include lists shared with the user
-        let owned_lists = list::Entity::find()
+        // Owned, shared-with-user, and shared-with-group are independent queries — issue
+        // them in parallel and merge in Rust (dedup because a list can appear in multiple
+        // sources).
+        let owned_fut = list::Entity::find()
             .filter(list::Column::Owner.eq(discord_user))
-            .all(&self.db)
-            .await?;
-
-        let shared_lists = list::Entity::find()
+            .all(&self.db);
+        let shared_fut = list::Entity::find()
             .inner_join(list_shared_user::Entity)
             .filter(list_shared_user::Column::UserId.eq(discord_user))
-            .all(&self.db)
-            .await?;
-
-        let group_lists = list::Entity::find()
+            .all(&self.db);
+        let group_fut = list::Entity::find()
             .inner_join(list_shared_group::Entity)
             .join(
                 JoinType::InnerJoin,
@@ -191,8 +191,9 @@ impl UltrosDb {
                 user_group::Relation::UserGroupMember.def(),
             )
             .filter(user_group_member::Column::UserId.eq(discord_user))
-            .all(&self.db)
-            .await?;
+            .all(&self.db);
+        let (owned_lists, shared_lists, group_lists) =
+            futures::try_join!(owned_fut, shared_fut, group_fut)?;
 
         let mut all_lists = owned_lists;
         all_lists.extend(shared_lists);

--- a/ultros-db/src/recently_updated.rs
+++ b/ultros-db/src/recently_updated.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+    ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
+    sea_query::OnConflict,
 };
 use universalis::{ItemId, WorldId};
 
@@ -12,25 +13,22 @@ impl UltrosDb {
         world_id: WorldId,
         item_id: ItemId,
     ) -> Result<(), anyhow::Error> {
-        // just assume most items have an update, handle the failure case manually
         let model = listing_last_updated::ActiveModel {
             item_id: ActiveValue::Set(item_id.0),
             world_id: ActiveValue::Set(world_id.0),
             date_time: ActiveValue::Set(Utc::now().naive_utc()),
         };
-        let updated = model.clone().update(&self.db).await;
-        match updated {
-            Ok(_updated) => {}
-            Err(_e) => {
-                match model.clone().insert(&self.db).await {
-                    Ok(_ok) => {}
-                    Err(_e) => {
-                        // ok now can we update?
-                        model.clone().update(&self.db).await?;
-                    }
-                }
-            }
-        }
+        listing_last_updated::Entity::insert(model)
+            .on_conflict(
+                OnConflict::columns([
+                    listing_last_updated::Column::ItemId,
+                    listing_last_updated::Column::WorldId,
+                ])
+                .update_column(listing_last_updated::Column::DateTime)
+                .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
         Ok(())
     }
 

--- a/ultros-db/src/retainers.rs
+++ b/ultros-db/src/retainers.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::collections::HashSet;
 
-use futures::future::try_join_all;
 use migration::sea_orm::IntoActiveModel;
 use sea_orm::ActiveModelTrait;
 use sea_orm::ActiveValue;
@@ -288,48 +288,38 @@ impl UltrosDb {
             .iter()
             .flat_map(|(owned, _)| owned.character_id)
             .collect();
-        let mut characters = if !character_ids.is_empty() {
-            try_join_all(character_ids.into_iter().map(|character| {
-                final_fantasy_character::Entity::find()
-                    .filter(final_fantasy_character::Column::Id.eq(character))
-                    .one(&self.db)
-            }))
-            .await?
-            .into_iter()
-            .flatten()
-            .collect()
+        let characters: HashMap<i32, final_fantasy_character::Model> = if character_ids.is_empty() {
+            HashMap::new()
         } else {
-            vec![]
+            final_fantasy_character::Entity::find()
+                .filter(final_fantasy_character::Column::Id.is_in(character_ids))
+                .all(&self.db)
+                .await?
+                .into_iter()
+                .map(|c| (c.id, c))
+                .collect()
         };
-        let mut value = owned_retainers
+        // Group retainers by character_id in a HashMap (O(n)) before flattening to FullRetainersList.
+        // The owned_retainers query was find_also_related(retainer::Entity), so each row is
+        // (owned_retainers::Model, Option<retainer::Model>); drop the rows that lack a related retainer.
+        let mut grouped: HashMap<Option<i32>, Vec<(owned_retainers::Model, retainer::Model)>> =
+            HashMap::new();
+        for (owned, retainer) in owned_retainers
             .into_iter()
-            .flat_map(|(retainer, owned)| owned.map(|o| (retainer.character_id, retainer, o)))
-            .fold(
-                Vec::<(
-                    Option<final_fantasy_character::Model>,
-                    Vec<(owned_retainers::Model, retainer::Model)>,
-                )>::new(),
-                |mut v, (character, retainer, owned)| {
-                    if let Some((_key, value)) = v
-                        .iter_mut()
-                        .find(|(c, _): &&mut (_, _)| c.as_ref().map(|c| c.id).eq(&character))
-                    {
-                        value.push((retainer, owned));
-                    } else {
-                        let character = character.map(|character_id| {
-                            let idx = characters
-                                .iter()
-                                .enumerate()
-                                .find(|(_, c)| c.id == character_id)
-                                .map(|(i, _)| i)
-                                .expect("Should have a character.");
-                            characters.remove(idx)
-                        });
-                        v.push((character, vec![(retainer, owned)]));
-                    }
-                    v
-                },
-            );
+            .flat_map(|(owned, retainer)| retainer.map(|r| (owned, r)))
+        {
+            grouped
+                .entry(owned.character_id)
+                .or_default()
+                .push((owned, retainer));
+        }
+        let mut value: FullRetainersList = grouped
+            .into_iter()
+            .map(|(character_id, retainers)| {
+                let character = character_id.and_then(|id| characters.get(&id).cloned());
+                (character, retainers)
+            })
+            .collect();
         value
             .iter_mut()
             .for_each(|(_, i)| i.sort_by_key(|(o, _)| o.weight));


### PR DESCRIPTION
## Summary

Hot-path query cleanups in the db layer. No behavior changes — same results, fewer round trips.

- **`recently_updated::set_last_updated`**: replace the try-update / on-fail insert / on-fail retry-update pattern (up to 3 round trips, errors silently swallowed) with `insert().on_conflict(...).update_column()`. One round trip, real error propagation.
- **`alerts::get_recent_alert_events_for_user`**: collapse \"fetch all alert ids for owner, then fetch events by those ids\" into a single `alert_event.find().inner_join(alert).filter(alert.owner)` query.
- **`alerts::get_first_endpoint_for_alert`**: was fetching all matching rules with `.all()` and using `.first()`. Now `.limit(1).one()` so the database does the limiting.
- **`lists::get_lists_for_user`**: the three independent lookups (owned, shared-with-user, shared-with-group) now run in parallel via `futures::try_join!` instead of three serial awaits.
- **`retainers::get_all_owned_retainers_and_character`**: replace `try_join_all` of N `find_by_id()` calls with one `find().is_in(character_ids)`. Also replace the O(n²) `Vec::iter_mut().find()` grouping fold with a `HashMap`, and rename the consistently-misleading `retainer` / `owned` variables to match their actual types (the original code called the `owned_retainers::Model` value `retainer` and the related `retainer::Model` value `owned`).

## Test plan

- [x] `./check_ci.sh` passes (fmt + clippy on all targets)
- [ ] Smoke: load retainer page (exercises `get_all_owned_retainers_and_character`)
- [ ] Smoke: load lists page (exercises `get_lists_for_user`)
- [ ] Smoke: load alerts page (exercises `get_recent_alert_events_for_user`)