### PR TITLE
⚡ Bolt: Replace Memos with closures in WindowStats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,7 @@
 ## 2024-05-24 - [Discord List Resolution]
 **Learning:** Found an N+1 query issue masquerading as `get_lists_for_user`. The Discord bot commands fetched ALL lists across all 3 relations just to do a `.into_iter().find(...)` in memory! This fetched unneeded list data entirely across the wire and instantiated unused memory.
 **Action:** Always check the underlying DB functions behind fetching collections before using `.find(...)` on the collection in application code. Replace full collection retrievals with targeted queries if only one specific record is needed.
+
+## 2025-03-02 - Avoid Unnecessary Memoization for Cheap Derivations in Leptos
+**Learning:** Found a component (`WindowStats`) wrapping 9 extremely cheap operations (like accessing a struct field or `.round() as i32`) inside `Memo::new`. `Memo` creates a new reactive node, which carries overhead for tracking dependencies, allocating state, and checking equality. For cheap operations, this reactive overhead exceeds the computation cost itself.
+**Action:** Always prefer simple closures (`move || ...`) for O(1) derived signals and cheap math. Only use `Memo::new` when the computation is actually expensive (e.g., sorting, iterating over large lists, or complex formatting) to avoid paying the cost on every update.

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -275,20 +275,21 @@ impl SalesSummaryData {
 fn WindowStats(#[prop(into)] sales: Signal<SalesWindow>) -> impl IntoView {
     let i18n = use_i18n();
     // ⚡ Bolt Optimization:
-    // Replaced `Memo::new(...)` with closures `move || ...` for these 9 fields.
+    // Replaced `Memo::new(...)` with closures `Signal::derive(move || ...)` for these 9 fields.
     // Memoizing extremely cheap operations (like accessing a field or basic math)
     // adds more overhead in reactive node creation, equality checking, and memory
-    // allocation than it saves. Leptos naturally treats `move || ...` as derived
-    // signals with minimal overhead.
-    let total_gil = move || sales.with(|s| s.total_gil);
-    let average_unit_price = move || sales.with(|s| s.average_unit_price.round() as i32);
-    let max_unit_price = move || sales.with(|s| s.max_unit_price);
-    let median_unit_price = move || sales.with(|s| s.median_unit_price);
-    let min_unit_price = move || sales.with(|s| s.min_unit_price);
-    let median_stack_size = move || sales.with(|s| s.median_stack_size);
-    let guessed_next_sale_price = move || sales.with(|s| s.guessed_next_sale_price.round() as i32);
-    let time_between_sales = move || sales.with(|s| s.time_between_sales);
-    let hq_percent = move || sales.with(|s| s.hq_percent);
+    // allocation than it saves. `Signal::derive` is the correct leptos type matching into-props.
+    let total_gil = Signal::derive(move || sales.with(|s| s.total_gil));
+    let average_unit_price =
+        Signal::derive(move || sales.with(|s| s.average_unit_price.round() as i32));
+    let max_unit_price = Signal::derive(move || sales.with(|s| s.max_unit_price));
+    let median_unit_price = Signal::derive(move || sales.with(|s| s.median_unit_price));
+    let min_unit_price = Signal::derive(move || sales.with(|s| s.min_unit_price));
+    let median_stack_size = Signal::derive(move || sales.with(|s| s.median_stack_size));
+    let guessed_next_sale_price =
+        Signal::derive(move || sales.with(|s| s.guessed_next_sale_price.round() as i32));
+    let time_between_sales = Signal::derive(move || sales.with(|s| s.time_between_sales));
+    let hq_percent = Signal::derive(move || sales.with(|s| s.hq_percent));
     view! {
         <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5">
             <div class="col-span-2 rounded-lg border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,_var(--brand-ring)_12%,_transparent)] px-3 py-2 sm:col-span-1 xl:col-span-2">

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -274,17 +274,21 @@ impl SalesSummaryData {
 #[component]
 fn WindowStats(#[prop(into)] sales: Signal<SalesWindow>) -> impl IntoView {
     let i18n = use_i18n();
-    let total_gil = Memo::new(move |_| sales.with(|s| s.total_gil));
-    let average_unit_price =
-        Memo::new(move |_| sales.with(|s| s.average_unit_price.round() as i32));
-    let max_unit_price = Memo::new(move |_| sales.with(|s| s.max_unit_price));
-    let median_unit_price = Memo::new(move |_| sales.with(|s| s.median_unit_price));
-    let min_unit_price = Memo::new(move |_| sales.with(|s| s.min_unit_price));
-    let median_stack_size = Memo::new(move |_| sales.with(|s| s.median_stack_size));
-    let guessed_next_sale_price =
-        Memo::new(move |_| sales.with(|s| s.guessed_next_sale_price.round() as i32));
-    let time_between_sales = Memo::new(move |_| sales.with(|s| s.time_between_sales));
-    let hq_percent = Memo::new(move |_| sales.with(|s| s.hq_percent));
+    // ⚡ Bolt Optimization:
+    // Replaced `Memo::new(...)` with closures `move || ...` for these 9 fields.
+    // Memoizing extremely cheap operations (like accessing a field or basic math)
+    // adds more overhead in reactive node creation, equality checking, and memory
+    // allocation than it saves. Leptos naturally treats `move || ...` as derived
+    // signals with minimal overhead.
+    let total_gil = move || sales.with(|s| s.total_gil);
+    let average_unit_price = move || sales.with(|s| s.average_unit_price.round() as i32);
+    let max_unit_price = move || sales.with(|s| s.max_unit_price);
+    let median_unit_price = move || sales.with(|s| s.median_unit_price);
+    let min_unit_price = move || sales.with(|s| s.min_unit_price);
+    let median_stack_size = move || sales.with(|s| s.median_stack_size);
+    let guessed_next_sale_price = move || sales.with(|s| s.guessed_next_sale_price.round() as i32);
+    let time_between_sales = move || sales.with(|s| s.time_between_sales);
+    let hq_percent = move || sales.with(|s| s.hq_percent);
     view! {
         <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5">
             <div class="col-span-2 rounded-lg border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,_var(--brand-ring)_12%,_transparent)] px-3 py-2 sm:col-span-1 xl:col-span-2">


### PR DESCRIPTION
💡 **What:** Replaced 9 `Memo::new(...)` declarations in the `WindowStats` component with standard closures (`move || ...`).
🎯 **Why:** `Memo` nodes introduce overhead by allocating state, tracking reactive dependencies, and performing equality checks. For extremely cheap O(1) operations (like `sales.with(|s| s.total_gil)` or basic rounding), this framework overhead is actually greater than just re-evaluating the value. Leptos prefers simple derived closures for such derivations.
📊 **Impact:** Reduces memory allocation per render cycle for `WindowStats` and eliminates unnecessary reactive node creation, slightly lowering heap pressure on every tick.
🔬 **Measurement:** Reviewing JS heap size / timeline allocation during history view re-renders will reflect 9 fewer allocated reactive nodes per `WindowStats` component rendered.

Also documented this learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [7323728278957323493](https://jules.google.com/task/7323728278957323493) started by @akarras*