### PR TITLE
fix(ssr): disable browser auto-translation to stop tachys hydration panics

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -185,9 +185,11 @@ pub fn shell(options: LeptosOptions, bootstrap_script: String) -> impl IntoView 
     let error_reporting_script = error_reporting_script();
     view! {
         <!DOCTYPE html>
-        <html lang="en" data-theme="dark" data-palette="violet">
+        // `translate="no"` + `<meta name="google" content="notranslate">` block Chrome's Google Translate from rewriting text nodes into `<font>` wrappers before hydration, which trips `failed_to_cast_text_node` in tachys (panic at `tachys-0.2.11/src/hydration.rs:227`). App has its own locale switcher.
+        <html lang="en" translate="no" data-theme="dark" data-palette="violet">
             <head>
                 <meta charset="utf-8" />
+                <meta name="google" content="notranslate" />
                 <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
                 <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png" />
                 <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png" />


### PR DESCRIPTION
## Summary

- Add `translate=\"no\"` on `<html>` and `<meta name=\"google\" content=\"notranslate\">` in `<head>` so Chrome's Google Translate stops rewriting text nodes into `<font>` wrappers before our WASM finishes hydrating.
- This is the dominant root cause behind the recurring `RustWasmPanic: internal error: entered unreachable code` (and bare `RuntimeError: unreachable`) failures in GlitchTip.

## Why

The panic location is `tachys-0.2.11/src/hydration.rs:227` — that's `failed_to_cast_text_node`. Hydration walks the SSR'd DOM expecting `Text` nodes and panics if it finds an element instead. The two telltale signals point at auto-translation:

1. The Chinese-encoded item URLs (`/item/%E6%B5%B7%E7%8C%AB%E8%8C%B6%E5%B1%8B/5302`, etc.) and `Asia/Shanghai` / China-IP users dominate the failing events.
2. GlitchTip issue #4 alone has **357 events** (`Uncaught RuntimeError: unreachable` from the WASM), and there's a long tail of single-event `/item/...` panics with the same shape; combined affected routes are `/item/{world}/{id}`, `/items/jobset/{job}`, `/items/category/Materia`.
3. Breadcrumbs show 5-7 seconds elapse between page render and `app run!` — plenty of time for Translate to wrap text nodes.

The app already ships its own locale switcher (en/fr/de/ja/cn/ko/tc), so non-English users still have a path to localized content; we're only opting out of browser-level auto-translation that was actively crashing them.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p ultros-app --all-targets -- -D warnings` clean (server crate not touched; full-workspace clippy skipped to avoid the ~10-minute vendored-OpenSSL first build on Windows)
- [ ] Deploy and monitor GlitchTip issue counts for `tachys-0.2.11/src/hydration.rs:227` panics over the next 24h
- [ ] (Optional follow-up) If residual `TypeError: Cannot read properties of undefined (reading 'document')` events on the same routes persist after deploy, investigate separately — current data is consistent with the same root cause but inconclusive on the single-frame stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)