### PR TITLE
docs: shared lists integration & onboarding design

### DIFF
--- a/docs/superpowers/plans/2026-05-11-analyzer-data-integrity.md
+++ b/docs/superpowers/plans/2026-05-11-analyzer-data-integrity.md
@@ -1,0 +1,858 @@
+# Analyzer Data Integrity & Guidance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strip the 1-gil sniper rows from the default Flip Finder view by replacing the analyzer's profit-estimate math with sanity-clamped, median-based stats, then re-tune presets and filters so the landing experience guides users to realistic flips.
+
+**Architecture:** All changes are localized to a single Leptos route file ([ultros-frontend/ultros-app/src/routes/analyzer.rs](../../ultros-frontend/ultros-app/src/routes/analyzer.rs)) plus the English locale JSON. No API, DB, or shared-types changes. The work is broken into pure-function logic changes (TDD via Rust unit tests) followed by Leptos query-param/filter-card wiring.
+
+**Tech Stack:** Rust, Leptos (SSR/hydrate), `leptos_i18n`, `humantime`, `chrono`. Tests are stock `#[cfg(test)] mod tests` blocks inside the same file.
+
+---
+
+## File Structure
+
+- **Modify** [ultros-frontend/ultros-app/src/routes/analyzer.rs](../../ultros-frontend/ultros-app/src/routes/analyzer.rs)
+  - `SaleSummary` gains `median_price: i32` and `days_since_last_sale: Option<Duration>`.
+  - `compute_summary` loses the `hq_data` parameter, gains a sniper-clamp, computes a median.
+  - `ProfitTable::new` gains a troll-listing guard and consumes the row's median instead of min.
+  - `AnalyzerTable` gains two new query signals (`min-buy`, `last-sold`), two filter cards, chips, "Clear all" wiring, and a new "Last sold" table column.
+  - Preset filter buttons re-tuned; one new "Realistic flips" preset added as the leading CTA.
+  - A new `#[cfg(test)] mod tests` block at the bottom covers the pure-function changes.
+- **Modify** [ultros-frontend/ultros-app/locales/en.json](../../ultros-frontend/ultros-app/locales/en.json)
+  - Six new keys for the new filter cards, chips, column header, and preset label.
+
+No new files. The other six locale JSONs (`cn`, `de`, `fr`, `ja`, `ko`, `tc`) already only populate ~2 analyzer keys each — `leptos_i18n` falls back to English for missing keys, so we don't touch them. (If a clippy/build error surfaces a missing key, copy the new English values into each file as a follow-up.)
+
+---
+
+## Task 1: Add a median + sniper-clamp to `SaleSummary`
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs:36-147`
+
+The goal of this task is two pure-function changes inside `compute_summary`:
+1. Drop any sale priced below `0.1 × raw_median` before computing the final summary (sniper guard).
+2. Add a `median_price: i32` field computed from the (clamped) prices.
+
+We also drop the HQ→NQ contamination here: `hq_data` parameter is removed entirely.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ultros-frontend/ultros-app/src/routes/analyzer.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ultros_api_types::recent_sales::{SaleData, Sales};
+
+    fn sale(price: i32, days_ago: i64) -> Sales {
+        let date = Utc::now()
+            .naive_utc()
+            .checked_sub_signed(Duration::days(days_ago))
+            .unwrap();
+        Sales { price_per_unit: price, sale_date: date }
+    }
+
+    fn sales_row(item_id: i32, hq: bool, prices_and_days: &[(i32, i64)]) -> SaleData {
+        SaleData {
+            item_id,
+            hq,
+            sales: prices_and_days.iter().map(|(p, d)| sale(*p, *d)).collect(),
+        }
+    }
+
+    #[test]
+    fn median_price_is_middle_of_clamped_sales() {
+        let row = sales_row(1, false, &[(100, 0), (110, 1), (120, 2), (130, 3), (140, 4), (150, 5)]);
+        let summary = compute_summary(row, false);
+        // Six even-length sample: median = (third + fourth) / 2 = (120 + 130) / 2 = 125
+        assert_eq!(summary.median_price, 125);
+    }
+
+    #[test]
+    fn sniper_sale_below_10pct_of_median_is_dropped() {
+        // Raw median of [1, 100, 110, 120, 130, 140] sorted = (110+120)/2 = 115.
+        // The "1" is well below 10% of 115 (=11), so it's dropped.
+        let row = sales_row(2, false, &[(1, 0), (100, 1), (110, 2), (120, 3), (130, 4), (140, 5)]);
+        let summary = compute_summary(row, false);
+        // Median of remaining [100, 110, 120, 130, 140] = 120.
+        assert_eq!(summary.median_price, 120);
+        // min_price should also reflect the clamp, not the sniper.
+        assert_eq!(summary.min_price, 100);
+    }
+
+    #[test]
+    fn hq_prices_do_not_contaminate_nq_summary() {
+        // An NQ row with normal prices. compute_summary no longer takes HQ context.
+        let row = sales_row(3, false, &[(500, 0), (510, 1), (520, 2), (530, 3), (540, 4), (550, 5)]);
+        let summary = compute_summary(row, false);
+        assert_eq!(summary.min_price, 500);
+        assert_eq!(summary.median_price, 525);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```
+cargo test -p ultros-app --lib routes::analyzer::tests
+```
+Expected: all three tests fail. The first two fail because `median_price` doesn't exist on `SaleSummary`. The third fails because `compute_summary` currently takes three args (`sale, hq_data, filter_outliers`).
+
+- [ ] **Step 3: Update `SaleSummary` and `compute_summary`**
+
+Replace the `SaleSummary` struct and `compute_summary` function at [analyzer.rs:36-147](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:36) with:
+
+```rust
+/// Computed sale stats
+#[derive(Hash, Clone, Debug, PartialEq)]
+struct SaleSummary {
+    item_id: i32,
+    hq: bool,
+    /// this value is limited by the summary returned by the API
+    num_sold: usize,
+    /// Represents the average time between sales within the `num_sold`
+    avg_sale_duration: Option<Duration>,
+    /// Time since the most-recent sale. `None` if no sales.
+    days_since_last_sale: Option<Duration>,
+    max_price: i32,
+    avg_price: i32,
+    /// Robust mid-point of the clamped sales — used as the realistic seller estimate.
+    median_price: i32,
+    /// Floor of the clamped sales — worst-case undercut.
+    min_price: i32,
+}
+
+/// Sniper-clamp threshold: drop any sale priced below this fraction of the raw median.
+const SNIPER_FRACTION: f64 = 0.1;
+
+fn median_i32(sorted: &[i32]) -> i32 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        ((sorted[n / 2 - 1] as i64 + sorted[n / 2] as i64) / 2) as i32
+    }
+}
+
+fn compute_summary(sale: SaleData, filter_outliers: bool) -> SaleSummary {
+    let now = Utc::now().naive_utc();
+    let SaleData { item_id, hq, sales } = sale;
+
+    if sales.is_empty() {
+        return SaleSummary {
+            item_id,
+            hq,
+            num_sold: 0,
+            avg_sale_duration: None,
+            days_since_last_sale: None,
+            max_price: 0,
+            avg_price: 0,
+            median_price: 0,
+            min_price: 0,
+        };
+    }
+
+    // 1. Raw-median pass for the sniper threshold.
+    let mut raw: Vec<i32> = sales.iter().map(|s| s.price_per_unit).collect();
+    raw.sort_unstable();
+    let raw_median = median_i32(&raw);
+    let floor = (raw_median as f64 * SNIPER_FRACTION) as i32;
+
+    // 2. Build the clamped vector. If the clamp would remove everything, keep the raw set.
+    let mut clamped: Vec<i32> = raw.iter().copied().filter(|p| *p >= floor).collect();
+    if clamped.is_empty() {
+        clamped = raw.clone();
+    }
+    let median_price = median_i32(&clamped);
+    let min_price = *clamped.first().unwrap_or(&0);
+    let max_price = *clamped.last().unwrap_or(&0);
+
+    // 3. Average price respects the existing IQR filter-outliers toggle.
+    let avg_price = if filter_outliers {
+        let mut prices = clamped.clone();
+        let filtered = filter_outliers_iqr_in_place(&mut prices);
+        if filtered.is_empty() {
+            0
+        } else {
+            (filtered.iter().map(|&p| p as i64).sum::<i64>() / filtered.len() as i64) as i32
+        }
+    } else {
+        (clamped.iter().map(|&p| p as i64).sum::<i64>() / clamped.len() as i64) as i32
+    };
+
+    // 4. Velocity. Newest first in the API's response.
+    let newest = sales.first().map(|s| s.sale_date);
+    let oldest = sales.last().map(|s| s.sale_date);
+    let avg_sale_duration = oldest.map(|last| {
+        let ms = (last - now).num_milliseconds().abs() / sales.len() as i64;
+        Duration::milliseconds(ms)
+    });
+    let days_since_last_sale =
+        newest.map(|n| Duration::milliseconds((now - n).num_milliseconds().max(0)));
+
+    SaleSummary {
+        item_id,
+        hq,
+        num_sold: sales.len(),
+        avg_sale_duration,
+        days_since_last_sale,
+        max_price,
+        avg_price,
+        median_price,
+        min_price,
+    }
+}
+```
+
+Note this signature change deliberately breaks `ProfitTable::new`. Task 2 fixes that.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run:
+```
+cargo test -p ultros-app --lib routes::analyzer::tests
+```
+Expected: the three tests pass. The whole crate will still fail to compile (`ProfitTable::new` calls `compute_summary` with the old signature) — that's fine for now.
+
+- [ ] **Step 5: Do not commit yet**
+
+The crate doesn't build. Commit happens at the end of Task 2 once the call site is fixed.
+
+---
+
+## Task 2: Wire `ProfitTable::new` to the new `compute_summary` + add troll-listing guard
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs:174-244`
+
+Three sub-changes:
+1. Drop the `hq_sales` map and the `hq_data` argument at the call site.
+2. Use `summary.median_price` (not `min_price`) as the historical anchor for `estimated_sale_price`.
+3. Skip any world-floor entry that's ≥ 50× the row's median (troll guard).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block:
+
+```rust
+#[test]
+fn troll_world_floor_does_not_inflate_estimate() {
+    use ultros_api_types::cheapest_listings::{CheapestListingItem, CheapestListings};
+    use ultros_api_types::recent_sales::RecentSales;
+
+    let sales = RecentSales {
+        sales: vec![sales_row(100, false, &[(1000, 0), (1000, 1), (1100, 2), (1000, 3), (1050, 4), (1000, 5)])],
+    };
+    // Region cheapest = a troll 999,999,999 listing on a foreign world.
+    let region = CheapestListings {
+        cheapest_listings: vec![CheapestListingItem {
+            item_id: 100,
+            hq: false,
+            cheapest_price: 999_999_999,
+            world_id: 42,
+        }],
+    };
+    // Our own world has a sane cheapest at 1100.
+    let world = CheapestListings {
+        cheapest_listings: vec![CheapestListingItem {
+            item_id: 100,
+            hq: false,
+            cheapest_price: 1100,
+            world_id: 1,
+        }],
+    };
+
+    let table = ProfitTable::new(sales, region, world, vec![], false);
+    assert_eq!(table.0.len(), 1);
+    let row = &table.0[0];
+    // The troll 999,999,999 floor must NOT be used — the row should fall through to median (=1025)
+    // capped against the local world floor (1100), so the estimated sale price is 1025.
+    assert_eq!(row.sale_summary.median_price, 1025);
+    assert_eq!(row.estimated_sale_price, 1025);
+}
+
+#[test]
+fn estimated_sale_price_uses_median_not_min() {
+    use ultros_api_types::cheapest_listings::{CheapestListingItem, CheapestListings};
+    use ultros_api_types::recent_sales::RecentSales;
+
+    let sales = RecentSales {
+        sales: vec![sales_row(
+            200,
+            false,
+            &[(800, 0), (1000, 1), (1000, 2), (1000, 3), (1000, 4), (1200, 5)],
+        )],
+    };
+    // Region floor is below median (a sane off-world deal).
+    let region = CheapestListings {
+        cheapest_listings: vec![CheapestListingItem {
+            item_id: 200,
+            hq: false,
+            cheapest_price: 700,
+            world_id: 42,
+        }],
+    };
+    // Local world floor is well above the median — the estimate should pin to median (=1000),
+    // not min (=800) and not the world floor (=5000).
+    let world = CheapestListings {
+        cheapest_listings: vec![CheapestListingItem {
+            item_id: 200,
+            hq: false,
+            cheapest_price: 5000,
+            world_id: 1,
+        }],
+    };
+
+    let table = ProfitTable::new(sales, region, world, vec![], false);
+    assert_eq!(table.0.len(), 1);
+    let row = &table.0[0];
+    assert_eq!(row.sale_summary.median_price, 1000);
+    assert_eq!(row.estimated_sale_price, 1000);
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run:
+```
+cargo test -p ultros-app --lib routes::analyzer::tests
+```
+Expected: compile error because `ProfitTable::new` still calls `compute_summary` with the old three-arg signature.
+
+- [ ] **Step 3: Replace `ProfitTable::new`**
+
+Replace the body of `impl ProfitTable` at [analyzer.rs:174-244](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:174) with:
+
+```rust
+/// Listings whose price is at least this multiple of the row's median sale are treated as troll
+/// listings and ignored when picking the world floor.
+const TROLL_MULTIPLE: i64 = 50;
+
+fn is_troll_listing(price: i32, median: i32) -> bool {
+    median > 0 && (price as i64) > (median as i64).saturating_mul(TROLL_MULTIPLE)
+}
+
+impl ProfitTable {
+    fn new(
+        sales: RecentSales,
+        global_cheapest_listings: CheapestListings,
+        world_cheapest_listings: CheapestListings,
+        cross_region: Vec<CheapestListings>,
+        filter_outliers: bool,
+    ) -> Self {
+        let mut region_cheapest = listings_to_map(global_cheapest_listings);
+        let world_cheapest = listings_to_map(world_cheapest_listings);
+
+        for cross in cross_region.into_iter().map(listings_to_map) {
+            for (key, (new_price, world_id)) in cross {
+                match region_cheapest.entry(key) {
+                    Entry::Occupied(mut entry) => {
+                        let (current_price, _) = entry.get();
+                        if *current_price > new_price {
+                            entry.insert((new_price, world_id));
+                        }
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert((new_price, world_id));
+                    }
+                }
+            }
+        }
+
+        let table = sales
+            .sales
+            .into_iter()
+            .flat_map(|sale| {
+                let item_id = sale.item_id;
+                let hq = sale.hq;
+                let key = ProfitKey { item_id, hq };
+                let (raw_region_price, region_world_id) = *region_cheapest.get(&key)?;
+                let summary = compute_summary(sale, filter_outliers);
+
+                // Troll-listing guard: if the region floor is implausibly high vs the median,
+                // drop the row entirely — the displayed "deal" would be fictional.
+                if is_troll_listing(raw_region_price, summary.median_price) {
+                    return None;
+                }
+
+                // Same guard on the local world floor — if it's a troll, ignore it and fall
+                // through to the median as the estimate.
+                let world_floor = world_cheapest.get(&key).and_then(|(price, _)| {
+                    if is_troll_listing(*price, summary.median_price) {
+                        None
+                    } else {
+                        Some(*price)
+                    }
+                });
+
+                let estimated_sale_price = match world_floor {
+                    Some(floor) => summary.median_price.min(floor),
+                    None => summary.median_price,
+                };
+
+                Some(ProfitData {
+                    estimated_sale_price,
+                    sale_summary: summary,
+                    cheapest_world_id: region_world_id,
+                    cheapest_price: raw_region_price,
+                })
+            })
+            .map(Arc::new)
+            .collect();
+
+        ProfitTable(table)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```
+cargo test -p ultros-app --lib routes::analyzer::tests
+```
+Expected: all five tests pass (3 from Task 1 + 2 new). The crate should build cleanly now.
+
+- [ ] **Step 5: Run the workspace-wide CI check**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: fmt-check passes, clippy passes. If clippy complains, fix the underlying issue.
+
+- [ ] **Step 6: Commit**
+
+```
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs
+git commit -m "$(cat <<'EOF'
+fix(analyzer): median-based sell estimate + sniper/troll clamps
+
+Drops HQ price contamination of NQ rows, switches the historical sale
+anchor from min-of-six to median-of-clamped-sales, and ignores world
+listings priced 50x above the median (troll guard) when computing
+estimated_sale_price. Adds days_since_last_sale to SaleSummary in
+preparation for the "Last sold" column.
+
+Unit tests cover the median, sniper, troll, and HQ-isolation cases.
+EOF
+)"
+```
+
+---
+
+## Task 3: Add the "Last sold" table column
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs:780-1032`
+- Modify: `ultros-frontend/ultros-app/locales/en.json`
+
+Surfaces the new `days_since_last_sale` field as its own column, after "Avg Sale Time".
+
+- [ ] **Step 1: Add the locale string**
+
+Open [ultros-frontend/ultros-app/locales/en.json](../../ultros-frontend/ultros-app/locales/en.json) and locate the `analyzer_col_avg_sale_time` line (~line 386). Add the following line directly after it:
+
+```json
+    "analyzer_col_last_sold": "Last Sold",
+```
+
+Also add (we use it in step 3 of the cell renderer):
+
+```json
+    "analyzer_last_sold_never": "—",
+```
+
+- [ ] **Step 2: Add the column header**
+
+In `AnalyzerTable`'s header `view!` at [analyzer.rs:879-883](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:879), add a new `columnheader` right after the existing "Avg Sale Time" header:
+
+```rust
+<div role="columnheader" class="w-30 p-4 hidden md:block">
+    {t!(i18n, analyzer_col_last_sold)}
+</div>
+```
+
+- [ ] **Step 3: Add the cell renderer**
+
+In the per-row `view!` at [analyzer.rs:1008-1027](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:1008), add a new cell directly after the "Avg Sale Time" cell:
+
+```rust
+<div role="cell" class="px-4 py-2 w-30 truncate hidden md:block flex items-center">
+    {data.inner
+        .sale_summary
+        .days_since_last_sale
+        .and_then(|d| d.to_std().ok())
+        .map(|d| {
+            let secs = d.as_secs();
+            let days = secs / 86_400;
+            let hours = (secs % 86_400) / 3_600;
+            if days > 0 { format!("{}d ago", days) }
+            else if hours > 0 { format!("{}h ago", hours) }
+            else { "just now".to_string() }
+        })
+        .unwrap_or_else(|| t_string!(i18n, analyzer_last_sold_never).to_string())}
+</div>
+```
+
+- [ ] **Step 4: Build and run E2E smoke**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: fmt and clippy pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs ultros-frontend/ultros-app/locales/en.json
+git commit -m "feat(analyzer): show days since last sale per row"
+```
+
+---
+
+## Task 4: Add the `min-buy` (Minimum Buy Price) filter
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs`
+- Modify: `ultros-frontend/ultros-app/locales/en.json`
+
+This is the single most important filter — it's what removes the 1-gil rows from any sort that surfaces them.
+
+- [ ] **Step 1: Add the locale strings**
+
+Append to the analyzer section of [ultros-frontend/ultros-app/locales/en.json](../../ultros-frontend/ultros-app/locales/en.json):
+
+```json
+    "analyzer_minimum_buy_price": "Minimum Buy Price",
+    "analyzer_minimum_buy_price_desc": "Hide rows where the buy-price is below this floor — filters out price-war and sniper listings",
+    "analyzer_min_buy_gte": "Buy ≥ ",
+```
+
+- [ ] **Step 2: Add the query signal**
+
+In `AnalyzerTable` near the existing `max_purchase_price` signal at [analyzer.rs:288](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:288), add:
+
+```rust
+let (min_buy_price, set_min_buy_price) = query_signal::<i32>("min-buy");
+```
+
+- [ ] **Step 3: Add a `.filter` to `sorted_data`**
+
+Inside the `Memo::new(move |_| { ... })` for `sorted_data`, add another `.filter` chained alongside the existing `max_purchase_price` filter at [analyzer.rs:379-383](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:379):
+
+```rust
+.filter(move |data| {
+    min_buy_price()
+        .map(|min| data.inner.cheapest_price >= min)
+        .unwrap_or(true)
+})
+```
+
+- [ ] **Step 4: Add the filter card**
+
+In the FilterCard grid, after the "Maximum Budget" card at [analyzer.rs:582-611](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:582), add:
+
+```rust
+<FilterCard
+    title=t_string!(i18n, analyzer_minimum_buy_price).to_string()
+    description=t_string!(i18n, analyzer_minimum_buy_price_desc).to_string()
+>
+    <div class="flex flex-col gap-2">
+        <div class="text-brand-300">
+            {move || {
+                min_buy_price()
+                    .map(|p| Either::Left(view! { <Gil amount=p /> }))
+                    .unwrap_or(Either::Right("---"))
+            }}
+        </div>
+        <input
+            class="input"
+            min=0
+            step=1000
+            placeholder="e.g. 5000"
+            type="number"
+            prop:value=min_buy_price
+            on:input=move |input| {
+                let value = event_target_value(&input);
+                if let Ok(p) = value.parse::<i32>() {
+                    set_min_buy_price(Some(p));
+                } else if value.is_empty() {
+                    set_min_buy_price(None);
+                }
+            }
+        />
+    </div>
+</FilterCard>
+```
+
+- [ ] **Step 5: Add the chip and clear-all wiring**
+
+In the chips block at [analyzer.rs:653-755](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:653), add another `if let Some(...)` block alongside the existing `max_purchase_price` chip:
+
+```rust
+if let Some(p) = min_buy_price() {
+    chips.push(view! {
+        <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
+            {t!(i18n, analyzer_min_buy_gte)} <Gil amount=p />
+            <button aria-label="Remove filter" class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_min_buy_price(None)>
+                <Icon icon=icondata::MdiClose />
+            </button>
+        </span>
+    }.into_any());
+}
+```
+
+In the "Clear all" button at [analyzer.rs:757-769](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:757), add `set_min_buy_price(None);` alongside the other setters.
+
+- [ ] **Step 6: Build and verify**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: fmt and clippy pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs ultros-frontend/ultros-app/locales/en.json
+git commit -m "feat(analyzer): minimum buy-price filter (?min-buy=)"
+```
+
+---
+
+## Task 5: Add the `last-sold` (Last Sold Within) filter
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs`
+- Modify: `ultros-frontend/ultros-app/locales/en.json`
+
+Mirror the existing `next-sale` filter pattern, but applied to `days_since_last_sale` rather than `avg_sale_duration`.
+
+- [ ] **Step 1: Add the locale strings**
+
+Append to the analyzer section of `en.json`:
+
+```json
+    "analyzer_last_sold_within": "Last Sold Within",
+    "analyzer_last_sold_within_desc": "Hide rows whose most recent sale is older than this (e.g. 7d, 1d 12h)",
+    "analyzer_last_sold_lte": "Last sold ≤ ",
+```
+
+- [ ] **Step 2: Add the query signal + memo**
+
+In `AnalyzerTable` near the existing `max_predicted_time` signal at [analyzer.rs:282](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:282), add:
+
+```rust
+let (last_sold_within, set_last_sold_within) = query_signal::<String>("last-sold");
+let last_sold_duration =
+    Memo::new(move |_| last_sold_within().and_then(|d| parse_duration(d.as_str()).ok()));
+let last_sold_string = Memo::new(move |_| {
+    last_sold_duration()
+        .map(|d| format_duration(d).to_string())
+        .unwrap_or("---".to_string())
+});
+```
+
+- [ ] **Step 3: Add a `.filter` to `sorted_data`**
+
+After the existing `predicted_time` filter at [analyzer.rs:384-394](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:384), add:
+
+```rust
+.filter(move |data| {
+    last_sold_duration()
+        .map(|max_age| {
+            data.inner
+                .sale_summary
+                .days_since_last_sale
+                .and_then(|d| d.to_std().ok())
+                .map(|d| d <= max_age)
+                .unwrap_or(false)
+        })
+        .unwrap_or(true)
+})
+```
+
+- [ ] **Step 4: Add the filter card**
+
+After the "Sale Time Prediction" card at [analyzer.rs:613-630](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:613), add:
+
+```rust
+<FilterCard
+    title=t_string!(i18n, analyzer_last_sold_within).to_string()
+    description=t_string!(i18n, analyzer_last_sold_within_desc).to_string()
+>
+    <div class="flex flex-col gap-2">
+        <div class="text-brand-300">{last_sold_string}</div>
+        <input
+            class="input"
+            placeholder="e.g. 7d"
+            title="Accepts formats like 1h 30m, 7d, 1M (month), etc."
+            prop:value=move || last_sold_within().unwrap_or_default()
+            on:input=move |input| {
+                let value = event_target_value(&input);
+                set_last_sold_within(Some(value))
+            }
+        />
+    </div>
+</FilterCard>
+```
+
+- [ ] **Step 5: Add the chip and clear-all wiring**
+
+Add a chip block alongside the existing `max_predicted_time` chip:
+
+```rust
+if last_sold_within().is_some() {
+    chips.push(view! {
+        <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
+            {t!(i18n, analyzer_last_sold_lte)} {last_sold_string()}
+            <button aria-label="Remove filter" class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_last_sold_within(None)>
+                <Icon icon=icondata::MdiClose />
+            </button>
+        </span>
+    }.into_any());
+}
+```
+
+In the "Clear all" button, add `set_last_sold_within(None);`.
+
+- [ ] **Step 6: Build and verify**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs ultros-frontend/ultros-app/locales/en.json
+git commit -m "feat(analyzer): last-sold-within filter (?last-sold=)"
+```
+
+---
+
+## Task 6: Re-tune the preset buttons
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs:1190-1200`
+- Modify: `ultros-frontend/ultros-app/locales/en.json`
+
+Replace the three existing presets so each one sets a minimum buy price (the actual 1-gil fix) and a last-sold cap (the actual liveness fix). Add a new leading "Realistic flips" preset.
+
+- [ ] **Step 1: Add the locale strings**
+
+In the analyzer section of `en.json`, add:
+
+```json
+    "analyzer_preset_realistic": "Realistic flips",
+    "analyzer_preset_big_ticket": "Big-ticket flips",
+    "analyzer_preset_volume": "Volume flips",
+```
+
+Optionally update the existing `analyzer_preset_300_return`, `analyzer_preset_500_return`, `analyzer_preset_100k_profit` strings if their copy no longer matches their new filter URLs (see Step 2).
+
+- [ ] **Step 2: Replace the preset buttons**
+
+Replace the `<div class="flex flex-wrap gap-4">` block at [analyzer.rs:1190-1200](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:1190) with:
+
+```rust
+<div class="flex flex-wrap gap-4">
+    <PresetFilterButton
+        href="?min-buy=5000&last-sold=7d&roi=30&sort=profit-per-day"
+        label=t_string!(i18n, analyzer_preset_realistic).to_string()
+    />
+    <PresetFilterButton
+        href="?min-buy=100000&last-sold=14d&roi=20&sort=profit"
+        label=t_string!(i18n, analyzer_preset_big_ticket).to_string()
+    />
+    <PresetFilterButton
+        href="?min-buy=1000&last-sold=3d&sort=profit-per-day"
+        label=t_string!(i18n, analyzer_preset_volume).to_string()
+    />
+    <PresetFilterButton
+        href="?min-buy=1000&last-sold=7d&roi=300&profit=0&sort=profit"
+        label=t_string!(i18n, analyzer_preset_300_return).to_string()
+    />
+    <PresetFilterButton
+        href="?min-buy=10000&last-sold=1M&roi=500&profit=200000"
+        label=t_string!(i18n, analyzer_preset_500_return).to_string()
+    />
+    <PresetFilterButton
+        href="?min-buy=1000&profit=100000"
+        label=t_string!(i18n, analyzer_preset_100k_profit).to_string()
+    />
+</div>
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: pass.
+
+- [ ] **Step 4: Manual smoke check**
+
+Bring up the app locally (`cargo run -p ultros` or the existing dev workflow) and visit `http://localhost:8080/flip-finder/Goblin`. Click each preset and confirm:
+
+- "Realistic flips" lands on a page with no 1-gil buy rows visible.
+- "Big-ticket flips" only shows rows with cheapest price ≥ 100,000.
+- The existing "300% return" preset no longer surfaces 1-gil rows in the first page of results.
+
+If the dev environment isn't trivially available, document this manual step in the PR description so a reviewer can verify it post-merge — do not skip it.
+
+- [ ] **Step 5: Commit**
+
+```
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs ultros-frontend/ultros-app/locales/en.json
+git commit -m "feat(analyzer): re-tune presets with min-buy + last-sold guards"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run the full CI check from a clean state**
+
+Run:
+```
+./check_ci.sh
+```
+Expected: fmt and clippy pass.
+
+- [ ] **Step 2: Run all analyzer-related unit tests**
+
+Run:
+```
+cargo test -p ultros-app --lib routes::analyzer
+```
+Expected: all five tests pass.
+
+- [ ] **Step 3: (Optional) Run E2E smoke**
+
+Run:
+```
+./scripts/run_e2e.sh
+```
+Expected: the existing Puppeteer harness still passes. If it doesn't, investigate — the only thing that should have changed visibly is the Flip Finder page; the harness may have a baseline screenshot to refresh.
+
+- [ ] **Step 4: Open the PR**
+
+Push the branch and open a PR titled `feat(analyzer): data-integrity & guidance (Tier 1)`. The body should reference:
+
+- The design doc at [docs/superpowers/specs/2026-05-11-analyzer-data-integrity-design.md](../specs/2026-05-11-analyzer-data-integrity-design.md).
+- The before/after evidence from the production data exploration (1-gil sniper rows dominated 71% of the top 500 by ROI before).
+- A note about the manual Goblin smoke test (Task 6 Step 4) if it was deferred to review.

--- a/docs/superpowers/specs/2026-05-11-analyzer-data-integrity-design.md
+++ b/docs/superpowers/specs/2026-05-11-analyzer-data-integrity-design.md
@@ -1,0 +1,152 @@
+# Analyzer Data Integrity & Guidance — Design
+
+**Date:** 2026-05-11
+**Status:** Awaiting user review
+**Scope:** Tier 1 of a three-tier improvement plan for the Flip Finder analyzer. Fix the math that makes the default ROI sort surface ~71% 1-gil price-war rows, then re-tune presets so the landing experience guides users to realistic flips. Tier 2 (confidence column, per-row explainer) and Tier 3 (onboarding wizard, unmet-demand tab) are sketched as a roadmap appendix but out of scope for this spec.
+
+---
+
+## Why
+
+I replayed the live `/api/v1/recentSales/Goblin` + `/api/v1/cheapest/{Goblin,North-America}` payloads through the current [analyzer.rs](../../ultros-frontend/ultros-app/src/routes/analyzer.rs) profit logic. Concrete findings:
+
+- **Default ROI sort is dominated by sniper listings.** Of the top 500 rows by ROI: 357 (71%) have a buy price of 1 gil, 481 (96%) have a buy price ≤ 100 gil. A new user lands on Flip Finder and sees a wall of unscalable 99,999%-ROI rows.
+- **HQ contamination of NQ estimates.** `compute_summary` folds HQ sale prices into the NQ row's `min_price` ([analyzer.rs:104-111](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:104)). 5,881 NQ rows have an estimated sell price < 50% of their own NQ sale average — the analyzer is *under-selling* the honest flips while the dishonest ones rank #1.
+- **No troll-listing guard.** 4,969 region-vs-world price gaps are produced by 999,999,999-gil joke listings being treated as the world floor.
+- **`estimated_sale_price = min(...)`** is the worst-case statistic. Median is the realistic seller price; current code uses `min` of the last six sales clamped against the world floor.
+- **Velocity ignores time since the most-recent sale.** 83 of the top 500 by ROI haven't sold in 30+ days; 25 haven't sold in 90+. The "average sale duration" computes a cadence across the last 6 sales but never penalises the gap between now and the newest one.
+
+These are arithmetic bugs and defaulting choices — no API changes, no DB changes, no new dependencies.
+
+## Non-goals
+
+- Adding new API endpoints. The `/api/v1/best_deals/{world}` endpoint exists but is not used by Flip Finder; we leave that alone.
+- Changing the server-side sales window. The API still caps at six sales per item; we work within that constraint.
+- Replacing the `filter_outliers_iqr_in_place` toggle. It stays as an opt-in pre-filter on `avg_price`; we add a separate sanity-clamp that applies unconditionally.
+- Building the Confidence column, per-row explainer, onboarding wizard, or unmet-demand tab. Those are Tier 2/3, sketched in the appendix.
+- Stack depth / alternate buy-worlds. Needs an API change; deferred.
+
+## Changes
+
+### 1. Drop HQ→NQ contamination
+
+[`compute_summary`](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:97) currently accepts an `hq_data: Option<&SaleData>` and includes those prices in `min_price` when computing an NQ row. Remove the parameter; `min_price` is computed only from the row's own sales. The caller in [`ProfitTable::new`](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:218-222) is simplified accordingly.
+
+Rationale: HQ and NQ are separate markets. Mixing them lets a single 1-gil HQ sale poison every NQ row for the same item.
+
+### 2. Replace `min` with median for `estimated_sale_price`
+
+In `SaleSummary`, add `median_price: i32`. Compute it as the median of the row's own sales (already only six values; a sort-and-pick is fine — no perf concern).
+
+Change [`estimated_sale_price`](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:225-230) to:
+
+```rust
+let estimated_sale_price = match world_cheapest.get(&key) {
+    Some((world_floor, _)) => summary.median_price.min(*world_floor),
+    None => summary.median_price,
+};
+```
+
+Rationale: a realistic seller prices at or near the recent median, not at the absolute floor. The min of the world's current listings still caps it (you can't sell above someone undercutting you), but the *historical* floor — which can be a single sniper — no longer drives the estimate.
+
+Keep `min_price` in the struct; it's still useful for Tier 2 tooltips ("worst recent sale was X").
+
+### 3. Troll-listing guard on the world floor
+
+Add a sanity check after merging cross-region listings in [`ProfitTable::new`](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:174-201): if `world_cheapest_price > 50 * median_recent_sale`, drop that world-floor entry and treat the row as if there's no world floor (i.e. fall through to `summary.median_price`).
+
+50× is generous enough to keep legitimate ultra-rare items (e.g. a desynth where the only recent sale was a lowball private trade) while filtering the joke listings I saw in the data — 999,999,999 against a 3,000-gil median.
+
+Implementation note: this needs the row's recent sales in scope when consulting the world-floor map. The cleanest path is to fold the clamp into the same iterator over `sales.sales` that already builds each `ProfitData`, instead of pre-merging maps. That's a small refactor; the inner shape doesn't change.
+
+### 4. Sniper-sale guard on `min_price` / `median_price`
+
+When building `SaleSummary`, drop any individual sale whose `price_per_unit < 0.1 * (raw median of the six)` before computing the final stats. With only six sales, dropping one outlier still leaves five.
+
+This is independent from the existing IQR outlier toggle. The IQR toggle is symmetric and opt-in; this clamp is asymmetric (low-side only), unconditional, and only fires on the obvious sniper cases.
+
+### 5. Velocity that respects gap-since-last-sale
+
+Change [`avg_sale_duration`](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:134-137) from "(oldest_sale - now) / len" to:
+
+```rust
+let newest = sales.first()?.sale_date;
+let oldest = sales.last()?.sale_date;
+let span_ms = (now - oldest).num_milliseconds();
+let avg_sale_duration = Duration::milliseconds(span_ms / sales.len() as i64);
+```
+
+The numerator stays unchanged (the current code already takes `|last - now|`, equivalent), but we also expose `days_since_last_sale = now - newest` as a new field on `SaleSummary`. The Tier 1 visible change is one new column in the analyzer table: **"Last sold"** showing `2d ago`, `30d ago`, etc.
+
+`profit_per_day` continues to use `avg_sale_duration` so existing URL filters keep working.
+
+A follow-up filter card "Last sold within" (defaulting unset) plugs into `days_since_last_sale`. This is the single highest-leverage filter for separating live items from dead ones.
+
+### 6. Preset re-tune
+
+Current presets ([analyzer.rs:1190-1200](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:1190)):
+- "300% return" → `?next-sale=7d&roi=300&profit=0&sort=profit&`
+- "500% return" → `?next-sale=1M&roi=500&profit=200000&`
+- "100k profit" → `?profit=100000`
+
+All three let the 1-gil rows through because none of them sets a minimum buy price. New presets:
+
+- **"Realistic flips" (new default landing CTA)** — `?max-price=&min-buy=5000&last-sold=7d&roi=30&sort=profit-per-day` — the answer to "what should I do with my next 30 minutes." Min buy 5k filters out the price-war noise; last-sold-within-7d filters out dead items; sort by ppd matches the actual decision.
+- **"Big-ticket flips"** — `?min-buy=100000&last-sold=14d&roi=20&sort=profit`
+- **"Volume flips"** — `?min-buy=1000&last-sold=3d&sort=profit-per-day`
+- Keep the existing "100k profit" preset; it's a useful third archetype.
+
+This needs one new URL query param + filter card: **Minimum buy price** (`min-buy`). The existing "Maximum Budget" (`max-price`) is the upper bound; the new param is the lower bound and is what actually solves the 1-gil problem.
+
+### 7. New filter cards
+
+Two new `FilterCard` entries in the existing grid, mirroring the patterns at [analyzer.rs:421-644](../../ultros-frontend/ultros-app/src/routes/analyzer.rs:421):
+
+- **Minimum buy price** — query param `min-buy`, integer, default unset.
+- **Last sold within** — query param `last-sold`, humantime duration (e.g. `7d`), default unset. Reuses the same `parse_duration` parsing as the existing `next-sale` predicted-time field.
+
+Both get filter chips in the active-filters bar and "Clear all" wiring.
+
+## File touch list
+
+- [ultros-frontend/ultros-app/src/routes/analyzer.rs](../../ultros-frontend/ultros-app/src/routes/analyzer.rs) — all logic and UI changes land here.
+- [ultros-frontend/ultros-app/locales/en.json](../../ultros-frontend/ultros-app/locales/en.json) and sibling locale files — strings for the two new filter cards, the new "Last sold" column, and the renamed presets. Default English content goes in; other locales fall back gracefully via the i18n setup.
+
+No changes to `ultros-api-types`, `ultros-db`, the Axum routes, or any other crate.
+
+## Testing
+
+Logic changes are unit-testable inside `analyzer.rs`:
+
+- `compute_summary` with HQ-only input, NQ-only input, and an NQ-with-HQ-sniper case → estimated stays anchored to NQ.
+- `compute_summary` with a six-sample series that contains one obvious sniper (10% of median) → that sample is excluded from `min_price` and `median_price`.
+- `ProfitTable::new` with a 999,999,999 troll listing in the world map → the row falls through to `median_price` instead of producing a $999M profit.
+- `days_since_last_sale` math on synthetic timestamps.
+
+UI changes are smoke-tested manually post-deploy on Goblin (Aether):
+
+1. Land on `/flip-finder/Goblin` — verify the default preset shows no buy-price-of-1 rows.
+2. Apply each new preset — verify the URL → filter wiring round-trips.
+3. Sort by ROI explicitly — verify 1-gil rows are now gone *because of the troll/sniper clamp*, not just hidden by the preset.
+
+A regression check on the existing E2E harness in `integration/` is enough; we are not adding new pages.
+
+## Risk
+
+Low. Every change is local to `analyzer.rs`, gated by either deterministic math or a query param that defaults to "unset" (preserves existing URLs). The only user-visible default change is the landing preset, which is opt-in via a CTA the user clicks — direct URLs and bookmarks keep working.
+
+The 50× troll-listing threshold is the only "tunable magic number" in the design; if it turns out to filter legitimate rare-item rows on production data, it's a one-line change to raise.
+
+## Tier 2 / Tier 3 roadmap (out of scope for this spec)
+
+Sketched here so the next spec inherits a clear backlog, not designed:
+
+**Tier 2 — Trust signals.**
+- Confidence column folding sample size + days-since-last-sale + price coefficient-of-variation into low/med/high.
+- Per-row explainer popover: "Estimated sell = median of last 6 sales (X). Your world floor: Y. Cheapest off-world: Z @ Worldname. Last sale: N days ago."
+- Stack depth / alternate buy-worlds — needs an API addition to return top-N listings at the floor per item.
+
+**Tier 3 — Guided flipper.**
+- First-visit onboarding step: budget, time horizon, home world → writes URL filters. Plugs into the recently-shipped `/welcome` route.
+- "Unmet demand" tab — items with recent sales but no current listings (276 on Goblin in today's snapshot).
+- "Avoid my own retainers" filter using `/api/v1/user/retainer` for logged-in users.

--- a/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-11
 **Status:** Awaiting user review
-**Scope:** Make the already-built Shared Lists backend usable. Three tiers: (1) surface ownership and permissions in existing UI, (2) ship the missing sharing/invite/group UI, (3) thread discovery into onboarding and analyzer flows. Includes targeted backend refactors (`web.rs` split, permission extractor, scoped WebSocket broadcasts).
+**Scope:** Make the already-built Shared Lists backend usable, and extend it with Discord guild integration. Four tiers: (1) surface ownership and permissions in existing UI, (2) ship the missing sharing/invite/group UI, (2b) bind lists/groups to Discord guilds with role-based access and channel notifications, (3) thread discovery into onboarding and analyzer flows. Includes targeted backend refactors (`web.rs` split, permission extractor, scoped WebSocket broadcasts).
 
 ---
 
@@ -27,12 +27,13 @@ Net: the product can ship Shared Lists end-to-end in roughly a week of frontend 
 
 ## Non-goals
 
-- **No new backend features.** Permissions stay at None/Read/Write/Owner; no fine-grained per-item permissions, no "expiring share", no transfer-ownership UI. Those are interesting and out of scope.
-- **No notifications system.** Sharing a list with a user does not send them a Discord DM, an in-app notification, or an email. The recipient discovers the list when they next open `/list`. A real notification layer is a separate spec.
-- **No tutorial / interactive walkthrough.** Onboarding is contextual nudges, not a guided tour. If we want a Shepherd.js-style overlay later, that's a different spec.
-- **No public lists.** A list is private, shared with named users, shared with groups the owner controls, or invite-link gated. There is no "discoverable" or "public to everyone" mode. (Possible Tier 4; explicitly deferred.)
-- **No mobile-specific layout work beyond responsive defaults.** The share modal and groups page must work on mobile, but a dedicated mobile UX pass is out of scope.
-- **No rename of `Lists` → `Collections` or similar.** Keep the existing terminology.
+- **No new permission levels.** Stays at None/Read/Write/Owner; no fine-grained per-item permissions, no "expiring share", no transfer-ownership UI.
+- **No general in-app notifications system.** "X shared a list with you" via a bell icon is a separate spec. Discord *channel* notifications for list events are in scope (Tier 2b) because they reuse the existing alert-delivery pipeline. In-app and Discord-DM notifications are not.
+- **No `GUILD_MEMBERS` privileged intent.** That intent requires Discord verification past 100 guilds and a privacy review. We resolve guild role membership lazily via per-user REST calls at OAuth callback time — see Tier 2b.4. If the bot ever needs to react to live role changes (someone gets promoted mid-session), that's a future expansion, not this spec.
+- **No tutorial / interactive walkthrough.** Onboarding is contextual nudges, not a guided tour.
+- **No public lists.** A list is private, shared with named users, shared with groups the owner controls, invite-link gated, or guild-bound (Tier 2b). No "discoverable to all" mode.
+- **No mobile-specific layout work beyond responsive defaults.**
+- **No rename of `Lists` → `Collections` or similar.**
 
 ## Tiers
 
@@ -40,6 +41,7 @@ The work is structured so each tier is independently shippable.
 
 - **Tier 1 — Make ownership visible.** Permission badges, owner attribution, sectioning. No new endpoints.
 - **Tier 2 — Sharing UI.** Share modal, invite link UI, groups page. Uses existing endpoints.
+- **Tier 2b — Discord guild integration.** Bind a list or group to a guild role for auto-membership; bind a list to a guild channel for event notifications. Adds OAuth scope, bot guild-join handler, new DB tables, reuses existing alert delivery pipeline.
 - **Tier 3 — Discovery & onboarding.** `/welcome` step, post-creation nudge, analyzer integration.
 - **Backend cleanup (parallel).** `web.rs` split, `RequireListPermission` extractor, scoped WebSocket broadcasts. Lands alongside Tier 2.
 
@@ -133,7 +135,89 @@ Nav: add `/groups` to the side nav alongside `/list`.
 
 The list-view page ([routes/list_view.rs](ultros-frontend/ultros-app/src/routes/list_view.rs)) gains a small "Shared with N people" indicator next to the title, clickable to open `<ShareListModal />`. For non-owners, it reads "Shared by {owner}" and is non-interactive.
 
-**Open question deferred to implementation:** how do users get added to a group without a user-search? Options: invite-to-group links analogous to invite-to-list, or "members are auto-added when they redeem an invite to a list shared with this group." Pick during plan-writing; both are small.
+**Open question deferred to implementation:** how do users get added to a group without a user-search? Options: invite-to-group links analogous to invite-to-list, or "members are auto-added when they redeem an invite to a list shared with this group." Pick during plan-writing; both are small. Tier 2b makes a third option viable — *guild-backed groups* (group membership is whoever has the bound Discord role).
+
+---
+
+## Tier 2b — Discord guild integration
+
+Goal: a Discord guild owner / officer can bind one of their guild's roles to an Ultros group (or directly to a list), and bind a guild channel to receive list-change notifications. Members of the role automatically gain the corresponding list permission the next time they log into Ultros. The bot must be in the guild.
+
+This tier is the most net-new — new tables, new OAuth scope, new bot handlers — but the architecture is straightforward because we deliberately avoid the privileged `GUILD_MEMBERS` intent.
+
+### 2b.1 Bot guild lifecycle
+
+When the Ultros bot joins or leaves a guild, sync minimal metadata:
+
+- New table `discord_guild(id, name, icon_url, joined_at, left_at)`. `left_at IS NOT NULL` is the soft-deleted state — keep the row so historical bindings can be re-activated if the bot is re-added.
+- New table `discord_guild_role(guild_id, role_id, name, color, position, is_managed)`. Composite primary key. Synced from the bot.
+
+Wire two handlers in [ultros/src/discord/mod.rs](ultros/src/discord/mod.rs):
+
+- `EventHandler::guild_create` — bot joined, or a guild came back online. Upsert `discord_guild`, fetch role list via REST, upsert `discord_guild_role` rows, mark missing roles as deleted.
+- `EventHandler::guild_role_create / update / delete` — keep `discord_guild_role` in sync without a full re-fetch.
+
+These events are part of the **non-privileged** GUILD intent set; no Discord verification needed.
+
+### 2b.2 OAuth scope upgrade: add `guilds`
+
+Currently [`ultros/src/main.rs` requests only `Identify`](ultros/src/main.rs). Add `guilds`. On the next login each existing user will be re-prompted by Discord to grant the additional scope; this is normal Discord UX and we don't try to hide it. The scope yields a list of guilds the user belongs to plus per-guild `permissions` (a bitfield — we read `MANAGE_GUILD` to identify "officer-level" users for the bind UI).
+
+We do **not** request `guilds.members.read`. We don't need the full member list; we resolve a single user's roles in a single guild on demand (see 2b.4).
+
+### 2b.3 Binding schema
+
+New tables:
+
+- `discord_guild_list_binding(id, guild_id, list_id, role_id, permission, created_at, created_by_user_id)` — binds a guild role to a list permission. `role_id` is nullable; `NULL` means `@everyone` (every member of the guild). `permission` is `ListPermission` (Read or Write — not Owner; owner-grant via role would be wild).
+- `discord_guild_group_binding(id, guild_id, group_id, role_id, created_at, created_by_user_id)` — binds a guild role to a group. Same nullability semantics. Permission is whatever the group is shared with on each list (separate concern).
+- `discord_guild_notification(id, guild_id, channel_id, list_id, events, created_at, created_by_user_id)` — binds a guild channel to a list. `events` is a bitfield of `ListChanged | ItemAddedRemoved | InviteUsed`.
+
+All three FK to `discord_guild(id)` with `ON DELETE CASCADE` so removing the bot tears down bindings cleanly. The `list_id` / `group_id` FKs also cascade.
+
+Authorization invariant: to create any binding, the calling user must have `MANAGE_GUILD` on the guild (read from the OAuth `guilds` payload, cached in their session). This is checked in the Axum handler — the bot never trusts client-supplied guild ids.
+
+### 2b.4 Lazy membership resolution
+
+We don't subscribe to live member events. Instead, role membership is re-evaluated at well-defined moments:
+
+- **At OAuth login.** After the existing `Identify` callback, for each guild in `discord_guild_list_binding ∪ discord_guild_group_binding` that the user belongs to (intersection of bot-known guilds and the user's guild list from OAuth), call `GET /guilds/{guild_id}/members/{user_id}` via the bot token. The response includes the member's role list. Upsert/delete the corresponding `list_shared_user` and `user_group_member` rows so the user's access matches their current roles.
+- **On binding create / edit.** When an officer creates or modifies a binding, enqueue a one-shot resolution for every Ultros user currently linked to that guild (find them via the OAuth `guilds` cache from their last login). This is bounded by users-who-have-logged-in, not the full guild member count.
+- **Hourly drift sweep.** A background tokio task re-resolves users who logged in more than 24 hours ago, capped at N per minute. Nice to have, not required for shipping.
+
+Lazy resolution intentionally accepts a "user gets promoted on Discord, doesn't see Editor permission on Ultros until they refresh / re-login" lag. The product reads as "permissions sync on login" — that's an acceptable mental model and saves us the privileged intent.
+
+### 2b.5 Notification dispatch
+
+New events emitted by the list backend:
+
+- `ListChanged` — list metadata (name/world/filters) edited.
+- `ItemAddedRemoved` — item added to or removed from the list.
+- `InviteUsed` — someone redeemed an invite link.
+
+The existing alert delivery pipeline ([ultros/src/alerts/delivery.rs:11-18](ultros/src/alerts/delivery.rs:11), [ultros/src/alerts/delivery.rs:40-88](ultros/src/alerts/delivery.rs:40)) already handles `DiscordChannel { channel_id }` dispatch with embed rendering. We add a thin `list_event_dispatcher` that, on each event, looks up `discord_guild_notification` rows matching `list_id` and `events`, builds an embed, and hands off to the existing delivery function. No new transport.
+
+Rate-limit and de-dup: an item bulk-add of 50 items should produce one batched embed, not 50. The dispatcher coalesces events for the same `(list_id, event_type)` over a 30-second window.
+
+### 2b.6 UI: guild tab in `<ShareListModal />`
+
+A fourth tab in the share modal (alongside Groups, Invite link, and the deferred People tab): **Discord guild**.
+
+Visible only to the list owner. Content:
+
+- If the user has not granted the `guilds` scope yet → "Connect your Discord guilds to bind roles" with a re-auth button.
+- Else, a dropdown of guilds where the user has `MANAGE_GUILD` *and* the Ultros bot is present. For guilds where bot is missing, show an "Invite Ultros to this guild" link with the bot install URL and the minimum required permissions (`Send Messages`, `Embed Links`, `Read Roles` — guild-only, no member-list, no message-content).
+- After picking a guild:
+  - **Roles**: list current `discord_guild_list_binding` rows for this guild+list. Each row: role-name pill (with guild's color), permission selector (Read/Write), revoke. "Add binding" → role dropdown + permission selector. `@everyone` is one of the role choices, prefixed with an icon to differentiate.
+  - **Notifications**: list current `discord_guild_notification` rows. Each row: channel name, event-type checkboxes, revoke. "Add notification" → channel dropdown (filtered to text channels the bot can post to) + event checkboxes.
+
+### 2b.7 Groups page integration
+
+The `/groups` page (Tier 2.3) gains the same guild-binding UI per group, scoped to `discord_guild_group_binding`. A group with a guild binding shows a Discord icon and the guild name below the group name.
+
+### 2b.8 Bot slash command (optional, post-Tier-2b)
+
+A `/ffxiv list` already exists ([ultros/src/discord/ffxiv/mod.rs:20-28](ultros/src/discord/ffxiv/mod.rs:20)). Extend with `/ffxiv list link` — an officer-only slash command that links the calling guild to an Ultros list by id (the user must own the list on Ultros). Convenience over the web UI; nice to have, not required for the tier.
 
 ---
 
@@ -212,6 +296,27 @@ Recipient opens invite URL
                        → 200 OK → redirect /list/{list_id}
                        → server emits ListUpdate (Tier B.3: scoped to subscribers of list_id)
                        → owner's open tab refreshes share count
+
+Officer binds a guild role             (Tier 2b)
+   └─→ <ShareListModal /> "Discord" tab
+        ├─ pick guild (must have MANAGE_GUILD + bot present)
+        ├─ pick role + permission → POST /api/v1/list/{id}/guild-binding
+        │     └─ enqueue lazy resolve for each linked Ultros user in that guild
+        └─ pick channel + events → POST /api/v1/list/{id}/guild-notification
+
+User logs in
+   └─→ /oauth callback
+        ├─ existing flow: upsert discord_user, set session cookie
+        └─ new (Tier 2b.4): for each guild they're in that has a binding,
+                            GET /guilds/{g}/members/{u} via bot token,
+                            reconcile list_shared_user + user_group_member
+                            rows against current roles
+
+List event fires (item added, edited, invite used)
+   └─→ list_event_dispatcher (Tier 2b.5)
+        ├─ look up discord_guild_notification rows
+        ├─ coalesce within 30s window
+        └─ delivery.rs → DiscordChannel { channel_id } → embed
 ```
 
 State on the recipient side:
@@ -231,8 +336,12 @@ State on the recipient side:
 
 - **Unit**: `RequireListPermission` extractor (B.2) — happy path per permission level + 403 for insufficient.
 - **Unit**: scoped broadcast filter (B.3) — subscribed clients receive, non-subscribed do not.
-- **Integration / e2e**: the existing Puppeteer harness in [integration/](integration/) gains one test: log in as user A, create list, generate invite, redeem as user B (via test-auth login flow added in commit 1cbf5b4c), assert list appears in B's `/list` page with "Shared · Editor" pill.
-- **Visual**: take screenshots of `/list` with owned-only, shared-only, and mixed states for the snapshot harness.
+- **Unit**: lazy role resolver (2b.4) — given a mocked `GET /guilds/{g}/members/{u}` response, produces the expected `list_shared_user` upsert/delete set.
+- **Unit**: event coalescer (2b.5) — N rapid `ItemAddedRemoved` events for the same list collapse to one embed.
+- **Integration / e2e**: the existing Puppeteer harness in [integration/](integration/) gains:
+  - **Invite redemption**: log in as user A, create list, generate invite, redeem as user B (via test-auth login flow added in commit 1cbf5b4c), assert list appears in B's `/list` with "Shared · Editor" pill.
+  - **Guild bind dry-run**: stub the Discord bot API behind a feature flag (test-mode delivery sink instead of real channel send), assert binding creation triggers a fake-resolve and that notifications hit the sink. The bot itself does not run in CI; mock its REST surface.
+- **Visual**: screenshots of `/list` with owned-only, shared-only, and mixed states; `<ShareListModal />` Groups/Invite/Discord tabs; `/groups` page.
 
 ## Roadmap / explicitly deferred
 
@@ -247,6 +356,10 @@ Sketched for context; not in scope:
 
 ## Open questions for plan-writing
 
-- How do non-owner members get added to a group? Invite-link analog vs. auto-add on list-invite-redemption-targeting-group. Pick one during planning; both are small.
-- Does `viewer_permission` go on the `List` DTO or a sibling `ListWithViewerContext` DTO? Adding to `List` is simpler but mixes concerns; sibling is cleaner but touches every call site. Lean simpler — put it on `List` as `Option<ListPermission>`, populated only by `get_lists_for_user`.
+- How do non-owner members get added to a group? Invite-link analog vs. auto-add on list-invite-redemption-targeting-group vs. guild-backed (Tier 2b). All three can coexist; planning picks the minimum for Tier 2 ship.
+- Does `viewer_permission` go on the `List` DTO or a sibling `ListWithViewerContext` DTO? *Decided: on `List` as `Option<ListPermission>`, populated by `get_lists_for_user`.*
 - Should "Leave list" require a confirm modal? Probably yes; cheap to add.
+- **Tier 2b**: does the bot need any additional Discord OAuth permissions at install time beyond `Send Messages + Embed Links`? `View Channels` is implicit; `Read Message History` is not needed. Pin during planning.
+- **Tier 2b**: bot install URL — generate per-deploy or hard-code the application id? Hard-code is fine; the bot's application id is public.
+- **Tier 2b**: how do we handle a guild where the bot was removed but bindings still exist? Lazy resolution stops syncing (the REST call fails); UI shows a "bot removed from this guild" warning on the binding row with a re-invite link. Don't auto-delete bindings — the officer may re-add the bot.
+- **Tier 2b**: the `guilds` OAuth scope re-prompt on first login after deploy will surprise existing users. Communicate via a small in-app banner ("We added Discord guild integration — log out and back in to enable") rather than forcing a hard re-auth.

--- a/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
@@ -1,0 +1,252 @@
+# Shared Lists Integration & Onboarding — Design
+
+**Date:** 2026-05-11
+**Status:** Awaiting user review
+**Scope:** Make the already-built Shared Lists backend usable. Three tiers: (1) surface ownership and permissions in existing UI, (2) ship the missing sharing/invite/group UI, (3) thread discovery into onboarding and analyzer flows. Includes targeted backend refactors (`web.rs` split, permission extractor, scoped WebSocket broadcasts).
+
+---
+
+## Why
+
+Shared Lists has an almost complete backend and almost no frontend.
+
+Concrete findings from walking the code:
+
+- **All sharing endpoints exist and are reachable.** `share_list_with_user`, `share_list_with_group`, `unshare_list_from_*`, `create_invite`, `use_invite`, `delete_invite`, full group CRUD, and group-member management are all wired in [ultros/src/web.rs:1195-1232](ultros/src/web.rs:1195). Permission enforcement is in place via `ListPermission` ([ultros-api-types/src/list.rs:5-23](ultros-api-types/src/list.rs:5)).
+- **The frontend shows shared lists silently.** [`get_lists`](ultros-frontend/ultros-app/src/api.rs:225) returns owned and shared lists merged, and [`EditLists`](ultros-frontend/ultros-app/src/routes/lists.rs:124) renders them in one undifferentiated grid. There is no badge for permission, no owner attribution, no separation between "Mine" and "Shared with me". The delete button is shown on every card even when the user has only `Read` — the backend will reject it, but the affordance is misleading.
+- **There is no UI to *share* a list.** No share modal, no user picker, no permission selector, no invite-link generator, no copy-link affordance. The "edit list" panel ([lists.rs:40-91](ultros-frontend/ultros-app/src/routes/lists.rs:40)) jumps straight from name/world to a Danger Zone.
+- **There is no UI for groups.** `user_group` exists in the DB, all CRUD endpoints exist, but no Leptos component creates, names, or manages a group's members. Group-based sharing is unreachable from the UI.
+- **There is no UI for invites.** `create_invite`/`use_invite` exist; users have no way to generate or redeem a link. This is the cleanest fit for "share with a friend who hasn't logged in yet."
+- **`/welcome` doesn't mention lists.** [routes/welcome.rs:1-163](ultros-frontend/ultros-app/src/routes/welcome.rs) is a home-world / price-zone / language picker. Lists are arguably the most engaging logged-in feature and don't appear in the discovery surface at all.
+- **`add_to_list` doesn't communicate permission.** [components/add_to_list.rs](ultros-frontend/ultros-app/src/components/add_to_list.rs) presents every list the user can see in one dropdown. A user with `Read`-only on a shared list will see it offered, click it, and get a server error.
+- **WebSocket broadcasts are unscoped.** [list_view.rs:88](ultros-frontend/ultros-app/src/routes/list_view.rs:88) subscribes to all `ListUpdate` events; the server fans every list change out to every connected client. Works at current scale, doesn't at 10×.
+- **`web.rs` is 1322 lines and growing.** It's the only file in `ultros/src/` that contains list, group, invite, retainer, alert, and auth handlers. Each `share_*` handler re-implements ownership check, error mapping, and broadcast plumbing. Adding the missing endpoints (none — already done) would have pushed it further.
+- **Stale comment in DB layer.** [ultros-db/src/lists.rs:173](ultros-db/src/lists.rs:173) reads "This should probably also include lists shared with the user" — but `get_lists_for_user` *does* now merge owned + shared + group-shared. The comment is misleading.
+
+Net: the product can ship Shared Lists end-to-end in roughly a week of frontend work plus a focused backend cleanup. The biggest risk is *not* doing the cleanup — adding a share modal, an invite UI, and a group page on top of the current `web.rs` and the current permission check sprawl makes the file untenable.
+
+## Non-goals
+
+- **No new backend features.** Permissions stay at None/Read/Write/Owner; no fine-grained per-item permissions, no "expiring share", no transfer-ownership UI. Those are interesting and out of scope.
+- **No notifications system.** Sharing a list with a user does not send them a Discord DM, an in-app notification, or an email. The recipient discovers the list when they next open `/list`. A real notification layer is a separate spec.
+- **No tutorial / interactive walkthrough.** Onboarding is contextual nudges, not a guided tour. If we want a Shepherd.js-style overlay later, that's a different spec.
+- **No public lists.** A list is private, shared with named users, shared with groups the owner controls, or invite-link gated. There is no "discoverable" or "public to everyone" mode. (Possible Tier 4; explicitly deferred.)
+- **No mobile-specific layout work beyond responsive defaults.** The share modal and groups page must work on mobile, but a dedicated mobile UX pass is out of scope.
+- **No rename of `Lists` → `Collections` or similar.** Keep the existing terminology.
+
+## Tiers
+
+The work is structured so each tier is independently shippable.
+
+- **Tier 1 — Make ownership visible.** Permission badges, owner attribution, sectioning. No new endpoints.
+- **Tier 2 — Sharing UI.** Share modal, invite link UI, groups page. Uses existing endpoints.
+- **Tier 3 — Discovery & onboarding.** `/welcome` step, post-creation nudge, analyzer integration.
+- **Backend cleanup (parallel).** `web.rs` split, `RequireListPermission` extractor, scoped WebSocket broadcasts. Lands alongside Tier 2.
+
+---
+
+## Tier 1 — Make ownership visible
+
+Goal: a user who already has shared lists today can immediately tell which is which, without us building any new endpoint.
+
+### 1.1 Permission badge on list cards
+
+`List` ([ultros-api-types/src/list.rs](ultros-api-types/src/list.rs)) does not currently carry the viewer's permission — the frontend only knows that a list came back from `get_lists_for_user`, not *why* it came back. Add a `viewer_permission: ListPermission` field to the response DTO. Server-side, `get_lists_for_user` already computes this implicitly via the join path; we surface it.
+
+Render as a small pill on each `ListCard` ([routes/lists.rs:33](ultros-frontend/ultros-app/src/routes/lists.rs:33)):
+
+- `Owner` → no badge (default state).
+- `Write` → blue "Shared · Editor" pill.
+- `Read` → grey "Shared · Viewer" pill.
+
+### 1.2 Owner attribution on shared cards
+
+For cards where `viewer_permission != Owner`, show the owner's Discord username under the world line. Requires `owner: Option<UserDisplay>` on the list DTO (already-public Discord avatar + username — same shape used in retainer ownership display).
+
+### 1.3 Hide destructive actions on shared lists
+
+In edit mode for a non-Owner card:
+
+- Hide the **Delete** button (Read or Write — only the owner can delete).
+- Hide the **Edit name / world** controls if `Read`.
+- Show "Leave list" instead of "Delete" — a new client-side affordance that calls `DELETE /api/v1/list/{id}/share/user/{me}`. This already works on the backend (a user can unshare themselves); we just expose it.
+
+### 1.4 Section the grid
+
+In [`EditLists`](ultros-frontend/ultros-app/src/routes/lists.rs:124), partition `lists` into two groups by `viewer_permission == Owner`. Render under two headings: **My Lists** and **Shared With Me**. Keep the search filter applying to both sections. Empty-state copy ("no_lists_found") becomes specific to "My Lists" — having only shared lists is fine.
+
+### 1.5 `add_to_list` shows permission and disables read-only
+
+In [`components/add_to_list.rs`](ultros-frontend/ultros-app/src/components/add_to_list.rs), use the new `viewer_permission` to:
+
+- Show the pill next to each list name in the dropdown.
+- Disable selection (greyed out, tooltip "You have read-only access") for `Read` lists.
+
+### 1.6 Drop the stale comment
+
+Remove the line at [ultros-db/src/lists.rs:173](ultros-db/src/lists.rs:173). The function does include shared lists; the comment now misleads.
+
+**Out:** No new pages, no new endpoints, no behaviour change to backend logic.
+
+---
+
+## Tier 2 — Sharing UI
+
+Goal: every existing backend sharing endpoint becomes reachable from the UI.
+
+### 2.1 Share modal (`<ShareListModal />`)
+
+Triggered from a new "Share" button on the owner's list-edit panel ([lists.rs:57](ultros-frontend/ultros-app/src/routes/lists.rs:57)) and on the list-view page header. Three tabs:
+
+1. **People** — search/select existing Ultros users (Discord display) → choose Read/Write → submit. Backed by `POST /api/v1/list/{id}/share/user`. Below the picker, a list of current shares with revoke buttons (`DELETE /api/v1/list/{id}/share/user/{user_id}`).
+2. **Groups** — same shape, scoped to groups the current user owns. Backed by `*/share/group`. If the user has no groups, show a "Create a group" CTA that opens the groups page.
+3. **Invite link** — list active invites with their remaining uses; "Create new link" with a permission selector and optional max-uses. Backed by `POST /api/v1/list/{id}/invite/create`. Each row has copy-to-clipboard for `https://ultros.app/list/invite/{invite_id}` and a revoke button.
+
+User search is the riskiest sub-piece. The current backend has no user-search endpoint. Two options:
+
+- **(A)** Add `GET /api/v1/user/search?q=...`. Discord display name prefix match, capped at ~20 results, requires auth.
+- **(B)** Defer the People tab; ship Tier 2 with only Groups and Invite link. Users who want to share with a specific friend create a one-use invite link and DM it.
+
+**Recommendation: B.** Invite links are *better* product than a name-search — they don't require the recipient to have logged into Ultros yet, and they sidestep username-collision UX. People-tab can come later if there's demand. Skipping it cuts the Tier 2 surface significantly.
+
+### 2.2 Invite redemption flow
+
+New route `/list/invite/{invite_id}` → server-rendered Leptos page that:
+
+- If the viewer is not logged in: show "Sign in with Discord to accept this invite", store the invite id in a cookie, redirect to OAuth, redirect back, redeem.
+- If logged in: call `POST /api/v1/invite/{id}/use`, then redirect to `/list/{list_id}`.
+- If the invite is exhausted or revoked: show "This invite is no longer valid" with a button back to the list owner's profile if available, else home.
+
+### 2.3 Groups page (`/groups`)
+
+A new route. List the groups the user owns. Each group:
+
+- Name (editable inline).
+- Member list (Discord avatar + name) with a "Remove" button per row.
+- "Add member" search → `POST /api/v1/group/{id}/member/{user_id}`. Same dependency on user-search as 2.1 People tab; same recommendation — **defer the search and add members via "Invite to group" link**, which becomes a new lightweight endpoint mirroring list invites. Or simpler: members are added implicitly when someone redeems a list invite that targets a group. (See open question below.)
+- "Delete group" with a confirmation.
+- "Create new group" button at the top.
+
+Nav: add `/groups` to the side nav alongside `/list`.
+
+### 2.4 Sharing status surface on `/list/{id}`
+
+The list-view page ([routes/list_view.rs](ultros-frontend/ultros-app/src/routes/list_view.rs)) gains a small "Shared with N people" indicator next to the title, clickable to open `<ShareListModal />`. For non-owners, it reads "Shared by {owner}" and is non-interactive.
+
+**Open question deferred to implementation:** how do users get added to a group without a user-search? Options: invite-to-group links analogous to invite-to-list, or "members are auto-added when they redeem an invite to a list shared with this group." Pick during plan-writing; both are small.
+
+---
+
+## Tier 3 — Discovery & onboarding
+
+Goal: a new user learns Shared Lists exists without us building a tutorial.
+
+### 3.1 `/welcome` gets a fourth step (logged-in only)
+
+After Language, add **Step 4: Make a list** ([routes/welcome.rs:122-134](ultros-frontend/ultros-app/src/routes/welcome.rs:122)). Render only when the user is authenticated (the current `/welcome` is reached pre-login too via "set my preferences"). The step explains in one sentence what a list is, links to `/list`, and is skippable. No form on the welcome page itself — just a nudge with an icon.
+
+For unauthenticated visitors, replace Step 4 with a "Sign in to save lists, share with friends, and get price alerts" prompt. Same icon, same slot — the welcome page picks the variant based on auth state.
+
+### 3.2 First-list-created nudge
+
+After `create_list` succeeds in [`EditLists`](ultros-frontend/ultros-app/src/routes/lists.rs:209) for the first time (detect: this user's `lists` length transitions 0 → 1), show a one-time toast: *"List created. You can share it with friends or a group — click the share icon any time."* Use `localStorage` to fire it at most once per user. No backend changes.
+
+### 3.3 Share affordance on cards with items
+
+A `ListCard` whose item count is > 0 and `viewer_permission == Owner` shows a small "Share" icon in its header. Clicking opens `<ShareListModal />` for that list. (Cards without items skip the affordance — there's nothing useful to share.)
+
+### 3.4 Analyzer → list integration awareness
+
+Today, the Recipe and Crafting analyzers can bulk-add ingredients to a list ([bulk_add_item_to_list](ultros-frontend/ultros-app/src/api.rs:250)) but the call sites are sparse. Audit each analyzer route ([analyzer.rs](ultros-frontend/ultros-app/src/routes/analyzer.rs), recipe analyzer, FC crafting analyzer, leve analyzer, venture analyzer) for an "Add results to a list" affordance. Where missing, add one. The dropdown filters to lists where `viewer_permission >= Write` and matches the analyzer's world/DC filter. This is mechanical and low-risk; it makes shared lists genuinely useful to a guild ("our weekly crafting run targets list").
+
+### 3.5 Empty-state copy on `/list`
+
+When `My Lists` is empty but `Shared With Me` has items, the empty-state copy changes from "create your first list" to "You don't own any lists yet — but {N} have been shared with you." This is a 2-line copy change in [lists.rs:248-254](ultros-frontend/ultros-app/src/routes/lists.rs:248).
+
+---
+
+## Backend cleanup (alongside Tier 2)
+
+These are not optional. Tier 2 doubles the number of list-handler call sites; without these, `web.rs` becomes unreadable.
+
+### B.1 Split `web.rs` into `web/handlers/{lists,groups,invites,...}.rs`
+
+[ultros/src/web.rs](ultros/src/web.rs) is 1322 lines and contains handlers for at least six bounded contexts. Move handlers into submodules; keep route registration in `web.rs` so the URL map stays in one place. This is a no-behavior-change refactor — should ship as its own commit before Tier 2 handlers grow.
+
+### B.2 `RequireListPermission` Axum extractor
+
+Every list-write handler currently calls `get_permission()` ([ultros-db/src/lists.rs:209, 225, 246, …](ultros-db/src/lists.rs:209)) and maps the result manually. Replace with an extractor:
+
+```rust
+struct RequireListPermission<const MIN: u8>(pub ListAccess);
+// implements FromRequestParts; rejects with 403 if user.perm < MIN
+```
+
+Handlers become `async fn share_list_with_user(perm: RequireListPermission<{Owner as u8}>, ...)`. Removes ~10 duplicated check sites, makes the auth contract visible at the function signature.
+
+### B.3 Scope WebSocket broadcasts by list id
+
+[ultros-api-types/src/websocket.rs:134](ultros-api-types/src/websocket.rs:134) defines `ListUpdate` with no addressing — every client gets every update. Add a per-connection subscription set on the server (the client already calls `subscribe_to_list` at [list_view.rs:88](ultros-frontend/ultros-app/src/routes/list_view.rs:88)); only forward `ListUpdate` events whose `list_id` is in the connection's subscribed set. Existing client API doesn't change; server filtering is added. Fixes the unbounded fan-out and prevents leaking other users' list change notifications (currently *every* list change is broadcast to *every* connected client — minor info leak today, real one once groups exist).
+
+### B.4 Drop `let _ = …` on broadcast sends
+
+[ultros/src/web.rs:602-606](ultros/src/web.rs:602) ignores broadcast send errors with `let _ =`. After B.3 the broadcaster has bounded fan-out and the only legitimate failure is "channel closed" (server shutting down). Log the failure at `warn!` rather than discarding — silent failures here mean a client missed a delete and shows stale UI until refresh.
+
+---
+
+## Architecture & data flow
+
+```
+Owner clicks "Share"
+   └─→ <ShareListModal /> opens (Tier 2.1)
+        ├─→ People tab        (deferred — uses invite link instead)
+        ├─→ Groups tab        POST /list/{id}/share/group
+        └─→ Invite link tab   POST /list/{id}/invite/create
+                              ─ user copies https://ultros.app/list/invite/{id}
+                              ─ shares via Discord/etc.
+
+Recipient opens invite URL
+   └─→ /list/invite/{id}      (Tier 2.2)
+        ├─ not logged in → cookie + OAuth → return
+        └─ logged in → POST /invite/{id}/use
+                       → 200 OK → redirect /list/{list_id}
+                       → server emits ListUpdate (Tier B.3: scoped to subscribers of list_id)
+                       → owner's open tab refreshes share count
+```
+
+State on the recipient side:
+
+- Their `get_lists()` now returns the new list (via `list_shared_user` join, already wired).
+- It appears under "Shared With Me" with a badge and the owner's name.
+- `add_to_list` dropdowns pick it up automatically.
+
+## Error handling
+
+- **Modal submission fails** → toast with server error message; modal stays open. Same pattern as the existing `edit_list` flow.
+- **Invite expired or revoked** → recipient lands on a dedicated "This invite is no longer valid" page (Tier 2.2). Owner sees zero remaining uses in the invite list and a "Revoked" tag.
+- **Permission mismatch on `add_to_list`** → after Tier 1.5, read-only lists are non-selectable so the server-side 403 should not fire; if it does (race with a revoke), show the error toast and refresh the list cache.
+- **Group deletion with active shares** → backend already cascades; UI confirmation explicitly says "This group is shared on N lists; those shares will be removed."
+
+## Testing
+
+- **Unit**: `RequireListPermission` extractor (B.2) — happy path per permission level + 403 for insufficient.
+- **Unit**: scoped broadcast filter (B.3) — subscribed clients receive, non-subscribed do not.
+- **Integration / e2e**: the existing Puppeteer harness in [integration/](integration/) gains one test: log in as user A, create list, generate invite, redeem as user B (via test-auth login flow added in commit 1cbf5b4c), assert list appears in B's `/list` page with "Shared · Editor" pill.
+- **Visual**: take screenshots of `/list` with owned-only, shared-only, and mixed states for the snapshot harness.
+
+## Roadmap / explicitly deferred
+
+Sketched for context; not in scope:
+
+- **User search** for a People tab in `<ShareListModal />`. Needs a `/api/v1/user/search` endpoint and rate limiting. Re-evaluate after Tier 2 ships if invite-link sharing turns out to be friction.
+- **Notifications.** "X shared a list with you" in a bell-icon dropdown. Wants a notification table, read/unread state, optionally Discord DM delivery. Whole separate spec.
+- **Public lists / discoverable lists.** "Top crafting lists this week." Different content model, different moderation problem.
+- **Per-item permission** (e.g., one user can mark items bought, another can only view). Likely YAGNI for the FFXIV use case.
+- **Transfer ownership.** Rare; can be done with a backend script for now.
+- **Mobile UX pass** on the share modal and groups page.
+
+## Open questions for plan-writing
+
+- How do non-owner members get added to a group? Invite-link analog vs. auto-add on list-invite-redemption-targeting-group. Pick one during planning; both are small.
+- Does `viewer_permission` go on the `List` DTO or a sibling `ListWithViewerContext` DTO? Adding to `List` is simpler but mixes concerns; sibling is cleaner but touches every call site. Lean simpler — put it on `List` as `Option<ListPermission>`, populated only by `get_lists_for_user`.
+- Should "Leave list" require a confirm modal? Probably yes; cheap to add.

--- a/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
+++ b/docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md
@@ -29,7 +29,8 @@ Net: the product can ship Shared Lists end-to-end in roughly a week of frontend 
 
 - **No new permission levels.** Stays at None/Read/Write/Owner; no fine-grained per-item permissions, no "expiring share", no transfer-ownership UI.
 - **No general in-app notifications system.** "X shared a list with you" via a bell icon is a separate spec. Discord *channel* notifications for list events are in scope (Tier 2b) because they reuse the existing alert-delivery pipeline. In-app and Discord-DM notifications are not.
-- **No `GUILD_MEMBERS` privileged intent.** That intent requires Discord verification past 100 guilds and a privacy review. We resolve guild role membership lazily via per-user REST calls at OAuth callback time — see Tier 2b.4. If the bot ever needs to react to live role changes (someone gets promoted mid-session), that's a future expansion, not this spec.
+- **No `GUILD_MEMBERS` privileged intent.** That intent requires Discord verification past 100 guilds and a privacy review. We resolve guild role membership lazily via the bot's own REST calls — see Tier 2b.4. If the bot ever needs to react to live role changes (someone gets promoted mid-session), that's a future expansion, not this spec.
+- **No new OAuth scopes.** We continue to request only `Identify`. The Discord user id we already have is sufficient — the *bot* is the source of truth for guild membership and roles. Existing users do not get re-prompted.
 - **No tutorial / interactive walkthrough.** Onboarding is contextual nudges, not a guided tour.
 - **No public lists.** A list is private, shared with named users, shared with groups the owner controls, invite-link gated, or guild-bound (Tier 2b). No "discoverable to all" mode.
 - **No mobile-specific layout work beyond responsive defaults.**
@@ -159,11 +160,13 @@ Wire two handlers in [ultros/src/discord/mod.rs](ultros/src/discord/mod.rs):
 
 These events are part of the **non-privileged** GUILD intent set; no Discord verification needed.
 
-### 2b.2 OAuth scope upgrade: add `guilds`
+### 2b.2 Bot-side guild discovery (no OAuth scope change)
 
-Currently [`ultros/src/main.rs` requests only `Identify`](ultros/src/main.rs). Add `guilds`. On the next login each existing user will be re-prompted by Discord to grant the additional scope; this is normal Discord UX and we don't try to hide it. The scope yields a list of guilds the user belongs to plus per-guild `permissions` (a bitfield — we read `MANAGE_GUILD` to identify "officer-level" users for the bind UI).
+OAuth stays at `Identify` — we already have the Discord user id, and that's all we need. The bot is the source of truth for "what guilds does this user share with us, and what roles do they have."
 
-We do **not** request `guilds.members.read`. We don't need the full member list; we resolve a single user's roles in a single guild on demand (see 2b.4).
+To populate the bind UI ("guilds where you're an officer and Ultros is present"), the web handler iterates the bot's known guild list (from `discord_guild`), calls `GET /guilds/{g}/members/{user_id}` via the bot's REST client for each, and filters to those where (a) the call returns 200 (user is a member) and (b) the member's role-permission bitfield includes `MANAGE_GUILD`. Results are cached per `(user_id, guild_id)` for ~5 minutes to keep modal opens cheap.
+
+Worst case the bot is in N guilds and the call is O(N) per modal open. Ultros today is in a small number of guilds; if that ever grows past a few hundred, switch to a more scalable strategy (e.g., subscribe to `GUILD_MEMBER_UPDATE` events under the `GUILD_MEMBERS` privileged intent, or maintain a `discord_guild_member` cache). Not this spec.
 
 ### 2b.3 Binding schema
 
@@ -175,17 +178,19 @@ New tables:
 
 All three FK to `discord_guild(id)` with `ON DELETE CASCADE` so removing the bot tears down bindings cleanly. The `list_id` / `group_id` FKs also cascade.
 
-Authorization invariant: to create any binding, the calling user must have `MANAGE_GUILD` on the guild (read from the OAuth `guilds` payload, cached in their session). This is checked in the Axum handler — the bot never trusts client-supplied guild ids.
+Authorization invariant: to create any binding, the calling user must have `MANAGE_GUILD` on the guild (computed from the bot's `GET /guilds/{g}/members/{user_id}` call described in 2b.2, not from anything the client supplied). The Axum handler runs this check before each binding mutation; the cached result from 2b.2 is acceptable for the read path but revalidated server-side on every write.
 
 ### 2b.4 Lazy membership resolution
 
-We don't subscribe to live member events. Instead, role membership is re-evaluated at well-defined moments:
+We don't subscribe to live member events. Instead, role membership is re-evaluated at well-defined moments, all going through the bot's REST client:
 
-- **At OAuth login.** After the existing `Identify` callback, for each guild in `discord_guild_list_binding ∪ discord_guild_group_binding` that the user belongs to (intersection of bot-known guilds and the user's guild list from OAuth), call `GET /guilds/{guild_id}/members/{user_id}` via the bot token. The response includes the member's role list. Upsert/delete the corresponding `list_shared_user` and `user_group_member` rows so the user's access matches their current roles.
-- **On binding create / edit.** When an officer creates or modifies a binding, enqueue a one-shot resolution for every Ultros user currently linked to that guild (find them via the OAuth `guilds` cache from their last login). This is bounded by users-who-have-logged-in, not the full guild member count.
+- **At login.** After the existing `Identify` callback, for each guild that has at least one binding (`discord_guild_list_binding ∪ discord_guild_group_binding`), call `GET /guilds/{guild_id}/members/{user_id}` via the bot. 404 means "not a member, no bindings apply"; 200 returns the role list. Upsert/delete the corresponding `list_shared_user` and `user_group_member` rows so the user's access matches their current roles.
+- **On binding create / edit.** When an officer creates or modifies a binding, enqueue a one-shot resolution for every Ultros user we've seen log in recently. Bounded by `discord_user` rows with a recent `last_login`, not the full guild member count. (Implies adding `last_login` to `discord_user` — small, useful elsewhere too.)
 - **Hourly drift sweep.** A background tokio task re-resolves users who logged in more than 24 hours ago, capped at N per minute. Nice to have, not required for shipping.
 
-Lazy resolution intentionally accepts a "user gets promoted on Discord, doesn't see Editor permission on Ultros until they refresh / re-login" lag. The product reads as "permissions sync on login" — that's an acceptable mental model and saves us the privileged intent.
+Lazy resolution intentionally accepts a "user gets promoted on Discord, doesn't see Editor permission on Ultros until they refresh / re-login" lag. The product reads as "permissions sync on login" — an acceptable mental model that saves us the privileged intent.
+
+Iterating per-binding-guild at login is cheap (a binding-set is small per user; most users are in zero bound guilds). For users in many bound guilds, calls fan out in parallel with a per-request timeout so a slow Discord API doesn't gate the login.
 
 ### 2b.5 Notification dispatch
 
@@ -205,8 +210,7 @@ A fourth tab in the share modal (alongside Groups, Invite link, and the deferred
 
 Visible only to the list owner. Content:
 
-- If the user has not granted the `guilds` scope yet → "Connect your Discord guilds to bind roles" with a re-auth button.
-- Else, a dropdown of guilds where the user has `MANAGE_GUILD` *and* the Ultros bot is present. For guilds where bot is missing, show an "Invite Ultros to this guild" link with the bot install URL and the minimum required permissions (`Send Messages`, `Embed Links`, `Read Roles` — guild-only, no member-list, no message-content).
+- A dropdown sourced from a new endpoint `GET /api/v1/discord/eligible-guilds` that returns the bot-known guilds where the calling user has `MANAGE_GUILD` (computed via 2b.2). If the list is empty, show "Invite Ultros to a Discord server where you're an admin" with the bot install URL and the minimum required permissions (`Send Messages`, `Embed Links` — guild-only, no member-list intent, no message-content intent).
 - After picking a guild:
   - **Roles**: list current `discord_guild_list_binding` rows for this guild+list. Each row: role-name pill (with guild's color), permission selector (Read/Write), revoke. "Add binding" → role dropdown + permission selector. `@everyone` is one of the role choices, prefixed with an icon to differentiate.
   - **Notifications**: list current `discord_guild_notification` rows. Each row: channel name, event-type checkboxes, revoke. "Add notification" → channel dropdown (filtered to text channels the bot can post to) + event checkboxes.
@@ -218,6 +222,35 @@ The `/groups` page (Tier 2.3) gains the same guild-binding UI per group, scoped 
 ### 2b.8 Bot slash command (optional, post-Tier-2b)
 
 A `/ffxiv list` already exists ([ultros/src/discord/ffxiv/mod.rs:20-28](ultros/src/discord/ffxiv/mod.rs:20)). Extend with `/ffxiv list link` — an officer-only slash command that links the calling guild to an Ultros list by id (the user must own the list on Ultros). Convenience over the web UI; nice to have, not required for the tier.
+
+### 2b.9 `DiscordGuildClient` trait — the seam for testability
+
+Every cross-process call to Discord goes through one trait. The web handlers, list-event dispatcher, lazy resolver, and binding-create endpoints all depend on a `&dyn DiscordGuildClient` (or `Arc<dyn DiscordGuildClient>` for tasks), never on `serenity::Http` directly.
+
+```rust
+#[async_trait]
+pub trait DiscordGuildClient: Send + Sync {
+    async fn list_bot_guilds(&self) -> Result<Vec<GuildInfo>, DiscordError>;
+    async fn get_guild_roles(&self, guild_id: GuildId) -> Result<Vec<RoleInfo>, DiscordError>;
+    async fn get_guild_text_channels(&self, guild_id: GuildId)
+        -> Result<Vec<ChannelInfo>, DiscordError>;
+    async fn get_member(&self, guild_id: GuildId, user_id: UserId)
+        -> Result<Option<MemberInfo>, DiscordError>; // None = 404 / not a member
+    async fn send_channel_embed(&self, channel_id: ChannelId, embed: Embed)
+        -> Result<(), DiscordError>;
+}
+```
+
+Two implementations:
+
+- **`SerenityGuildClient`** — production. Wraps `serenity::CacheAndHttp`. Lives next to the existing bot bootstrap in [ultros/src/discord/mod.rs](ultros/src/discord/mod.rs). Built once at startup, shared via the existing app-state pattern.
+- **`MockGuildClient`** — tests. `HashMap`-backed; tests preload guilds/roles/members and assert on captured `send_channel_embed` calls. Lives in a `#[cfg(test)]` module under the same crate.
+
+The web handlers take `Arc<dyn DiscordGuildClient>` as Axum state. The list-event dispatcher takes it as a constructor arg. The lazy resolver takes it as a function arg. No production code path constructs the serenity client directly except `main.rs`. This makes the entire Tier 2b unit-testable without a live bot.
+
+`MemberInfo`, `RoleInfo`, `ChannelInfo`, `GuildInfo` are local structs in `ultros/src/discord/types.rs` — not serenity types. Keeps the trait's surface stable across serenity major-version bumps and prevents serenity types leaking into web handlers.
+
+**General-pattern note (not required for shipping this spec):** the codebase has no pervasive mocking pattern today. Adopting `DiscordGuildClient` is a deliberate first beachhead; if the pattern works, it can extend to the universalis HTTP client and the FFXIV character-fetcher next. We do **not** retrofit existing untested code in this spec — only the new Tier 2b code is built behind a trait. That keeps scope honest while still leaving the codebase in a better testable state than we found it.
 
 ---
 
@@ -299,18 +332,20 @@ Recipient opens invite URL
 
 Officer binds a guild role             (Tier 2b)
    └─→ <ShareListModal /> "Discord" tab
-        ├─ pick guild (must have MANAGE_GUILD + bot present)
+        ├─ GET /api/v1/discord/eligible-guilds
+        │     └─ DiscordGuildClient.list_bot_guilds() ⨯ get_member(g, user)
+        │        filtered to MANAGE_GUILD = "officer in a bot-present guild"
         ├─ pick role + permission → POST /api/v1/list/{id}/guild-binding
-        │     └─ enqueue lazy resolve for each linked Ultros user in that guild
+        │     └─ enqueue lazy resolve for recently-active Ultros users
         └─ pick channel + events → POST /api/v1/list/{id}/guild-notification
 
 User logs in
-   └─→ /oauth callback
+   └─→ /oauth callback (Identify only — no scope change)
         ├─ existing flow: upsert discord_user, set session cookie
-        └─ new (Tier 2b.4): for each guild they're in that has a binding,
-                            GET /guilds/{g}/members/{u} via bot token,
-                            reconcile list_shared_user + user_group_member
-                            rows against current roles
+        └─ new (Tier 2b.4): for each guild with at least one binding,
+                            DiscordGuildClient.get_member(g, user_id)
+                            → reconcile list_shared_user + user_group_member
+                              rows against current roles
 
 List event fires (item added, edited, invite used)
    └─→ list_event_dispatcher (Tier 2b.5)
@@ -340,7 +375,7 @@ State on the recipient side:
 - **Unit**: event coalescer (2b.5) — N rapid `ItemAddedRemoved` events for the same list collapse to one embed.
 - **Integration / e2e**: the existing Puppeteer harness in [integration/](integration/) gains:
   - **Invite redemption**: log in as user A, create list, generate invite, redeem as user B (via test-auth login flow added in commit 1cbf5b4c), assert list appears in B's `/list` with "Shared · Editor" pill.
-  - **Guild bind dry-run**: stub the Discord bot API behind a feature flag (test-mode delivery sink instead of real channel send), assert binding creation triggers a fake-resolve and that notifications hit the sink. The bot itself does not run in CI; mock its REST surface.
+  - **Guild bind happy path**: the e2e server is started with `MockGuildClient` as the `DiscordGuildClient` Axum-state binding instead of the serenity-backed one. Preload it with a fake guild + roles + a fake member. Assert that creating a binding + logging in user B reconciles their permissions, and that an item-add fires a captured `send_channel_embed` call on the mock. The real bot never runs in CI.
 - **Visual**: screenshots of `/list` with owned-only, shared-only, and mixed states; `<ShareListModal />` Groups/Invite/Discord tabs; `/groups` page.
 
 ## Roadmap / explicitly deferred
@@ -362,4 +397,5 @@ Sketched for context; not in scope:
 - **Tier 2b**: does the bot need any additional Discord OAuth permissions at install time beyond `Send Messages + Embed Links`? `View Channels` is implicit; `Read Message History` is not needed. Pin during planning.
 - **Tier 2b**: bot install URL — generate per-deploy or hard-code the application id? Hard-code is fine; the bot's application id is public.
 - **Tier 2b**: how do we handle a guild where the bot was removed but bindings still exist? Lazy resolution stops syncing (the REST call fails); UI shows a "bot removed from this guild" warning on the binding row with a re-invite link. Don't auto-delete bindings — the officer may re-add the bot.
-- **Tier 2b**: the `guilds` OAuth scope re-prompt on first login after deploy will surprise existing users. Communicate via a small in-app banner ("We added Discord guild integration — log out and back in to enable") rather than forcing a hard re-auth.
+- **Tier 2b**: `eligible-guilds` cache TTL — start at 5 minutes. If users complain that newly-added bots don't appear in the picker, drop to 1 minute or add a "refresh" button.
+- **Tier 2b**: should `DiscordGuildClient` be a workspace-level trait (in `ultros-api-types` or a new `ultros-discord` crate) or stay private to the `ultros` binary? Lean private — only one consumer today. Promote if a second crate ever needs it.

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -13,8 +13,7 @@ use anyhow::anyhow;
 use futures::future::try_join_all;
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, Condition, EntityTrait, IntoActiveModel, JoinType,
-    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait,
-    sea_query::Expr,
+    ModelTrait, QueryFilter, QuerySelect, RelationTrait, TransactionTrait, sea_query::Expr,
 };
 use std::{collections::HashMap, sync::Arc};
 use tracing::instrument;
@@ -77,7 +76,10 @@ impl UltrosDb {
                 JoinType::InnerJoin,
                 list_shared_group::Relation::UserGroup.def(),
             )
-            .join(JoinType::InnerJoin, user_group::Relation::UserGroupMember.def())
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
             .filter(list_shared_group::Column::ListId.eq(list_id))
             .filter(user_group_member::Column::UserId.eq(user_id))
             .into_tuple()


### PR DESCRIPTION
## Summary

Tier 1 of the Shared Lists integration plan + the parallel backend cleanup. Eighteen commits across backend (Rust/Axum/SeaORM) and frontend (Leptos) that together make the previously-invisible Shared Lists feature usable, and tighten the web layer for the larger Tier 2 work that follows.

See [docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md](docs/superpowers/specs/2026-05-11-shared-lists-integration-design.md) and [docs/superpowers/plans/2026-05-11-shared-lists-tier1.md](docs/superpowers/plans/2026-05-11-shared-lists-tier1.md).

### Backend
- `RequireListPermission<const MIN: u8>` Axum extractor (`ultros/src/web/list_permission.rs`); `get_list`/`delete_list` migrated.
- `send_list_event` helper replaces 8 silent `let _ = senders.lists.send(...)` patterns; failures log at warn level.
- `List` DTO gets two new `Option`s (`owner_username`, `viewer_permission`) with `#[serde(default)]` for back-compat with the Discord-bot path.
- New `get_lists_for_user_enriched` (batched username + per-list permission) and `get_discord_username` in `ultros-db`.
- Three list-fetching handlers populate the new fields.
- `web.rs` split from 1322 → 943 lines + three `web/handlers/{lists,groups,invites}.rs` modules.

### Frontend
- `PermissionPill` component renders "Shared · Editor" / "Shared · Viewer" badges (Owner/None render nothing).
- `/list` sectioned into "My Lists" / "Shared With Me"; page `<h1>` renamed to a generic "Lists" to avoid the heading collision; empty state when only shared lists exist gets new copy.
- Non-owners see "Leave list" instead of the name/world/save/delete edit panel. Backed by the existing `DELETE /api/v1/list/{id}/share/user/{user_id}` endpoint; button disables while user resource is loading.
- `add_to_list` modal shows inline permission pills and disables the Add button for read-only lists (tooltip explains why).

### Tests
- 3 new unit tests in `web/list_permission.rs` (constant ↔ enum drift detection).
- 2 in `ultros-api-types/src/list.rs` (serde default + roundtrip).
- 1 in `ultros-db/src/common_type_conversions.rs` (`TryFrom<list::Model>` leaves new fields `None`).
- `cargo test -p ultros-db --lib` → 18/0. `cargo test -p ultros-api-types --lib` → 65/0. (`cargo test -p ultros` skipped on Windows due to pre-existing `ultros_app` WASM linker issue.)

### CI
- `cargo fmt --all -- --check` clean (verified locally).
- `cargo clippy` not run — submodule not initialized in this worktree. Should be clean in CI.

## Deferred (filed or noted; not in scope)
- `ApiError::as_status_code` collapses every non-`NoAuthCookie` error to HTTP 500 — insufficient-permission rejections surface as 500 instead of 403. Pre-existing; affected every list handler before this PR. Filed as a separate task.
- Per-card `get_login()` Resource in `ListCard` produces N requests for N cards. Pragmatic follow-up; current architecture matches the codebase's existing pattern (`apps_menu.rs`, `profile_display.rs`).
- Plan's B.3 (scope WebSocket broadcasts by list_id) turned out to be already done in `web/api/real_time_data.rs:185-220`. Spec updated to reflect this.
- People-search tab in the eventual share modal — Tier 2 calls this out and defers in favor of invite links.

## Test plan
- [ ] Two-account manual: A creates list, shares Read with B → B sees "Shared · Viewer" pill + "Shared by A" attribution, edit panel shows only "Leave list", `add_to_list` modal disables that row.
- [ ] Two-account manual: A shares Write with B → B sees "Shared · Editor", `add_to_list` row is enabled.
- [ ] Confirm `/ffxiv list` Discord slash command still works (its `db.get_lists_for_user` signature is unchanged).
- [ ] CI green (fmt + clippy + unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)