### PR TITLE
fix(nav): pin side rail to viewport (100vh fixed)

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -1518,6 +1518,12 @@ a:not(.nav-link):not(.btn):not(.btn-primary):not(.btn-secondary):not(
 
 .app-shell > .side-nav {
     grid-area: side;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 240px;
+    z-index: 30;
 }
 .app-shell > .top-bar {
     grid-area: top;
@@ -1540,6 +1546,9 @@ a:not(.nav-link):not(.btn):not(.btn-primary):not(.btn-secondary):not(
 @media (min-width: 1024px) {
     .app-shell.app-shell-collapsed {
         grid-template-columns: 56px minmax(0, 1fr);
+    }
+    .app-shell.app-shell-collapsed > .side-nav {
+        width: 56px;
     }
 }
 


### PR DESCRIPTION
## Summary

The side rail was a CSS grid cell on desktop, so when page content exceeded 100vh the grid row grew and the sidebar grew with it — instead of staying pinned to the left at full viewport height.

Made `.app-shell > .side-nav` `position: fixed` with `top: 0; bottom: 0; left: 0; width: 240px` (and `width: 56px` for the collapsed state). The grid column still reserves 240px (or 56px collapsed) so the topbar / content / ad-rail layout is unchanged — the sidebar just no longer participates in row sizing.

## Notes for reviewer

- Mobile drawer rules at `style/tailwind.css:1554` already set their own `position: fixed` + `width: 280px` + `transform: translateX(-100%)`, which override the new base rule cleanly. Drawer behavior is unaffected.
- `.side-nav` already has `overflow-y: auto`, so if the nav links ever exceed viewport height the column scrolls independently.

## Test plan

- [ ] Load any long page (e.g. items list) at >= 1024px; sidebar stays at 100vh while main content scrolls past it
- [ ] Toggle collapse — sidebar shrinks to 56px and content reflows correctly
- [ ] Mobile (<1024px): hamburger still opens/closes the drawer with backdrop

🤖 Generated with [Claude Code](https://claude.com/claude-code)