### PR TITLE
fix(push): route delivery via reqwest and ship CA bundle in runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,18 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,15 +979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,37 +1614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "socket2 0.6.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.87+curl-8.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
-dependencies = [
- "cc",
- "libc",
- "libnghttp2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2666,19 +2614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,12 +3015,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -4348,32 +4277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "isahc"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d93e1769c5c2b13a8e0d8ca9b6466c60bafade047326f25e3bcb97a947d875"
-dependencies = [
- "async-channel",
- "castaway",
- "crossbeam-utils",
- "curl",
- "curl-sys",
- "encoding_rs",
- "event-listener",
- "futures-lite",
- "http 0.2.12",
- "log",
- "mime",
- "polling",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url",
- "waker-fn",
-]
-
-[[package]]
 name = "isocountry"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,16 +4924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libnghttp2-sys"
-version = "0.1.13+1.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492e00167f1418c15648144f42bbfc63099806ecee9bf8d09a6353d6b4856b3c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,18 +4940,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5937,12 +5818,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -6428,20 +6303,6 @@ dependencies = [
  "tokio",
  "tracing",
  "trim-in-place",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7518,7 +7379,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -8583,17 +8444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "sluice"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160b744a45e8261307bcfe03c98e2f8274502207d534c9a64b675c4db1b6bd58"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
 ]
 
 [[package]]
@@ -9798,16 +9648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10537,12 +10377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10841,9 +10675,7 @@ dependencies = [
  "chrono",
  "ct-codecs",
  "ece",
- "futures-lite",
  "http 0.2.12",
- "isahc",
  "jwt-simple",
  "log",
  "pem 3.0.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,11 @@ cfg-if = "1.0.4"
 git-const = "1.1.0"
 gloo-net = { version = "0.7.0", features = ["http", "websocket"] }
 dotenvy = "0.15.7"
-web-push = "0.11.0"
+# Default features pull in `isahc` (libcurl) for sending — we route push delivery
+# through the existing `reqwest` client instead so we get embedded webpki-roots
+# for TLS and real error messages on failure (web-push collapses isahc errors to
+# `WebPushError::Unspecified` and discards the cause).
+web-push = { version = "0.11.0", default-features = false }
 
 [patch.crates-io]
 #leptos = { path = "../leptos/leptos" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=builder /app/Cargo.toml /app/
 RUN mkdir /usr/local/share/fonts
 COPY --from=builder /app/ultros/static/*.ttf /usr/local/share/fonts
 RUN apt update; apt upgrade -y
-RUN apt install libfreetype6 fontconfig libfontconfig1 -y; apt-get clean; rm -rf /var/lib/apt/lists/*;
+RUN apt install libfreetype6 fontconfig libfontconfig1 ca-certificates -y; apt-get clean; rm -rf /var/lib/apt/lists/*;
 WORKDIR /app
 ENV RUST_LOG="info"
 ENV LEPTOS_OUTPUT_NAME="ultros"

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -235,6 +235,14 @@ async fn send_dm(
 /// subscription has been revoked), soft-delete the row so we don't keep trying
 /// to send to a dead endpoint. Other errors propagate to the caller as-is,
 /// which lets `alert_event.delivery_error` capture the failure.
+///
+/// The HTTP request is constructed by `web-push`'s `request_builder` (which
+/// owns TTL/Urgency/crypto-header logic) and sent via `reqwest`. We avoid the
+/// built-in `IsahcWebPushClient` because (a) it links libcurl, which needs the
+/// system CA bundle present on disk — a footgun on slim container images — and
+/// (b) the crate's `From<isahc::Error>` impl discards the underlying cause and
+/// surfaces every transport failure as `WebPushError::Unspecified`, leaving
+/// operators with no signal about what actually broke.
 async fn send_webpush(
     subscription_id: i32,
     title: &str,
@@ -243,8 +251,7 @@ async fn send_webpush(
     config: &WebPushConfig,
 ) -> Result<()> {
     use web_push::{
-        ContentEncoding, IsahcWebPushClient, SubscriptionInfo, WebPushClient, WebPushError,
-        WebPushMessageBuilder,
+        ContentEncoding, SubscriptionInfo, WebPushError, WebPushMessageBuilder, request_builder,
     };
 
     let sub = db.get_push_subscription_by_id(subscription_id).await?;
@@ -273,10 +280,22 @@ async fn send_webpush(
         .build()
         .map_err(|e| anyhow!("web push build failed: {e:?}"))?;
 
-    let client =
-        IsahcWebPushClient::new().map_err(|e| anyhow!("isahc client init failed: {e:?}"))?;
+    let http_req = request_builder::build_request::<reqwest::Body>(message);
+    let req = reqwest::Request::try_from(http_req)
+        .map_err(|e| anyhow!("push request convert failed: {e}"))?;
 
-    match client.send(message).await {
+    let resp = reqwest::Client::new()
+        .execute(req)
+        .await
+        .map_err(|e| anyhow!("push send failed: {e}"))?;
+
+    let status = resp.status();
+    let body_bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| anyhow!("push response read failed: {e}"))?;
+
+    match request_builder::parse_response(status, body_bytes.to_vec()) {
         Ok(()) => {
             // Best-effort touch — if the update fails we still report success
             // since the push itself went through.
@@ -289,7 +308,7 @@ async fn send_webpush(
                 .await;
             Err(anyhow!("push subscription expired"))
         }
-        Err(e) => Err(anyhow!("push send failed: {e:?}")),
+        Err(e) => Err(anyhow!("push send failed: {e}")),
     }
 }
 


### PR DESCRIPTION
## Summary

Browser push notifications were failing in production with the opaque error `Push send failed: Unspecified`. Glitchtip had no signal because the backend wasn't reporting these failures with any useful detail.

Two stacked problems:

1. **`web-push` 0.11's default transport (`isahc`/libcurl) collapses every transport failure into `WebPushError::Unspecified`.** Its `From<isahc::Error>` impl is literally `fn from(_: isahc::Error) -> Self { Self::Unspecified }` — the underlying error is thrown away. So no matter what really happened (TLS, DNS, connect, timeout), we only saw \"Unspecified\".
2. **The runner image was `debian:bookworm-slim`, which doesn't ship `ca-certificates`.** libcurl had no CA bundle to verify TLS handshakes against, so every push to FCM/Mozilla failed at the TLS layer. Discord/webhook deliveries kept working because `reqwest` uses rustls with embedded `webpki-roots` — no on-disk CA dependency.

## Changes

- **`Dockerfile`** — install `ca-certificates` in the runner apt step. Immediate fix for the production deploy and defense-in-depth for any future libcurl/openssl consumer.
- **`Cargo.toml`** — set `web-push = { version = \"0.11.0\", default-features = false }`. libcurl/curl-sys are no longer linked into the binary.
- **`ultros/src/alerts/delivery.rs`** — `send_webpush` now builds the HTTP request via `web_push::request_builder::build_request::<reqwest::Body>` and sends it through `reqwest::Client`. `EndpointNotFound`/`EndpointNotValid` still soft-delete the subscription as before.

## Knock-on benefits

- Errors now surface real causes (\"tcp connect error: …\", \"error trying to connect: dns error: …\") instead of an opaque variant — the next push regression won't need a long detective session.
- One fewer HTTP stack in the binary (no libcurl), one fewer system dep (no CA bundle on disk needed for push).

## Test plan

- [x] `cargo check -p ultros` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] After deploy: trigger a price-alert event with a WebPush endpoint; verify the browser actually receives the notification
- [ ] Sanity-check that an expired subscription still soft-deletes (returns 404/410 from the push service → \"push subscription expired\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)