### PR TITLE
fix(client): defer panic reporting to avoid executor re-entry

### DIFF
--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -3,6 +3,7 @@ use any_spawner::Executor;
 use anyhow::{Result, anyhow};
 use futures::{Future, future::join};
 use gloo_net::http::Request;
+use leptos::leptos_dom::helpers::set_timeout;
 use leptos::{prelude::*, task::spawn_local};
 use log::{Level, error, info};
 use rexie::{ObjectStore, Rexie, Store, Transaction, TransactionMode};
@@ -211,26 +212,13 @@ fn set_panic_hook() {
 }
 
 fn report_rust_panic(panic_info: &std::panic::PanicHookInfo<'_>) {
-    let global = js_sys::global();
-    let reporter = js_sys::Reflect::get(&global, &JsValue::from_str("__ultrosReportRustPanic"));
-    let Ok(reporter) = reporter else {
-        return;
-    };
-    let Some(reporter) = reporter.dyn_ref::<js_sys::Function>() else {
-        return;
-    };
-
     let message = panic_info
         .payload()
         .downcast_ref::<&str>()
         .copied()
-        .or_else(|| {
-            panic_info
-                .payload()
-                .downcast_ref::<String>()
-                .map(String::as_str)
-        })
-        .unwrap_or("Rust WASM panic");
+        .map(String::from)
+        .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "Rust WASM panic".to_string());
     let location = panic_info
         .location()
         .map(|location| {
@@ -243,10 +231,30 @@ fn report_rust_panic(panic_info: &std::panic::PanicHookInfo<'_>) {
         })
         .unwrap_or_else(|| "unknown".to_string());
 
-    let _ = reporter.call2(
-        &JsValue::NULL,
-        &JsValue::from_str(message),
-        &JsValue::from_str(&location),
+    // Defer the JS call so it runs after the current task pops off the
+    // wasm-bindgen-futures executor. If a panic fires mid-poll and we call
+    // the reporter synchronously, any executor re-entry from the JS side
+    // (a promise callback, another spawned future being woken) hits the
+    // still-borrowed task-queue RefCell and triggers a secondary
+    // `RefCell already borrowed` panic — see GlitchTip issues 909/881/915.
+    set_timeout(
+        move || {
+            let global = js_sys::global();
+            let Ok(reporter) =
+                js_sys::Reflect::get(&global, &JsValue::from_str("__ultrosReportRustPanic"))
+            else {
+                return;
+            };
+            let Some(reporter) = reporter.dyn_ref::<js_sys::Function>() else {
+                return;
+            };
+            let _ = reporter.call2(
+                &JsValue::NULL,
+                &JsValue::from_str(&message),
+                &JsValue::from_str(&location),
+            );
+        },
+        std::time::Duration::from_millis(0),
     );
 }
 


### PR DESCRIPTION
## Summary

- Defers the JS call to `window.__ultrosReportRustPanic` via `set_timeout(.., 0)` so the reporter runs *after* the current task pops off the wasm-bindgen-futures executor.
- Eliminates the secondary `RustWasmPanic: RefCell already borrowed` and tertiary `RuntimeError: unreachable` panics that cascade from any primary panic during an async poll.

## Why

The current `report_rust_panic` runs synchronously inside `std::panic::set_hook` and calls `reporter.call2(..)` while the wasm-bindgen-futures executor is still mid-poll (its task-queue `RefCell` is borrowed). Any code path the JS reporter triggers that re-enters the executor — a Promise callback being polled, another spawned future being woken — hits the still-borrowed `RefCell` at [js-sys-0.3.98 / wasm-bindgen-futures `singlethread.rs:142`](https://docs.rs/wasm-bindgen-futures/) and panics again with `RefCell already borrowed`. That second panic propagates out as the wasm `unreachable` instruction.

Result: every primary panic during a poll produces **three** GlitchTip issues:
1. The actual panic
2. `RustWasmPanic: RefCell already borrowed` (issues 909, 881, 915)
3. `RuntimeError: unreachable` (issue 163 — **39 events**, the highest-volume real error in the project)

#628 fixed the hydration unwrap that was causing most of these, but the cascade machinery is still loaded; the next panic site that fires during a poll will reproduce the same triple-report. This is defense-in-depth.

## What changed

- `report_rust_panic` now captures `message` and `location` as owned `String`s (the `panic_info` reference is only valid during the hook).
- The actual JS call is moved inside a `leptos::leptos_dom::helpers::set_timeout(.., Duration::from_millis(0))` closure, which schedules it as a fresh JS task. By the time it runs, the executor's `RefCell` is no longer borrowed.

## Test plan

- [ ] Manually trigger a Rust panic from inside an async future (e.g. add a temporary `panic!()` in a Leptos effect on a non-critical page).
- [ ] Confirm GlitchTip receives the primary panic event.
- [ ] Confirm GlitchTip does **not** receive a follow-up `RefCell already borrowed` or `RuntimeError: unreachable` event for the same trace.
- [ ] Smoke-test that normal hydration still ships GlitchTip events for non-async panics (the `setTimeout(0)` deferral is still synchronous-ish — it fires on the next event-loop tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)