### PR TITLE
fix(analyzer): UX polish — reactive tax toggle, collapsed tool header, bounded sales filter

### DIFF
--- a/ultros-frontend/ultros-app/src/components/tool_help.rs
+++ b/ultros-frontend/ultros-app/src/components/tool_help.rs
@@ -16,33 +16,32 @@ pub fn ToolHeader(
     let help_href_text = help_href.to_string();
 
     view! {
-        <section class="panel p-4 sm:p-6 rounded-2xl flex flex-col gap-4">
-            <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
-                <div class="flex flex-col gap-2 max-w-3xl">
-                    <h1 class="text-2xl sm:text-3xl font-bold text-[color:var(--brand-fg)]">
-                        {title.clone()}
-                    </h1>
-                    <p class="text-base sm:text-lg text-[color:var(--color-text)] leading-relaxed">
-                        {summary.clone()}
-                    </p>
-                    {move || {
-                        context_text.clone().map(|context| view! {
-                            <p class="text-sm text-[color:var(--color-text-muted)]">{context}</p>
-                        })
-                    }}
-                </div>
+        <section class="panel px-4 py-3 sm:px-6 sm:py-4 rounded-2xl flex flex-col gap-3">
+            <div class="flex flex-row items-center justify-between gap-3">
+                <h1 class="text-xl sm:text-2xl font-bold text-[color:var(--brand-fg)]">
+                    {title.clone()}
+                </h1>
                 <button
                     type="button"
-                    class="btn-secondary self-start"
+                    class="btn-secondary self-center"
                     aria-expanded=move || if is_open() { "true" } else { "false" }
                     on:click=move |_| set_is_open.update(|open| *open = !*open)
                 >
                     <Icon icon=i::BsInfoCircle width="1em" height="1em" />
-                    <span>"About this tool"</span>
+                    <span>{move || if is_open() { "Hide info" } else { "About this tool" }}</span>
                 </button>
             </div>
             <Show when=move || is_open()>
-                <div class="rounded-xl border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)] p-4 flex flex-col gap-3">
+                <div class="rounded-xl border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)] p-4 flex flex-col gap-3 max-w-3xl">
+                    <p class="text-base text-[color:var(--color-text)] leading-relaxed">
+                        {summary.clone()}
+                    </p>
+                    {
+                        let context_text = context_text.clone();
+                        move || context_text.clone().map(|context| view! {
+                            <p class="text-sm text-[color:var(--color-text-muted)]">{context}</p>
+                        })
+                    }
                     <p class="text-sm leading-relaxed text-[color:var(--color-text)]">
                         {help_body.clone()}
                     </p>

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -523,19 +523,20 @@ fn AnalyzerTable(
                         }
                     />
                 </ToolbarField>
-                <ToolbarField label="Sales (Min)">
+                <ToolbarField label="Sales (Min, of 6)">
                     <input
                         class="input input-sm w-24"
                         min=0
-                        max=1000
+                        max=6
                         step=1
-                        placeholder="e.g. 5"
+                        placeholder="0–6"
+                        title="Each item only ships its 6 most recent sales. Set 1–6 to require that many of those sales were observed."
                         type="number"
                         prop:value=minimum_sales
                         on:input=move |input| {
                             let value = event_target_value(&input);
                             if let Ok(sales) = value.parse::<usize>() {
-                                set_minimum_sales(Some(sales));
+                                set_minimum_sales(Some(sales.min(6)));
                             } else if value.is_empty() {
                                 set_minimum_sales(None);
                             }
@@ -592,13 +593,13 @@ fn AnalyzerTable(
                     // Default unwrap_or(true) means post-tax is the default
                     <ToolbarPills>
                         <button
-                            aria-pressed={if tax_enabled().unwrap_or(true) { "false" } else { "true" }}
+                            aria-pressed=move || if tax_enabled().unwrap_or(true) { "false" } else { "true" }
                             on:click=move |_| set_tax_enabled(Some(false))
                         >
                             "Pre-tax"
                         </button>
                         <button
-                            aria-pressed={if tax_enabled().unwrap_or(true) { "true" } else { "false" }}
+                            aria-pressed=move || if tax_enabled().unwrap_or(true) { "true" } else { "false" }
                             on:click=move |_| set_tax_enabled(Some(true))
                         >
                             "Post-tax"

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -352,19 +352,20 @@ fn VendorResaleTable(
                         }
                     />
                 </ToolbarField>
-                <ToolbarField label="Sales (Min)">
+                <ToolbarField label="Sales (Min, of 6)">
                     <input
                         class="input input-sm w-24"
                         min=0
-                        max=1000
+                        max=6
                         step=1
-                        placeholder="e.g. 5"
+                        placeholder="0–6"
+                        title="Each item only ships its 6 most recent sales. Set 1–6 to require that many of those sales were observed."
                         type="number"
                         prop:value=minimum_sales
                         on:input=move |input| {
                             let value = event_target_value(&input);
                             if let Ok(sales) = value.parse::<usize>() {
-                                set_minimum_sales(Some(sales));
+                                set_minimum_sales(Some(sales.min(6)));
                             } else if value.is_empty() {
                                 set_minimum_sales(None);
                             }
@@ -401,13 +402,13 @@ fn VendorResaleTable(
                 <ToolbarField label="Prices">
                     <ToolbarPills>
                         <button
-                            aria-pressed={if tax_enabled().unwrap_or(true) { "false" } else { "true" }}
+                            aria-pressed=move || if tax_enabled().unwrap_or(true) { "false" } else { "true" }
                             on:click=move |_| set_tax_enabled(Some(false))
                         >
                             "Pre-tax"
                         </button>
                         <button
-                            aria-pressed={if tax_enabled().unwrap_or(true) { "true" } else { "false" }}
+                            aria-pressed=move || if tax_enabled().unwrap_or(true) { "true" } else { "false" }
                             on:click=move |_| set_tax_enabled(Some(true))
                         >
                             "Post-tax"


### PR DESCRIPTION
## Summary

Three small UX fixes on Flip Finder (and, where applicable, Vendor Resale):

- **Pre-tax/Post-tax pill is now reactive.** The `aria-pressed` attribute was set with a Rust `{ if … }` block instead of a `move ||` closure, so it evaluated once at render time and the highlight never moved when you clicked. Same bug existed in Vendor Resale. (`recipe_analyzer.rs` and `trends.rs` already used the closure form — left alone.)
- **`ToolHeader` collapses the prose by default.** The hero band was eating ~5 rows on every analyzer page. Now it renders title + "About this tool" button; clicking the button reveals the summary, context, and help body in the existing disclosure. Affects every tool using `ToolHeader` (Flip Finder, Vendor Resale, Recipe Analyzer, FC Crafting, Leve, Trends, Scrip Sources, Venture).
- **Sales (Min) filter is bounded to the data window.** The API only ships the 6 most recent sales per item (`SALE_HISTORY_SIZE`) and there's no quantity field, so the filter could never meaningfully require more than 6. The input accepted up to 1000 and silently filtered everything for higher values. Now: `max=6`, `placeholder="0–6"`, label is "Sales (Min, of 6)", tooltip explains the window, and the value is clamped on parse.

## Out of scope

- The in-panel `CalculationSummary` ("How profit is estimated") and `AssumptionBadge` chips are still visible — those are a separate secondary band. Worth revisiting if you want more compression.
- A velocity-based replacement for Sales (Min) (sales/day instead of raw count) would be more useful given the existing "Last sold ≤ N days" chip. Not done here.

## Test plan

- [ ] Open Flip Finder, click Pre-tax / Post-tax pills — highlight should track the selection
- [ ] Open Vendor Resale, same check
- [ ] Confirm the "About this tool" disclosure on Flip Finder hides the summary + context until expanded, and that the existing "Open full help" link still works
- [ ] Spot-check other tools that use `ToolHeader` (Recipe Analyzer, Leve, Trends) — header should be a single compact row
- [ ] Type 1000 in Sales (Min) on Flip Finder — input should clamp to 6 and not nuke the result set

🤖 Generated with [Claude Code](https://claude.com/claude-code)