### PR TITLE
⚡ Bolt: Optimize SearchBox VirtualScroller allocations and reactivity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 ## 2025-02-13 - Optimize Retainer Lookup in `ultros-db`
 **Learning:** Found a nested loop where we were searching linearly through a `HashMap` of retainers for every single listing being added to the database (`retainers.values().find(|r| r.id == l.retainer_id)`). This turns an $O(K)$ insertion step into $O(N \times K)$ where $N$ is the number of retainers in the map.
 **Action:** Always prefer reverse lookup maps when repeatedly looking up items by a secondary key (like ID when the primary map key is Name). Building a `HashMap<i32, &retainer::Model>` beforehand makes the lookup $O(1)$.
+
+## 2024-05-18 - [Optimizing Leptos Reactivity & Arc Clones]
+**Learning:** In Leptos, using a `move ||` closure for view arguments creates a dynamic node tracking reactivity. For static/immutable strings, computing it once (outside closure or immediately resolving inside `{ }` block without closure) avoids reactive tracking overhead. Also, when passing structs like `SearchResult` around, passing `Arc<SearchResult>` and cloning the `Arc` is O(1) and far cheaper than extracting and cloning its inner `String` components multiple times for callbacks.
+**Action:** Always prefer cloning `Arc` instead of `String` within closures, and omit `move ||` for static derivations when rendering Leptos components.

--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -399,35 +399,33 @@ pub fn SearchBox() -> impl IntoView {
                         each=search_results.into()
                         key={move |result: &Arc<SearchResult>| result.url.clone()}
                         view={move |result: Arc<SearchResult>| {
-                            let url = result.url.clone();
                             let navigate = navigate.clone();
 
-                            // Clone URL for different closures to satisfy borrow checker
-                            let url_for_class = url.clone();
-                            let url_for_aria = url.clone();
-                            let url_for_click = url.clone();
-                            let url_for_id = url.clone();
+                            // Clone Arc for different closures to satisfy borrow checker
+                            let res_for_aria = result.clone();
+                            let res_for_class = result.clone();
+                            let res_for_click = result.clone();
 
                             view! {
                                 <div
-                                    id=get_id_from_url(&url_for_id)
+                                    id=get_id_from_url(&result.url)
                                     role="option"
                                     aria-selected=move || {
                                         match focused_url.get() {
-                                            Some(f) if f == url_for_aria => "true",
+                                            Some(f) if f == res_for_aria.url => "true",
                                             _ => "false",
                                         }
                                     }
                                     class=move || {
                                         let hl = match focused_url.get() {
-                                            Some(f) if f == url_for_class => " bg-[color:var(--color-background-elevated)]",
+                                            Some(f) if f == res_for_class.url => " bg-[color:var(--color-background-elevated)]",
                                             _ => "",
                                         };
                                         format!("p-2 hover:bg-[color:var(--color-background-elevated)] cursor-pointer flex items-center gap-2{}", hl)
                                     }
                                     on:click=move |_| {
                                         navigate(
-                                            &url_for_click,
+                                            &res_for_click.url,
                                             NavigateOptions {
                                                 scroll: false,
                                                 ..Default::default()
@@ -489,18 +487,14 @@ pub fn SearchBox() -> impl IntoView {
                                         <span class="font-medium">{result.title.clone()}</span>
                                         <span class="text-xs text-[color:var(--color-text-muted)]">
                                             {
-                                                let category = result.category.clone();
-                                                let result_type = result.result_type.clone();
-                                                move || {
-                                                    if let Some(cat) = &category {
-                                                        if !cat.is_empty() {
-                                                            format!("{} - {}", result_type, cat)
-                                                        } else {
-                                                            result_type.clone()
-                                                        }
+                                                if let Some(cat) = &result.category {
+                                                    if !cat.is_empty() {
+                                                        format!("{} - {}", result.result_type, cat)
                                                     } else {
-                                                        result_type.clone()
+                                                        result.result_type.clone()
                                                     }
+                                                } else {
+                                                    result.result_type.clone()
                                                 }
                                             }
                                         </span>


### PR DESCRIPTION
⚡ Bolt: Optimize SearchBox VirtualScroller allocations and reactivity

💡 What:
- Replaced 4x `String::clone()` per search result row with 3x `Arc::clone()`.
- Removed an unnecessary `move ||` reactive closure block inside the search box component rendering logic that generated a dynamic leptos text node.

🎯 Why:
- Cloning an internal `String` inside a loop for closure bindings is an expensive heap allocation compared to just cloning the outer `Arc<SearchResult>`.
- Passing a closure to `view!` for static data wrapped in an `Arc` registers unnecessary fine-grained reactivity tracking when standard static text generation suffices.

📊 Impact:
- Zero String heap allocations from the URL path mapping for events (`navigate`, `aria-selected`, `class`).
- Reduces overall virtual dom generation/reactivity overhead per result row inside the `VirtualScroller`.

🔬 Measurement:
- Inspect CPU profile/heap allocations when searching and observing memory load within `ultros-frontend`.

---
*PR created automatically by Jules for task [12788485499181609296](https://jules.google.com/task/12788485499181609296) started by @akarras*