### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HttpOnly flag to authentication cookies

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-20 - Set HttpOnly Flag for Auth and PKCE Cookies
+**Vulnerability:** The authentication cookies (`discord_auth`, `pkce_challenge`, `pkce_verifier`) did not have the `HttpOnly` flag set, making them accessible to client-side scripts and vulnerable to Cross-Site Scripting (XSS) attacks.
+**Learning:** Even if cookies are set with `Secure` and `SameSite` flags, sensitive cookies like authentication and PKCE tokens must also use the `HttpOnly` flag to prevent client-side access.
+**Prevention:** Always verify that the `HttpOnly` flag is explicitly enabled when setting session or authentication cookies via `CookieBuilder` or `Cookie::new`.

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -139,9 +139,14 @@ pub async fn begin_login(
     let cookies = cookies.add(
         CookieBuilder::new("pkce_challenge", pkce_challenge.as_str().to_string())
             .same_site(SameSite::Strict)
-            .secure(true),
+            .secure(true)
+            .http_only(true),
     );
-    let cookies = cookies.add(Cookie::new("pkce_verifier", pkce_verifier.secret().clone()));
+    let cookies = cookies.add(
+        CookieBuilder::new("pkce_verifier", pkce_verifier.secret().clone())
+            .http_only(true)
+            .build(),
+    );
 
     let mut request = config
         .inner
@@ -193,6 +198,7 @@ pub async fn redirect(
     let mut cookie = Cookie::new("discord_auth", token);
     cookie.set_secure(true);
     cookie.set_same_site(SameSite::Lax);
+    cookie.set_http_only(true);
     cookie.make_permanent();
     cookies = cookies.add(cookie);
     Ok((cookies, Redirect::to("/")))
@@ -412,6 +418,7 @@ pub mod test_auth {
         // Mirror oauth::redirect, but allow non-https so local E2E works.
         cookie.set_secure(false);
         cookie.set_same_site(SameSite::Lax);
+        cookie.set_http_only(true);
         cookie.set_path("/");
         cookie.make_permanent();
 


### PR DESCRIPTION
Adds `HttpOnly` flag to authentication cookies for better security.

---
*PR created automatically by Jules for task [9278141773380730299](https://jules.google.com/task/9278141773380730299) started by @akarras*