### PR TITLE
Redesign list sharing and invite acceptance flows

### DIFF
--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -22,10 +22,7 @@ use ultros_api_types::{
     retainer::{Retainer, RetainerListings},
     search::SearchResult,
     trends::TrendsData,
-    user::{
-        OwnedRetainer, UserData, UserRetainerListings, UserRetainers,
-        group::{CreateGroup, UserGroup},
-    },
+    user::{OwnedRetainer, UserData, UserRetainerListings, UserRetainers, group::UserGroup},
 };
 
 use crate::error::{AppError, AppResult};
@@ -325,18 +322,6 @@ pub(crate) async fn delete_list_items(list_items: Vec<i32>) -> AppResult<()> {
 
 pub(crate) async fn get_groups() -> AppResult<Vec<UserGroup>> {
     fetch_api("/api/v1/group").await
-}
-
-pub(crate) async fn create_group(group: CreateGroup) -> AppResult<UserGroup> {
-    post_api("/api/v1/group/create", group).await
-}
-
-pub(crate) async fn add_group_member(group_id: i32, user_id: i64) -> AppResult<()> {
-    post_api(
-        &format!("/api/v1/group/{group_id}/member/add/{user_id}"),
-        (),
-    )
-    .await
 }
 
 pub(crate) async fn get_list_shares(

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -533,6 +533,7 @@ pub fn AppInner(cookies: Cookies) -> impl IntoView {
                         </ParentRoute>
                         <Route path=path!("alerts") view=Alerts />
                         <ParentRoute path=path!("list") view=Lists>
+                            <Route path=path!("invite/:invite_id") view=ListInviteAccept />
                             <Route path=path!(":id") view=ListView />
                             <Route path=path!("") view=EditLists />
                         </ParentRoute>

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -3,23 +3,29 @@ use crate::i18n::{t, t_string};
 use icondata as i;
 use leptos::either::Either;
 use leptos::prelude::*;
-use leptos_router::components::{A, Outlet};
+use leptos_router::{
+    components::{A, Outlet},
+    hooks::{use_navigate, use_params_map},
+};
 
 use crate::api::{
-    add_group_member, create_group, create_list, create_list_invite, delete_list,
-    delete_list_invite, edit_list, get_groups, get_list_invites, get_list_shares,
-    get_lists_with_permissions, get_login, leave_list, share_list_with_group, share_list_with_user,
-    unshare_list_from_group, unshare_list_from_user, use_list_invite,
+    create_list, create_list_invite, delete_list, delete_list_invite, edit_list, get_groups,
+    get_list_invites, get_list_shares, get_lists_with_permissions, get_login, leave_list,
+    share_list_with_group, share_list_with_user, unshare_list_from_group, unshare_list_from_user,
+    use_list_invite,
 };
 use crate::components::ad::Ad;
 use crate::components::modal::Modal;
 use crate::components::{loading::*, tooltip::*, world_name::*, world_picker::*};
 use crate::global_state::home_world::get_price_zone;
-use ultros_api_types::list::{
-    CreateInvite, CreateList, List, ListPermission, ListWithPermission, ShareListGroup,
-    ShareListUser,
+use crate::global_state::{
+    clipboard_text::GlobalLastCopiedText,
+    toasts::{Toasts, use_toast},
 };
-use ultros_api_types::user::group::CreateGroup;
+use ultros_api_types::list::{
+    CreateInvite, CreateList, List, ListInvite, ListPermission, ListSharedGroup, ListSharedUser,
+    ListWithPermission, ShareListGroup, ShareListUser,
+};
 
 fn permission_label(permission: ListPermission) -> &'static str {
     match permission {
@@ -37,17 +43,92 @@ fn editable_permission(value: &str) -> ListPermission {
     }
 }
 
+fn invite_url(invite_id: &str) -> String {
+    #[cfg(feature = "hydrate")]
+    {
+        if let Some(window) = web_sys::window()
+            && let Ok(origin) = window.location().origin()
+        {
+            return format!("{origin}/list/invite/{invite_id}");
+        }
+    }
+    format!("/list/invite/{invite_id}")
+}
+
+fn copy_invite_url(
+    invite_id: &str,
+    last_copied: Option<GlobalLastCopiedText>,
+    toasts: Option<Toasts>,
+) {
+    let url = invite_url(invite_id);
+    #[cfg(feature = "hydrate")]
+    if let Some(window) = web_sys::window() {
+        let clipboard = window.navigator().clipboard();
+        let _ = clipboard.write_text(&url);
+    }
+    if let Some(last_copied) = last_copied {
+        last_copied.0.set(Some(url));
+    }
+    if let Some(toasts) = toasts {
+        toasts.success("Invite link copied");
+    }
+}
+
+fn invite_uses_label(invite: &ListInvite) -> String {
+    format!(
+        "{}/{} uses",
+        invite.uses,
+        invite
+            .max_uses
+            .map(|max_uses| max_uses.to_string())
+            .unwrap_or_else(|| "∞".to_string())
+    )
+}
+
+#[component]
+fn AccessRow(
+    icon: icondata_core::Icon,
+    label: String,
+    detail: String,
+    trailing: String,
+    #[prop(into)] on_delete: Callback<()>,
+) -> impl IntoView {
+    view! {
+        <div class="flex items-center gap-3 py-2">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--color-text)_10%,transparent)] text-[color:var(--color-text-muted)]">
+                <Icon icon width="1.25em" height="1.25em" />
+            </div>
+            <div class="min-w-0 flex-1">
+                <div class="flex items-baseline gap-2">
+                    <span class="truncate font-bold text-[color:var(--color-text)]">{label}</span>
+                    <span class="shrink-0 text-sm text-[color:var(--color-text-muted)]">{detail}</span>
+                </div>
+            </div>
+            <div class="hidden min-w-12 flex-1 border-b border-dotted border-[color:color-mix(in_srgb,var(--color-text-muted)_70%,transparent)] md:block"></div>
+            <div class="shrink-0 text-sm text-[color:var(--color-text)]">{trailing}</div>
+            <button
+                type="button"
+                class="btn-ghost p-2 text-[color:var(--color-text-muted)] hover:text-red-200"
+                aria-label="Remove access"
+                on:click=move |_| on_delete.run(())
+            >
+                <Icon icon=i::BiTrashSolid />
+            </button>
+        </div>
+    }
+}
+
 #[component]
 fn ShareListModal(list: List, set_visible: WriteSignal<bool>) -> impl IntoView {
     let list_id = list.id;
-    let (user_id, set_user_id) = signal(String::new());
-    let (user_permission, set_user_permission) = signal(ListPermission::Read);
-    let (group_permission, set_group_permission) = signal(ListPermission::Read);
+    let list_name = list.name.clone();
+    let (recipient, set_recipient) = signal(String::new());
+    let (recipient_permission, set_recipient_permission) = signal(ListPermission::Read);
     let (invite_permission, set_invite_permission) = signal(ListPermission::Read);
     let (invite_max_uses, set_invite_max_uses) = signal(String::new());
-    let (new_group_name, set_new_group_name) = signal(String::new());
-    let (selected_group, set_selected_group) = signal::<Option<i32>>(None);
-    let (member_id, set_member_id) = signal(String::new());
+    let last_copied = use_context::<GlobalLastCopiedText>();
+    let toasts = use_toast();
+    let last_copied_invite = RwSignal::new(None::<String>);
 
     let share_user = Action::new(move |data: &(i64, ListPermission)| {
         let (target_user_id, permission) = *data;
@@ -77,12 +158,6 @@ fn ShareListModal(list: List, set_visible: WriteSignal<bool>) -> impl IntoView {
         Action::new(move |invite: &CreateInvite| create_list_invite(list_id, invite.clone()));
     let delete_invite =
         Action::new(move |invite_id: &String| delete_list_invite(invite_id.clone()));
-    let create_group =
-        Action::new(move |name: &String| create_group(CreateGroup { name: name.clone() }));
-    let add_member = Action::new(move |data: &(i32, i64)| {
-        let (group_id, user_id) = *data;
-        add_group_member(group_id, user_id)
-    });
 
     let share_data = Resource::new(
         move || {
@@ -93,8 +168,6 @@ fn ShareListModal(list: List, set_visible: WriteSignal<bool>) -> impl IntoView {
                 unshare_group.version().get(),
                 create_invite.version().get(),
                 delete_invite.version().get(),
-                create_group.version().get(),
-                add_member.version().get(),
             )
         },
         move |_| async move {
@@ -105,254 +178,160 @@ fn ShareListModal(list: List, set_visible: WriteSignal<bool>) -> impl IntoView {
         },
     );
 
+    Effect::new(move |_| {
+        let Some(result) = create_invite.value().get() else {
+            return;
+        };
+        match result {
+            Ok(invite) => {
+                let already_copied = last_copied_invite
+                    .with_untracked(|id| id.as_deref() == Some(invite.id.as_str()));
+                if !already_copied {
+                    copy_invite_url(&invite.id, last_copied, toasts);
+                    last_copied_invite.set(Some(invite.id));
+                }
+            }
+            Err(e) => {
+                if let Some(toasts) = toasts {
+                    toasts.error(format!("Could not create invite link: {e}"));
+                }
+            }
+        }
+    });
+
+    let copy_latest_invite = move |invites: Vec<ListInvite>| {
+        if let Some(invite) = invites.last() {
+            copy_invite_url(&invite.id, last_copied, toasts);
+        }
+    };
+
     view! {
-        <Modal set_visible=set_visible max_width="max-w-3xl w-[95%] sm:w-[720px]".to_string()>
-            <div class="space-y-5">
-                <div>
-                    <h2 class="text-2xl font-bold text-[color:var(--brand-fg)]">"Share list"</h2>
-                    <p class="text-sm text-[color:var(--color-text-muted)]">{list.name.clone()}</p>
+        <Modal set_visible=set_visible max_width="max-w-5xl w-[96%] sm:w-[820px]".to_string()>
+            <div class="space-y-6">
+                <div class="pr-10">
+                    <h2 class="text-3xl font-black text-[color:var(--color-text)]">"Share list: " {list_name.clone()}</h2>
                 </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <section class="space-y-3">
-                        <h3 class="font-semibold">"Share with user"</h3>
-                        <input
-                            class="input w-full"
-                            placeholder="Discord user ID"
-                            prop:value=user_id
-                            on:input=move |ev| set_user_id(event_target_value(&ev))
-                        />
-                        <select
-                            class="input w-full"
-                            on:change=move |ev| set_user_permission(editable_permission(&event_target_value(&ev)))
-                        >
-                            <option value="Read">"Read"</option>
-                            <option value="Write">"Write"</option>
-                        </select>
-                        <button
-                            class="btn-primary"
-                            prop:disabled=move || { user_id().parse::<i64>().is_err() }
-                            on:click=move |_| {
-                                if let Ok(parsed) = user_id().parse::<i64>() {
-                                    share_user.dispatch((parsed, user_permission()));
-                                    set_user_id(String::new());
-                                }
-                            }
-                        >
-                            <Icon icon=i::BiUserPlusRegular /> "Share"
-                        </button>
-                    </section>
-
-                    <section class="space-y-3">
-                        <h3 class="font-semibold">"Invites"</h3>
-                        <div class="flex flex-col sm:flex-row gap-2">
-                            <select
-                                class="input flex-1"
-                                on:change=move |ev| set_invite_permission(editable_permission(&event_target_value(&ev)))
-                            >
-                                <option value="Read">"Read"</option>
-                                <option value="Write">"Write"</option>
-                            </select>
-                            <input
-                                class="input flex-1"
-                                placeholder="Max uses"
-                                prop:value=invite_max_uses
-                                on:input=move |ev| set_invite_max_uses(event_target_value(&ev))
-                            />
-                        </div>
-                        <button
-                            class="btn-primary"
-                            on:click=move |_| {
-                                let max_uses = invite_max_uses().parse::<i32>().ok();
-                                create_invite.dispatch(CreateInvite {
-                                    permission: invite_permission(),
-                                    max_uses,
-                                });
-                                set_invite_max_uses(String::new());
-                            }
-                        >
-                            <Icon icon=i::BiLinkRegular /> "Create invite"
-                        </button>
-                    </section>
-                </div>
-
-                <section class="space-y-3">
-                    <h3 class="font-semibold">"Groups"</h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <div class="flex gap-2">
-                            <input
-                                class="input flex-1"
-                                placeholder="New group name"
-                                prop:value=new_group_name
-                                on:input=move |ev| set_new_group_name(event_target_value(&ev))
-                            />
-                            <button
-                                class="btn-secondary"
-                                prop:disabled=move || new_group_name().trim().is_empty()
-                                on:click=move |_| {
-                                    let name = new_group_name().trim().to_string();
-                                    if !name.is_empty() {
-                                        create_group.dispatch(name);
-                                        set_new_group_name(String::new());
-                                    }
-                                }
-                            >
-                                <Icon icon=i::BiPlusRegular /> "Create"
-                            </button>
-                        </div>
-                        <div class="flex gap-2">
-                            <input
-                                class="input flex-1"
-                                placeholder="Member Discord user ID"
-                                prop:value=member_id
-                                on:input=move |ev| set_member_id(event_target_value(&ev))
-                            />
-                            <button
-                                class="btn-secondary"
-                            prop:disabled=move || {
-                                selected_group().is_none() || member_id().parse::<i64>().is_err()
-                            }
-                                on:click=move |_| {
-                                    if let (Some(group_id), Ok(parsed)) = (selected_group(), member_id().parse::<i64>()) {
-                                        add_member.dispatch((group_id, parsed));
-                                        set_member_id(String::new());
-                                    }
-                                }
-                            >
-                                <Icon icon=i::BiUserPlusRegular /> "Add"
-                            </button>
-                        </div>
-                    </div>
-                </section>
 
                 <Suspense fallback=move || view! { <Loading /> }>
                     {move || share_data.get().map(|data| match data {
                         Ok((users, shared_groups, invites, owned_groups)) => {
-                            if selected_group().is_none()
-                                && let Some(group) = owned_groups.first()
-                            {
-                                set_selected_group(Some(group.id));
-                            }
+                            let owned_groups_for_submit = owned_groups.clone();
+                            let invites_for_copy = invites.clone();
+                            let latest_invite_url = invites
+                                .last()
+                                .map(|invite| invite_url(&invite.id))
+                                .unwrap_or_default();
                             view! {
-                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                    <section class="space-y-2">
-                                        <h3 class="font-semibold">"Current user shares"</h3>
-                                        <div class="space-y-2">
-                                            <For
-                                                each=move || users.clone()
-                                                key=|share| share.user_id
-                                                children=move |share| {
-                                                    view! {
-                                                        <div class="card p-3 flex items-center justify-between gap-3">
-                                                            <div class="min-w-0">
-                                                                <div class="font-semibold truncate">{share.username}</div>
-                                                                <div class="text-sm text-[color:var(--color-text-muted)]">
-                                                                    {share.user_id.to_string()} " · " {permission_label(share.permission)}
-                                                                </div>
-                                                            </div>
-                                                            <button class="btn-danger btn-sm" on:click=move |_| {
-                                                                unshare_user.dispatch(share.user_id);
-                                                            }>
-                                                                <Icon icon=i::BiTrashSolid />
-                                                            </button>
-                                                        </div>
-                                                    }
-                                                }
+                                <div class="space-y-6">
+                                    <section class="space-y-3">
+                                        <h3 class="text-lg font-bold text-[color:var(--color-text)]">"Add people or groups"</h3>
+                                        <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_7rem_7rem]">
+                                            <input
+                                                class="input w-full text-base"
+                                                placeholder="Search Discord ID or Group name..."
+                                                prop:value=recipient
+                                                on:input=move |ev| set_recipient(event_target_value(&ev))
                                             />
-                                        </div>
-                                    </section>
-                                    <section class="space-y-2">
-                                        <h3 class="font-semibold">"Current group shares"</h3>
-                                        <div class="space-y-2">
-                                            <For
-                                                each=move || shared_groups.clone()
-                                                key=|share| share.group_id
-                                                children=move |share| {
-                                                    view! {
-                                                        <div class="card p-3 flex items-center justify-between gap-3">
-                                                            <div class="min-w-0">
-                                                                <div class="font-semibold truncate">{share.group_name}</div>
-                                                                <div class="text-sm text-[color:var(--color-text-muted)]">
-                                                                    {permission_label(share.permission)}
-                                                                </div>
-                                                            </div>
-                                                            <button class="btn-danger btn-sm" on:click=move |_| {
-                                                                unshare_group.dispatch(share.group_id);
-                                                            }>
-                                                                <Icon icon=i::BiTrashSolid />
-                                                            </button>
-                                                        </div>
-                                                    }
-                                                }
-                                            />
-                                        </div>
-                                    </section>
-                                    <section class="space-y-2">
-                                        <h3 class="font-semibold">"Share with group"</h3>
-                                        <div class="flex flex-col sm:flex-row gap-2">
                                             <select
-                                                class="input flex-1"
-                                                on:change=move |ev| {
-                                                    set_selected_group(event_target_value(&ev).parse::<i32>().ok());
-                                                }
-                                            >
-                                                <For
-                                                    each=move || owned_groups.clone()
-                                                    key=|group| group.id
-                                                    children=move |group| {
-                                                        view! { <option value=group.id.to_string()>{group.name}</option> }
-                                                    }
-                                                />
-                                            </select>
-                                            <select
-                                                class="input flex-1"
-                                                on:change=move |ev| set_group_permission(editable_permission(&event_target_value(&ev)))
+                                                class="input w-full"
+                                                on:change=move |ev| set_recipient_permission(editable_permission(&event_target_value(&ev)))
                                             >
                                                 <option value="Read">"Read"</option>
                                                 <option value="Write">"Write"</option>
                                             </select>
                                             <button
+                                                type="button"
                                                 class="btn-primary"
-                                                prop:disabled=move || selected_group().is_none()
+                                                prop:disabled=move || recipient().trim().is_empty()
                                                 on:click=move |_| {
-                                                    if let Some(group_id) = selected_group() {
-                                                        share_group.dispatch((group_id, group_permission()));
+                                                    let raw = recipient().trim().to_string();
+                                                    if raw.is_empty() {
+                                                        return;
+                                                    }
+                                                    if let Ok(user_id) = raw.parse::<i64>() {
+                                                        share_user.dispatch((user_id, recipient_permission()));
+                                                        set_recipient(String::new());
+                                                        return;
+                                                    }
+                                                    let raw_lower = raw.to_lowercase();
+                                                    if let Some(group) = owned_groups_for_submit
+                                                        .iter()
+                                                        .find(|group| group.name.to_lowercase() == raw_lower)
+                                                    {
+                                                        share_group.dispatch((group.id, recipient_permission()));
+                                                        set_recipient(String::new());
+                                                    } else if let Some(toasts) = toasts {
+                                                        toasts.error("Enter a Discord user ID or an exact group name you own");
                                                     }
                                                 }
                                             >
-                                                "Share"
+                                                "Invite"
                                             </button>
                                         </div>
                                     </section>
-                                    <section class="space-y-2">
-                                        <h3 class="font-semibold">"Active invites"</h3>
-                                        <div class="space-y-2">
-                                            <For
-                                                each=move || invites.clone()
-                                                key=|invite| invite.id.clone()
-                                                children=move |invite| {
-                                                    let invite_id = invite.id.clone();
-                                                    view! {
-                                                        <div class="card p-3 flex items-center justify-between gap-3">
-                                                            <div class="min-w-0">
-                                                                <div class="font-mono text-sm truncate">{invite.id}</div>
-                                                                <div class="text-sm text-[color:var(--color-text-muted)]">
-                                                                    {permission_label(invite.permission)}
-                                                                    " · "
-                                                                    {invite.uses.to_string()}
-                                                                    "/"
-                                                                    {invite.max_uses.map(|m| m.to_string()).unwrap_or_else(|| "∞".to_string())}
-                                                                </div>
-                                                            </div>
-                                                            <button class="btn-danger btn-sm" on:click=move |_| {
-                                                                delete_invite.dispatch(invite_id.clone());
-                                                            }>
-                                                                <Icon icon=i::BiTrashSolid />
-                                                            </button>
-                                                        </div>
-                                                    }
-                                                }
+
+                                    <section class="space-y-3">
+                                        <h3 class="text-lg font-bold text-[color:var(--color-text)]">"Or share via link"</h3>
+                                        <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_7rem_9rem_14rem]">
+                                            <input
+                                                class="input w-full font-mono text-sm"
+                                                readonly
+                                                prop:value=latest_invite_url
+                                                placeholder="Create an invite link..."
+                                                on:click=move |_| copy_latest_invite(invites_for_copy.clone())
                                             />
+                                            <select
+                                                class="input w-full"
+                                                on:change=move |ev| set_invite_permission(editable_permission(&event_target_value(&ev)))
+                                            >
+                                                <option value="Read">"Read"</option>
+                                                <option value="Write">"Write"</option>
+                                            </select>
+                                            <input
+                                                class="input w-full"
+                                                inputmode="numeric"
+                                                placeholder="Max uses"
+                                                prop:value=invite_max_uses
+                                                on:input=move |ev| set_invite_max_uses(event_target_value(&ev))
+                                            />
+                                            <button
+                                                type="button"
+                                                class="btn-primary"
+                                                prop:disabled=create_invite.pending()
+                                                on:click=move |_| {
+                                                    let max_uses = invite_max_uses().trim().parse::<i32>().ok();
+                                                    create_invite.dispatch(CreateInvite {
+                                                        permission: invite_permission(),
+                                                        max_uses,
+                                                    });
+                                                    set_invite_max_uses(String::new());
+                                                }
+                                            >
+                                                <Icon icon=i::BsClipboard2Fill />
+                                                <span>"Copy Invite Link"</span>
+                                            </button>
+                                        </div>
+                                    </section>
+
+                                    <div class="h-px bg-[color:var(--color-outline)]"></div>
+
+                                    <section class="space-y-3">
+                                        <h3 class="text-lg font-bold text-[color:var(--color-text)]">"Who has access"</h3>
+                                        <AccessList
+                                            users=users
+                                            groups=shared_groups
+                                            invites=invites
+                                            unshare_user
+                                            unshare_group
+                                            delete_invite
+                                        />
+                                        <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--color-text)_4%,transparent)] p-3 text-sm text-[color:var(--color-text-muted)]">
+                                            "Tip: group names must match one of your owned groups exactly. Discord users can be added by numeric Discord user ID."
+                                            {if owned_groups.is_empty() {
+                                                Some(view! { <span> " You do not own any groups yet." </span> })
+                                            } else {
+                                                None
+                                            }}
                                         </div>
                                     </section>
                                 </div>
@@ -365,6 +344,178 @@ fn ShareListModal(list: List, set_visible: WriteSignal<bool>) -> impl IntoView {
                 </Suspense>
             </div>
         </Modal>
+    }
+}
+
+#[component]
+fn AccessList(
+    users: Vec<ListSharedUser>,
+    groups: Vec<ListSharedGroup>,
+    invites: Vec<ListInvite>,
+    unshare_user: Action<i64, Result<(), crate::error::AppError>>,
+    unshare_group: Action<i32, Result<(), crate::error::AppError>>,
+    delete_invite: Action<String, Result<(), crate::error::AppError>>,
+) -> impl IntoView {
+    let is_empty = users.is_empty() && groups.is_empty() && invites.is_empty();
+    view! {
+        <div class="space-y-1">
+            <Show when=move || is_empty>
+                <div class="rounded-lg border border-dashed border-[color:var(--color-outline)] p-5 text-center text-[color:var(--color-text-muted)]">
+                    "Only the owner has access right now."
+                </div>
+            </Show>
+
+            <For
+                each=move || users.clone()
+                key=|share| share.user_id
+                children=move |share| {
+                    let user_id = share.user_id;
+                    view! {
+                        <AccessRow
+                            icon=i::BsPersonCircle
+                            label=share.username
+                            detail="(Discord User)".to_string()
+                            trailing=permission_label(share.permission).to_string()
+                            on_delete=Callback::new(move |_| {
+                                unshare_user.dispatch(user_id);
+                            })
+                        />
+                    }
+                }
+            />
+
+            <For
+                each=move || groups.clone()
+                key=|share| share.group_id
+                children=move |share| {
+                    let group_id = share.group_id;
+                    view! {
+                        <AccessRow
+                            icon=i::BiGroupSolid
+                            label=share.group_name
+                            detail="(Group)".to_string()
+                            trailing=permission_label(share.permission).to_string()
+                            on_delete=Callback::new(move |_| {
+                                unshare_group.dispatch(group_id);
+                            })
+                        />
+                    }
+                }
+            />
+
+            <For
+                each=move || invites.clone()
+                key=|invite| invite.id.clone()
+                children=move |invite| {
+                    let invite_id = invite.id.clone();
+                    let label = format!("Link: {}", invite.id.chars().take(10).collect::<String>());
+                    let trailing = invite_uses_label(&invite);
+                    view! {
+                        <AccessRow
+                            icon=i::BiLinkRegular
+                            label
+                            detail=format!("(Invite · {})", permission_label(invite.permission))
+                            trailing
+                            on_delete=Callback::new(move |_| {
+                                delete_invite.dispatch(invite_id.clone());
+                            })
+                        />
+                    }
+                }
+            />
+        </div>
+    }
+}
+
+#[component]
+pub fn ListInviteAccept() -> impl IntoView {
+    let params = use_params_map();
+    let navigate = use_navigate();
+    let invite_id =
+        Memo::new(move |_| params.with(|p| p.get("invite_id").clone().unwrap_or_default()));
+    let login = Resource::new(|| (), |_| async move { get_login().await });
+    let redeem_invite = Action::new(move |invite_id: &String| use_list_invite(invite_id.clone()));
+    let redeem_started = RwSignal::new(false);
+
+    Effect::new(move |_| {
+        if redeem_started.get() {
+            return;
+        }
+        let Some(Ok(_)) = login.get() else {
+            return;
+        };
+        let invite_id = invite_id();
+        if invite_id.is_empty() {
+            return;
+        }
+        redeem_started.set(true);
+        redeem_invite.dispatch(invite_id);
+    });
+
+    Effect::new(move |_| {
+        if let Some(Ok(list_id)) = redeem_invite.value().get() {
+            navigate(&format!("/list/{list_id}"), Default::default());
+        }
+    });
+
+    view! {
+        <div class="panel mx-auto max-w-xl rounded-xl p-6">
+            <div class="space-y-4">
+                <div>
+                    <h1 class="text-2xl font-bold text-[color:var(--brand-fg)]">"Accept list invite"</h1>
+                    <p class="text-sm text-[color:var(--color-text-muted)]">"Sign in with Discord to add this shared list to your account."</p>
+                </div>
+
+                <Suspense fallback=move || view! { <Loading /> }>
+                    {move || match login.get() {
+                        None => view! { <Loading /> }.into_any(),
+                        Some(Err(e)) => {
+                            if matches!(
+                                e,
+                                crate::error::AppError::ApiError(
+                                    ultros_api_types::result::ApiError::NotAuthenticated
+                                )
+                            ) {
+                                let href = format!("/login?next=/list/invite/{}", invite_id());
+                                view! {
+                                    <div class="space-y-4">
+                                        <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] p-4 text-sm text-[color:var(--color-text-muted)]">
+                                            "This invite is tied to your Ultros account, so you need to log in before accepting it."
+                                        </div>
+                                        <a class="btn-primary" href=href>
+                                            <Icon icon=i::BsPersonCircle />
+                                            <span>"Sign in with Discord"</span>
+                                        </a>
+                                    </div>
+                                }.into_any()
+                            } else {
+                                view! {
+                                    <div class="alert alert-error">{format!("Could not load invite: {e}")}</div>
+                                }.into_any()
+                            }
+                        }
+                        Some(Ok(_)) => {
+                            match redeem_invite.value().get() {
+                                Some(Ok(_)) => view! {
+                                    <div class="text-sm text-[color:var(--color-text-muted)]">"Opening shared list..."</div>
+                                }.into_any(),
+                                Some(Err(e)) => view! {
+                                    <div class="space-y-3">
+                                        <div class="alert alert-error">{format!("Could not accept invite: {e}")}</div>
+                                        <A href="/list" attr:class="btn-secondary">"Back to lists"</A>
+                                    </div>
+                                }.into_any(),
+                                None => view! {
+                                    <div class="text-sm text-[color:var(--color-text-muted)]">
+                                        {move || if redeem_invite.pending().get() { "Accepting invite..." } else { "Preparing invite..." }}
+                                    </div>
+                                }.into_any(),
+                            }
+                        }
+                    }}
+                </Suspense>
+            </div>
+        </div>
     }
 }
 

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -7,7 +7,7 @@ use axum_extra::extract::{
     PrivateCookieJar,
     cookie::{Cookie, Key, SameSite},
 };
-use cookie::CookieBuilder;
+use cookie::{CookieBuilder, time::Duration};
 use oauth2::{
     AccessToken, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointNotSet,
     EndpointSet, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RevocationUrl, Scope,
@@ -130,11 +130,50 @@ impl Display for OAuthScope {
     }
 }
 
+const LOGIN_NEXT_COOKIE: &str = "login_next";
+
+#[derive(Deserialize, Default)]
+pub struct LoginParameters {
+    next: Option<String>,
+}
+
+fn safe_login_next(next: Option<&str>) -> Option<String> {
+    let next = next?.trim();
+    if next.is_empty()
+        || !next.starts_with('/')
+        || next.starts_with("//")
+        || next.contains('\\')
+        || next.contains('\n')
+        || next.contains('\r')
+        || next.contains("://")
+    {
+        return None;
+    }
+    Some(next.to_string())
+}
+
 pub async fn begin_login(
-    cookies: PrivateCookieJar,
+    mut cookies: PrivateCookieJar,
     State(config): State<DiscordAuthConfig>,
+    Query(params): Query<LoginParameters>,
 ) -> (PrivateCookieJar, Redirect) {
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    if let Some(raw_next) = params.next.as_deref() {
+        if let Some(next) = safe_login_next(Some(raw_next)) {
+            cookies = cookies.add(
+                CookieBuilder::new(LOGIN_NEXT_COOKIE, next)
+                    .same_site(SameSite::Lax)
+                    .secure(true)
+                    .http_only(true)
+                    .path("/")
+                    .max_age(Duration::minutes(10))
+                    .build(),
+            );
+        } else if let Some(cookie) = cookies.get(LOGIN_NEXT_COOKIE) {
+            cookies = cookies.remove(cookie);
+        }
+    }
 
     let cookies = cookies.add(
         CookieBuilder::new("pkce_challenge", pkce_challenge.as_str().to_string())
@@ -184,6 +223,13 @@ pub async fn redirect(
     } else {
         None
     };
+    let redirect_to = if let Some(login_next) = cookies.get(LOGIN_NEXT_COOKIE) {
+        let redirect_to = safe_login_next(Some(login_next.value())).unwrap_or_else(|| "/".into());
+        cookies = cookies.remove(login_next);
+        redirect_to
+    } else {
+        "/".to_string()
+    };
     let mut request = config.inner.client.exchange_code(code);
     if let Some(pkce_verifier) = pkce_verifier {
         request = request.set_pkce_verifier(PkceCodeVerifier::new(pkce_verifier));
@@ -201,7 +247,7 @@ pub async fn redirect(
     cookie.set_http_only(true);
     cookie.make_permanent();
     cookies = cookies.add(cookie);
-    Ok((cookies, Redirect::to("/")))
+    Ok((cookies, Redirect::to(&redirect_to)))
 }
 
 pub async fn logout(
@@ -371,6 +417,36 @@ impl DiscordAuthConfig {
                 http_client,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_login_next;
+
+    #[test]
+    fn safe_login_next_accepts_same_origin_relative_paths() {
+        assert_eq!(
+            safe_login_next(Some("/list/invite/abc123")),
+            Some("/list/invite/abc123".to_string())
+        );
+        assert_eq!(
+            safe_login_next(Some("  /settings?tab=account  ")),
+            Some("/settings?tab=account".to_string())
+        );
+    }
+
+    #[test]
+    fn safe_login_next_rejects_external_or_malformed_targets() {
+        assert_eq!(safe_login_next(None), None);
+        assert_eq!(safe_login_next(Some("")), None);
+        assert_eq!(safe_login_next(Some("https://evil.example")), None);
+        assert_eq!(safe_login_next(Some("//evil.example/path")), None);
+        assert_eq!(safe_login_next(Some("/\\evil")), None);
+        assert_eq!(
+            safe_login_next(Some("/path\r\nLocation: //evil.example")),
+            None
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Reworked the list share modal into a single-column dialog with add-recipient, invite-link, and consolidated access sections.
- Added support for sharing by numeric Discord user ID or owned group name match, plus fresh invite creation/copy behavior with invite URLs rooted at the current origin.
- Added `/list/invite/:invite_id` so invite links can be redeemed directly, with post-login return support through a safe relative `next` parameter.
- Removed now-unused frontend group helper APIs and tightened invite/login error handling.

## Testing
- `cargo fmt --all`
- `cargo leptos build`
- `bash ./check_ci.sh`
- Added OAuth tests covering safe and unsafe login վերադարձ targets; full `cargo test -p ultros oauth::tests` is still blocked locally by an MSVC linker issue in the existing test binary.