### PR TITLE
Fix duplicate release strip setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,10 +115,6 @@ pathfinder_simd = { git = "https://github.com/servo/pathfinder.git" } # needed o
 opt-level = "z"
 strip = "debuginfo"
 # codegen-units = 1
-# Keep line tables only so Glitchtip can resolve server stack frames to
-# file:line without bloating the binary with full DWARF type info.
-debug = "line-tables-only"
-strip = "none"
 
 [profile.wasm-release]
 inherits = "release"


### PR DESCRIPTION
## Summary
- remove the conflicting release profile line-table debuginfo block
- keep release builds configured with strip = "debuginfo"
- fix Cargo manifest parsing for release Docker builds

## Verification
- cargo metadata --no-deps --format-version=1
- ./check_ci.sh