### PR TITLE
Restore currency exchange SpecialShop rows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,15 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"

--- a/proc-macros/xiv-gen-macros/src/lib.rs
+++ b/proc-macros/xiv-gen-macros/src/lib.rs
@@ -56,17 +56,12 @@ impl ToTokens for FromCsvReceiver {
 
             if let Some(count) = f.count {
                 // Array field
-                let indices = (0..count).map(|i| {
-                    let c = col_name.replace("{}", &i.to_string());
-                    quote! {
-                        header.iter().position(|h| h == #c).expect(&format!("Column {} not found", #c))
-                    }
-                });
                 quote! {
                     #field_ident: {
-                        let indices = [#( #indices ),*];
                         let mut vec = Vec::with_capacity(#count);
-                        for idx in indices {
+                        for column_index in 0..#count {
+                            let col_name = #col_name.replace("{}", &column_index.to_string());
+                            let idx = header.iter().position(|h| h == &col_name).expect(&format!("Column {} not found", col_name));
                             let val = row.get(idx).unwrap_or_default();
                             vec.push(val.parse().unwrap_or_else(|_| panic!("Failed to parse {} at index {} with value '{}' as {}", stringify!(#field_ident), idx, val, stringify!(#ty))));
                         }

--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -104,26 +104,60 @@ struct ShopItems {
     cost: Vec<ItemAmount>,
 }
 
-#[allow(dead_code)]
 fn from_lists(
-    item: impl Iterator<Item = ItemId>,
+    item: impl Iterator<Item = u16>,
     amount: impl Iterator<Item = u32>,
 ) -> impl Iterator<Item = Option<ItemAmount>> {
     let items = &tracked_data().items;
     item.zip(amount).map(|(item_id, amount)| {
+        if item_id == 0 || amount == 0 {
+            return None;
+        }
+
+        let item_id = ItemId(item_id as i32);
         let item = items.get(&item_id)?;
         Some(ItemAmount { item, amount })
     })
 }
 
-fn shop_items(_special_shop: &SpecialShop) -> impl Iterator<Item = ShopItems> + '_ {
-    // NOTE: The SpecialShop struct has been restructured and no longer contains
-    // the detailed item_receive_*/count_receive_*/item_cost_*/count_cost_* fields.
-    // Only `item: Vec<u16>` (60 entries) is available, which does not provide
-    // enough information to reconstruct the full receive/cost breakdown.
-    // Return an empty iterator so the code compiles; currency exchange detail
-    // will not show individual trade rows until the data schema is restored.
-    std::iter::empty()
+fn shop_items(special_shop: &SpecialShop) -> impl Iterator<Item = ShopItems> + '_ {
+    let SpecialShop {
+        item_receive_0,
+        count_receive_0,
+        item_receive_1,
+        count_receive_1,
+        item_cost_0,
+        count_cost_0,
+        item_cost_1,
+        count_cost_1,
+        item_cost_2,
+        count_cost_2,
+        ..
+    } = special_shop;
+
+    let recv_0 = from_lists(
+        item_receive_0.iter().copied(),
+        count_receive_0.iter().copied(),
+    );
+    let recv_1 = from_lists(
+        item_receive_1.iter().copied(),
+        count_receive_1.iter().copied(),
+    );
+    let cost_0 = from_lists(item_cost_0.iter().copied(), count_cost_0.iter().copied());
+    let cost_1 = from_lists(item_cost_1.iter().copied(), count_cost_1.iter().copied());
+    let cost_2 = from_lists(item_cost_2.iter().copied(), count_cost_2.iter().copied());
+
+    recv_0
+        .zip(recv_1)
+        .zip(
+            cost_0
+                .zip(cost_1.zip(cost_2))
+                .map(|(cost_0, (cost_1, cost_2))| (cost_0, cost_1, cost_2)),
+        )
+        .map(|((recv_0, recv_1), (cost_0, cost_1, cost_2))| ShopItems {
+            recv: [recv_0, recv_1].into_iter().flatten().collect(),
+            cost: [cost_0, cost_1, cost_2].into_iter().flatten().collect(),
+        })
 }
 
 #[component]
@@ -256,10 +290,13 @@ pub fn ExchangeItem() -> impl IntoView {
             .values()
             .flat_map(move |shop| {
                 shop_items(shop)
-                    .filter(move |items| {
+                    .filter_map(move |mut items| {
                         // make sure the item is valid on the marketboard before we lookup prices for it
-                        items.cost.iter().any(|i| i.item.key_id.0 == item.0)
-                            && items.recv.iter().any(|i| i.item.item_search_category != 0)
+                        let has_marketable_item =
+                            items.recv.iter().any(|i| i.item.item_search_category != 0);
+                        items.cost.retain(|i| i.item.key_id.0 == item.0);
+
+                        (!items.cost.is_empty() && has_marketable_item).then_some(items)
                     })
                     .map(move |items| (items, shop))
             })
@@ -827,12 +864,15 @@ pub fn ExchangeItem() -> impl IntoView {
     }.into_any()
 }
 
-// NOTE: The SpecialShop struct no longer has item_cost_0/1/2 fields.
-// This function previously used the field_iter macro to iterate over those fields.
-// Now it returns an empty iterator as a stub until the data schema is restored.
 #[allow(dead_code)]
-fn item_cost_iter(_shop: &SpecialShop) -> impl Iterator<Item = ItemId> + '_ {
-    std::iter::empty()
+fn item_cost_iter(shop: &SpecialShop) -> impl Iterator<Item = ItemId> + '_ {
+    shop.item_cost_0
+        .iter()
+        .chain(shop.item_cost_1.iter())
+        .chain(shop.item_cost_2.iter())
+        .copied()
+        .filter(|item_id| *item_id != 0)
+        .map(|item_id| ItemId(item_id as i32))
 }
 
 // #[derive(TableRow, Clone, Default, Debug)]

--- a/xiv-gen/src/csv_to_bincode.rs
+++ b/xiv-gen/src/csv_to_bincode.rs
@@ -100,10 +100,15 @@ fn read_csv_vec<T: FromCsv>(path: &str) -> Vec<T> {
                 .replace("<%>", "Percent")
                 .replace("ItemIngredient", "Ingredient");
 
-            // Map SaintCoinach's Item{Receive}[x][0] to English's Item[x].Item[0]
-            if s.starts_with("ItemReceive[") && s.ends_with("][0]") {
-                let num = &s[12..s.len() - 4];
-                s = format!("Item[{}].Item[0]", num);
+            if let Some((slot, item_index)) = split_multi_indexed_column(&s, "ItemReceive[") {
+                s = format!("Item[{slot}].Item[{item_index}]");
+            } else if let Some((slot, item_index)) = split_multi_indexed_column(&s, "CountReceive[")
+            {
+                s = format!("Item[{slot}].ReceiveCount[{item_index}]");
+            } else if let Some((slot, item_index)) = split_multi_indexed_column(&s, "ItemCost[") {
+                s = format!("Item[{slot}].ItemCost[{item_index}]");
+            } else if let Some((slot, item_index)) = split_multi_indexed_column(&s, "CountCost[") {
+                s = format!("Item[{slot}].CurrencyCost[{item_index}]");
             }
             s
         })
@@ -112,6 +117,11 @@ fn read_csv_vec<T: FromCsv>(path: &str) -> Vec<T> {
     records
         .map(|r| T::from_csv_row(&header, &r.unwrap()))
         .collect()
+}
+
+fn split_multi_indexed_column<'a>(column: &'a str, prefix: &str) -> Option<(&'a str, &'a str)> {
+    let indexes = column.strip_prefix(prefix)?.strip_suffix(']')?;
+    indexes.split_once("][")
 }
 
 fn read_csv_to_map<K, T>(path: &str) -> HashMap<K, T>

--- a/xiv-gen/src/lib.rs
+++ b/xiv-gen/src/lib.rs
@@ -303,6 +303,26 @@ pub struct SpecialShop {
     pub name: String,
     #[xiv_gen(column = "Item[{}].Item[0]", count = 60)]
     pub item: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].Item[0]", count = 60)]
+    pub item_receive_0: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].ReceiveCount[0]", count = 60)]
+    pub count_receive_0: Vec<u32>,
+    #[xiv_gen(column = "Item[{}].Item[1]", count = 60)]
+    pub item_receive_1: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].ReceiveCount[1]", count = 60)]
+    pub count_receive_1: Vec<u32>,
+    #[xiv_gen(column = "Item[{}].ItemCost[0]", count = 60)]
+    pub item_cost_0: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].CurrencyCost[0]", count = 60)]
+    pub count_cost_0: Vec<u32>,
+    #[xiv_gen(column = "Item[{}].ItemCost[1]", count = 60)]
+    pub item_cost_1: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].CurrencyCost[1]", count = 60)]
+    pub count_cost_1: Vec<u32>,
+    #[xiv_gen(column = "Item[{}].ItemCost[2]", count = 60)]
+    pub item_cost_2: Vec<u16>,
+    #[xiv_gen(column = "Item[{}].CurrencyCost[2]", count = 60)]
+    pub count_cost_2: Vec<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Encode, Decode, FromCsv)]


### PR DESCRIPTION
## Summary
- Restored `SpecialShop` receive/cost fields so currency exchange rows can be reconstructed again.
- Fixed CSV header normalization for SaintCoinach-style `SpecialShop` columns across English/CN/KO/TC data.
- Rewired the currency exchange page to surface real exchange entries again, including currencies like Wolf Marks.
- Kept zero-placeholder slots out of the derived item lists so empty rows do not leak into the UI.

## Testing
- `cargo fmt --all`
- `./check_ci.sh` passed after adjusting the local Windows shell environment and initializing missing submodules.
- Verified against datamining data that Wolf Marks (`Item 25`) are used as a SpecialShop cost item in rows such as `Wolf Gear`.