### PR TITLE
fix(bot): paste-friendly item commands and multi-locale support

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1027,20 +1027,31 @@ fn ListingsContent(item_id: Memo<i32>, world: Memo<String>) -> impl IntoView {
 #[component]
 fn DiscordCommandChip(
     #[prop(into)] item_name: Signal<String>,
+    #[prop(into)] item_id: Signal<i32>,
     #[prop(into)] world_name: Signal<String>,
 ) -> impl IntoView {
-    let command = Signal::derive(move || {
+    // The `item` slash-command parameter is typed as an INTEGER on the Discord side,
+    // so a pasted command needs the item id, not a name. We show the name in the chip
+    // for human readability and put the id in the clipboard payload.
+    let display_command = Signal::derive(move || {
         format!(
             "/ffxiv prices current item:{} world:{}",
             item_name.get(),
             world_name.get(),
         )
     });
+    let clipboard_command = Signal::derive(move || {
+        format!(
+            "/ffxiv prices current item:{} world:{}",
+            item_id.get(),
+            world_name.get(),
+        )
+    });
     view! {
         <div class="inline-flex items-center gap-2 rounded-md border border-brand-500/30 bg-black/30 px-2.5 py-1 text-xs">
             <span class="text-[color:var(--color-text-muted)]">"Discord:"</span>
-            <code class="font-mono">{move || command.get()}</code>
-            <Clipboard clipboard_text=command />
+            <code class="font-mono">{move || display_command.get()}</code>
+            <Clipboard clipboard_text=clipboard_command />
         </div>
     }
 }
@@ -1166,6 +1177,7 @@ pub fn ItemView() -> impl IntoView {
                                 <div class="mt-1.5">
                                     <DiscordCommandChip
                                         item_name=Signal::derive(move || item_name().to_string())
+                                        item_id=Signal::derive(move || item_id.get())
                                         world_name=Signal::derive(move || world.get())
                                     />
                                 </div>

--- a/ultros/src/discord/ffxiv/alert.rs
+++ b/ultros/src/discord/ffxiv/alert.rs
@@ -2,9 +2,9 @@ use anyhow::anyhow;
 use itertools::Itertools;
 use poise::CreateReply;
 use poise::serenity_prelude::CreateEmbed;
-use xiv_gen::ItemId;
 
 use crate::discord::ffxiv::helpers;
+use crate::discord::ffxiv::helpers::{discord_locale_to_xiv_language, localized_item_name};
 
 use super::{Context, Error, ULTROS_COLOR};
 
@@ -103,14 +103,16 @@ async fn list(ctx: Context<'_>) -> Result<(), Error> {
             .await?;
         return Ok(());
     }
-    let items = &xiv_gen_db::data().items;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let lines = rows
         .into_iter()
         .map(|(a, t)| {
-            let item_name = items
-                .get(&ItemId(t.item_id))
-                .map(|it| it.name.as_str())
-                .unwrap_or("?");
+            let item_name = localized_item_name(t.item_id, user_lang);
+            let item_name = if item_name.is_empty() {
+                "?".to_string()
+            } else {
+                item_name
+            };
             let status = if a.enabled { "✅" } else { "⏸" };
             format!(
                 "{status} `#{id}` {name} ≤ {price} gil{hq}",

--- a/ultros/src/discord/ffxiv/analyze.rs
+++ b/ultros/src/discord/ffxiv/analyze.rs
@@ -1,9 +1,11 @@
 use poise::serenity_prelude::Color;
 use std::fmt::Write;
-use xiv_gen::ItemId;
 
 use crate::analyzer_service::ResaleOptions;
-use crate::discord::ffxiv::helpers::{clamp_sold_amount, threshold_days_to_sold_within};
+use crate::discord::ffxiv::helpers::{
+    clamp_sold_amount, discord_locale_to_xiv_language, localized_item_name,
+    threshold_days_to_sold_within,
+};
 
 use super::{Context, Error};
 
@@ -52,8 +54,7 @@ pub(crate) async fn profit(
     let amount = clamp_sold_amount(number_recently_sold);
     let filter_sale = threshold_days_to_sold_within(threshold_days, amount);
 
-    let xiv_data = xiv_gen_db::data();
-    let items = &xiv_data.items;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let resale = ResaleOptions {
         minimum_profit: Some(minimum_profit),
         filter_sale: Some(filter_sale),
@@ -75,10 +76,7 @@ pub(crate) async fn profit(
             .description({
                 let mut content = format!("`{:<30} |  roi  | profit`\n", "item name");
                 for sale in sales {
-                    let item_name = items
-                        .get(&ItemId(sale.item_id))
-                        .map(|i| i.name.as_str())
-                        .unwrap_or_default();
+                    let item_name = localized_item_name(sale.item_id, user_lang);
                     let item_name: String = item_name.chars().take(30).collect();
                     writeln!(
                         &mut content,

--- a/ultros/src/discord/ffxiv/helpers.rs
+++ b/ultros/src/discord/ffxiv/helpers.rs
@@ -4,7 +4,7 @@
 use anyhow::anyhow;
 use ultros_api_types::world_helper::AnySelector;
 use ultros_db::entity::active_listing;
-use xiv_gen::ItemId;
+use xiv_gen::{ItemId, Language};
 
 use super::{Context, Error};
 use crate::analyzer_service::{SoldAmount, SoldWithin};
@@ -66,36 +66,140 @@ pub(crate) fn top_n_cheapest_listings(
         .collect()
 }
 
-/// Discord autocomplete handler for item-name string args. Returns up to 99 game items
-/// whose lowercased name contains the partial input. The choice value is the item name
-/// (callers should resolve it to an id via [`resolve_item_id`]).
+/// Map Discord's locale string (e.g. "ja", "de", "zh-CN") to the closest
+/// `xiv_gen::Language`. Falls back to English for unrecognized or missing locales.
+///
+/// Discord's documented locale codes:
+/// <https://discord.com/developers/docs/reference#locales>
+pub(crate) fn discord_locale_to_xiv_language(locale: Option<&str>) -> Language {
+    match locale.unwrap_or("") {
+        "ja" => Language::Ja,
+        "de" => Language::De,
+        "fr" => Language::Fr,
+        "zh-CN" => Language::Cn,
+        "ko" => Language::Ko,
+        "zh-TW" => Language::Tc,
+        _ => Language::En,
+    }
+}
+
+/// Look up an item id by name across every supported locale. Matches the lowercased
+/// name exactly; returns the first locale that contains the name. Used so users can
+/// paste a localized item name from anywhere on the site and have the bot resolve it.
+pub(crate) fn resolve_item_id_any_locale(name: &str) -> Option<i32> {
+    let lowered = name.to_lowercase();
+    for (_, data) in xiv_gen_db::all_locales() {
+        if let Some((ItemId(id), _)) = data
+            .items
+            .iter()
+            .find(|(_, item)| item.name.to_lowercase() == lowered)
+        {
+            return Some(*id);
+        }
+    }
+    None
+}
+
+/// A single autocomplete suggestion: a display label (localized into the user's
+/// language when possible) and the item id it resolves to. Returned by
+/// [`localized_item_matches`] and used to build the two flavors of Discord
+/// autocomplete (string-valued and integer-valued).
+pub(crate) struct LocalizedItemMatch {
+    pub label: String,
+    pub item_id: i32,
+}
+
+/// Search every supported locale for items whose name contains `partial`. Each
+/// matched item appears at most once: when more than one locale matched, the
+/// user's locale wins for the display name; otherwise the first locale that
+/// matched wins. If the localized display differs from the English name, the
+/// English name is appended in parentheses so the user can confirm the item.
+pub(crate) fn localized_item_matches(
+    partial: &str,
+    user_lang: Language,
+) -> Vec<LocalizedItemMatch> {
+    let needle = partial.to_lowercase();
+    let en = xiv_gen_db::data_for(Language::En);
+
+    let mut seen: std::collections::HashMap<i32, (Language, String)> =
+        std::collections::HashMap::new();
+    for (lang, data) in xiv_gen_db::all_locales() {
+        for (ItemId(id), item) in &data.items {
+            if item.name.is_empty() || !name_matches_lowered(&item.name, &needle) {
+                continue;
+            }
+            seen.entry(*id)
+                .and_modify(|(existing_lang, existing_name)| {
+                    if *existing_lang != user_lang && lang == user_lang {
+                        *existing_lang = lang;
+                        *existing_name = item.name.to_string();
+                    }
+                })
+                .or_insert_with(|| (lang, item.name.to_string()));
+        }
+    }
+
+    let mut out: Vec<LocalizedItemMatch> = seen
+        .into_iter()
+        .filter_map(|(id, (_, display))| {
+            let en_name = en.items.get(&ItemId(id))?.name.to_string();
+            if en_name.is_empty() {
+                return None;
+            }
+            let label = if display == en_name {
+                en_name
+            } else {
+                format!("{display} ({en_name})")
+            };
+            Some(LocalizedItemMatch { label, item_id: id })
+        })
+        .collect();
+    out.sort_by(|a, b| a.label.cmp(&b.label));
+    out.truncate(99);
+    out
+}
+
+/// Discord autocomplete handler for item-name string args. Searches every supported
+/// locale for substring matches; deduplicates by item id; prefers the user's locale
+/// for display when the same item matched in multiple locales. The choice value is
+/// the canonical English item name so existing callers of [`resolve_item_id`] keep
+/// working unchanged.
 pub(crate) async fn autocomplete_item<'a>(
-    _ctx: Context<'_>,
+    ctx: Context<'_>,
     partial: &'a str,
 ) -> impl Iterator<Item = poise::serenity_prelude::AutocompleteChoice> + 'a {
-    let partial = partial.to_lowercase();
-    xiv_gen_db::data()
-        .items
-        .values()
-        .filter(move |item| name_matches_lowered(&item.name, &partial))
-        .map(|item| {
-            poise::serenity_prelude::AutocompleteChoice::new(
-                item.name.to_string(),
-                item.name.to_string(),
-            )
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
+    let en = xiv_gen_db::data_for(Language::En);
+    localized_item_matches(partial, user_lang)
+        .into_iter()
+        .filter_map(move |m| {
+            let en_name = en.items.get(&ItemId(m.item_id))?.name.to_string();
+            Some(poise::serenity_prelude::AutocompleteChoice::new(
+                m.label, en_name,
+            ))
         })
-        .take(99)
 }
 
 /// Resolve a user-supplied item name (case-insensitive exact match) to an FFXIV item id.
-/// Returns `None` if no item with that exact name exists.
+/// Returns `None` if no item with that exact name exists in any supported locale.
 pub(crate) fn resolve_item_id(name: &str) -> Option<i32> {
-    let lowered = name.to_lowercase();
-    xiv_gen_db::data()
+    resolve_item_id_any_locale(name)
+}
+
+/// Return the localized display name for an item id, falling back to the English name,
+/// then to the empty string if the item is unknown.
+pub(crate) fn localized_item_name(item_id: i32, lang: Language) -> String {
+    let id = ItemId(item_id);
+    if let Some(item) = xiv_gen_db::data_for(lang).items.get(&id)
+        && !item.name.is_empty()
+    {
+        return item.name.to_string();
+    }
+    xiv_gen_db::data_for(Language::En)
         .items
-        .iter()
-        .find(|(_, item)| item.name.to_lowercase() == lowered)
-        .map(|(ItemId(id), _)| *id)
+        .get(&id)
+        .map(|i| i.name.to_string())
+        .unwrap_or_default()
 }
 
 /// Parse a world/datacenter/region name from a user-supplied string via the world cache.

--- a/ultros/src/discord/ffxiv/item_prices.rs
+++ b/ultros/src/discord/ffxiv/item_prices.rs
@@ -5,7 +5,10 @@ use ultros_db::world_data::world_cache::AnySelector;
 use xiv_gen::ItemId;
 
 use crate::discord::ffxiv::ULTROS_COLOR;
-use crate::discord::ffxiv::helpers::{name_matches_lowered, top_n_cheapest_listings};
+use crate::discord::ffxiv::helpers::{
+    discord_locale_to_xiv_language, localized_item_matches, localized_item_name,
+    name_matches_lowered, top_n_cheapest_listings,
+};
 use crate::web::item_card::generate_image;
 
 use super::{Context, Error};
@@ -17,18 +20,13 @@ pub(crate) async fn prices(_ctx: Context<'_>) -> Result<(), Error> {
 }
 
 async fn autocomplete_item<'a>(
-    _ctx: Context<'_>,
+    ctx: Context<'_>,
     partial: &'a str,
 ) -> impl Iterator<Item = poise::serenity_prelude::AutocompleteChoice> + 'a {
-    let partial = partial.to_lowercase();
-    xiv_gen_db::data()
-        .items
-        .values()
-        .filter(move |item| name_matches_lowered(&item.name, &partial))
-        .map(|item| {
-            poise::serenity_prelude::AutocompleteChoice::new(item.name.to_string(), item.key_id.0)
-        })
-        .take(99)
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
+    localized_item_matches(partial, user_lang)
+        .into_iter()
+        .map(|m| poise::serenity_prelude::AutocompleteChoice::new(m.label, m.item_id))
 }
 
 async fn autocomplete_world<'a>(
@@ -53,15 +51,19 @@ async fn current(
     hq_only: Option<bool>,
 ) -> Result<(), Error> {
     ctx.defer().await?;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let worlds = &ctx.data().world_cache;
     let world = worlds.lookup_value_by_name(&world)?;
     let world_ids = worlds
         .get_all_worlds_in(&world)
         .ok_or(anyhow!("bad world data"))?;
-    let item_data = xiv_gen_db::data()
+    // Verify the id is real before issuing the DB call; the title uses the
+    // user's locale, falling back to English.
+    xiv_gen_db::data_for(xiv_gen::Language::En)
         .items
         .get(&ItemId(item))
         .ok_or(anyhow!("bad item id"))?;
+    let item_display_name = localized_item_name(item, user_lang);
     let listings = ctx
         .data()
         .db
@@ -86,7 +88,7 @@ async fn current(
     ctx.send(
         poise::CreateReply::default().embed(
             poise::serenity_prelude::CreateEmbed::new()
-                .title(&item_data.name)
+                .title(&item_display_name)
                 .description(format!(
                     "```\n{:<10} {:3} {:<7} {}\n{}\n```",
                     "price", "hq", "quantity", "world", listings,
@@ -109,22 +111,26 @@ async fn history(
     world: String,
 ) -> Result<(), Error> {
     ctx.defer().await?;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let data = ctx.data();
-    let item = xiv_gen_db::data()
+    // The image generator needs the canonical English `Item` reference for its
+    // metadata lookups; the embed title uses the user's locale for display.
+    let item_en = xiv_gen_db::data_for(xiv_gen::Language::En)
         .items
         .get(&ItemId(item))
         .ok_or(anyhow!("Item not found"))?;
+    let item_display_name = localized_item_name(item, user_lang);
     let world = data
         .world_helper
         .lookup_world_by_name(&world)
         .ok_or(anyhow!("Unable to find world"))?;
-    let png = generate_image(&data.db, &data.world_helper, item, &world).await?;
+    let png = generate_image(&data.db, &data.world_helper, item_en, &world).await?;
     let attachment = CreateAttachment::bytes(png, "chart.png");
     ctx.send(
         poise::CreateReply::default()
             .embed(
                 poise::serenity_prelude::CreateEmbed::new()
-                    .title([&item.name, " - ", world.get_name()].concat())
+                    .title([&item_display_name, " - ", world.get_name()].concat())
                     .color(ULTROS_COLOR)
                     .image("attachment://chart.png"),
             )

--- a/ultros/src/discord/ffxiv/lists.rs
+++ b/ultros/src/discord/ffxiv/lists.rs
@@ -1,4 +1,8 @@
 use super::{Context, Error};
+use crate::discord::ffxiv::helpers::{
+    discord_locale_to_xiv_language, localized_item_matches, localized_item_name,
+    resolve_item_id_any_locale,
+};
 use anyhow::anyhow;
 use itertools::Itertools;
 use poise::serenity_prelude::User;
@@ -96,18 +100,23 @@ async fn autocomplete_list_name(
 }
 
 async fn autocomplete_item_name_global(
-    _ctx: Context<'_>,
+    ctx: Context<'_>,
     partial: &str,
 ) -> impl Iterator<Item = poise::serenity_prelude::AutocompleteChoice> {
-    let partial = partial.to_ascii_lowercase();
-    let items = &xiv_gen_db::data().items;
-    items
-        .iter()
-        .filter(move |(_, i)| !i.name.is_empty() && i.name.to_ascii_lowercase().contains(&partial))
-        .take(25)
-        .map(|(_, i)| {
-            poise::serenity_prelude::AutocompleteChoice::new(i.name.clone(), i.name.clone())
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
+    let en = xiv_gen_db::data_for(xiv_gen::Language::En);
+    localized_item_matches(partial, user_lang)
+        .into_iter()
+        .filter_map(move |m| {
+            let en_name = en.items.get(&ItemId(m.item_id))?.name.to_string();
+            if en_name.is_empty() {
+                return None;
+            }
+            Some(poise::serenity_prelude::AutocompleteChoice::new(
+                m.label, en_name,
+            ))
         })
+        .take(25)
         .collect::<Vec<_>>()
         .into_iter()
 }
@@ -321,11 +330,9 @@ async fn add_item(
     #[description = "hq? Leave blank for no filter"] hq: Option<bool>,
 ) -> Result<(), Error> {
     let author_id = ctx.author().id.get() as i64;
-    let (i, item) = xiv_gen_db::data()
-        .items
-        .iter()
-        .find(|(_, i)| i.name == item_name)
-        .ok_or(anyhow!("Unable to find item"))?;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
+    let item_id = resolve_item_id_any_locale(&item_name).ok_or(anyhow!("Unable to find item"))?;
+    let display_name = localized_item_name(item_id, user_lang);
     let list = ctx
         .data()
         .db
@@ -336,13 +343,13 @@ async fn add_item(
         .ok_or(anyhow!("List not found"))?;
     ctx.data()
         .db
-        .add_item_to_list(&list, author_id, i.0, hq, quantity, None)
+        .add_item_to_list(&list, author_id, item_id, hq, quantity, None)
         .await?;
     ctx.send(
         poise::CreateReply::default().embed(
             poise::serenity_prelude::CreateEmbed::new()
                 .title("Item added")
-                .description(format!("{} added to list {}", item.name, list.name)),
+                .description(format!("{} added to list {}", display_name, list.name)),
         ),
     )
     .await?;
@@ -358,12 +365,8 @@ async fn remove_item(
     list_name: String,
     #[description = "item to remove"] item_name: String,
 ) -> Result<(), Error> {
-    let items = &xiv_gen_db::data().items;
     let author_id = ctx.author().id.get() as i64;
-    let (id, _) = items
-        .iter()
-        .find(|(_, item)| item.name == item_name)
-        .ok_or(anyhow!("Unable to find item"))?;
+    let id = resolve_item_id_any_locale(&item_name).ok_or(anyhow!("Unable to find item"))?;
     let lists = ctx.data().db.get_lists_for_user(author_id).await?;
     let list = lists
         .into_iter()
@@ -375,7 +378,7 @@ async fn remove_item(
         .get_list_items(list.id, author_id)
         .await?
         .into_iter()
-        .find(|i| i.item_id == id.0)
+        .find(|i| i.item_id == id)
         .ok_or(anyhow!("Unable to find item on list"))?;
     ctx.data()
         .db
@@ -406,16 +409,12 @@ async fn show_list(
     list_listings
         .iter_mut()
         .for_each(|(_, listings)| listings.sort_by_key(|(l, _)| l.price_per_unit));
-    let items = &xiv_gen_db::data().items;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let description = list_listings
         .iter()
         .map(|(list, listings)| {
-            // get the item name, and first listing
             (
-                items
-                    .get(&ItemId(list.item_id))
-                    .map(|i| i.name.as_str())
-                    .unwrap_or_default(),
+                localized_item_name(list.item_id, user_lang),
                 listings
                     .first()
                     .map(|(l, _)| format!("{}", l.price_per_unit))

--- a/ultros/src/discord/ffxiv/retainer.rs
+++ b/ultros/src/discord/ffxiv/retainer.rs
@@ -1,10 +1,11 @@
 use crate::EventType;
-use crate::discord::ffxiv::helpers::name_matches_lowered_ascii;
+use crate::discord::ffxiv::helpers::{
+    discord_locale_to_xiv_language, localized_item_name, name_matches_lowered_ascii,
+};
 use itertools::Itertools;
 use poise::serenity_prelude::Color;
 use std::fmt::Write;
 use ultros_db::{entity::active_listing, world_data::world_cache::AnySelector};
-use xiv_gen::ItemId;
 
 use super::{Context, Error};
 
@@ -147,8 +148,7 @@ async fn check_undercuts(ctx: Context<'_>) -> Result<(), Error> {
     ctx.defer_ephemeral().await?;
     let user_id = ctx.author().id.get();
     let under_cut_items = ctx.data().db.get_retainer_undercut_items(user_id).await?;
-    let data = xiv_gen_db::data();
-    let item_db = &data.items;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let mut embeds = Vec::new();
     for (_, retainer, items) in &under_cut_items {
         if !items.is_empty() {
@@ -158,11 +158,7 @@ async fn check_undercuts(ctx: Context<'_>) -> Result<(), Error> {
                     "name", "price", "target price", "behind"
                 ),
                 |mut s, (listing, undercut)| {
-                    let item_id = ItemId(listing.item_id);
-                    let item_name = item_db
-                        .get(&item_id)
-                        .map(|i| i.name.as_str())
-                        .unwrap_or_default();
+                    let item_name = localized_item_name(listing.item_id, user_lang);
                     let _ = writeln!(
                         s,
                         "{:>30} {:>10}->{:>10} {:>5}",
@@ -212,8 +208,7 @@ async fn check_listings(ctx: Context<'_>) -> Result<(), Error> {
     if retainers.is_empty() {
         ctx.say("No retainers found :(").await?;
     }
-    let data = xiv_gen_db::data();
-    let items = &data.items;
+    let user_lang = discord_locale_to_xiv_language(ctx.locale());
     let embeds = retainers
         .into_iter()
         .map(|(_, retainer, listings)| {
@@ -226,10 +221,7 @@ async fn check_listings(ctx: Context<'_>) -> Result<(), Error> {
             )
             .unwrap();
             for listing in listings {
-                let item_name = items
-                    .get(&ItemId(listing.item_id))
-                    .map(|i| i.name.as_str())
-                    .unwrap_or_default();
+                let item_name = localized_item_name(listing.item_id, user_lang);
                 let active_listing::Model {
                     price_per_unit,
                     quantity,

--- a/xiv-gen-db/src/lib.rs
+++ b/xiv-gen-db/src/lib.rs
@@ -1,4 +1,6 @@
 use flate2::FlushDecompress;
+#[cfg(feature = "embed")]
+use std::sync::OnceLock;
 use std::sync::RwLock;
 #[cfg(feature = "embed")]
 use xiv_gen::Language;
@@ -33,6 +35,68 @@ pub fn data() -> &'static xiv_gen::Data {
 #[cfg(not(feature = "embed"))]
 pub fn data() -> &'static xiv_gen::Data {
     XIV_DATA.read().unwrap().expect("XIV data not initialized")
+}
+
+// Per-locale lazily-decoded data caches. Each slot is populated on first access
+// to `data_for(lang)` and then reused. Lives for the process lifetime — the
+// decoded structures are intentionally leaked to hand out `&'static` references
+// the same way `XIV_DATA` does.
+#[cfg(feature = "embed")]
+const LOCALE_COUNT: usize = 7;
+
+#[cfg(feature = "embed")]
+const ALL_LANGUAGES: [Language; LOCALE_COUNT] = [
+    Language::En,
+    Language::Ja,
+    Language::De,
+    Language::Fr,
+    Language::Cn,
+    Language::Ko,
+    Language::Tc,
+];
+
+#[cfg(feature = "embed")]
+fn language_index(lang: Language) -> usize {
+    match lang {
+        Language::En => 0,
+        Language::Ja => 1,
+        Language::De => 2,
+        Language::Fr => 3,
+        Language::Cn => 4,
+        Language::Ko => 5,
+        Language::Tc => 6,
+    }
+}
+
+#[cfg(feature = "embed")]
+static PER_LOCALE: [OnceLock<&'static xiv_gen::Data>; LOCALE_COUNT] = [
+    OnceLock::new(),
+    OnceLock::new(),
+    OnceLock::new(),
+    OnceLock::new(),
+    OnceLock::new(),
+    OnceLock::new(),
+    OnceLock::new(),
+];
+
+/// Return a `&'static` reference to the decoded data for the given language.
+/// Decompresses and leaks on first access for that locale; subsequent calls
+/// reuse the cached reference. Unlike `data()`, this does not interact with the
+/// mutable `XIV_DATA` global, so it is safe to use alongside locale switches.
+#[cfg(feature = "embed")]
+pub fn data_for(lang: Language) -> &'static xiv_gen::Data {
+    PER_LOCALE[language_index(lang)].get_or_init(|| {
+        let decoded = decompress_data(bincode(lang)).expect("embedded bincode must decode");
+        Box::leak(Box::new(decoded))
+    })
+}
+
+/// Iterate over every supported language paired with its data, populating any
+/// locales that haven't been touched yet. Use sparingly — the first call will
+/// decode all 7 locales.
+#[cfg(feature = "embed")]
+pub fn all_locales() -> impl Iterator<Item = (Language, &'static xiv_gen::Data)> {
+    ALL_LANGUAGES.iter().map(|&lang| (lang, data_for(lang)))
 }
 
 pub fn try_init(bytes: &[u8]) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

- **Item-page Discord chip now pastes successfully.** `DiscordCommandChip` copies the item id rather than the localized name; the chip's display is unchanged. The bot's `item` slash-command parameter is typed as INTEGER, so the previous `item:Vintage Viking Sword` text was rejected by Discord client-side validation before the bot ever saw it.
- **Bot accepts and displays item names in every supported locale.** `xiv-gen-db` exposes `data_for(Language)` and `all_locales()` (lazy per-locale decode, leaked via `OnceLock`). A new `localized_item_matches` helper searches every locale, dedupes by item id, and prefers the user's Discord locale for the autocomplete label (annotating with the English name when they differ). `localized_item_name` renders display names in the user's locale with English fallback.
- **All ffxiv autocompletes and embeds are now locale-aware.** Touched: `prices current`/`history`, `analyze profit`, `alert list`, `list add_item`/`remove_item`/`show_list`, retainer `check_undercuts`/`check_listings`. Existing string-keyed lookups (`resolve_item_id`) now match across every locale, so pasted Japanese/German/etc. item names also resolve.

## Why

Reported in conversation: the `/ffxiv prices current item:<name> world:<world>` rendered by the item page is unusable when pasted (wrong type), and the bot has no concept of language — autocomplete only returns English item names, embeds always display in English, and non-English pasted names fail name lookups.

## Notes for reviewers

- First call to `all_locales()` pays the cost of decoding all 7 locale bincodes (~tens of MB resident). Aaron OK'd the memory tradeoff over the alternative of accepting localized names only via roundtripping.
- The shared `helpers::autocomplete_item` keeps its value type (English item name) so existing callers (`alert price`) work unchanged; only the display label is localized.
- `item_prices::autocomplete_item` keeps the i32 value type (the bot's `item` parameter is `i32`), which is also what the chip now copies.
- `ctx.locale()` returns Discord's locale strings; `discord_locale_to_xiv_language` maps the 6 non-EN locales we have data for (`ja`, `de`, `fr`, `zh-CN`, `ko`, `zh-TW`) and falls back to English for everything else.

## Test plan

- [ ] In Discord, run `/ffxiv prices current` and confirm autocomplete returns items for English typing and at least one other locale (e.g. typing `ヴァイキング` with the Discord client in JA).
- [ ] From the item page, click the copy button on the Discord chip, paste into Discord, hit enter — command should execute (vs. the prior \"invalid integer\" client-side rejection).
- [ ] With a non-English Discord client, run `/ffxiv prices current` on a known item — embed title should display in the user's locale.
- [ ] `/ffxiv alert list` — alert lines show item names in the user's locale.
- [ ] `/ffxiv list show_list` — list contents render in the user's locale.
- [ ] `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both clean (verified locally via `./check_ci.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)