### PR TITLE
refactor(ultros/web): collapse ApiError/WebError duplication into one macro

### DIFF
--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -26,68 +26,79 @@ use crate::{analyzer_service::AnalyzerError, event};
 
 use super::character_verifier_service::VerifierError;
 
-#[derive(Debug, Error)]
-pub enum ApiError {
-    #[error("OAuth configuration error {0}")]
-    ConfigurationError(#[from] ConfigurationError),
-    #[error("Error creating oauth token {0}")]
-    RequestErrorToken(
-        #[from]
-        RequestTokenError<
-            oauth2::reqwest::Error<reqwest::Error>,
-            StandardErrorResponse<RevocationErrorResponseType>,
-        >,
-    ),
-    #[error("Generic error {0}")]
-    AnyhowError(#[from] anyhow::Error),
-    #[error("Parse int failed {0}")]
-    ParseIntError(#[from] ParseIntError),
-    #[error("{0}")]
-    WorldSelectError(#[from] WorldCacheError),
-    #[error("Db Error {0}")]
-    DbError(#[from] SeaDbErr),
-    #[error("Error communicaing with universalis {0}")]
-    UniversalisError(#[from] universalis::Error),
-    #[error("Error sending listing update {0}")]
-    ListingSendError(
-        #[from] SendError<event::EventType<Arc<Vec<ultros_db::entity::active_listing::Model>>>>,
-    ),
-    #[error("Error making an internal HTTP request {0}")]
-    ReqwestError(#[from] reqwest::Error),
-    #[error("Internal HTTP Error {0}")]
-    AxumError(#[from] axum::http::Error),
-    #[error("IO Error {0}")]
-    StdError(#[from] std::io::Error),
-    #[error("Error reading lodestone server name {0}")]
-    LodestoneServerParse(#[from] lodestone::model::server::ServerParseError),
-    #[error("Lodestone error {0}")]
-    LodestoneError(#[from] lodestone::LodestoneError),
-    // this is kind of bad if I ever use the elapsed error for something else but I'll pretend
-    #[error("Universalis is being slow. {0}. Will continue waiting")]
-    TimeoutElapsed(#[from] Elapsed),
-    #[error("Analyzer Error: {0}")]
-    AnalyzerError(#[from] AnalyzerError),
-    #[error("Verifier error {0}")]
-    VerificationError(#[from] VerifierError),
-    #[error("Error generating sitemap {0}")]
-    SiteMapError(#[from] SitemapIndexError),
-    #[error("Error generating url set {0}")]
-    UrlSetError(#[from] UrlSetError),
-    #[error("Token error {0}")]
-    TokenError(
-        #[from]
-        RequestTokenError<
-            oauth2::reqwest::Error<reqwest::Error>,
-            StandardErrorResponse<BasicErrorResponseType>,
-        >,
-    ),
+/// Generates an `Error`-deriving enum with the variants shared between `ApiError` and `WebError`.
+/// The shared variants and their `#[from]` / `#[error]` attributes are kept in one place so the
+/// two enums can't drift. Caller passes in any enum-specific variants between braces.
+macro_rules! define_error_enum {
+    ($name:ident { $($extra:tt)* }) => {
+        #[derive(Debug, Error)]
+        pub enum $name {
+            #[error("OAuth configuration error {0}")]
+            ConfigurationError(#[from] ConfigurationError),
+            #[error("Error creating oauth token {0}")]
+            RequestErrorToken(
+                #[from]
+                RequestTokenError<
+                    oauth2::reqwest::Error<reqwest::Error>,
+                    StandardErrorResponse<RevocationErrorResponseType>,
+                >,
+            ),
+            #[error("Generic error {0}")]
+            AnyhowError(#[from] anyhow::Error),
+            #[error("Parse int failed {0}")]
+            ParseIntError(#[from] ParseIntError),
+            #[error("{0}")]
+            WorldSelectError(#[from] WorldCacheError),
+            #[error("Db Error {0}")]
+            DbError(#[from] SeaDbErr),
+            #[error("Error communicaing with universalis {0}")]
+            UniversalisError(#[from] universalis::Error),
+            #[error("Error sending listing update {0}")]
+            ListingSendError(
+                #[from] SendError<event::EventType<Arc<Vec<ultros_db::entity::active_listing::Model>>>>,
+            ),
+            #[error("Error making an internal HTTP request {0}")]
+            ReqwestError(#[from] reqwest::Error),
+            #[error("Internal HTTP Error {0}")]
+            AxumError(#[from] axum::http::Error),
+            #[error("IO Error {0}")]
+            StdError(#[from] std::io::Error),
+            #[error("Error reading lodestone server name {0}")]
+            LodestoneServerParse(#[from] lodestone::model::server::ServerParseError),
+            #[error("Lodestone error {0}")]
+            LodestoneError(#[from] lodestone::LodestoneError),
+            // this is kind of bad if I ever use the elapsed error for something else but I'll pretend
+            #[error("Universalis is being slow. {0}. Will continue waiting")]
+            TimeoutElapsed(#[from] Elapsed),
+            #[error("Analyzer Error: {0}")]
+            AnalyzerError(#[from] AnalyzerError),
+            #[error("Verifier error {0}")]
+            VerificationError(#[from] VerifierError),
+            #[error("Error generating sitemap {0}")]
+            SiteMapError(#[from] SitemapIndexError),
+            #[error("Error generating url set {0}")]
+            UrlSetError(#[from] UrlSetError),
+            #[error("Token error {0}")]
+            TokenError(
+                #[from]
+                RequestTokenError<
+                    oauth2::reqwest::Error<reqwest::Error>,
+                    StandardErrorResponse<BasicErrorResponseType>,
+                >,
+            ),
+            $($extra)*
+        }
+    };
+}
+
+define_error_enum!(ApiError {
     #[error("API conversions error {0}")]
     ApiConversionError(#[from] ApiConversionError),
     #[error("No Auth Cookie")]
     NoAuthCookie,
     #[error("Discord token was invalid")]
     DiscordTokenInvalid(PrivateCookieJar<Key>),
-}
+});
 
 impl ApiError {
     fn as_status_code(&self) -> StatusCode {
@@ -126,63 +137,9 @@ impl IntoResponse for ApiError {
     }
 }
 
-#[derive(Debug, Error)]
-pub enum WebError {
+define_error_enum!(WebError {
     #[error("Not authorized to view this page")]
     NotAuthenticated,
-    #[error("OAuth configuration error {0}")]
-    ConfigurationError(#[from] ConfigurationError),
-    #[error("Error creating oauth token {0}")]
-    RequestErrorToken(
-        #[from]
-        RequestTokenError<
-            oauth2::reqwest::Error<reqwest::Error>,
-            StandardErrorResponse<RevocationErrorResponseType>,
-        >,
-    ),
-    #[error("Generic error {0}")]
-    AnyhowError(#[from] anyhow::Error),
-    #[error("Parse int failed {0}")]
-    ParseIntError(#[from] ParseIntError),
-    #[error("{0}")]
-    WorldSelectError(#[from] WorldCacheError),
-    #[error("Db Error {0}")]
-    DbError(#[from] SeaDbErr),
-    #[error("Error communicaing with universalis {0}")]
-    UniversalisError(#[from] universalis::Error),
-    #[error("Error sending listing update {0}")]
-    ListingSendError(
-        #[from] SendError<event::EventType<Arc<Vec<ultros_db::entity::active_listing::Model>>>>,
-    ),
-    #[error("Error making an internal HTTP request {0}")]
-    ReqwestError(#[from] reqwest::Error),
-    #[error("Internal HTTP Error {0}")]
-    AxumError(#[from] axum::http::Error),
-    #[error("IO Error {0}")]
-    StdError(#[from] std::io::Error),
-    #[error("Error reading lodestone server name {0}")]
-    LodestoneServerParse(#[from] lodestone::model::server::ServerParseError),
-    #[error("Lodestone error {0}")]
-    LodestoneError(#[from] lodestone::LodestoneError),
-    // this is kind of bad if I ever use the elapsed error for something else but I'll pretend
-    #[error("Universalis is being slow. {0}. Will continue waiting")]
-    TimeoutElapsed(#[from] Elapsed),
-    #[error("Analyzer Error: {0}")]
-    AnalyzerError(#[from] AnalyzerError),
-    #[error("Verifier error {0}")]
-    VerificationError(#[from] VerifierError),
-    #[error("Error generating sitemap {0}")]
-    SiteMapError(#[from] SitemapIndexError),
-    #[error("Error generating url set {0}")]
-    UrlSetError(#[from] UrlSetError),
-    #[error("Token error {0}")]
-    TokenError(
-        #[from]
-        RequestTokenError<
-            oauth2::reqwest::Error<reqwest::Error>,
-            StandardErrorResponse<BasicErrorResponseType>,
-        >,
-    ),
     #[error("Item id {0} is not valid")]
     InvalidItemId(i32),
     #[error("World not found {0}")]
@@ -191,7 +148,7 @@ pub enum WebError {
     NotFound,
     #[error("Bad request")]
     BadRequest,
-}
+});
 
 impl WebError {
     fn as_status_code(&self) -> StatusCode {


### PR DESCRIPTION
## Summary

`ApiError` and `WebError` shared **19 identical variants** (every `#[from]` arm between them) copy-pasted twice. Each variant's `#[error]` string was maintained in two places and silently drift-prone — auditor finding.

Replaces both definitions with a single declarative macro `define_error_enum!(name { extras })` that emits the shared variants once and accepts enum-specific trailing variants. The unique parts stay where they belong:

- `ApiError` keeps `ApiConversionError`, `NoAuthCookie`, `DiscordTokenInvalid`
- `WebError` keeps `NotAuthenticated`, `InvalidItemId`, `WorldNotFound`, `NotFound`, `BadRequest`

No behavior change: all `#[from]` impls, error strings, and `IntoResponse` / status-code mappings are preserved. Net -41 lines.

Includes a `cargo fmt` pass on `ultros-db/src/lists.rs` that was already failing on main.

## Not in scope

The audit also recommended splitting [ultros/src/web.rs](ultros/src/web.rs) (currently 1323 lines) into per-resource handler modules. That's deferred to a separate PR — bigger, mechanical, higher merge-conflict risk.

## Test plan

- [x] `./check_ci.sh` passes
- [x] All `?`/error conversions in callers continue to compile (verified by clippy --all-targets)