### PR TITLE
fix: hydration panic on /items/jobset/{job} (GlitchTip 2326 et al.)

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -622,27 +622,36 @@ fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView
                                 <div class="flex flex-col gap-3 mt-2 pt-3 border-t border-white/5">
                                     <div class="flex flex-col gap-2 text-sm">
                                         <CheapestPrice item_id=*id show_hq=false label=t_string!(i18n, nq).to_string() />
-                                        {if item.can_be_hq {
-                                            view! {
-                                                <CheapestPrice item_id=*id show_hq=true label=t_string!(i18n, hq).to_string() />
-                                            }.into_any()
-                                        } else {
-                                            view! { <div/> }.into_any()
-                                        }}
-                                        {
-                                            if let Some(price) = crate::components::related_items::get_vendor_price(id.0) {
+                                        // Always emit a stable wrapper div so the SSR and CSR view
+                                        // trees agree on element shape/count for this tuple slot.
+                                        // Conditional rendering inside the wrapper keeps the
+                                        // outer (AnyView, AnyView, AnyView) tuple types matching
+                                        // between server and client (fixes tachys hydration panic).
+                                        <div>
+                                            {if item.can_be_hq {
                                                 view! {
-                                                    <div class="flex items-center gap-2">
-                                                        <span class="text-xs font-bold px-1.5 py-0.5 rounded bg-white/10 text-[color:var(--color-text-muted)] whitespace-nowrap">
-                                                            {t!(i18n, item_explorer_vendor)}
-                                                        </span>
-                                                        <Gil amount=price as i32 />
-                                                    </div>
+                                                    <CheapestPrice item_id=*id show_hq=true label=t_string!(i18n, hq).to_string() />
                                                 }.into_any()
                                             } else {
                                                 ().into_any()
+                                            }}
+                                        </div>
+                                        <div>
+                                            {
+                                                if let Some(price) = crate::components::related_items::get_vendor_price(id.0) {
+                                                    view! {
+                                                        <div class="flex items-center gap-2">
+                                                            <span class="text-xs font-bold px-1.5 py-0.5 rounded bg-white/10 text-[color:var(--color-text-muted)] whitespace-nowrap">
+                                                                {t!(i18n, item_explorer_vendor)}
+                                                            </span>
+                                                            <Gil amount=price as i32 />
+                                                        </div>
+                                                    }.into_any()
+                                                } else {
+                                                    ().into_any()
+                                                }
                                             }
-                                        }
+                                        </div>
                                     </div>
                                     <div class="flex items-center gap-2 mt-1">
                                         <div class="flex-1">


### PR DESCRIPTION
## Summary

Resolves **GlitchTip 2326, 697, 2334, 156, 2388** — `panicked at tachys-0.2.11/src/hydration.rs:163:9: internal error: entered unreachable code` on every `/items/jobset/{JOB}` route (PLD, THM, NIN, RDM, etc.).

**Root cause.** The per-item card on the jobset items grid built a `<div class="flex flex-col gap-2 text-sm">` whose middle child was
`if item.can_be_hq { view!{ <CheapestPrice .../> }.into_any() } else { view!{ <div/> }.into_any() }`.
The two `into_any()` arms erase to different concrete view types, so the `(AnyView, AnyView, AnyView)` tuple that tachys constructs has a different shape on the SSR side vs. the CSR side, and the hydration walker trips its `unreachable!()` assert when the DOM it finds doesn't match the view tree it expects.

**Fix.** Wrap the HQ slot and the vendor slot in stable `<div>` containers, so the outer tuple always sees the same root element shape on both sides. Conditional content now lives *inside* the wrapper and uses `().into_any()` for the empty branch (which serializes as empty consistently between SSR and CSR). This is the defensive Leptos 0.7/tachys pattern: keep tuple slot shapes constant, vary only the children.

## Test plan

- [ ] Load `/items/jobset/PLD` in a fresh tab (cold cache, SSR path) — confirm no console panic, NQ row renders, HQ row renders.
- [ ] Same for `/items/jobset/THM`.
- [ ] Same for `/items/jobset/NIN`.
- [ ] Same for `/items/jobset/RDM`.
- [ ] Spot-check a jobset where most items can NOT be HQ (e.g. crafting-disciple sets) — confirm the missing-HQ slot collapses cleanly without a stray empty box.
- [ ] Spot-check that vendor-priced items still show the vendor pill.

## Expected downstream impact

This panic cascades into a flurry of `Cannot read properties of undefined (reading 'document')` TypeErrors because the WASM heap is torn down mid-hydration. Retiring this panic should also close:

- GlitchTip **7, 16, 40, 192, 234, 582, 1047** — `document` TypeErrors clustered on these routes.
- The `/item/{world}/{id}` clones in the **2380–2416** range — same `CheapestPrice` Suspense tuple shape, just a different parent route hitting it.

## CI notes

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean. (Full-workspace clippy couldn't run in this worktree due to a local openssl-sys/perl env issue unrelated to the change; the touched crate is `ultros-app` and it lints clean with `-D warnings`.)