### PR TITLE
⚡ Bolt: Optimize retainer undercut item calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,7 @@
 ## 2024-05-18 - [Optimizing Leptos Reactivity & Arc Clones]
 **Learning:** In Leptos, using a `move ||` closure for view arguments creates a dynamic node tracking reactivity. For static/immutable strings, computing it once (outside closure or immediately resolving inside `{ }` block without closure) avoids reactive tracking overhead. Also, when passing structs like `SearchResult` around, passing `Arc<SearchResult>` and cloning the `Arc` is O(1) and far cheaper than extracting and cloning its inner `String` components multiple times for callbacks.
 **Action:** Always prefer cloning `Arc` instead of `String` within closures, and omit `move ||` for static derivations when rendering Leptos components.
+
+## 2025-03-02 - Optimize Nested Iterator Chains to Reduce Allocations
+**Learning:** In `get_retainer_undercut_items`, the previous implementation chained `.filter().collect::<Vec<_>>()` and then iterated again with `.iter().map().min()` to calculate `number_behind` and `price_to_beat`. This forced the allocation of a throwaway Vector for every single listing being checked just to compute its length and find a minimum value.
+**Action:** Always compute aggregates directly within a single zero-allocation `for` loop pass over the original iterator/slice instead of relying on intermediate `Vec` allocations from `.collect()` during multi-step iterator chains.

--- a/ultros-db/src/retainers.rs
+++ b/ultros-db/src/retainers.rs
@@ -201,23 +201,29 @@ impl UltrosDb {
                                             return None;
                                         }
                                         // now check if the given listing is UNDERCUTTING than our given listing
-                                        let listings_in_range: Vec<_> = listings
-                                            .iter()
-                                            .filter(|all_l| {
-                                                all_l.price_per_unit < l.price_per_unit
-                                                    && (!l.hq || l.hq == all_l.hq)
-                                                    // filter our own retainer listings
-                                                    && !retainer_ids
-                                                        .contains(&all_l.retainer_id)
-                                            })
-                                            .collect();
+                                        let mut number_behind = 0;
+                                        let mut price_to_beat = None;
+
+                                        for all_l in listings.iter() {
+                                            if all_l.price_per_unit < l.price_per_unit
+                                                && (!l.hq || l.hq == all_l.hq)
+                                                // filter our own retainer listings
+                                                && !retainer_ids.contains(&all_l.retainer_id)
+                                            {
+                                                number_behind += 1;
+                                                price_to_beat = Some(
+                                                    price_to_beat
+                                                        .map(|p| {
+                                                            std::cmp::min(p, all_l.price_per_unit)
+                                                        })
+                                                        .unwrap_or(all_l.price_per_unit),
+                                                );
+                                            }
+                                        }
+
                                         return Some(ListingUndercutData {
-                                            number_behind: listings_in_range.len(),
-                                            price_to_beat: listings_in_range
-                                                .iter()
-                                                .map(|x| x.price_per_unit)
-                                                .min()
-                                                .unwrap_or_default(),
+                                            number_behind,
+                                            price_to_beat: price_to_beat.unwrap_or_default(),
                                         });
                                     }
                                     None


### PR DESCRIPTION
💡 What: Replaced an intermediate `Vec` allocation (`filter().collect::<Vec<_>>().iter().min()`) with a single-pass `for` loop in `get_retainer_undercut_items`.
🎯 Why: Creating a temporary `Vec` on every single undercut check iteration was unnecessarily wasteful for memory and CPU when simply counting and tracking a minimum value.
📊 Impact: Eliminates a major source of allocations during the `get_retainer_undercut_items` query, making the undercut calculation significantly more memory efficient and slightly faster.
🔬 Measurement: Code can be measured via profiling allocations during undercut listings checks. Tested locally with `cargo check` and `cargo test`.

---
*PR created automatically by Jules for task [25610126369167918](https://jules.google.com/task/25610126369167918) started by @akarras*