### PR TITLE
fix: polish shared list subscriptions

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -980,5 +980,13 @@
     "recipe_analyzer_tool_summary": "Find recipes where estimated craft cost is lower than the market price for the finished item.",
     "recipe_analyzer_tool_context": "Configure crafter levels first so the results match recipes you can actually make.",
     "recipe_analyzer_tool_help": "Recipe Analyzer uses cheapest ingredient listings, optional subcraft checks, your crafter levels, and recent sales. A profitable recipe is strongest when the output also sells regularly.",
-    "trends_world_context_prefix": "World context: "
+    "trends_world_context_prefix": "World context: ",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -980,5 +980,13 @@
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",
-    "add_to_list_read_only": "Read-only — can't add items"
+    "add_to_list_read_only": "Read-only — can't add items",
+    "list_view_subscribe_tooltip": "Subscribe to price alerts on every priced item in this list",
+    "list_view_subscribe_aria": "Notify me on this list",
+    "list_view_subscribe_button": "Notify me",
+    "list_subscribe_success_toast": "Subscribed to list",
+    "list_subscribe_title": "Notify me on this list: {{name}}",
+    "list_subscribe_description": "You'll be notified when any item in this list drops to or below its target price. Set per-item targets from the list page.",
+    "list_subscribe_submit": "Subscribe",
+    "list_item_row_target_price_label": "Target price (gil)"
 }

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -284,12 +284,12 @@ pub fn ListItemRow(
                                         }
                                     />
 
-                                    <label class="text-xs">"Target price (gil)"</label>
+                                    <label class="text-xs">{t!(i18n, list_item_row_target_price_label)}</label>
                                     <input
                                         class="input w-24"
                                         type="number"
                                         min="0"
-                                        placeholder="None"
+                                        placeholder=move || t_string!(i18n, none).to_string()
                                         prop:value=move || {
                                             temp_item
                                                 .with(|i| {

--- a/ultros-frontend/ultros-app/src/components/list_subscribe_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/list_subscribe_drawer.rs
@@ -11,6 +11,7 @@ use ultros_api_types::alert::{AlertTrigger, CreateAlertRequest};
 use crate::api::{create_alert, list_endpoints};
 use crate::components::{icon::Icon, modal::Modal};
 use crate::global_state::toasts::use_toast;
+use crate::i18n::*;
 
 #[component]
 pub fn ListSubscribeDrawer(
@@ -18,6 +19,7 @@ pub fn ListSubscribeDrawer(
     list_name: String,
     set_visible: SignalSetter<bool>,
 ) -> impl IntoView {
+    let i18n = use_i18n();
     let endpoints = Resource::new(|| (), |_| list_endpoints());
     let selected = RwSignal::new(HashSet::<i32>::new());
     let (error, set_error) = signal::<Option<String>>(None);
@@ -35,7 +37,9 @@ pub fn ListSubscribeDrawer(
         set_error.set(None);
         let endpoint_ids: Vec<i32> = selected.get().into_iter().collect();
         if endpoint_ids.is_empty() {
-            set_error.set(Some("Pick at least one endpoint".into()));
+            set_error.set(Some(
+                t_string!(i18n, alert_drawer_err_endpoint_required).to_string(),
+            ));
             return;
         }
         let req = CreateAlertRequest {
@@ -48,7 +52,7 @@ pub fn ListSubscribeDrawer(
             match create_alert(req).await {
                 Ok(_) => {
                     if let Some(t) = toasts {
-                        t.success("Subscribed to list");
+                        t.success(t_string!(i18n, list_subscribe_success_toast));
                     }
                     set_visible.set(false);
                 }
@@ -62,23 +66,22 @@ pub fn ListSubscribeDrawer(
     view! {
         <Modal set_visible>
             <div class="p-4 space-y-4 w-[28rem]">
-                <h2 class="text-xl font-bold">"Notify me on this list: " {list_name.clone()}</h2>
+                <h2 class="text-xl font-bold">{t!(i18n, list_subscribe_title, name = list_name.clone())}</h2>
                 <p class="text-sm opacity-80">
-                    "You'll be notified when any item in this list drops to or below its target price. "
-                    "Set per-item targets from the list page."
+                    {t!(i18n, list_subscribe_description)}
                 </p>
 
                 <div class="space-y-1">
-                    <label class="text-sm font-semibold">"Deliver to"</label>
+                    <label class="text-sm font-semibold">{t!(i18n, alert_drawer_deliver_to)}</label>
                     <Suspense fallback=move || {
-                        view! { <div class="text-sm opacity-70">"Loading endpoints..."</div> }
+                        view! { <div class="text-sm opacity-70">{t!(i18n, alert_drawer_loading_endpoints)}</div> }
                     }>
                         {move || endpoints.get().map(|r| match r {
                             Ok(list) if list.is_empty() => view! {
                                 <p class="text-sm opacity-70">
-                                    "No endpoints yet. "
-                                    <a href="/alerts" class="underline">"Add one"</a>
-                                    " before subscribing."
+                                    {t!(i18n, alert_drawer_no_endpoints_prefix)}
+                                    <a href="/alerts" class="underline">{t!(i18n, alert_drawer_no_endpoints_link)}</a>
+                                    {t!(i18n, alert_drawer_no_endpoints_suffix)}
                                 </p>
                             }.into_any(),
                             Ok(list) => view! {
@@ -114,11 +117,11 @@ pub fn ListSubscribeDrawer(
 
                 <div class="flex justify-end gap-2 pt-2">
                     <button class="btn-ghost" on:click=move |_| set_visible.set(false)>
-                        "Cancel"
+                        {t!(i18n, cancel)}
                     </button>
                     <button class="btn" on:click=submit>
                         <Icon icon=i::BsBell width="1em" height="1em" />
-                        <span class="ml-1">"Subscribe"</span>
+                        <span class="ml-1">{t!(i18n, list_subscribe_submit)}</span>
                     </button>
                 </div>
             </div>

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -194,14 +194,14 @@ pub fn ListView() -> impl IntoView {
                     </div>
 
                     <div class="flex flex-wrap gap-2 self-start lg:self-auto">
-                        <Tooltip tooltip_text="Subscribe to price alerts on every priced item in this list".to_string()>
+                        <Tooltip tooltip_text=t_string!(i18n, list_view_subscribe_tooltip).to_string()>
                             <button
                                 class="btn-secondary"
-                                aria-label="Notify me on this list"
+                                aria-label=t_string!(i18n, list_view_subscribe_aria)
                                 on:click=move |_| set_subscribe_open(true)
                             >
                                 <Icon icon=i::BsBell />
-                                <span>"Notify me"</span>
+                                <span>{t!(i18n, list_view_subscribe_button)}</span>
                             </button>
                         </Tooltip>
                         <Tooltip tooltip_text=t_string!(i18n, list_view_tooltip_purchasing_view).to_string()>

--- a/ultros/src/alerts/price_alert_tracker.rs
+++ b/ultros/src/alerts/price_alert_tracker.rs
@@ -70,13 +70,16 @@ pub(crate) fn format_threshold_alert_message(
 /// subscribes to multiple lists.
 pub(crate) fn format_list_threshold_alert_message(
     list_name: &str,
+    list_id: i32,
     item_name: &str,
     item_id: i32,
     matched_price: i32,
     target_price: i64,
 ) -> (String, String) {
     let title = format!("📋 {list_name}: {item_name} at {matched_price} gil");
-    let body = format!("Target: {target_price} gil\nhttps://ultros.app/item/{item_id}");
+    let body = format!(
+        "Target: {target_price} gil\nItem: https://ultros.app/item/{item_id}\nList: https://ultros.app/list/{list_id}"
+    );
     (title, body)
 }
 
@@ -435,6 +438,7 @@ async fn handle_added(
         let item_name = resolve_item_name(rule.item_id);
         let (title, body) = format_list_threshold_alert_message(
             &rule.list_name,
+            rule.list_id,
             &item_name,
             rule.item_id,
             matched_price,


### PR DESCRIPTION
Follow-up from reviewing the shared-list alert PR.\n\n- Localizes the new list subscription drawer and toolbar strings.\n- Uses the stored list id in shared-list alert messages so alert emails link back to the list.\n\nValidation: ./check_ci.sh (with Strawberry Perl on PATH for vendored OpenSSL).