### PR TITLE
refactor(ultros-app): extract use_region_for_world hook

### DIFF
--- a/ultros-frontend/ultros-app/src/global_state/mod.rs
+++ b/ultros-frontend/ultros-app/src/global_state/mod.rs
@@ -3,6 +3,7 @@ pub mod clipboard_text;
 pub mod cookies;
 pub mod home_world;
 mod local_world_data;
+pub mod region_for_world;
 pub mod theme;
 pub mod user;
 pub use local_world_data::LocalWorldData;

--- a/ultros-frontend/ultros-app/src/global_state/region_for_world.rs
+++ b/ultros-frontend/ultros-app/src/global_state/region_for_world.rs
@@ -1,0 +1,45 @@
+//! Region-name lookup shared by analyzer pages.
+//!
+//! Resolves a world name (typically from a route param or query string) to the region it
+//! belongs to. Falls back to the user's home world's region, then to North-America if neither
+//! is set. Lives here rather than per-page because the analyzer pages all need exactly this
+//! string to feed `get_cheapest_listings(&region)` and the home-world / cache reads have to
+//! happen in a tracked context.
+
+use leptos::prelude::*;
+use ultros_api_types::world_helper::AnyResult;
+
+use crate::global_state::{LocalWorldData, home_world::use_home_world};
+
+const DEFAULT_REGION: &str = "North-America";
+
+/// Returns a reactive `Memo<String>` of the region name for `world_name_source`.
+///
+/// `world_name_source` is typically a closure over a route-param signal or a query-string
+/// signal (anything that yields `Option<String>` reactively). When the source returns
+/// `None`, the user's home world is consulted; if that is also `None`, the default region
+/// (`"North-America"`) is returned. The result is suitable to feed directly to
+/// `get_cheapest_listings`.
+pub fn use_region_for_world<F>(world_name_source: F) -> Memo<String>
+where
+    F: Fn() -> Option<String> + 'static + Send + Sync,
+{
+    let (home_world, _) = use_home_world();
+    Memo::new(move |_| {
+        let Some(worlds) = use_context::<LocalWorldData>().and_then(|d| d.0.ok()) else {
+            return DEFAULT_REGION.to_string();
+        };
+
+        let world_name = world_name_source()
+            .or_else(|| home_world.get().map(|w| w.name))
+            .unwrap_or_else(|| DEFAULT_REGION.to_string());
+
+        worlds
+            .lookup_world_by_name(&world_name)
+            .map(|world| {
+                let region = worlds.get_region(world);
+                AnyResult::Region(region).get_name().to_string()
+            })
+            .unwrap_or_else(|| DEFAULT_REGION.to_string())
+    })
+}

--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -7,7 +7,7 @@ use crate::{
         filter_card::*, gil::*, item_icon::*, query_button::QueryButton, skeleton::BoxSkeleton,
         virtual_scroller::*, world_picker::WorldOnlyPicker,
     },
-    global_state::{LocalWorldData, home_world::use_home_world},
+    global_state::{home_world::use_home_world, region_for_world::use_region_for_world},
 };
 use chrono::Utc;
 use leptos::{either::Either, prelude::*};
@@ -17,7 +17,6 @@ use std::{cmp::Reverse, collections::HashMap, fmt::Display, str::FromStr, sync::
 use ultros_api_types::{
     cheapest_listings::{CheapestListings, CheapestListingsMap},
     recent_sales::{RecentSales, SaleData},
-    world_helper::AnyResult,
 };
 use xiv_gen::{
     CompanyCraftPartId, CompanyCraftProcessId, CompanyCraftSequence, CompanyCraftSupplyItemId,
@@ -523,25 +522,7 @@ pub fn FCCraftingAnalyzer() -> impl IntoView {
     let params = use_params_map();
     let (home_world, _) = use_home_world();
 
-    let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        // Default to home world region or North-America
-        let world_name = params
-            .with(|p| p.get("world").clone())
-            .or_else(|| home_world.get().map(|w| w.name))
-            .unwrap_or_else(|| "North-America".to_string());
-
-        worlds
-            .lookup_world_by_name(&world_name)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .unwrap_or_else(|| "North-America".to_string())
-    });
+    let region = use_region_for_world(move || params.with(|p| p.get("world").clone()));
 
     let global_cheapest_listings = ArcResource::new(region, move |region: String| async move {
         get_cheapest_listings(&region).await

--- a/ultros-frontend/ultros-app/src/routes/leve_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/leve_analyzer.rs
@@ -8,7 +8,9 @@ use crate::{
         gil::*, icon::Icon, item_icon::*, query_button::QueryButton, skeleton::BoxSkeleton,
         virtual_scroller::*, world_picker::WorldOnlyPicker,
     },
-    global_state::{LocalWorldData, home_world::use_home_world},
+    global_state::{
+        LocalWorldData, home_world::use_home_world, region_for_world::use_region_for_world,
+    },
 };
 use icondata as i;
 use leptos::{either::Either, prelude::*};
@@ -20,7 +22,6 @@ use std::{cmp::Reverse, collections::HashMap, sync::Arc};
 use ultros_api_types::{
     cheapest_listings::{CheapestListings, CheapestListingsMap},
     recent_sales::{RecentSales, SaleData},
-    world_helper::AnyResult,
 };
 use xiv_gen::{
     ClassJobCategoryId, CraftLeve, ItemId, Leve, LeveId, LeveRewardItemGroupId, LeveRewardItemId,
@@ -496,25 +497,7 @@ pub fn LeveAnalyzer() -> impl IntoView {
     let (home_world, _) = use_home_world();
     let nav = use_navigate();
 
-    let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        // Default to home world region or North-America
-        let world_name = query
-            .with(|p| p.get("world").clone())
-            .or_else(|| home_world.get().map(|w| w.name))
-            .unwrap_or_else(|| "North-America".to_string());
-
-        worlds
-            .lookup_world_by_name(&world_name)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .unwrap_or_else(|| "North-America".to_string())
-    });
+    let region = use_region_for_world(move || query.with(|p| p.get("world").clone()));
 
     let global_cheapest_listings = ArcResource::new(region, move |region: String| async move {
         get_cheapest_listings(&region).await

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -10,7 +10,8 @@ use crate::{
         virtual_scroller::*, world_picker::WorldOnlyPicker,
     },
     global_state::{
-        LocalWorldData, cookies::Cookies, crafter_levels::CrafterLevels, home_world::use_home_world,
+        cookies::Cookies, crafter_levels::CrafterLevels, home_world::use_home_world,
+        region_for_world::use_region_for_world,
     },
 };
 use icondata as i;
@@ -20,7 +21,6 @@ use std::{cmp::Reverse, collections::HashMap, fmt::Display, str::FromStr, sync::
 use ultros_api_types::{
     cheapest_listings::{CheapestListings, CheapestListingsMap},
     recent_sales::{RecentSales, SaleData},
-    world_helper::AnyResult,
 };
 use xiv_gen::{ItemId, Recipe, RecipeLevelTableId};
 
@@ -736,25 +736,7 @@ pub fn RecipeAnalyzer() -> impl IntoView {
     let params = use_params_map();
     let (home_world, _) = use_home_world();
 
-    let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        // Default to home world region or North-America
-        let world_name = params
-            .with(|p| p.get("world").clone())
-            .or_else(|| home_world.get().map(|w| w.name))
-            .unwrap_or_else(|| "North-America".to_string());
-
-        worlds
-            .lookup_world_by_name(&world_name)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .unwrap_or_else(|| "North-America".to_string())
-    });
+    let region = use_region_for_world(move || params.with(|p| p.get("world").clone()));
 
     let global_cheapest_listings = ArcResource::new(region, move |region: String| async move {
         get_cheapest_listings(&region).await

--- a/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
+++ b/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
@@ -6,7 +6,9 @@ use crate::{
         gil::*, item_icon::*, query_button::QueryButton, skeleton::BoxSkeleton,
         virtual_scroller::*, world_picker::WorldOnlyPicker,
     },
-    global_state::{LocalWorldData, home_world::use_home_world},
+    global_state::{
+        LocalWorldData, home_world::use_home_world, region_for_world::use_region_for_world,
+    },
 };
 use leptos::prelude::*;
 use leptos_router::{
@@ -14,10 +16,7 @@ use leptos_router::{
     hooks::{query_signal, use_navigate, use_query_map},
 };
 use std::{cmp::Reverse, sync::Arc};
-use ultros_api_types::{
-    cheapest_listings::{CheapestListings, CheapestListingsMap},
-    world_helper::AnyResult,
-};
+use ultros_api_types::cheapest_listings::{CheapestListings, CheapestListingsMap};
 use xiv_gen::{CollectablesShopRewardScripId, ItemId, Recipe};
 
 use crate::i18n::*;
@@ -454,25 +453,7 @@ pub fn ScripSources() -> impl IntoView {
     let (home_world, _) = use_home_world();
     let nav = use_navigate();
 
-    let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        // Default to home world region or North-America
-        let world_name = query
-            .with(|p| p.get("world").clone())
-            .or_else(|| home_world.get().map(|w| w.name))
-            .unwrap_or_else(|| "North-America".to_string());
-
-        worlds
-            .lookup_world_by_name(&world_name)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .unwrap_or_else(|| "North-America".to_string())
-    });
+    let region = use_region_for_world(move || query.with(|p| p.get("world").clone()));
 
     let global_cheapest_listings = ArcResource::new(region, move |region: String| async move {
         get_cheapest_listings(&region).await

--- a/ultros-frontend/ultros-app/src/routes/venture_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/venture_analyzer.rs
@@ -8,7 +8,9 @@ use crate::{
         gil::*, icon::Icon, item_icon::*, query_button::QueryButton, skeleton::BoxSkeleton,
         virtual_scroller::*, world_picker::WorldOnlyPicker,
     },
-    global_state::{LocalWorldData, home_world::use_home_world},
+    global_state::{
+        LocalWorldData, home_world::use_home_world, region_for_world::use_region_for_world,
+    },
 };
 use icondata as i;
 use itertools::Itertools;
@@ -25,7 +27,6 @@ use std::{
 use ultros_api_types::{
     cheapest_listings::{CheapestListings, CheapestListingsMap},
     recent_sales::{RecentSales, SaleData},
-    world_helper::AnyResult,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -431,25 +432,7 @@ pub fn VentureAnalyzer() -> impl IntoView {
     let (home_world, _) = use_home_world();
     let nav = use_navigate();
 
-    let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        // Default to home world region or North-America
-        let world_name = query
-            .with(|p| p.get("world").clone())
-            .or_else(|| home_world.get().map(|w| w.name))
-            .unwrap_or_else(|| "North-America".to_string());
-
-        worlds
-            .lookup_world_by_name(&world_name)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .unwrap_or_else(|| "North-America".to_string())
-    });
+    let region = use_region_for_world(move || query.with(|p| p.get("world").clone()));
 
     let global_cheapest_listings = ArcResource::new(region, move |region: String| async move {
         get_cheapest_listings(&region).await


### PR DESCRIPTION
## Summary

Each analyzer page that displays cheapest-listings data needs the same region-name lookup: take the world from the URL (route param or query string), fall back to the user's home world, fall back to North-America, then resolve the region from the `WorldHelper` cache.

That ~18-line `Memo` was copy-pasted in five files. Extract to a single `use_region_for_world(world_name_source) -> Memo<String>` hook in [global_state::region_for_world](ultros-frontend/ultros-app/src/global_state/region_for_world.rs) and replace the duplicates in:

- `fc_crafting_analyzer`
- `leve_analyzer`
- `recipe_analyzer`
- `scrip_sources`
- `venture_analyzer`

Net **-82 lines**. Each call site collapses from ~18 lines to one:

```rust
let region = use_region_for_world(move || query.with(|p| p.get(\"world\").clone()));
```

No behavior change — fallback chain and region lookup are preserved exactly.

## Not in scope

[analyzer.rs](ultros-frontend/ultros-app/src/routes/analyzer.rs) is intentionally left alone: its region resolution returns `Result<String, AppError>` rather than falling back to North-America (the page errors out without a world rather than defaulting), so it doesn't fit the shared hook's signature.

## Test plan

- [x] `./check_ci.sh` passes
- [ ] Smoke: open `/leve`, `/scrip-sources`, `/venture`, `/recipe-analyzer`, `/fc-crafting` with and without a `?world=` query — region should resolve to the world's region when set, home-world's region otherwise, North-America as final fallback