### PR TITLE
fix(jobset): stop hydration panic by keeping price-slot element shape stable

### DIFF
--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -114,6 +114,50 @@ pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
     }
 }
 
+/// Render a gil amount when present, falling back to an em-dash placeholder
+/// when `amount` is `None` — without changing the element shape.
+///
+/// Switching between `<Gil>` (`<div><button/><div/></div>`) and a bare
+/// `<span>"—"</span>` via `into_any()` triggered tachys hydration mismatches
+/// at `hydration.rs:163` (`failed_to_cast_element`) on `/items/jobset/<JOB>`:
+/// if the server resolved the cheapest-listings resource and rendered a
+/// `<Gil>` but the client briefly evaluated the `None` arm (or vice versa),
+/// the dynamic-block child had a different root tag than the SSR DOM and the
+/// hydration walker panicked. Always emitting the same `<div>` + icon + value
+/// shape removes that class of mismatch entirely — the icon is just hidden
+/// via CSS when the value is unknown, so the SSR and CSR view trees agree on
+/// element types/positions regardless of resource state.
+#[component]
+pub fn GilOrDash(#[prop(into)] amount: Signal<Option<i32>>) -> impl IntoView {
+    let icon_class = move || {
+        if amount().is_some() {
+            "inline-flex"
+        } else {
+            "hidden"
+        }
+    };
+    let value_class = move || {
+        if amount().is_some() {
+            ""
+        } else {
+            "text-[color:var(--color-text-muted)]"
+        }
+    };
+    view! {
+        <div class="flex flex-row items-center">
+            <span class=icon_class>
+                <GilIcon />
+            </span>
+            <div class=value_class>
+                {move || amount()
+                    .map(|t| t.separate_with_commas())
+                    .unwrap_or_else(|| "—".to_string())
+                }
+            </div>
+        </div>
+    }
+}
+
 #[component]
 pub fn GenericGil<T>(#[prop(into)] amount: Signal<T>) -> impl IntoView
 where

--- a/ultros-frontend/ultros-app/src/components/job_set_card.rs
+++ b/ultros-frontend/ultros-app/src/components/job_set_card.rs
@@ -8,7 +8,7 @@ use leptos::prelude::*;
 use leptos_router::components::A;
 use ultros_api_types::cheapest_listings::CheapestListingsMap;
 
-use crate::components::gil::Gil;
+use crate::components::gil::GilOrDash;
 use crate::components::item_icon::{IconSize, ItemIcon};
 use crate::components::job_set_grouping::JobSetGroup;
 use crate::global_state::cheapest_prices::CheapestPrices;
@@ -194,8 +194,12 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
         })
     });
 
-    let total_nq = move || totals.with(|(nq, _)| *nq);
-    let total_hq = move || totals.with(|(_, hq)| *hq);
+    // Pre-narrow the totals into the `Option<i32>` shape `GilOrDash` consumes;
+    // the conversion has to happen before the view block so the SSR/CSR view
+    // trees do not branch on `Some`/`None` at the element level (see the
+    // module docs on `GilOrDash` for the hydration-mismatch failure mode).
+    let total_nq = Signal::derive(move || totals.with(|(nq, _)| nq.map(|t| t as i32)));
+    let total_hq = Signal::derive(move || totals.with(|(_, hq)| hq.map(|t| t as i32)));
 
     view! {
         <div class="group relative flex flex-col p-4 rounded-xl panel
@@ -248,10 +252,7 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
                         {t!(i18n, job_set_card_total_nq)}
                     </span>
                     <div class="flex flex-row items-center gap-1.5">
-                        {move || match total_nq() {
-                            Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                            None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                        }}
+                        <GilOrDash amount=total_nq />
                     </div>
                 </div>
                 <div class="flex flex-col">
@@ -259,10 +260,7 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
                         {t!(i18n, job_set_card_total_hq)}
                     </span>
                     <div class="flex flex-row items-center gap-1.5">
-                        {move || match total_hq() {
-                            Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                            None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                        }}
+                        <GilOrDash amount=total_hq />
                     </div>
                 </div>
                 <A

--- a/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
+++ b/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
@@ -17,7 +17,7 @@ use crate::api::get_cheapest_listings;
 use crate::components::add_set_to_list::AddSetToList;
 use crate::components::cheapest_price::CheapestPrice;
 use crate::components::crafting_cost::IngredientsIter;
-use crate::components::gil::Gil;
+use crate::components::gil::{Gil, GilOrDash};
 use crate::components::item_icon::{IconSize, ItemIcon};
 use crate::components::job_set_grouping::{GroupableItem, JobSetGroup, group_into_sets};
 use crate::components::meta::{MetaDescription, MetaTitle};
@@ -610,10 +610,7 @@ pub fn JobSetDetail() -> impl IntoView {
                                             });
                                             view! {
                                                 <div class="text-lg font-bold">
-                                                    {match total {
-                                                        Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                                                        None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                                                    }}
+                                                    <GilOrDash amount=total.map(|t| t as i32) />
                                                 </div>
                                                 {match (shard_total, total) {
                                                     (Some(with_shards), Some(no_shards)) if with_shards > no_shards => view! {
@@ -650,10 +647,7 @@ pub fn JobSetDetail() -> impl IntoView {
                                                 .and_then(|map| materials_total(&entries, map, true));
                                             view! {
                                                 <div class="text-lg font-bold">
-                                                    {match total {
-                                                        Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                                                        None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                                                    }}
+                                                    <GilOrDash amount=total.map(|t| t as i32) />
                                                 </div>
                                                 {match (shard_total, total) {
                                                     (Some(with_shards), Some(no_shards)) if with_shards > no_shards => view! {
@@ -710,10 +704,7 @@ pub fn JobSetDetail() -> impl IntoView {
                                         _ => None,
                                     })
                                 });
-                                match total {
-                                    Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                                    None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                                }
+                                view! { <GilOrDash amount=total.map(|t| t as i32) /> }
                             }}
                         </Suspense>
                     </div>
@@ -732,10 +723,7 @@ pub fn JobSetDetail() -> impl IntoView {
                                         .as_ref()
                                         .and_then(|map| set_total(&g, map, false))
                                 });
-                                match total {
-                                    Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),
-                                    None => view! { <span class="text-[color:var(--color-text-muted)]">"—"</span> }.into_any(),
-                                }
+                                view! { <GilOrDash amount=total.map(|t| t as i32) /> }
                             }}
                         </Suspense>
                     </div>


### PR DESCRIPTION
## Summary
- Adds a `GilOrDash` helper component whose root element shape never changes regardless of whether a price is available — closes the second half of the `/items/jobset/<JOB>` hydration mismatch that #693 only partially fixed.
- Replaces the four `Some(t) => <Gil .../>, None => <span>"—"</span>` dynamic blocks in `JobSetCard` and `job_set_detail` with `<GilOrDash amount=… />`.

## Why
`#693` sorted `data.items` deterministically to stop `tachys hydration.rs:163: failed_to_cast_element` on `/items/jobset/<JOB>`, but the panic kept firing on the deployed release. Tracing the latest GlitchTip events (issues [1017](https://glitchtip.ultros.app/ultros/issues/1017), [2334](https://glitchtip.ultros.app/ultros/issues/2334), [601](https://glitchtip.ultros.app/ultros/issues/601), [4922](https://glitchtip.ultros.app/ultros/issues/4922), and friends) showed the panic stack is now inside `JobSetCard`'s NQ/HQ "total cost" slot:

```rust
{move || match total_nq() {
    Some(t) => view! { <Gil amount=t as i32 /> }.into_any(),  // <div><button/><div/></div>
    None    => view! { <span class="…">"—"</span> }.into_any(), // <span>…</span>
}}
```

Different root tags on the two branches. When SSR resolved the `CheapestPrices` resource and rendered `<Gil>` but the CSR initial pass briefly saw `None` (or vice versa), tachys hit `failed_to_cast_element` and the panic hook chain produced the secondary `RefCell already borrowed` event we see paired with each one. Same bug class as #652 — just on a slot that arrived with #669.

## Fix
A single helper that always emits `<div class="flex flex-row items-center"><span class=…><GilIcon/></span><div class=…>{value}</div></div>`. The icon's wrapper toggles `inline-flex`/`hidden` via a class binding; the value text flips between the formatted number and `"—"`. No `into_any()` branching at the element level, so the SSR HTML and CSR view tree agree on element types at every position regardless of resource state.

Applied at five call sites: `JobSetCard` (NQ + HQ totals) and `job_set_detail` (materials totals × 2 + side-by-side zone totals × 2).

## Test plan
- [x] `cargo check -p ultros-app` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (with vendored OpenSSL build)
- [x] `cargo test -p ultros-app --lib` — pre-existing `test_job_filtering` / `test_sort_order` failures reproduce on `main` (data drift in the `ffxiv-datamining` submodule), not caused by this change
- [ ] After deploy, watch GlitchTip for `/items/jobset/<JOB>` panics to taper off — the cascading `RefCell already borrowed` events should drop as the upstream `failed_to_cast_element` panic stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)