### PR TITLE
feat(observability): enable Glitchtip performance sampling via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,9 @@ VAPID_PUBLIC_KEY=your-vapid-public-key
 # Optional Glitchtip / Sentry error reporting (leave unset to disable)
 # GLITCHTIP_DSN=https://<public_key>@glitchtip.example.com/<project_id>
 # GLITCHTIP_SECURITY_REPORT_URL=https://glitchtip.example.com/api/<project_id>/security/?glitchtip_key=<public_key>
+# Performance / transaction sampling for the backend. 0.0 disables
+# (default — matches prior behavior); 1.0 sends every request as a
+# transaction; pick something low like 0.05–0.1 in production.
+# GLITCHTIP_TRACES_SAMPLE_RATE=0.1
+# Tags transactions/errors so dev noise stays separate from prod.
+# GLITCHTIP_ENVIRONMENT=development

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -201,14 +201,21 @@ async fn main() -> Result<()> {
     // Glitchtip / Sentry error reporting. No-op when GLITCHTIP_DSN is unset, so
     // local dev runs without it. The guard must be held for the duration of
     // main() so the background transport can flush on shutdown.
+    //
+    // GLITCHTIP_TRACES_SAMPLE_RATE controls performance/transaction sampling:
+    // 0.0 disables (default — matches prior behavior), 1.0 sends every request.
+    // Glitchtip 4.x and Sentry both accept transaction envelopes.
     let _sentry_guard = std::env::var("GLITCHTIP_DSN").ok().map(|dsn| {
+        let traces_sample_rate = std::env::var("GLITCHTIP_TRACES_SAMPLE_RATE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.0);
         sentry::init((
             dsn,
             sentry::ClientOptions {
                 release: sentry::release_name!(),
-                // Glitchtip currently ignores performance traces; keep low so
-                // we don't waste bandwidth if a real Sentry endpoint is used.
-                traces_sample_rate: 0.0,
+                environment: std::env::var("GLITCHTIP_ENVIRONMENT").ok().map(Into::into),
+                traces_sample_rate,
                 attach_stacktrace: true,
                 send_default_pii: false,
                 ..Default::default()


### PR DESCRIPTION
## Summary

While this PR was open, a1567358 + be270dbc landed on main and wired up sentry-tracing + sentry-tower — which is most of what this PR originally did. **However** main hardcoded \`traces_sample_rate: 0.0\` with the comment _\"Glitchtip currently ignores performance traces\"_, which is why the Performance view is still empty.

That comment is stale: Glitchtip 4.x accepts transaction envelopes. The only thing blocking performance data is that hardcoded zero.

## What changed

- \`GLITCHTIP_TRACES_SAMPLE_RATE\` env var (default 0.0, so behavior is unchanged unless you opt in)
- \`GLITCHTIP_ENVIRONMENT\` env var so dev noise stays separate from prod
- \`.env.example\` documents both

## To actually see data

1. Set \`GLITCHTIP_TRACES_SAMPLE_RATE=0.1\` (or \`1.0\` locally) in prod env
2. Optionally \`GLITCHTIP_ENVIRONMENT=production\`
3. Restart — transactions show up in Performance view within a few requests, named by axum's matched path (e.g. \`GET /retainer/:id\`)

## Test plan

- [x] \`cargo fmt --all -- --check\` passes
- [ ] CI clippy passes (could not run locally — vendored openssl-sys build fails on my MSYS Perl install; CI Linux is fine)
- [ ] With env unset: confirm app behaves identically to current main (no transactions sent)
- [ ] With \`GLITCHTIP_TRACES_SAMPLE_RATE=1.0\`: confirm transactions appear in Glitchtip Performance view

🤖 Generated with [Claude Code](https://claude.com/claude-code)