### PR TITLE
⚡ Bolt: replace full-list fetch with db-level find by name

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,7 @@
 ## 2025-03-02 - Optimize Nested Iterator Chains to Reduce Allocations
 **Learning:** In `get_retainer_undercut_items`, the previous implementation chained `.filter().collect::<Vec<_>>()` and then iterated again with `.iter().map().min()` to calculate `number_behind` and `price_to_beat`. This forced the allocation of a throwaway Vector for every single listing being checked just to compute its length and find a minimum value.
 **Action:** Always compute aggregates directly within a single zero-allocation `for` loop pass over the original iterator/slice instead of relying on intermediate `Vec` allocations from `.collect()` during multi-step iterator chains.
+
+## 2024-05-24 - [Discord List Resolution]
+**Learning:** Found an N+1 query issue masquerading as `get_lists_for_user`. The Discord bot commands fetched ALL lists across all 3 relations just to do a `.into_iter().find(...)` in memory! This fetched unneeded list data entirely across the wire and instantiated unused memory.
+**Action:** Always check the underlying DB functions behind fetching collections before using `.find(...)` on the collection in application code. Replace full collection retrievals with targeted queries if only one specific record is needed.

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -259,6 +259,48 @@ impl UltrosDb {
         Ok(all_lists)
     }
 
+    pub async fn get_list_by_name_for_user(
+        &self,
+        discord_user: i64,
+        list_name: &str,
+    ) -> Result<Option<list::Model>> {
+        let owned_list = list::Entity::find()
+            .filter(list::Column::Owner.eq(discord_user))
+            .filter(list::Column::Name.eq(list_name))
+            .one(&self.db)
+            .await?;
+        if owned_list.is_some() {
+            return Ok(owned_list);
+        }
+
+        let shared_list = list::Entity::find()
+            .inner_join(list_shared_user::Entity)
+            .filter(list_shared_user::Column::UserId.eq(discord_user))
+            .filter(list::Column::Name.eq(list_name))
+            .one(&self.db)
+            .await?;
+        if shared_list.is_some() {
+            return Ok(shared_list);
+        }
+
+        let group_list = list::Entity::find()
+            .inner_join(list_shared_group::Entity)
+            .join(
+                JoinType::InnerJoin,
+                list_shared_group::Relation::UserGroup.def(),
+            )
+            .join(
+                JoinType::InnerJoin,
+                user_group::Relation::UserGroupMember.def(),
+            )
+            .filter(user_group_member::Column::UserId.eq(discord_user))
+            .filter(list::Column::Name.eq(list_name))
+            .one(&self.db)
+            .await?;
+
+        Ok(group_list)
+    }
+
     pub async fn get_list(&self, list_id: i32, discord_user: i64) -> Result<list::Model> {
         let permission = self.get_permission(list_id, discord_user).await?;
         if permission < ListPermission::Read {

--- a/ultros/src/discord/ffxiv/lists.rs
+++ b/ultros/src/discord/ffxiv/lists.rs
@@ -146,10 +146,8 @@ async fn share_user(
     let list = ctx
         .data()
         .db
-        .get_lists_for_user(owner.id)
+        .get_list_by_name_for_user(owner.id, &list_name)
         .await?
-        .into_iter()
-        .find(|list| list.name == list_name)
         .ok_or(anyhow!("Unable to find list `{list_name}`"))?;
 
     ctx.data()
@@ -192,10 +190,8 @@ async fn create_invite(
     let list = ctx
         .data()
         .db
-        .get_lists_for_user(owner.id)
+        .get_list_by_name_for_user(owner.id, &list_name)
         .await?
-        .into_iter()
-        .find(|list| list.name == list_name)
         .ok_or(anyhow!("Unable to find list `{list_name}`"))?;
     let invite = ctx
         .data()
@@ -290,14 +286,11 @@ async fn remove(
     list_name: String,
 ) -> Result<(), Error> {
     ctx.defer_ephemeral().await?;
-    let user_lists = ctx
+    let lists = ctx
         .data()
         .db
-        .get_lists_for_user(ctx.author().id.get() as i64)
-        .await?;
-    let lists = user_lists
-        .into_iter()
-        .find(|list| list.name == list_name)
+        .get_list_by_name_for_user(ctx.author().id.get() as i64, &list_name)
+        .await?
         .ok_or(anyhow!("Failed to find list {list_name}"))?;
     ctx.data()
         .db
@@ -336,10 +329,8 @@ async fn add_item(
     let list = ctx
         .data()
         .db
-        .get_lists_for_user(author_id)
+        .get_list_by_name_for_user(author_id, &list_name)
         .await?
-        .into_iter()
-        .find(|l| l.name == list_name)
         .ok_or(anyhow!("List not found"))?;
     ctx.data()
         .db
@@ -367,10 +358,11 @@ async fn remove_item(
 ) -> Result<(), Error> {
     let author_id = ctx.author().id.get() as i64;
     let id = resolve_item_id_any_locale(&item_name).ok_or(anyhow!("Unable to find item"))?;
-    let lists = ctx.data().db.get_lists_for_user(author_id).await?;
-    let list = lists
-        .into_iter()
-        .find(|l| l.name == list_name)
+    let list = ctx
+        .data()
+        .db
+        .get_list_by_name_for_user(author_id, &list_name)
+        .await?
         .ok_or(anyhow!("Unable to find list"))?;
     let item = ctx
         .data()
@@ -396,10 +388,11 @@ async fn show_list(
 ) -> Result<(), Error> {
     ctx.defer_or_broadcast().await?;
     let discord_user = ctx.author().id.get() as i64;
-    let lists = ctx.data().db.get_lists_for_user(discord_user).await?;
-    let list = lists
-        .into_iter()
-        .find(|list| list.name == list_name)
+    let list = ctx
+        .data()
+        .db
+        .get_list_by_name_for_user(discord_user, &list_name)
+        .await?
         .ok_or(anyhow!("Unable to get list"))?;
     let mut list_listings = ctx
         .data()


### PR DESCRIPTION
💡 What: Implemented `get_list_by_name_for_user` in `ultros-db/src/lists.rs` and refactored `ultros/src/discord/ffxiv/lists.rs` commands to use it.
🎯 Why: Previously, finding a specific list by name loaded all owned, shared, and group lists into memory via large multi-relation joins. This scaled poorly for users with many lists. Pushing the `filter` condition to the database leverages the DB index and reduces over-the-wire payload size.
📊 Impact: Expected reduction in database load, lower memory allocations, and faster resolution time for Discord bot commands operating on named lists.
🔬 Measurement: Use `cargo test` and confirm tests pass. Memory use of the bot under load can be verified for improvements.

---
*PR created automatically by Jules for task [6203167817921413734](https://jules.google.com/task/6203167817921413734) started by @akarras*