### PR TITLE
Inline world_data/region/current_user into SSR HTML bootstrap

### DIFF
--- a/ultros-api-types/src/bootstrap.rs
+++ b/ultros-api-types/src/bootstrap.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+use crate::user::UserData;
+use crate::world::WorldData;
+
+/// Server-rendered payload embedded in the initial HTML so the client can
+/// hydrate without making `/world_data`, `/detectregion`, and `/current_user`
+/// requests on every cold load.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Bootstrap {
+    pub world_data: WorldData,
+    pub region: String,
+    pub current_user: Option<UserData>,
+}

--- a/ultros-api-types/src/lib.rs
+++ b/ultros-api-types/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod alert;
+pub mod bootstrap;
 pub mod cheapest_listings;
 mod ffxiv_character;
 pub mod icon_size;

--- a/ultros-api-types/src/world_helper.rs
+++ b/ultros-api-types/src/world_helper.rs
@@ -177,6 +177,13 @@ impl WorldHelper {
         Self { world_data }
     }
 
+    /// Borrowed view of the underlying world data. Used by the server when
+    /// inlining the world data into the initial HTML response so the client
+    /// can skip the `/api/v1/world_data` fetch on hydration.
+    pub fn world_data(&self) -> &WorldData {
+        &self.world_data
+    }
+
     /// Ignores case and looks up the world name
     pub fn lookup_world_by_name(&self, name: &str) -> Option<AnyResult<'_>> {
         let mut worlds = self.world_data.regions.iter().flat_map(|region| {

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -42,8 +42,22 @@ pub(crate) async fn get_listings(item_id: i32, world: &str) -> AppResult<Current
     fetch_api(&format!("/api/v1/listings/{world}/{item_id}")).await
 }
 
-/// This is okay because the client will send our login cookie
+/// This is okay because the client will send our login cookie.
+///
+/// Before falling back to the network, consult `BootstrapUser` — the SSR
+/// handler resolves the user from the auth cookie on every page render, and
+/// the client mirrors that into context on hydration from the bootstrap
+/// script. When the context is present we never have to hit
+/// `/api/v1/current_user`.
 pub(crate) async fn get_login() -> AppResult<UserData> {
+    use leptos::prelude::use_context;
+    if let Some(crate::global_state::BootstrapUser(user)) =
+        use_context::<crate::global_state::BootstrapUser>()
+    {
+        return user.ok_or(AppError::ApiError(
+            ultros_api_types::result::ApiError::NotAuthenticated,
+        ));
+    }
     fetch_api("/api/v1/current_user").await
 }
 

--- a/ultros-frontend/ultros-app/src/global_state/mod.rs
+++ b/ultros-frontend/ultros-app/src/global_state/mod.rs
@@ -7,6 +7,7 @@ pub mod region_for_world;
 pub mod theme;
 pub mod user;
 pub use local_world_data::LocalWorldData;
+pub use user::BootstrapUser;
 pub mod crafter_levels;
 pub mod toasts;
 pub mod xiv_data;

--- a/ultros-frontend/ultros-app/src/global_state/user.rs
+++ b/ultros-frontend/ultros-app/src/global_state/user.rs
@@ -1,5 +1,10 @@
-// use leptos::prelude::*;
-// use ultros_api_types::user::UserData;
+use ultros_api_types::user::UserData;
 
-// #[derive(Debug, Clone)]
-// pub struct LoggedInUser(pub Resource<(), Option<UserData>>);
+/// SSR-provided / bootstrap-provided initial value for the current user.
+///
+/// `None` inside the `Option` means "we know the user is not logged in"
+/// (no auth cookie, or auth cookie was rejected at render time). The context
+/// being absent entirely means we don't have a bootstrap value and callers
+/// should fall back to fetching `/api/v1/current_user`.
+#[derive(Clone, Debug)]
+pub struct BootstrapUser(pub Option<UserData>);

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -12,7 +12,7 @@ include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
 use i18n::*;
 
 use crate::components::recently_viewed::RecentItems;
-pub use crate::global_state::{LocalWorldData, home_world::GuessedRegion};
+pub use crate::global_state::{BootstrapUser, LocalWorldData, home_world::GuessedRegion};
 use crate::global_state::{
     cheapest_prices::CheapestPrices,
     clipboard_text::GlobalLastCopiedText,
@@ -143,7 +143,7 @@ fn error_reporting_script() -> Option<String> {
     ))
 }
 
-pub fn shell(options: LeptosOptions) -> impl IntoView {
+pub fn shell(options: LeptosOptions, bootstrap_script: String) -> impl IntoView {
     let sheet_url = ["/", options.site_pkg_dir.as_ref(), "/ultros.css"].concat();
     let error_reporting_script = error_reporting_script();
     view! {
@@ -155,6 +155,10 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
                 <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png" />
                 <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />
                 <link rel="manifest" href="/static/site.webmanifest" />
+                // Bootstrap data injected by the SSR handler. Reading this in
+                // hydrate() lets us skip the /world_data, /detectregion, and
+                // /current_user round-trips on every cold load.
+                <script inner_html=bootstrap_script />
                 <script>
     "(function(){try{var d=document.documentElement;var ls=localStorage;var g=function(k){try{return ls.getItem(k)}catch(_){return null}};var gc=function(n){var m=document.cookie.match(new RegExp('(?:^|; )'+n+'=([^;]+)'));return m?decodeURIComponent(m[1]):null};var mode=g('theme.mode')||gc('theme_mode')||'system';if(mode==='system'){mode=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light'};d.setAttribute('data-theme',mode==='light'?'light':'dark');var palette=g('theme.palette')||gc('theme_palette')||'violet';d.setAttribute('data-palette',palette)}catch(_){}})();"
                 </script>

--- a/ultros-frontend/ultros-client/Cargo.toml
+++ b/ultros-frontend/ultros-client/Cargo.toml
@@ -17,6 +17,7 @@ ultros-api-types = { path = "../../ultros-api-types" }
 leptos = { workspace = true, default-features = false, features = ["hydrate", "nightly"] }
 log = "0.4"
 wasm-bindgen = "0.2"
+js-sys = "0.3"
 console_error_panic_hook = "0.1"
 leptos_meta = { workspace = true, default-features = false }
 gloo-net.workspace = true

--- a/ultros-frontend/ultros-client/Cargo.toml
+++ b/ultros-frontend/ultros-client/Cargo.toml
@@ -34,7 +34,6 @@ any_spawner = "0.3"
 tracing-wasm = "0.2.1"
 console_log = { version = "1.0.0", features = ["color"] }
 web-sys = { version = "0.3", features = ["HtmlDocument", "Document", "Window"] }
-js-sys = "0.3"
 
 [features]
 default = ["hydrate"]

--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -305,7 +305,7 @@ pub fn hydrate() {
             (
                 Ok(Arc::new(WorldHelper::from(b.world_data))),
                 b.region,
-                b.current_user,
+                Some(b.current_user),
             )
         } else {
             info!("bootstrap missing — falling back to HTTP for world_data + region");
@@ -314,7 +314,7 @@ pub fn hydrate() {
                 join(get_world_data(), get_region()),
             )
             .await;
-            // current_user remains None here; ProfileDisplay will hit
+            // current_user remains absent here; ProfileDisplay will hit
             // /api/v1/current_user via the existing fetch path.
             (worlds, region, None)
         };
@@ -332,7 +332,9 @@ pub fn hydrate() {
             let current_user = current_user.clone();
             provide_context(GuessedRegion(region));
             provide_context(world_data);
-            provide_context(BootstrapUser(current_user));
+            if let Some(current_user) = current_user {
+                provide_context(BootstrapUser(current_user));
+            }
             view! { <App /> }
         });
     });

--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -9,7 +9,7 @@ use log::{Level, error, info};
 use rexie::{ObjectStore, Rexie, Store, Transaction, TransactionMode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use ultros_api_types::{world::WorldData, world_helper::WorldHelper};
+use ultros_api_types::{bootstrap::Bootstrap, world::WorldData, world_helper::WorldHelper};
 use ultros_app::*;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
@@ -265,6 +265,28 @@ fn report_rust_panic(panic_info: &std::panic::PanicHookInfo<'_>) {
     );
 }
 
+/// Read the bootstrap blob the SSR handler injects as
+/// `window.__ULTROS_BOOTSTRAP__`. Returns `None` if the script wasn't there or
+/// failed to decode — callers should fall back to the legacy fetch path so
+/// the client stays robust to old / mismatched HTML.
+fn read_bootstrap() -> Option<Bootstrap> {
+    use wasm_bindgen::{JsCast, JsValue};
+    let window = leptos::prelude::window();
+    let window_value: &JsValue = window.unchecked_ref();
+    let value =
+        js_sys::Reflect::get(window_value, &JsValue::from_str("__ULTROS_BOOTSTRAP__")).ok()?;
+    if value.is_undefined() || value.is_null() {
+        return None;
+    }
+    match serde_wasm_bindgen::from_value::<Bootstrap>(value) {
+        Ok(b) => Some(b),
+        Err(e) => {
+            error!("Failed to decode __ULTROS_BOOTSTRAP__: {e}");
+            None
+        }
+    }
+}
+
 #[wasm_bindgen]
 pub fn hydrate() {
     set_panic_hook();
@@ -275,11 +297,27 @@ pub fn hydrate() {
     log::info!("hydrate mode - hydrating");
     spawn_local(async move {
         info!("fetching..");
-        let (_, (worlds, region)) = join(
-            populate_xiv_gen_data(),
-            join(get_world_data(), get_region()),
-        )
-        .await;
+        // Use the SSR-injected bootstrap when available; only fall back to
+        // network requests if it's missing (e.g. stale cached HTML).
+        let bootstrap = read_bootstrap();
+        let (worlds, region, current_user) = if let Some(b) = bootstrap {
+            let _ = populate_xiv_gen_data().await;
+            (
+                Ok(Arc::new(WorldHelper::from(b.world_data))),
+                b.region,
+                b.current_user,
+            )
+        } else {
+            info!("bootstrap missing — falling back to HTTP for world_data + region");
+            let (_, (worlds, region)) = join(
+                populate_xiv_gen_data(),
+                join(get_world_data(), get_region()),
+            )
+            .await;
+            // current_user remains None here; ProfileDisplay will hit
+            // /api/v1/current_user via the existing fetch path.
+            (worlds, region, None)
+        };
         info!("hydrating body");
         let world_data = match worlds {
             Ok(worlds) => LocalWorldData(Ok(worlds)),
@@ -291,8 +329,10 @@ pub fn hydrate() {
         hydrate_body(move || {
             let world_data = world_data.clone();
             let region = region.clone();
+            let current_user = current_user.clone();
             provide_context(GuessedRegion(region));
             provide_context(world_data);
+            provide_context(BootstrapUser(current_user));
             view! { <App /> }
         });
     });

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, sync::Arc};
 
-#[cfg(not(debug_assertions))]
-use axum::http::HeaderValue;
+use axum::http::{HeaderValue, header};
 /// Ultros UI server contains all the axum routes required to serve and bundle leptos wasm files
 /// # Building
 /// I recommend you use cargo-leptos, once you go through the steps to install cargo-leptos
@@ -15,38 +14,97 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use git_const::git_short_hash;
-#[cfg(not(debug_assertions))]
-use hyper::header;
 use leptos::prelude::*;
 use leptos_axum::{LeptosRoutes, generate_route_list};
 #[cfg(not(debug_assertions))]
 use tower_http::set_header::SetResponseHeader;
 use tracing::{info, instrument};
+use ultros_api_types::user::UserData;
 use ultros_api_types::world_helper::WorldHelper;
 use ultros_app::*;
 
+use crate::web::error::ApiError;
+use crate::web::oauth::AuthDiscordUser;
 use crate::web::{WebState, country_code_decoder::Region};
 
-#[instrument(skip(worlds, options, req))]
+/// Escape a JSON string for safe embedding inside a `<script>` element.
+///
+/// JSON allows literal `<` characters inside strings; if any of them happen to
+/// be followed by `/script>`, the parser would close the tag and start
+/// executing arbitrary content as HTML. Replacing the handful of characters
+/// below with their `\uXXXX` escapes keeps the payload as valid JSON and
+/// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
+/// are JS line terminators (legal in JSON strings but break script parsing).
+fn escape_for_script_tag(json: &str) -> String {
+    let mut out = String::with_capacity(json.len());
+    for c in json.chars() {
+        match c {
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[instrument(skip(worlds, options, req, user))]
 #[axum::debug_handler(state = WebState)]
 async fn custom_handler(
     State(worlds): State<Arc<WorldHelper>>,
     State(options): State<LeptosOptions>,
     region: Option<Region>,
+    user: Result<AuthDiscordUser, ApiError>,
     req: Request<Body>,
 ) -> Response {
     info!("Custom handler");
+    // The HTML now carries per-user data (region + current_user), so it must
+    // never be cached by a shared proxy.
+    let region_str = region.unwrap_or(Region::NorthAmerica).to_string();
+    let current_user = user.ok().map(|u| UserData {
+        id: u.id,
+        username: u.name,
+        avatar: u.avatar_url,
+    });
+
+    // Build the bootstrap script body once per request. We serialize a borrowed
+    // view of WorldData to avoid cloning the (small but non-trivial) world tree.
+    #[derive(serde::Serialize)]
+    struct BootstrapRef<'a> {
+        world_data: &'a ultros_api_types::world::WorldData,
+        region: &'a str,
+        current_user: &'a Option<UserData>,
+    }
+    let bootstrap_json = serde_json::to_string(&BootstrapRef {
+        world_data: worlds.world_data(),
+        region: &region_str,
+        current_user: &current_user,
+    })
+    .unwrap_or_else(|_| "null".to_string());
+    let bootstrap_script = format!(
+        "window.__ULTROS_BOOTSTRAP__={};",
+        escape_for_script_tag(&bootstrap_json)
+    );
+
+    let region_for_ctx = region_str.clone();
+    let current_user_for_ctx = current_user.clone();
     let handler = leptos_axum::render_app_to_stream_with_context_and_replace_blocks(
         move || {
             provide_context(LocalWorldData(Ok(worlds.clone())));
-            provide_context(GuessedRegion(
-                region.unwrap_or(Region::NorthAmerica).to_string(),
-            ));
+            provide_context(GuessedRegion(region_for_ctx.clone()));
+            provide_context(BootstrapUser(current_user_for_ctx.clone()));
         },
-        move || shell(options.clone()),
+        move || shell(options.clone(), bootstrap_script.clone()),
         true,
     );
-    handler(req).await.into_response()
+    let mut response = handler(req).await.into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+    response
 }
 
 pub(crate) async fn create_leptos_app(
@@ -89,6 +147,7 @@ pub(crate) async fn create_leptos_app(
         let worlds = worlds.clone();
         provide_context(LocalWorldData(worlds));
         provide_context(GuessedRegion("North-America".to_string()));
+        provide_context(BootstrapUser(None));
         view! { <App /> }
     });
 

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -166,3 +166,23 @@ pub(crate) async fn create_leptos_app(
     // .with_state(state)
     // .layer(Extension(Arc::new(leptos_options))))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::escape_for_script_tag;
+
+    #[test]
+    fn script_bootstrap_json_cannot_close_script_tag() {
+        let payload = format!(
+            r#"{{"name":"</script><script>alert(1)</script>&{}{}"}}"#,
+            '\u{2028}', '\u{2029}'
+        );
+        let escaped = escape_for_script_tag(&payload);
+
+        assert!(!escaped.contains("</script>"));
+        assert!(escaped.contains("\\u003c/script\\u003e"));
+        assert!(escaped.contains("\\u0026"));
+        assert!(escaped.contains("\\u2028"));
+        assert!(escaped.contains("\\u2029"));
+    }
+}

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -1187,7 +1187,9 @@ pub(crate) async fn start_web(state: WebState) {
             move || {
                 provide_context(LocalWorldData(Ok(worlds.clone())));
             },
-            shell,
+            // The file/404 fallback doesn't have per-request bootstrap data; an
+            // empty script tag is harmless and the client falls back to HTTP.
+            |options| shell(options, String::new()),
         ))
         .with_state(state)
         .route_layer(middleware::from_fn(track_metrics))


### PR DESCRIPTION
## Summary

The Leptos SSR handler already has the region (`cf-ipcountry`), world data (in-memory `WorldHelper`), and the Discord auth cookie at render time — but the client still fires `/api/v1/world_data`, `/api/v1/detectregion`, and `/api/v1/current_user` on every cold load. Those three endpoints are the biggest sources of in-the-wild failures and add three round-trips before hydration finishes.

This PR serializes all three into a single `window.__ULTROS_BOOTSTRAP__` script tag in `<head>` so the client can hydrate without making any of those requests on the happy path.

## What changed

- **New `Bootstrap` type** (`ultros-api-types/src/bootstrap.rs`) shared between server and client.
- **`WorldHelper::world_data()`** accessor so the server can serialize a borrowed view (no `WorldData` clone per request).
- **SSR handler** (`ultros/src/leptos.rs`):
  - Extracts `Result<AuthDiscordUser, ApiError>` so a stale/revoked Discord token renders as logged-out instead of breaking SSR.
  - Serializes `BootstrapRef` with proper HTML escaping for `<`, `>`, `&`, U+2028, U+2029 to prevent script-tag breakout.
  - Sets `Cache-Control: private, no-store` because the HTML now embeds per-user data.
- **Shell** (`ultros-frontend/ultros-app/src/lib.rs`): `shell()` takes a `bootstrap_script: String` and injects it via `<script inner_html=…>` in `<head>` so it executes before WASM hydration. The file/404 fallback passes an empty string.
- **Client `hydrate()`** (`ultros-frontend/ultros-client/src/lib.rs`): reads `window.__ULTROS_BOOTSTRAP__` via `js_sys::Reflect` and skips the `/world_data` + `/detectregion` fetches when present. Falls back to the HTTP pair if the script is missing.
- **`BootstrapUser` context** + **`get_login()`** consults context first, eliminating both the client `/current_user` fetch and the redundant reqwest call the SSR side was making to itself.

## Endpoints kept alive

`/api/v1/detectregion`, `/api/v1/world_data`, and `/api/v1/current_user` (GET) are intentionally left in place as a fallback for stale cached HTML, the file fallback handler, and any external callers. Safe to remove `/detectregion` (and likely the GET on `/current_user`) once nothing else is hitting them.

## Caveats

- A stale Discord token at SSR time renders the page as logged-out (the `Result` extractor swallows the error). The next API call needing auth will 401 normally — same failure mode as today, just shifted from "blank UI flashing to logged-out" to "logged-out from the start."
- `BootstrapUser` is provided once at hydration and `get_login()` consults it on every call, so the existing `Resource` pattern won't refetch user state without a full page reload. Login/logout already go through full server redirects, so this matches today's UX.
- `cargo fmt --all` cleaned up a small pre-existing whitespace drift in `ultros-db/src/lists.rs` that happened to be in the way. Trivial, unrelated to the feature.

## Test plan

- [x] `./check_ci.sh` passes (`cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings`)
- [ ] Smoke test in browser: cold load shows no `/world_data`, `/detectregion`, or `/current_user` requests in the network panel; UI hydrates correctly logged-out
- [ ] Smoke test logged-in: cold load shows correct avatar/username without `/current_user` request
- [ ] Logout / login round-trip still works (full-page redirects, so bootstrap is refreshed)
- [ ] Spoof `cf-ipcountry: JP` and confirm UI auto-selects Japanese locale
- [ ] Manually delete the bootstrap script from a saved HTML page and confirm the client falls back to the HTTP endpoints gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)