### PR TITLE
Align crafting analyzer toggles with cookie fallbacks

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -203,6 +203,16 @@ fn FCCraftingAnalyzerTable(
     let (min_daily_sales, set_min_daily_sales) = query_signal::<f32>("min-sales");
     let (exclude_shards_url, set_exclude_shards) = query_signal::<bool>("shards-exclude");
     let (use_on_hand_url, set_use_on_hand) = query_signal::<bool>("on-hand");
+    let cookies = use_context::<Cookies>().unwrap();
+    let (craft_options, _) =
+        cookies.use_cookie_typed::<_, CraftOptions>(craft_options::COOKIE_NAME);
+    let exclude_shards_enabled = move || {
+        exclude_shards_url()
+            .unwrap_or_else(|| craft_options.get().unwrap_or_default().exclude_shards)
+    };
+    let use_on_hand_enabled = move || {
+        use_on_hand_url().unwrap_or_else(|| craft_options.get().unwrap_or_default().use_on_hand)
+    };
 
     let computed_data = Memo::new(move |_| {
         let sales_map: HashMap<i32, Vec<&SaleData>> = if let Some(ref sales) = recent_sales {
@@ -217,18 +227,14 @@ fn FCCraftingAnalyzerTable(
 
         // Hoist context lookups ONCE; the on-hand SNAPSHOT is rebuilt
         // per sequence inside the loop because compute_ingredient_cost consumes it.
-        let opts_cookie = use_context::<Cookies>()
-            .unwrap()
-            .use_cookie_typed::<_, CraftOptions>(craft_options::COOKIE_NAME)
-            .0;
-        let opts_value = opts_cookie.get().unwrap_or_default();
-        let shards = if exclude_shards_url().unwrap_or(opts_value.exclude_shards) {
+        let opts_value = craft_options.get().unwrap_or_default();
+        let shards = if exclude_shards_enabled() {
             ShardsMode::ExcludeShards
         } else {
             ShardsMode::IncludeMarket
         };
         let on_hand_map = use_context::<OnHandMap>();
-        let use_on_hand = use_on_hand_url().unwrap_or(opts_value.use_on_hand);
+        let use_on_hand = use_on_hand_enabled();
 
         let mut results = Vec::new();
 
@@ -415,16 +421,16 @@ fn FCCraftingAnalyzerTable(
                 <ToolbarField label="Exclude Shards">
                     <ToolbarPills>
                         <button
-                            aria-pressed=move || if exclude_shards_url().unwrap_or(true) { "false" } else { "true" }
+                            aria-pressed=move || if exclude_shards_enabled() { "false" } else { "true" }
                             title="If enabled, crystal/shard/cluster ingredient costs are not counted toward the craft cost. Most crafters keep a stockpile."
-                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_url().unwrap_or(true)))
+                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_enabled()))
                         >
                             "Off"
                         </button>
                         <button
-                            aria-pressed=move || if exclude_shards_url().unwrap_or(true) { "true" } else { "false" }
+                            aria-pressed=move || if exclude_shards_enabled() { "true" } else { "false" }
                             title="If enabled, crystal/shard/cluster ingredient costs are not counted toward the craft cost. Most crafters keep a stockpile."
-                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_url().unwrap_or(true)))
+                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_enabled()))
                         >
                             "On"
                         </button>
@@ -433,16 +439,16 @@ fn FCCraftingAnalyzerTable(
                 <ToolbarField label="Use On-Hand">
                     <ToolbarPills>
                         <button
-                            aria-pressed=move || if use_on_hand_url().unwrap_or(false) { "false" } else { "true" }
+                            aria-pressed=move || if use_on_hand_enabled() { "false" } else { "true" }
                             title="Deduct ingredients you already own from the craft cost. Set per-ingredient totals on the item page."
-                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_url().unwrap_or(false)))
+                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_enabled()))
                         >
                             "Off"
                         </button>
                         <button
-                            aria-pressed=move || if use_on_hand_url().unwrap_or(false) { "true" } else { "false" }
+                            aria-pressed=move || if use_on_hand_enabled() { "true" } else { "false" }
                             title="Deduct ingredients you already own from the craft cost. Set per-ingredient totals on the item page."
-                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_url().unwrap_or(false)))
+                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_enabled()))
                         >
                             "On"
                         </button>

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -125,6 +125,15 @@ fn RecipeAnalyzerTable(
 
     let cookies = use_context::<Cookies>().unwrap();
     let (crafter_levels, _) = cookies.use_cookie_typed::<_, CrafterLevels>("CRAFTER_LEVELS");
+    let (craft_options, _) =
+        cookies.use_cookie_typed::<_, CraftOptions>(craft_options::COOKIE_NAME);
+    let exclude_shards_enabled = move || {
+        exclude_shards_url()
+            .unwrap_or_else(|| craft_options.get().unwrap_or_default().exclude_shards)
+    };
+    let use_on_hand_enabled = move || {
+        use_on_hand_url().unwrap_or_else(|| craft_options.get().unwrap_or_default().use_on_hand)
+    };
 
     let has_levels = Memo::new(move |_| {
         let levels = crafter_levels.get().unwrap_or_default();
@@ -164,18 +173,14 @@ fn RecipeAnalyzerTable(
 
         // Hoist context lookups ONCE; the on-hand SNAPSHOT is rebuilt
         // per recipe inside the loop because compute_cost consumes it.
-        let opts_cookie = use_context::<Cookies>()
-            .unwrap()
-            .use_cookie_typed::<_, CraftOptions>(craft_options::COOKIE_NAME)
-            .0;
-        let opts_value = opts_cookie.get().unwrap_or_default();
-        let shards = if exclude_shards_url().unwrap_or(opts_value.exclude_shards) {
+        let opts_value = craft_options.get().unwrap_or_default();
+        let shards = if exclude_shards_enabled() {
             ShardsMode::ExcludeShards
         } else {
             ShardsMode::IncludeMarket
         };
         let on_hand_map = use_context::<OnHandMap>();
-        let use_on_hand = use_on_hand_url().unwrap_or(opts_value.use_on_hand);
+        let use_on_hand = use_on_hand_enabled();
 
         for recipe in recipes.values() {
             // Filter by job and level
@@ -469,16 +474,16 @@ fn RecipeAnalyzerTable(
                 <ToolbarField label="Exclude Shards">
                     <ToolbarPills>
                         <button
-                            aria-pressed=move || if exclude_shards_url().unwrap_or(true) { "false" } else { "true" }
+                            aria-pressed=move || if exclude_shards_enabled() { "false" } else { "true" }
                             title="If enabled, crystal/shard/cluster ingredient costs are not counted toward the craft cost. Most crafters keep a stockpile."
-                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_url().unwrap_or(true)))
+                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_enabled()))
                         >
                             "Off"
                         </button>
                         <button
-                            aria-pressed=move || if exclude_shards_url().unwrap_or(true) { "true" } else { "false" }
+                            aria-pressed=move || if exclude_shards_enabled() { "true" } else { "false" }
                             title="If enabled, crystal/shard/cluster ingredient costs are not counted toward the craft cost. Most crafters keep a stockpile."
-                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_url().unwrap_or(true)))
+                            on:click=move |_| set_exclude_shards(Some(!exclude_shards_enabled()))
                         >
                             "On"
                         </button>
@@ -487,16 +492,16 @@ fn RecipeAnalyzerTable(
                 <ToolbarField label="Use On-Hand">
                     <ToolbarPills>
                         <button
-                            aria-pressed=move || if use_on_hand_url().unwrap_or(false) { "false" } else { "true" }
+                            aria-pressed=move || if use_on_hand_enabled() { "false" } else { "true" }
                             title="Deduct ingredients you already own from the craft cost. Set per-ingredient totals on the item page."
-                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_url().unwrap_or(false)))
+                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_enabled()))
                         >
                             "Off"
                         </button>
                         <button
-                            aria-pressed=move || if use_on_hand_url().unwrap_or(false) { "true" } else { "false" }
+                            aria-pressed=move || if use_on_hand_enabled() { "true" } else { "false" }
                             title="Deduct ingredients you already own from the craft cost. Set per-ingredient totals on the item page."
-                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_url().unwrap_or(false)))
+                            on:click=move |_| set_use_on_hand(Some(!use_on_hand_enabled()))
                         >
                             "On"
                         </button>


### PR DESCRIPTION
## Summary
- Fixed the recipe and FC crafting analyzer toggle state so `Exclude Shards` and `Use On-Hand` use the same cookie-backed fallback as the cost calculation.
- This removes the mismatch where the toolbar could show one state while the analyzer math used another.

## Testing
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- `cargo check -p ultros-app --features ssr` and `./check_ci.sh` were blocked by missing `xiv-gen/ffxiv-datamining/csv/en/Item.csv` after submodule init failed in this environment.