### PR TITLE
Add Sentry-compatible browser crash telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ POSTGRES_MAX_CONNECTIONS=50
 PORT=8080
 RUST_LOG=ultros=info,warn
 
+# Optional browser crash telemetry. GlitchTip DSNs work because it speaks the
+# Sentry protocol.
+# ULTROS_ERROR_REPORTING_DSN=https://public-key@glitchtip.example.com/1
+# ULTROS_ERROR_REPORTING_ENVIRONMENT=development
+# ULTROS_ERROR_REPORTING_SAMPLE_RATE=1.0
+# ULTROS_ERROR_REPORTING_TRACES_SAMPLE_RATE=0.0
+# ULTROS_ERROR_REPORTING_SDK_URL=https://browser.sentry-cdn.com/10.52.0/bundle.min.js
+
 # Optional Leptos environment overrides
 # LEPTOS_OUTPUT_NAME=ultros
 # LEPTOS_ENVIRONMENT=development

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8932,6 +8932,7 @@ dependencies = [
  "console_log",
  "futures",
  "gloo-net 0.6.0",
+ "js-sys",
  "leptos",
  "leptos_meta",
  "log",

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -1,0 +1,101 @@
+# Frontend Error Reporting
+
+Ultros can report browser crashes and Rust WASM panics to any Sentry-compatible
+collector. The intended self-hosted target is GlitchTip, which accepts events
+from the official Sentry browser SDK.
+
+## Collector
+
+GlitchTip is the best fit for the current app because it is self-hostable and
+keeps the integration on the Sentry protocol. That lets us point the same
+browser instrumentation at GlitchTip, Sentry SaaS, or another compatible
+backend by changing the DSN.
+
+Minimum deployment shape:
+
+- GlitchTip web service
+- PostgreSQL
+- Optional Valkey/Redis for larger installs
+- HTTPS reverse proxy
+
+Create a frontend/browser project in GlitchTip and copy its public DSN into the
+Ultros environment.
+
+## Ultros Environment
+
+```bash
+ULTROS_ERROR_REPORTING_DSN=https://public-key@glitchtip.example.com/1
+ULTROS_ERROR_REPORTING_ENVIRONMENT=production
+ULTROS_ERROR_REPORTING_SAMPLE_RATE=1.0
+ULTROS_ERROR_REPORTING_TRACES_SAMPLE_RATE=0.0
+ULTROS_ERROR_REPORTING_SDK_URL=https://browser.sentry-cdn.com/10.34.0/bundle.min.js
+```
+
+`ULTROS_ERROR_REPORTING_DSN` is the only required setting. If it is empty or
+unset, no SDK is loaded and no events are sent.
+
+`ULTROS_ERROR_REPORTING_TRACES_SAMPLE_RATE` defaults to `0.0` because this is
+crash telemetry first. Raise it later if browser performance traces are useful.
+
+`ULTROS_ERROR_REPORTING_SDK_URL` can point at a self-hosted copy of the Sentry
+browser bundle if we want to avoid loading the SDK from Sentry's CDN.
+
+## Rust WASM Panics
+
+The WASM hydrate entrypoint installs a panic hook that still forwards panic
+details to `console.error` for local debugging, then calls a JavaScript bridge
+installed by the shell. The bridge captures a synthetic `RustWasmPanic`
+exception and tags it with `runtime=wasm`.
+
+This is better than `panic = "abort"` for the current app: the hook gets the
+Rust panic message and source location while the JavaScript SDK can attach the
+browser stack. `panic = "abort"` would usually degrade the reported error to a
+generic WASM trap unless we build more custom stack capture around it.
+
+## Symbols, Source Maps, And WASM Debug Files
+
+Use GlitchTip source map upload for the generated JavaScript glue and any
+future bundled JavaScript. Do not publish source maps publicly; upload them to
+the collector during deployment.
+
+The `wasm-split` mentioned in Sentry's WASM docs is Sentry Symbolicator's tool,
+not Binaryen's module-splitting tool. It post-processes a `.wasm` artifact for
+symbolication:
+
+- Adds a `build_id` custom section when one is missing.
+- Strips debug sections from the shipped `.wasm`.
+- Writes a private debug `.wasm` file that can be uploaded to the collector.
+
+Example:
+
+```bash
+wasm-split target/site/pkg/ultros_bg.wasm \
+  --debug-out target/site/pkg/ultros_bg.debug.wasm \
+  --strip
+```
+
+Upload the `*.debug.wasm` file as a debug information file, and ship the stripped
+`.wasm` that still contains the matching `build_id`.
+
+For WASM, the practical production path is:
+
+- Build the WASM with DWARF debug info available in the release artifact.
+- Run Sentry's `wasm-split` to add/retain a `build_id`, strip the shipped file,
+  and keep the private debug file.
+- Upload generated JavaScript source maps for the wasm-bindgen glue.
+- Upload the private WASM debug file to a collector that supports Sentry debug
+  information files and WASM symbolication.
+- Keep Rust commit/release metadata attached to each event through `release`.
+
+Sentry's browser-side WASM stack enrichment uses `@sentry/wasm` with
+`wasmIntegration()`. Ultros currently has no JavaScript bundling step, so the
+server shell initializes the browser SDK as a lightweight first pass and the
+Rust panic hook reports `RustWasmPanic` events. If we want first-class
+Sentry-style WASM symbolication, add a tiny JS bundle that imports
+`@sentry/browser` and `@sentry/wasm`, initializes `wasmIntegration()`, and then
+wire the release pipeline to run `wasm-split` and upload debug files.
+
+Before choosing GlitchTip for the full symbolication path, verify its support
+for Sentry debug information files with WASM DWARF. Its Sentry-compatible SDK
+ingestion is a good match for browser errors, but Sentry's WASM symbolication
+depends on the native debug-file processing path.

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -67,8 +67,84 @@ use leptos_router::components::{A, ParentRoute, Route, Router, Routes};
 use leptos_router::path;
 use log::info;
 
+fn error_reporting_script() -> Option<String> {
+    let dsn = std::env::var("ULTROS_ERROR_REPORTING_DSN").ok()?;
+    if dsn.trim().is_empty() {
+        return None;
+    }
+
+    let environment = std::env::var("ULTROS_ERROR_REPORTING_ENVIRONMENT")
+        .or_else(|_| std::env::var("LEPTOS_ENVIRONMENT"))
+        .unwrap_or_else(|_| "production".to_string());
+    let sample_rate = std::env::var("ULTROS_ERROR_REPORTING_SAMPLE_RATE")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(1.0);
+    let traces_sample_rate = std::env::var("ULTROS_ERROR_REPORTING_TRACES_SAMPLE_RATE")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(0.0);
+    let release = format!("ultros@{}", git_short_hash!());
+
+    let config = serde_json::json!({
+        "dsn": dsn,
+        "release": release,
+        "environment": environment,
+        "sampleRate": sample_rate.clamp(0.0, 1.0),
+        "tracesSampleRate": traces_sample_rate.clamp(0.0, 1.0),
+        "autoSessionTracking": false,
+        "sendDefaultPii": false,
+        "attachStacktrace": true,
+    });
+    let sdk_url = std::env::var("ULTROS_ERROR_REPORTING_SDK_URL")
+        .unwrap_or_else(|_| "https://browser.sentry-cdn.com/10.52.0/bundle.min.js".to_string());
+    let config = serde_json::to_string(&config).expect("Sentry config should serialize");
+    let sdk_url = serde_json::to_string(&sdk_url).expect("SDK URL should serialize");
+
+    Some(format!(
+        r#"(function(){{
+    var config = {config};
+    var sdkUrl = {sdk_url};
+
+    window.__ultrosReportRustPanic = function(message, location) {{
+        var Sentry = window.Sentry;
+        if (!Sentry || !Sentry.captureException) {{
+            return;
+        }}
+
+        var error = new Error(message || "Rust WASM panic");
+        error.name = "RustWasmPanic";
+        Sentry.withScope(function(scope) {{
+            scope.setTag("runtime", "wasm");
+            if (location) {{
+                scope.setContext("rust_panic", {{ location: location }});
+            }}
+            Sentry.captureException(error);
+        }});
+    }};
+
+    var init = function() {{
+        if (!window.Sentry || !window.Sentry.init) {{
+            return;
+        }}
+        window.Sentry.init(config);
+    }};
+
+    var script = document.createElement("script");
+    script.src = sdkUrl;
+    script.crossOrigin = "anonymous";
+    script.onload = init;
+    script.onerror = function() {{
+        console.warn("Ultros error reporting SDK failed to load");
+    }};
+    document.head.appendChild(script);
+}})();"#
+    ))
+}
+
 pub fn shell(options: LeptosOptions) -> impl IntoView {
     let sheet_url = ["/", options.site_pkg_dir.as_ref(), "/ultros.css"].concat();
+    let error_reporting_script = error_reporting_script();
     view! {
         <!DOCTYPE html>
         <html lang="en" data-theme="dark" data-palette="violet">
@@ -93,6 +169,10 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
                 <meta property="og:type" content="website" />
                 <meta property="og:locale" content="en-US" />
                 <meta property="og:site_name" content="Ultros" />
+                {error_reporting_script
+                    .map(|script| {
+                        view! { <script>{script}</script> }
+                    })}
                 <AutoReload options=options.clone() />
                 <HydrationScripts options />
                 <MetaTags />

--- a/ultros-frontend/ultros-client/Cargo.toml
+++ b/ultros-frontend/ultros-client/Cargo.toml
@@ -33,6 +33,7 @@ any_spawner = "0.3"
 tracing-wasm = "0.2.1"
 console_log = { version = "1.0.0", features = ["color"] }
 web-sys = { version = "0.3", features = ["HtmlDocument", "Document", "Window"] }
+js-sys = "0.3"
 
 [features]
 default = ["hydrate"]

--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use ultros_api_types::{world::WorldData, world_helper::WorldHelper};
 use ultros_app::*;
 use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue};
 
 #[derive(Serialize, Deserialize)]
 struct Data {
@@ -199,9 +200,56 @@ async fn get_region() -> String {
         .unwrap()
 }
 
+fn set_panic_hook() {
+    std::panic::set_hook(Box::new(|panic_info| {
+        console_error_panic_hook::hook(panic_info);
+        report_rust_panic(panic_info);
+    }));
+}
+
+fn report_rust_panic(panic_info: &std::panic::PanicHookInfo<'_>) {
+    let global = js_sys::global();
+    let reporter = js_sys::Reflect::get(&global, &JsValue::from_str("__ultrosReportRustPanic"));
+    let Ok(reporter) = reporter else {
+        return;
+    };
+    let Some(reporter) = reporter.dyn_ref::<js_sys::Function>() else {
+        return;
+    };
+
+    let message = panic_info
+        .payload()
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| {
+            panic_info
+                .payload()
+                .downcast_ref::<String>()
+                .map(String::as_str)
+        })
+        .unwrap_or("Rust WASM panic");
+    let location = panic_info
+        .location()
+        .map(|location| {
+            format!(
+                "{}:{}:{}",
+                location.file(),
+                location.line(),
+                location.column()
+            )
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let _ = reporter.call2(
+        &JsValue::NULL,
+        &JsValue::from_str(message),
+        &JsValue::from_str(&location),
+    );
+}
+
 #[wasm_bindgen]
 pub fn hydrate() {
-    console_error_panic_hook::set_once();
+    set_panic_hook();
     // tracing_wasm::set_as_global_default();
     console_log::init_with_level(Level::Info).unwrap();
     // check that we have the right client version data


### PR DESCRIPTION
## Summary
- Add opt-in browser error reporting driven by `ULTROS_ERROR_REPORTING_DSN`, with defaults documented in `.env.example`
- Install a Rust WASM panic hook that still logs locally and forwards panic details into the browser telemetry bridge
- Document the self-hosted path with GlitchTip, plus the Sentry `wasm-split` workflow for private WASM debug files and JS source maps

## Testing
- `./check_ci.sh` passed
- `cargo check -p ultros-client --target wasm32-unknown-unknown` passed