### PR TITLE
fix: rustls CryptoProvider panic + Discord command nesting (GlitchTip triage)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9863,6 +9863,7 @@ dependencies = [
  "reqwest 0.11.27",
  "resvg",
  "rkyv",
+ "rustls 0.23.36",
  "sentry",
  "sentry-tower",
  "sentry-tracing",

--- a/ultros/Cargo.toml
+++ b/ultros/Cargo.toml
@@ -93,6 +93,12 @@ web-push = { workspace = true }
 # installing OpenSSL dev headers separately, and on Linux it removes the libssl-dev
 # bootstrap requirement (CI still has libssl-dev installed; vendored is harmless there).
 openssl = { version = "0.10", features = ["vendored"] }
+# Direct dep so we can install a process-level CryptoProvider at startup.
+# Transitive consumers (serenity, reqwest 0.12/0.13, sqlx, tokio-rustls, sentry) pull
+# in rustls 0.23 with both `aws-lc-rs` and `ring` activated via feature unification,
+# which makes `ClientConfig::builder()` panic with "Could not automatically determine
+# the process-level CryptoProvider". We install one explicitly in `main()`.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 [dev-dependencies]
 tempfile = "3.6.0"

--- a/ultros/src/discord/ffxiv/alert.rs
+++ b/ultros/src/discord/ffxiv/alert.rs
@@ -11,6 +11,13 @@ use crate::event::EventType;
 use super::{Context, Error, ULTROS_COLOR};
 
 /// Manage price alerts and delivery endpoints.
+//
+// Discord slash commands support at most two levels of nesting (command > group >
+// subcommand). `ffxiv > alert` already consumes both levels, so the inner `endpoint`
+// group cannot be a subcommand group of its own — Discord rejects registration with
+// `Invalid Form Body (... .options.N: Value of field "type" must be one of (1,).)`.
+// We flatten the former `endpoint` group into `endpoint-list`/`endpoint-remove`/
+// `endpoint-here` siblings here.
 #[poise::command(
     slash_command,
     prefix_command,
@@ -22,13 +29,15 @@ use super::{Context, Error, ULTROS_COLOR};
         "mute",
         "unmute",
         "remove",
-        "endpoint",
+        "endpoint_list",
+        "endpoint_remove",
+        "endpoint_here",
         "webhook"
     )
 )]
 pub(crate) async fn alert(ctx: Context<'_>) -> Result<(), Error> {
     ctx.say(
-        "Use one of: `price`, `list`, `list-subscribe`, `list-updates`, `mute`, `unmute`, `remove`, `endpoint`, `webhook`.\n\
+        "Use one of: `price`, `list`, `list-subscribe`, `list-updates`, `mute`, `unmute`, `remove`, `endpoint-list`, `endpoint-remove`, `endpoint-here`, `webhook`.\n\
          e.g. `/ffxiv alert price item:Tsai_tou_Vounou price:50000`",
     )
     .await?;
@@ -421,27 +430,19 @@ async fn remove(
     Ok(())
 }
 
-// ----- endpoint sub-subcommand -----
-
-/// Manage delivery endpoints used by your alerts.
-#[poise::command(
-    slash_command,
-    prefix_command,
-    subcommands("endpoint_list", "endpoint_remove", "endpoint_here")
-)]
-async fn endpoint(ctx: Context<'_>) -> Result<(), Error> {
-    ctx.say("Use one of: `list`, `remove`, `here`.").await?;
-    Ok(())
-}
+// ----- endpoint flat subcommands -----
+// Previously these lived under a nested `endpoint` subcommand group, but Discord
+// doesn't allow a subcommand group inside a subcommand group (see comment on
+// `alert` above). They're flat siblings of the other alert subcommands now.
 
 /// List your delivery endpoints.
-#[poise::command(slash_command, prefix_command, rename = "list")]
+#[poise::command(slash_command, prefix_command, rename = "endpoint-list")]
 async fn endpoint_list(ctx: Context<'_>) -> Result<(), Error> {
     let owner = ctx.author().id.get() as i64;
     let endpoints = ctx.data().db.list_endpoints(owner).await?;
     if endpoints.is_empty() {
         ctx.say(
-            "You have no endpoints. Create one with `/ffxiv alert endpoint here` or \
+            "You have no endpoints. Create one with `/ffxiv alert endpoint-here` or \
              `/ffxiv alert price` (which creates a DM endpoint automatically).",
         )
         .await?;
@@ -472,10 +473,10 @@ async fn endpoint_list(ctx: Context<'_>) -> Result<(), Error> {
 }
 
 /// Delete an endpoint (also unlinks it from any alert).
-#[poise::command(slash_command, prefix_command, rename = "remove")]
+#[poise::command(slash_command, prefix_command, rename = "endpoint-remove")]
 async fn endpoint_remove(
     ctx: Context<'_>,
-    #[description = "Endpoint id (see `/ffxiv alert endpoint list`)"] id: i32,
+    #[description = "Endpoint id (see `/ffxiv alert endpoint-list`)"] id: i32,
 ) -> Result<(), Error> {
     let owner = ctx.author().id.get() as i64;
     ctx.data().db.delete_endpoint(owner, id).await?;
@@ -484,7 +485,7 @@ async fn endpoint_remove(
 }
 
 /// Register the current channel as a delivery endpoint and bind it to one of your alerts.
-#[poise::command(slash_command, prefix_command, rename = "here")]
+#[poise::command(slash_command, prefix_command, rename = "endpoint-here")]
 async fn endpoint_here(
     ctx: Context<'_>,
     #[description = "Alert id to also bind to this channel (optional)"] bind_to: Option<i32>,
@@ -544,7 +545,7 @@ async fn endpoint_here(
     } else {
         ctx.say(format!(
             "Endpoint `#{endpoint_id}` registered for this channel. \
-             Use `/ffxiv alert endpoint here bind_to:<alert_id>` to attach it to an alert."
+             Use `/ffxiv alert endpoint-here bind_to:<alert_id>` to attach it to an alert."
         ))
         .await?;
     }

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -198,6 +198,15 @@ async fn main() -> Result<()> {
     // Load environment variables from `.env` file, if present
     dotenv().ok();
 
+    // Install a process-level rustls CryptoProvider. Multiple transitive deps
+    // (serenity/poise, reqwest 0.12/0.13, sqlx, tokio-rustls, sentry) unify on
+    // rustls 0.23 with BOTH `aws-lc-rs` and `ring` features active, so
+    // `ClientConfig::builder()` panics on first TLS connect ("Could not
+    // automatically determine the process-level CryptoProvider"). Install
+    // once at startup before any TLS handshake. Ignore the result because a
+    // double-install only fails if some upstream beat us to it, which is fine.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Glitchtip / Sentry error reporting. No-op when GLITCHTIP_DSN is unset, so
     // local dev runs without it. The guard must be held for the duration of
     // main() so the background transport can flush on shutdown.


### PR DESCRIPTION
## Summary

Two distinct backend panics surfaced in GlitchTip triage, both with clear root causes — fixing both here. Each is in its own commit.

### 1. rustls CryptoProvider panic ([#4888](https://glitchtip.ultros.app/ultros/issues/4888), 13 events)

`panic: Could not automatically determine the process-level CryptoProvider from Rustls crate features.`

`cargo tree -i rustls:0.23.36` shows the dep graph unifies on rustls 0.23 with both `aws-lc-rs` and `ring` features active (reqwest 0.12/0.13, serenity/poise, sqlx-postgres, tokio-rustls, sentry, rustls-platform-verifier). With both providers compiled in, rustls' auto-pick refuses to choose and panics on the first TLS handshake. In the captured stack the panic surfaced inside poise prefix dispatch (`ultros::main::async_block$0` → tokio → poise → reqwest 0.12 → hyper-rustls → rustls).

Fix: add `rustls = "0.23"` as a direct dep with only the `aws-lc-rs` feature, and call `rustls::crypto::aws_lc_rs::default_provider().install_default()` at the top of `main()` before any TLS work. `aws-lc-rs` is already in `Cargo.lock`, so this adds no new compile artifact.

### 2. Discord command registration failure ([#4873](https://glitchtip.ultros.app/ultros/issues/4873), 19 events)

`failed to register Discord application commands: Invalid Form Body (2.options.6.options.7: Value of field "type" must be one of (1,).)`

Decoded path: command index 2 is `ffxiv`, option 6 is `alert`, option 7 inside `alert` is `endpoint`. Discord requires the inner option to be type 1 (SUB_COMMAND), but `endpoint` was registered as type 2 (SUB_COMMAND_GROUP) because it carried its own `subcommands(...)`. Discord caps slash-command nesting at two levels (`command > group > subcommand`), and `ffxiv > alert` already used both — `alert > endpoint > endpoint_list` was one level too deep. Every slash command for the bot failed to register as a result.

Fix: drop the `endpoint` wrapper and expose the three former sub-subcommands as direct siblings of `alert`'s other subcommands, renamed `endpoint-list` / `endpoint-remove` / `endpoint-here` so the slash UI stays self-describing. Help text and `#[description]` strings updated to match.

## Other triage in this pass

- [GlitchTip #4965](https://glitchtip.ultros.app/ultros/issues/4965) (`CompileError: invalid value type 'externref'`) — older browser without WebAssembly reference-types support. Marked **ignored** in GlitchTip.
- [GlitchTip #4964](https://glitchtip.ultros.app/ultros/issues/4964) (`market_heat` nested-aggregate ClickHouse error) — already fixed on a separate branch in commit `d5ff8cf7`. No action needed here.
- WASM hydration cluster on `/items/jobset/*` / `/items/category/*` (`tachys-0.2.15/src/hydration.rs:163: unreachable`) — multi-issue SSR/CSR mismatch. Two recent commits (eb2e5250, b8f8d970) attacked it; it's still firing. Needs its own focused investigation; deliberately out of scope here.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [ ] Bot restart in dev: `/ffxiv alert endpoint-list`, `/ffxiv alert endpoint-here`, `/ffxiv alert endpoint-remove` register and respond
- [ ] First outbound TLS handshake (e.g., a Discord interaction or push delivery) no longer panics; resolve [GlitchTip #4888](https://glitchtip.ultros.app/ultros/issues/4888) and [#4873](https://glitchtip.ultros.app/ultros/issues/4873) once verified in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)