### PR TITLE
build: revert WASM debug-symbols experiment, strip instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,10 +117,6 @@ opt-level = "z"
 strip = "debuginfo"
 # codegen-units = 1
 
-[profile.wasm-release]
-inherits = "release"
-debug = 1
-
 [profile.dev]
 # opt-level = 1
 # codegen-units = 256
@@ -139,14 +135,7 @@ opt-level = 1
 name = "ultros"
 bin-package = "ultros"
 lib-package = "ultros-client"
-lib-profile-release = "wasm-release"
 output-name = "ultros"
-wasm-opt-features = [
-    "-Oz",
-    "-g",
-    "--enable-bulk-memory",
-    "--enable-nontrapping-float-to-int",
-]
 # The site root folder is where cargo-leptos generate all output.
 # NOTE: It is relative to the workspace root when running in a workspace.
 # WARNING: all content of this folder will be erased on a rebuild.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,27 +13,6 @@ RUN rustup target add wasm32-unknown-unknown
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 RUN cargo binstall cargo-leptos@0.3 -y
 RUN cargo binstall wasm-bindgen-cli@0.2.121 -y
-# Install a recent binaryen so cargo-leptos picks up wasm-opt from PATH instead
-# of its bundled (older) version, which can't decode DWARF emitted by recent
-# nightly rustc ("unknown subopcode 225 ... unsupported version of DWARF").
-# Binaryen ships libbinaryen.so alongside the binary, so we copy lib/* into
-# /usr/local/lib and ldconfig before invoking wasm-opt.
-ARG BINARYEN_VERSION=version_129
-RUN set -eux; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) asset="binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" ;; \
-        aarch64) asset="binaryen-${BINARYEN_VERSION}-aarch64-linux.tar.gz" ;; \
-        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
-    esac; \
-    curl -L --proto '=https' --tlsv1.2 -fsSL \
-        "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/${asset}" \
-        | tar -xz -C /tmp; \
-    cp "/tmp/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/; \
-    cp -r "/tmp/binaryen-${BINARYEN_VERSION}/lib/." /usr/local/lib/; \
-    rm -rf "/tmp/binaryen-${BINARYEN_VERSION}"; \
-    ldconfig; \
-    wasm-opt --version
 # RUN cargo install --locked cargo-leptos --version 0.2.43 -v
 COPY ./rust-toolchain .
 RUN rustup update
@@ -43,7 +22,7 @@ RUN apt install -y git pkg-config fontconfig libfontconfig1-dev
 COPY . .
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 ENV WASM_BINDGEN_WEAKREF=1
-RUN cargo leptos --manifest-path=./Cargo.toml build --release --wasm-debug -vv
+RUN cargo leptos --manifest-path=./Cargo.toml build --release -vv
 
 FROM debian:bookworm-slim as runner
 COPY --from=builder /app/target/release/ultros /app/


### PR DESCRIPTION
## Summary

We added a WASM-debug-symbols pipeline a few PRs back (#624 → #625 → #626) to get richer stacks in production, but ended up just stripping symbols. This rolls back the leftover machinery so the build is back to a plain stripped wasm.

## What changes

**Cargo.toml**
- Remove `[profile.wasm-release]` (inherited release + `debug = 1`).
- Remove `lib-profile-release = "wasm-release"` from `[[workspace.metadata.leptos]]`, so the wasm build falls through to `[profile.release]`, which already has `strip = "debuginfo"`.
- Remove the `wasm-opt-features` override (the `-g` keep-DWARF flag and friends). cargo-leptos's defaults are fine.

**Dockerfile**
- Drop the upstream binaryen 129 install block. That existed only because the bundled wasm-opt couldn't decode DWARF from recent nightly rustc — with no DWARF emitted, the bundled version works again.
- Drop `--wasm-debug` from the `cargo leptos build` invocation.

## Net effect

- Smaller stripped wasm shipped to clients.
- Docker builder no longer pulls a binaryen release tarball from GitHub on every build.
- No behavioral change to the server binary (its profile didn't move).

## Test plan

- [ ] CI: clippy + fmt pass.
- [ ] Docker build succeeds end-to-end (no DWARF-related wasm-opt failure, since DWARF is no longer emitted).
- [ ] Loaded site loads and the client wasm boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)