### PR TITLE
Dockerfile: bump binaryen to version_129 + aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,24 @@ RUN cargo binstall wasm-bindgen-cli@0.2.121 -y
 # Install a recent binaryen so cargo-leptos picks up wasm-opt from PATH instead
 # of its bundled (older) version, which can't decode DWARF emitted by recent
 # nightly rustc ("unknown subopcode 225 ... unsupported version of DWARF").
-ARG BINARYEN_VERSION=version_128
-RUN curl -L --proto '=https' --tlsv1.2 -sSf \
-    "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
-    | tar -xz -C /tmp \
-    && cp "/tmp/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/ \
-    && cp -r "/tmp/binaryen-${BINARYEN_VERSION}/lib/." /usr/local/lib/ \
-    && rm -rf "/tmp/binaryen-${BINARYEN_VERSION}" \
-    && ldconfig \
-    && wasm-opt --version
+# Binaryen ships libbinaryen.so alongside the binary, so we copy lib/* into
+# /usr/local/lib and ldconfig before invoking wasm-opt.
+ARG BINARYEN_VERSION=version_129
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) asset="binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" ;; \
+        aarch64) asset="binaryen-${BINARYEN_VERSION}-aarch64-linux.tar.gz" ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -L --proto '=https' --tlsv1.2 -fsSL \
+        "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${asset}" \
+        | tar -xz -C /tmp; \
+    cp "/tmp/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/; \
+    cp -r "/tmp/binaryen-${BINARYEN_VERSION}/lib/." /usr/local/lib/; \
+    rm -rf "/tmp/binaryen-${BINARYEN_VERSION}"; \
+    ldconfig; \
+    wasm-opt --version
 # RUN cargo install --locked cargo-leptos --version 0.2.43 -v
 COPY ./rust-toolchain .
 RUN rustup update


### PR DESCRIPTION
## Summary

Builds on the binaryen install added in #625. Two small tweaks:

- **Bump `BINARYEN_VERSION` 128 → 129** — latest upstream release. Same DWARF fix, one version newer.
- **Make the install step arch-aware** (`x86_64` / `aarch64`) and fail loudly on other arches. The image only builds x86_64 today, but the case keeps us honest if we ever cross-build for arm.

Everything else (the `lib/*` + `ldconfig` step from #625 so `libbinaryen.so` is findable, the comment explaining the DWARF subopcode issue) is preserved unchanged.

## Verification

The binaryen install step itself was exercised end-to-end locally — the tarball downloads, extracts, `wasm-opt --version` prints `wasm-opt version 129 (version_129)`. The full DWARF + wasm-opt pass was not run to completion locally (build hit unrelated `git_short_hash!` macro issue specific to running inside a Claude worktree under Docker), but #625 already validated that approach at version 128; this is just a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)