### PR TITLE
🎨 Palette: Add aria-label to Budget filter remove button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Missing label associations and ARIA labels in Endpoint Forms
 **Learning:** Found that `EndpointCreateForm` inputs lacked standard `id` and `for` associations, and icon-only buttons like "Delete endpoint" lacked `aria-label`. Standard accessible form practices seem to be occasionally missed in Leptos `view!` macros.
 **Action:** Next time, remember to apply `id` and `for` attributes to `input` and `label` elements when creating or editing forms to ensure screen readers announce them properly. Always ensure `aria-label` is present on interactive elements that only contain icons.
+## 2026-05-14 - Added aria-label to max_purchase_price filter button
+**Learning:** Found that the button to remove the `max_purchase_price` filter chip in `analyzer.rs` was missing an `aria-label`, unlike the other filter removal buttons. This is an accessibility issue where screen readers wouldn't announce the purpose of the icon-only button.
+**Action:** Always verify that dynamically generated icon-only buttons (like inside a loop or conditional rendering block) have appropriate `aria-label` attributes.

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -750,7 +750,7 @@ fn AnalyzerTable(
                             chips.push(view! {
                                 <span class="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-[color:var(--color-text)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)] border-[color:var(--color-outline)]">
                                     "Budget ≤ " <Gil amount=p />
-                                    <button class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_max_purchase_price(None)>
+                                    <button aria-label="Remove filter" class="ml-1 text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]" on:click=move |_| set_max_purchase_price(None)>
                                         <Icon icon=icondata::MdiClose />
                                     </button>
                                 </span>


### PR DESCRIPTION
💡 **What**: Added `aria-label="Remove filter"` to the icon-only button used to remove the "Budget" (max purchase price) filter in the analyzer view.
🎯 **Why**: Without an ARIA label, screen readers only announce this as a generic "button" because it only contains an icon. Adding the label provides necessary context to users relying on assistive technologies.
♿ **Accessibility**: Improved keyboard and screen reader accessibility by ensuring all interactive elements have an accessible name. Matches existing patterns used by other filter chips in the codebase.

---
*PR created automatically by Jules for task [13857870726282989415](https://jules.google.com/task/13857870726282989415) started by @akarras*