### PR TITLE
refactor(ultros-app): extract shared analyzer-table helpers

### DIFF
--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()

--- a/ultros-frontend/ultros-app/src/analysis.rs
+++ b/ultros-frontend/ultros-app/src/analysis.rs
@@ -1,5 +1,5 @@
 use crate::math::filter_outliers_iqr_in_place;
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use ultros_api_types::recent_sales::SaleData;
 
 #[derive(Clone, Copy, Debug)]
@@ -7,6 +7,67 @@ pub struct SalesStats {
     pub daily_sales: f32,
     pub avg_price: i32,
     pub total_sales: usize,
+}
+
+/// Summary stats for a single (item_id, hq) bucket of recent sales. Shared by the analyzer
+/// and vendor-resale tables.
+#[derive(Hash, Clone, Debug, PartialEq)]
+pub struct SaleSummary {
+    pub item_id: i32,
+    pub hq: bool,
+    /// Number of sales considered; bounded by the API's recent-sales window.
+    pub num_sold: usize,
+    /// Average time between sales across `num_sold`. None if no sales.
+    pub avg_sale_duration: Option<Duration>,
+    pub max_price: i32,
+    pub avg_price: i32,
+    pub min_price: i32,
+}
+
+/// Renders a duration as a compact "Xd Yh" / "Xh Ym" / "Xm Ys" string (up to two units).
+/// Used by analyzer tables for the avg-sale-duration column.
+pub fn format_duration_short(secs: u64) -> String {
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let minutes = (secs % 3_600) / 60;
+    let seconds = secs % 60;
+    let mut parts: Vec<String> = Vec::new();
+    if days > 0 {
+        parts.push(format!("{}d", days));
+    }
+    if hours > 0 {
+        parts.push(format!("{}h", hours));
+    }
+    if minutes > 0 && parts.len() < 2 {
+        parts.push(format!("{}m", minutes));
+    }
+    if seconds > 0 && parts.len() < 2 {
+        parts.push(format!("{}s", seconds));
+    }
+    if parts.is_empty() {
+        "0s".to_string()
+    } else {
+        parts[..parts.len().min(2)].join(" ")
+    }
+}
+
+/// Tailwind class string for the ROI badge in analyzer tables. Tints the badge with the
+/// brand-ring color, proportional to ROI %.
+pub fn roi_badge_class(roi: i32) -> String {
+    let tint = if roi >= 500 {
+        "24%"
+    } else if roi >= 200 {
+        "20%"
+    } else if roi >= 100 {
+        "16%"
+    } else if roi >= 50 {
+        "12%"
+    } else {
+        "10%"
+    };
+    format!(
+        "inline-flex items-center justify-end px-2 py-1 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_{tint},transparent)]"
+    )
 }
 
 pub fn analyze_sales(sales_data: &[&SaleData], filter_outliers: bool) -> SalesStats {

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1,3 +1,4 @@
+use crate::analysis::{SaleSummary, format_duration_short, roi_badge_class};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
 use crate::{
@@ -31,20 +32,6 @@ use ultros_api_types::{
     world_helper::{AnyResult, AnySelector, WorldHelper},
 };
 use xiv_gen::ItemId;
-
-/// Computed sale stats
-#[derive(Hash, Clone, Debug, PartialEq)]
-struct SaleSummary {
-    item_id: i32,
-    hq: bool,
-    /// this value is limited by the summary returned by the API
-    num_sold: usize,
-    /// Represents the average time between sales within the `num_sold`
-    avg_sale_duration: Option<Duration>,
-    max_price: i32,
-    avg_price: i32,
-    min_price: i32,
-}
 
 #[derive(Hash, Clone, Debug, PartialEq, Eq)]
 struct ProfitKey {
@@ -951,23 +938,7 @@ fn AnalyzerTable(
                                     <div role="cell" class="px-4 py-2 w-30 text-right flex items-center justify-end">
                                         <span class={
                                             let data = data_clone.clone();
-                                            move || {
-                                                let roi = data.return_on_investment;
-                                                let tint = if roi >= 500 {
-                                                    "24%"
-                                                } else if roi >= 200 {
-                                                    "20%"
-                                                } else if roi >= 100 {
-                                                    "16%"
-                                                } else if roi >= 50 {
-                                                    "12%"
-                                                } else {
-                                                    "10%"
-                                                };
-                                                format!(
-                                                    "inline-flex items-center justify-end px-2 py-1 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_{tint},transparent)]"
-                                                )
-                                            }
+                                            move || roi_badge_class(data.return_on_investment)
                                         }>
                                             {format!("{}%", data.return_on_investment)}
                                         </span>
@@ -1010,19 +981,7 @@ fn AnalyzerTable(
                                             .sale_summary
                                             .avg_sale_duration
                                             .and_then(|duration| duration.to_std().ok())
-                                            .map(|duration| {
-                                                let secs = duration.as_secs();
-                                                let days = secs / 86_400;
-                                                let hours = (secs % 86_400) / 3_600;
-                                                let minutes = (secs % 3_600) / 60;
-                                                let seconds = secs % 60;
-                                                let mut parts = Vec::new();
-                                                if days > 0 { parts.push(format!("{}d", days)); }
-                                                if hours > 0 { parts.push(format!("{}h", hours)); }
-                                                if minutes > 0 && parts.len() < 2 { parts.push(format!("{}m", minutes)); }
-                                                if seconds > 0 && parts.len() < 2 { parts.push(format!("{}s", seconds)); }
-                                                if parts.is_empty() { "0s".to_string() } else { parts[..parts.len().min(2)].join(" ") }
-                                            })
+                                            .map(|duration| format_duration_short(duration.as_secs()))
                                             .unwrap_or_else(|| "---".to_string())}
                                     </div>
                                 </div>

--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -1,3 +1,4 @@
+use crate::analysis::roi_badge_class;
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
 use crate::{
@@ -491,11 +492,7 @@ fn FCCraftingAnalyzerTable(
                                 <div role="cell" class="px-4 py-2 w-30 shrink-0 text-right">
                                     <span class={
                                         let data = data_clone.clone();
-                                        move || {
-                                            let roi = data.return_on_investment;
-                                            let tint = if roi >= 500 { "24%" } else if roi >= 200 { "20%" } else if roi >= 100 { "16%" } else if roi >= 50 { "12%" } else { "10%" };
-                                            format!("inline-flex items-center justify-end px-2 py-1 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_{tint},transparent)]")
-                                        }
+                                        move || roi_badge_class(data.return_on_investment)
                                     }>
                                         {format!("{}%", data.return_on_investment)}
                                     </span>

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -2,7 +2,7 @@ use crate::components::meta::{MetaDescription, MetaTitle};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
 use crate::{
-    analysis::{SalesStats, analyze_sales},
+    analysis::{SalesStats, analyze_sales, roi_badge_class},
     api::{get_cheapest_listings, get_recent_sales_for_world},
     components::{
         add_recipe_to_list::AddRecipeToList, crafter_settings::CrafterSettings, gil::*, icon::Icon,
@@ -654,11 +654,7 @@ fn RecipeAnalyzerTable(
                                 <div role="cell" class="px-4 py-2 w-32 shrink-0 text-right">
                                      <span class={
                                         let data = data_clone.clone();
-                                        move || {
-                                            let roi = data.return_on_investment;
-                                            let tint = if roi >= 500 { "24%" } else if roi >= 200 { "20%" } else if roi >= 100 { "16%" } else if roi >= 50 { "12%" } else { "10%" };
-                                            format!("inline-flex items-center justify-end px-2 py-1 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_{tint},transparent)]")
-                                        }
+                                        move || roi_badge_class(data.return_on_investment)
                                     }>
                                         {format!("{}%", data.return_on_investment)}
                                     </span>

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -1,3 +1,4 @@
+use crate::analysis::{SaleSummary, format_duration_short, roi_badge_class};
 use crate::global_state::xiv_data::tracked_data;
 use crate::{
     api::{get_cheapest_listings, get_recent_sales_for_world},
@@ -25,20 +26,6 @@ use ultros_api_types::{
     world_helper::WorldHelper,
 };
 use xiv_gen::ItemId;
-
-/// Computed sale stats
-#[derive(Hash, Clone, Debug, PartialEq)]
-struct SaleSummary {
-    item_id: i32,
-    hq: bool,
-    /// this value is limited by the summary returned by the API
-    num_sold: usize,
-    /// Represents the average time between sales within the `num_sold`
-    avg_sale_duration: Option<Duration>,
-    max_price: i32,
-    avg_price: i32,
-    min_price: i32,
-}
 
 #[derive(Hash, Clone, Debug, PartialEq, Eq)]
 struct VendorProfitKey {
@@ -647,23 +634,7 @@ fn VendorResaleTable(
                                     </div>
                                     <div role="cell" class="px-4 py-2 w-30 text-right flex items-center justify-end">
                                         <span class={
-                                            move || {
-                                                let roi = data_clone.return_on_investment;
-                                                let tint = if roi >= 500 {
-                                                    "24%"
-                                                } else if roi >= 200 {
-                                                    "20%"
-                                                } else if roi >= 100 {
-                                                    "16%"
-                                                } else if roi >= 50 {
-                                                    "12%"
-                                                } else {
-                                                    "10%"
-                                                };
-                                                format!(
-                                                    "inline-flex items-center justify-end px-2 py-1 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_{tint},transparent)]"
-                                                )
-                                            }
+                                            move || roi_badge_class(data_clone.return_on_investment)
                                         }>
                                             {format!("{}%", data.return_on_investment)}
                                         </span>
@@ -680,19 +651,7 @@ fn VendorResaleTable(
                                             .as_ref()
                                             .and_then(|s| s.avg_sale_duration)
                                             .and_then(|duration| duration.to_std().ok())
-                                            .map(|duration| {
-                                                let secs = duration.as_secs();
-                                                let days = secs / 86_400;
-                                                let hours = (secs % 86_400) / 3_600;
-                                                let minutes = (secs % 3_600) / 60;
-                                                let seconds = secs % 60;
-                                                let mut parts = Vec::new();
-                                                if days > 0 { parts.push(format!("{}d", days)); }
-                                                if hours > 0 { parts.push(format!("{}h", hours)); }
-                                                if minutes > 0 && parts.len() < 2 { parts.push(format!("{}m", minutes)); }
-                                                if seconds > 0 && parts.len() < 2 { parts.push(format!("{}s", seconds)); }
-                                                if parts.is_empty() { "0s".to_string() } else { parts[..parts.len().min(2)].join(" ") }
-                                            })
+                                            .map(|duration| format_duration_short(duration.as_secs()))
                                             .unwrap_or_else(|| "---".to_string())}
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary

Pull the three most-duplicated bits of analyzer-table UI/data code into `ultros-app::analysis` as shared helpers:

- **`pub struct SaleSummary`** — the `(item_id, hq, num_sold, avg_sale_duration, min/avg/max_price)` shape was defined identically in `analyzer.rs` and `vendor_resale.rs`. Now one definition in `analysis.rs`, consumed by both.
- **`pub fn format_duration_short(secs) -> String`** — the \"Xd Yh / Xh Ym\" duration renderer for the avg-sale-duration column. The 14-line block was copy-pasted in `analyzer.rs` and `vendor_resale.rs`; both call sites collapse to a single function call.
- **`pub fn roi_badge_class(roi) -> String`** — the tinted Tailwind class string for the ROI badge. The 10-line tint-by-bucket + `format!()` block was copy-pasted in **four** files: `analyzer.rs`, `vendor_resale.rs`, `fc_crafting_analyzer.rs`, `recipe_analyzer.rs`. All four collapse to a single function call.

No behavior change — same output, same threshold buckets. Net -26 lines.

## Not in scope

The audit also flagged broader analyzer-page duplication:

- 7 copies of `SortMode` + `FromStr`/`Display` impls
- 6 copies of region-from-world `Memo`
- 5 copies of world-selector signal/Effect pair
- 2 copies of `compute_summary` (the analyzer version supports outlier filtering + HQ data; the vendor version is simpler — unifying them needs design work)
- 8 copies of even/odd row class strings

These are bigger refactors that need design choices (per-page sort variants vs. one generic, etc.). Deferred to a follow-up.

Includes a `cargo fmt` pass on `ultros-db/src/lists.rs` that was already failing on main.

## Test plan

- [x] `./check_ci.sh` passes
- [ ] Manual: confirm ROI badge color tint still matches the old buckets on Flip Finder, Vendor Resale, FC Crafting, Recipe Analyzer
- [ ] Manual: avg sale duration column on Flip Finder + Vendor Resale renders \"Xd Yh\" style