### PR TITLE
chore(deps): bump derive_more 1 → 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,31 +1885,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl 2.1.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1918,6 +1898,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -7658,7 +7639,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
- "derive_more 2.1.1",
+ "derive_more",
  "futures-util",
  "log",
  "ouroboros",
@@ -11351,7 +11332,7 @@ dependencies = [
  "bincode 2.0.1",
  "codegen-rs",
  "csv",
- "derive_more 1.0.0",
+ "derive_more",
  "dumb_csv",
  "heck 0.4.1",
  "lazy_static",

--- a/xiv-gen/Cargo.toml
+++ b/xiv-gen/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 serde = { workspace = true }
 bincode = {version = "2.0.1"}
 csv = {version = "1.4.0"}
-derive_more = {version = "1.0.0", features = ["from_str"]}
+derive_more = {version = "2.1.1", features = ["from_str"]}
 dumb_csv = {path = "../dumb-csv"}
 xiv-gen-macros = {path = "../proc-macros/xiv-gen-macros"}
 


### PR DESCRIPTION
## Summary

Bump `derive_more` from 1.0.0 → 2.1.1.

The only consumer in the workspace is the `xiv-gen` build script's codegen, which derives `derive_more::FromStr` on column-value enums. The feature flag (`from_str`) and the derive path are unchanged between v1 and v2, so this is a Cargo.toml-only change — no source migration was needed.

## Verification

- [x] `./check_ci.sh` (fmt-check + clippy `-D warnings`) — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)