### PR TITLE
fix(client): retry hydration fetches on transient failure

### DIFF
--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -175,7 +175,7 @@ async fn populate_xiv_gen_data() -> anyhow::Result<()> {
     try_populate_xiv_gen_data().await
 }
 
-async fn get_world_data() -> Result<Arc<WorldHelper>, anyhow::Error> {
+async fn fetch_world_data_once() -> Result<Arc<WorldHelper>, anyhow::Error> {
     let json: WorldData = Request::get("/api/v1/world_data")
         .send()
         .await
@@ -186,18 +186,25 @@ async fn get_world_data() -> Result<Arc<WorldHelper>, anyhow::Error> {
     Ok(Arc::new(WorldHelper::from(json)))
 }
 
+async fn get_world_data() -> Result<Arc<WorldHelper>, anyhow::Error> {
+    retry(fetch_world_data_once, 3).await
+}
+
+async fn fetch_region_once() -> Result<String, anyhow::Error> {
+    Request::get("/api/v1/detectregion")
+        .send()
+        .await
+        .map_err(|e| anyhow!("failed to fetch region: {e}"))?
+        .text()
+        .await
+        .map_err(|e| anyhow!("failed to read region response: {e}"))
+}
+
 async fn get_region() -> String {
-    let response = match Request::get("/api/v1/detectregion").send().await {
-        Ok(resp) => resp,
-        Err(e) => {
-            error!("failed to fetch region: {e}");
-            return String::new();
-        }
-    };
-    match response.text().await {
+    match retry(fetch_region_once, 3).await {
         Ok(text) => text,
         Err(e) => {
-            error!("failed to read region response: {e}");
+            error!("region detection failed after retries: {e}");
             String::new()
         }
     }


### PR DESCRIPTION
## Summary

- Wraps `get_world_data` and `get_region` in the existing `retry(.., 3)` helper so transient fetch drops (GFW blips, brief network handoffs, aborted navigations) no longer leave users with degraded UI.
- Follow-on to #628, which stopped panicking but still surfaced a fully-empty world list on any single failure.

## Context

[GlitchTip](https://ultros.app) was full of `RustWasmPanic / RuntimeError: unreachable` events on `/api/v1/world_data` and `/api/v1/detectregion`. #628 fixed the panic, but real users (especially in CN/Asia: `8.219.99.0`, `101.47.25.0`, both Shanghai timezone) were still hitting empty world selectors on every flaky load.

Three retries is cheap — a successful refetch costs ~200ms and the helper is already proven on `try_populate_xiv_gen_data_internal`.

## Test plan

- [ ] Throttle the `/api/v1/world_data` response in DevTools to fail once, succeed on retry — verify world list still populates after a short delay.
- [ ] Block `/api/v1/world_data` entirely — verify existing `LocalWorldData::failed` error path still kicks in after the 3 attempts.
- [ ] Block `/api/v1/detectregion` entirely — verify region fallback to `""` still happens (consumer treats unknown region as no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)