### PR TITLE
fix(bootstrap): preserve Discord snowflake precision through SSR HTML

### DIFF
--- a/ultros-api-types/src/user/user_data.rs
+++ b/ultros-api-types/src/user/user_data.rs
@@ -2,7 +2,101 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
 pub struct UserData {
+    // Discord snowflake. Serialized as a JSON string so the value survives a
+    // round-trip through any JS engine — snowflakes routinely exceed 2^53 and
+    // would silently lose precision if parsed into a JS Number. The custom
+    // deserializer accepts either a string or a JSON number to remain
+    // compatible with older clients / cached payloads.
+    #[serde(with = "u64_string")]
     pub id: u64,
     pub username: String,
     pub avatar: String,
+}
+
+mod u64_string {
+    use serde::{
+        Deserializer, Serializer,
+        de::{self, Visitor},
+    };
+    use std::fmt;
+
+    pub fn serialize<S: Serializer>(value: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = u64;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("a u64 expressed as a string or JSON number")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<u64, E> {
+                v.parse::<u64>().map_err(de::Error::custom)
+            }
+
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<u64, E> {
+                Ok(v)
+            }
+
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<u64, E> {
+                u64::try_from(v).map_err(de::Error::custom)
+            }
+
+            fn visit_f64<E: de::Error>(self, v: f64) -> Result<u64, E> {
+                // f64 only represents integers exactly up to 2^53; anything
+                // larger has already lost precision by the time we see it, so
+                // refuse rather than return a silently corrupted id.
+                const MAX_SAFE: f64 = 9_007_199_254_740_992.0;
+                if !v.is_finite() || v.fract() != 0.0 || v.is_sign_negative() || v > MAX_SAFE {
+                    return Err(de::Error::custom(format!(
+                        "u64 value {v} cannot be represented exactly as f64"
+                    )));
+                }
+                Ok(v as u64)
+            }
+        }
+
+        deserializer.deserialize_any(V)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UserData;
+
+    #[test]
+    fn snowflake_round_trips_as_string() {
+        let user = UserData {
+            id: 66154228472619010,
+            username: "aaron".to_string(),
+            avatar: "x".to_string(),
+        };
+        let json = serde_json::to_string(&user).unwrap();
+        assert!(json.contains("\"id\":\"66154228472619010\""), "{json}");
+        let back: UserData = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, user);
+    }
+
+    #[test]
+    fn deserializes_legacy_numeric_id() {
+        let json = r#"{"id":123456,"username":"a","avatar":"x"}"#;
+        let user: UserData = serde_json::from_str(json).unwrap();
+        assert_eq!(user.id, 123456);
+    }
+
+    #[test]
+    fn rejects_unsafe_float_id() {
+        // 66154228472619010 cannot be represented exactly as f64; if the
+        // value reached us as a float we know precision has already been
+        // lost, so we must reject rather than silently corrupt the id.
+        let json = r#"{"id":66154228472619010.0,"username":"a","avatar":"x"}"#;
+        let err = serde_json::from_str::<UserData>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be represented"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -9,7 +9,9 @@ use log::{Level, error, info};
 use rexie::{ObjectStore, Rexie, Store, Transaction, TransactionMode};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use ultros_api_types::{bootstrap::Bootstrap, world::WorldData, world_helper::WorldHelper};
+use ultros_api_types::{
+    bootstrap::Bootstrap, user::UserData, world::WorldData, world_helper::WorldHelper,
+};
 use ultros_app::*;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
@@ -211,6 +213,32 @@ async fn get_region() -> String {
     }
 }
 
+/// Best-effort fetch of the current user when the SSR bootstrap is missing.
+///
+/// Returns `Some(user)` if logged in, `None` if the server says we're not
+/// authenticated (401 / etc.). Any other failure also collapses to `None` —
+/// the hydration view tree just renders as logged-out, which matches what
+/// the SSR side would have rendered for an unauthenticated request.
+async fn fetch_current_user_fallback() -> Option<UserData> {
+    let response = match Request::get("/api/v1/current_user").send().await {
+        Ok(r) => r,
+        Err(e) => {
+            error!("current_user fetch failed: {e}");
+            return None;
+        }
+    };
+    if !response.ok() {
+        return None;
+    }
+    match response.json::<UserData>().await {
+        Ok(user) => Some(user),
+        Err(e) => {
+            error!("current_user parse failed: {e}");
+            None
+        }
+    }
+}
+
 fn set_panic_hook() {
     std::panic::set_hook(Box::new(|panic_info| {
         console_error_panic_hook::hook(panic_info);
@@ -308,15 +336,23 @@ pub fn hydrate() {
                 Some(b.current_user),
             )
         } else {
-            info!("bootstrap missing — falling back to HTTP for world_data + region");
-            let (_, (worlds, region)) = join(
+            info!(
+                "bootstrap missing — falling back to HTTP for world_data + region + current_user"
+            );
+            // Fetch current_user alongside the other fallbacks so we can
+            // provide BootstrapUser context before hydration runs. Otherwise
+            // the SSR DOM (rendered with the server's view of auth state)
+            // and the client view tree (auth state still loading) diverge
+            // and tachys hydration panics at hydration.rs:163.
+            let (_, ((worlds, region), current_user)) = join(
                 populate_xiv_gen_data(),
-                join(get_world_data(), get_region()),
+                join(
+                    join(get_world_data(), get_region()),
+                    fetch_current_user_fallback(),
+                ),
             )
             .await;
-            // current_user remains absent here; ProfileDisplay will hit
-            // /api/v1/current_user via the existing fetch path.
-            (worlds, region, None)
+            (worlds, region, Some(current_user))
         };
         info!("hydrating body");
         let world_data = match worlds {


### PR DESCRIPTION
## Summary

- `UserData.id` is now serialized as a JSON string and deserialized from either a string or a number, so Discord snowflakes above 2^53 survive the JS parser intact. This is what was breaking `__ULTROS_BOOTSTRAP__` decoding for logged-in users and cascading into a tachys hydration panic.
- The bootstrap-missing fallback in `hydrate()` now also fetches `/api/v1/current_user` (in parallel with world_data + region) and unconditionally provides the `BootstrapUser` context before hydration, so any future bootstrap decode failure degrades cleanly instead of crashing the page.

## Why

Reported via console output: `Failed to decode __ULTROS_BOOTSTRAP__: Error: invalid type: floating point '66154228472619010.0', expected u64`, followed by `panicked at .../tachys-0.2.11/src/hydration.rs:163: internal error: entered unreachable code`.

Chain of events:
1. SSR in `ultros/src/leptos.rs` emits `serde_json::to_string(&BootstrapRef { ... })` — `UserData.id: u64` becomes a bare JSON number like `66154228472619010`.
2. The browser's JS parser converts that integer literal to f64 (Number can only represent integers exactly up to 2^53 ≈ 9.0e15). Precision lost before any Rust code runs.
3. `serde_wasm_bindgen::from_value::<Bootstrap>` sees a float where it expects u64 and errors out.
4. Client falls back to the legacy fetch path. The fallback was deliberately *not* setting `BootstrapUser`, so the client view tree expected "auth still loading" while the SSR DOM showed the logged-in view → tachys hydration mismatch → unreachable panic.

This hit any logged-in user with a Discord ID above 2^53 (i.e., basically every account created in the last several years).

## Changes

- **`ultros-api-types/src/user/user_data.rs`** — custom `u64_string` serde adapter on `UserData.id`. Serializes as a string, deserializes from string or number, rejects f64 inputs above the safe-integer boundary (since those values have already lost precision and silently returning a corrupted id would be worse than the loud error). Matches Discord's own snowflake-as-string convention.
- **`ultros-frontend/ultros-client/src/lib.rs`** — new `fetch_current_user_fallback()` helper; fallback path joins it with world_data + region, always provides `BootstrapUser(Option<UserData>)` before hydration. Treats network errors / non-2xx as `None` (renders logged-out, same as an unauthenticated SSR would).

The `/api/v1/current_user` JSON shape changes from `"id": 12345` to `"id": "12345"`. The only consumer is this repo's own WASM client, which accepts either via the adapter.

## Tests

New unit tests in `user_data.rs`:
- `snowflake_round_trips_as_string` — UserData with a real snowflake serializes as a string and deserializes back to the same u64.
- `deserializes_legacy_numeric_id` — backward-compatible with JSON that still emits `id` as a number (e.g. cached responses, third-party clients).
- `rejects_unsafe_float_id` — confirms we error rather than silently corrupt when an f64 above 2^53 is presented.

## Verification

- `cargo test -p ultros-api-types --lib user` — 3/3 pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros-api-types --all-targets -- -D warnings` — clean
- `cargo check -p ultros-client --target wasm32-unknown-unknown` — clean

The 4 `clippy::type_complexity` errors visible in `ultros-app/src/ws/realtime.rs` on a full workspace `cargo clippy --target wasm32-unknown-unknown` run are pre-existing on `origin/main` (confirmed by stash-and-rerun); this PR does not introduce them and CI doesn't flag them.

## Test plan

- [ ] Deploy to staging; log in with an account whose Discord ID exceeds 2^53; confirm no `__ULTROS_BOOTSTRAP__` decode error in console and no tachys hydration panic.
- [ ] Confirm `window.__ULTROS_BOOTSTRAP__.current_user.id` is now a string in the SSR HTML.
- [ ] Sanity-check the legacy-numeric path: synthetically corrupt the bootstrap script so it's missing, confirm the fallback fetches `/api/v1/current_user` and the page hydrates without panic for both logged-in and logged-out users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)