### PR TITLE
fix(frontend): /login and /invitebot anchors must opt out of SPA routing

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/bot.rs
+++ b/ultros-frontend/ultros-app/src/routes/bot.rs
@@ -24,6 +24,7 @@ pub fn BotGuide() -> impl IntoView {
                     {t!(i18n, bot_invite_suffix)}
                 </p>
                 <a
+                    rel="external"
                     href="/invitebot"
                     class="self-start rounded-md bg-brand-500 px-5 py-2.5 font-semibold text-white shadow hover:bg-brand-400 transition-colors"
                 >

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -484,7 +484,7 @@ pub fn ListInviteAccept() -> impl IntoView {
                                         <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] p-4 text-sm text-[color:var(--color-text-muted)]">
                                             "This invite is tied to your Ultros account, so you need to log in before accepting it."
                                         </div>
-                                        <a class="btn-primary" href=href>
+                                        <a class="btn-primary" rel="external" href=href>
                                             <Icon icon=i::BsPersonCircle />
                                             <span>{t!(i18n, lists_sign_in_discord_button)}</span>
                                         </a>


### PR DESCRIPTION
## Summary

A user reported that clicking **Sign in with Discord** on the list-invite acceptance page renders the SPA NotFound (404) instead of taking them to the OAuth flow. The original report (and a missed repro attempt) suggested a recent OAuth-related regression — but the actual cause is older and unrelated to the CSRF fix in #697.

## Root cause

`leptos_router` installs a document-level click handler that intercepts **every** `<a>` click and tries to resolve the href against the SPA route table. The escape hatches ([leptos_router-0.8.13/src/location/mod.rs:298](https://github.com/leptos-rs/leptos/blob/main/router/src/location/mod.rs)) are:

- `rel="external"` (or any rel containing `external`)
- `target` set, `download` attribute, modifier keys, cross-origin href

`/login` and `/invitebot` are **backend** Axum routes ([ultros/src/web.rs:1509](https://github.com/akarras/ultros/blob/main/ultros/src/web.rs#L1509), [:1512](https://github.com/akarras/ultros/blob/main/ultros/src/web.rs#L1512)) — they don't exist in the SPA route table ([lib.rs](https://github.com/akarras/ultros/blob/main/ultros-frontend/ultros-app/src/lib.rs)). When the router intercepts a click to `/login`, no `<Route>` matches and `fallback=NotFound` renders. That's the "404" the friend saw.

Two of the three "Sign in with Discord" entry points already opt out correctly:

| Location | `rel="external"`? |
|---|---|
| `components/profile_display.rs` (top-right avatar) | yes |
| `components/apps_menu.rs` (mobile menu) | yes |
| `routes/lists.rs:487` (list invite acceptance) | **no — fixed here** |
| `routes/bot.rs:26` (`/invitebot` button on bot guide) | **no — fixed here** |

## Why it wasn't caught

The broken paths are narrow:
- `/list/invite/:id` requires a specific shared-list invite URL **while logged out**
- `/bot` is a static guide page; clicking the invite-bot button mid-session was just rare

The common nav and avatar entry points work, which is why the maintainer couldn't reproduce.

## Changes

- `routes/lists.rs` — add `rel="external"` to the sign-in anchor in `ListInviteAccept`
- `routes/bot.rs` — add `rel="external"` to the `/invitebot` anchor in `BotGuide`

Two-character semantic fix, no functional or styling impact beyond restoring real browser navigation.

## Test plan

- [ ] Manual: open `/list/invite/<any-id>` in a private/incognito window. Click **Sign in with Discord** → should redirect to `discord.com/oauth2/authorize`, not render NotFound.
- [ ] Manual: open `/bot` and click **Invite Bot** → should hit the `/invitebot` Axum handler (which redirects to Discord's bot install URL), not render NotFound.
- [ ] Regression: avatar and mobile-menu sign-in still work (they had `rel="external"` already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)