### PR TITLE
chore(sentry): filter unactionable WASM fetch errors from GlitchTip noise

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -115,6 +115,51 @@ fn error_reporting_script() -> Option<String> {
         }});
     }};
 
+    // Patterns for unactionable noise from the Sentry browser SDK's
+    // global unhandledrejection handler — almost always users navigating
+    // away during WASM streaming compile, ad blockers, or corporate
+    // proxies cutting off a /pkg/<hash>/ultros.wasm fetch. See
+    // GlitchTip issues #21 (~880 events), #2374, and #2404.
+    var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
+
+    function isUltrosWasmFetchAbort(event) {{
+        try {{
+            var ex = event && event.exception && event.exception.values && event.exception.values[0];
+            if (!ex) return false;
+
+            // "WebAssembly compilation aborted: ..." — always network/abort.
+            if (ex.type === "TypeError" && typeof ex.value === "string"
+                && ex.value.indexOf("WebAssembly compilation aborted") === 0) {{
+                return true;
+            }}
+
+            // "TypeError: Failed to fetch" originating from the wasm-bindgen
+            // glue loading /pkg/<hash>/ultros.{{js,wasm}}.
+            if (ex.type === "TypeError" && ex.value === "Failed to fetch") {{
+                var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+                for (var i = 0; i < frames.length; i++) {{
+                    var fname = frames[i] && frames[i].filename;
+                    if (typeof fname === "string" && ULTROS_PKG_BUNDLE_RE.test(fname)) {{
+                        return true;
+                    }}
+                }}
+            }}
+        }} catch (_) {{ /* be defensive — never let the filter throw */ }}
+        return false;
+    }}
+
+    var existingBeforeSend = config && config.beforeSend;
+    config = config || {{}};
+    config.beforeSend = function(event, hint) {{
+        if (isUltrosWasmFetchAbort(event)) {{
+            return null;
+        }}
+        if (typeof existingBeforeSend === "function") {{
+            return existingBeforeSend(event, hint);
+        }}
+        return event;
+    }};
+
     var init = function() {{
         if (!window.Sentry || !window.Sentry.init) {{
             return;


### PR DESCRIPTION
## Summary

Adds a `beforeSend` hook around the inline Sentry browser SDK init in `ultros-frontend/ultros-app/src/lib.rs::error_reporting_script` that drops two well-defined unactionable patterns the SDK's global `auto.browser.global_handlers.onunhandledrejection` keeps flagging:

- `TypeError: "Failed to fetch"` where any stack frame filename matches `/pkg/<hash>/ultros.(js|wasm)` — the wasm-bindgen glue couldn't finish loading the bundle (tab closed mid-load, ad blocker, corporate proxy, etc.).
- `TypeError` whose message starts with `"WebAssembly compilation aborted"` — always a network/abort, never our code.

The filter is defensive (try/catch, optional chaining via `&&` guards) and preserves any user-provided `beforeSend` if we add one later. All other Sentry events — including the existing `RustWasmPanic` captures from `__ultrosReportRustPanic` and any user-thrown JS errors — flow through unchanged.

## Why

Three GlitchTip issues fire constantly from real users navigating away during WASM streaming compile or having flaky networks. They are not bugs in our code, but they drown out real signal:

- **Issue #21** — ~880 events. `TypeError: Failed to fetch` originating in `Module.nt` (the wasm-bindgen loader) trying to GET `/pkg/<hash>/ultros.wasm`.
- **Issue #2374** — 4 events. Same pattern but the SDK attributes it directly to `/pkg/<hash>/ultros.js`.
- **Issue #2404** — 1 event. `TypeError: WebAssembly compilation aborted: Network error: Response body loading was aborted`.

The actual hydration panic that is likely *causing* some of the failed wasm loads on certain routes is being tracked separately — this PR is purely about silencing the post-hoc network noise that is making the issue list unreadable.

## Test plan

- [ ] Smoke-load https://ultros.app, confirm hydration still works and no new GlitchTip events appear from a clean navigation.
- [ ] In DevTools console run `throw new Error("sentry filter test")` — confirm a new event appears in GlitchTip (the filter must not drop arbitrary errors).
- [ ] In DevTools, throttle network to Offline, hard-reload a page, then quickly close the tab while `/pkg/<hash>/ultros.wasm` is still in flight — confirm no new event is generated.
- [ ] Sanity: `cargo fmt --all -- --check` is clean; `cargo clippy -p ultros-app --all-targets -- -D warnings` is clean. Full-workspace clippy was not re-run here due to concurrent local build lock contention, but the change is a Rust string literal inside `ultros-app` only — other crates do not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)