### PR TITLE
ci: Docker build check on PRs + fix znver2 SIGILL on CI runners

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,9 +4,14 @@ rustflags = ["--cfg=web_sys_unstable_apis"]
 # Target-scoped rustflags REPLACE [build].rustflags rather than merging, so the
 # web_sys cfg is repeated here. Only applied to native x86_64 Linux builds —
 # the WASM target (wasm32-unknown-unknown) keeps the [build] rustflags above,
-# which is important because target-cpu=znver2 is meaningless / breaking for WASM.
+# which is important because target-cpu=* is meaningless / breaking for WASM.
 #
-# znver2 = Zen 2 (Threadripper 3970x, Ryzen 3000-series). Enables AVX2, FMA3,
-# BMI1/2, but not AVX-512. Binaries built with this WILL SIGILL on pre-Zen2 CPUs.
+# x86-64-v3 = modern AMD64 baseline (Haswell+, Zen+): AVX2, BMI1/2, FMA, F16C.
+# Chosen over znver2 because cargo applies these rustflags to build scripts and
+# proc-macros (compiled for the *host* target, which on Linux is also
+# x86_64-unknown-linux-gnu). GitHub Actions runners aren't all Zen 2, so
+# znver2-targeted build scripts would intermittently SIGILL mid-build. v3 is
+# universal across modern x86 and gives up only minor scheduling hints vs
+# znver2 — set `RUSTFLAGS` locally if you want a hotter target for dev builds.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["--cfg=web_sys_unstable_apis", "-C", "target-cpu=znver2"]
+rustflags = ["--cfg=web_sys_unstable_apis", "-C", "target-cpu=x86-64-v3"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,16 @@ on:
             - "**/*.md"
             - ".github/workflows/book.yml"
             - ".github/workflows/book-check.yml"
+    # PRs build the image to catch Dockerfile breakage early, but never push,
+    # sign, or upload symbols. The `push:` flag below is gated on event_name.
+    pull_request:
+        branches:
+            - "main"
+        paths-ignore:
+            - "userguide/**"
+            - "**/*.md"
+            - ".github/workflows/book.yml"
+            - ".github/workflows/book-check.yml"
 
 env:
     # Use ghcr.io for GitHub Container Registry
@@ -38,6 +48,7 @@ jobs:
               uses: docker/setup-buildx-action@v3
 
             - name: Log in to registry
+              if: github.event_name != 'pull_request'
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
@@ -60,11 +71,15 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=gha
-                  cache-to: type=gha,mode=max
+                  # PRs read main's cache but don't write — avoids thrashing
+                  # the shared cache from short-lived branches.
+                  cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
 
             - name: Install cosign
+              if: github.event_name != 'pull_request'
               uses: sigstore/cosign-installer@v4.0.0
             - name: Sign published Docker image
+              if: github.event_name != 'pull_request'
               env:
                   TAGS: ${{ steps.meta.outputs.tags }}
                   DIGEST: ${{ steps.build-and-push.outputs.digest }}
@@ -79,6 +94,7 @@ jobs:
             # being set; cleanly no-ops if they aren't.
 
             - name: Check GlitchTip configuration
+              if: github.event_name != 'pull_request'
               id: glitchtip-check
               env:
                   AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger to `docker-publish.yml` so PRs build the image but never push, sign, or upload symbols — catches Dockerfile breakage before it lands on main. `cache-to` is gated to main pushes so PR builds read main's layer cache without thrashing it.
- Drops the native `target-cpu` from `znver2` to `x86-64-v3` in `.cargo/config.toml`. Cargo applies `[target.x86_64-unknown-linux-gnu].rustflags` to build scripts and proc-macros (the host target on Linux runners is also `x86_64-unknown-linux-gnu`), so `znver2`-targeted build scripts SIGILL when GH Actions assigns a non-Zen 2 runner — exactly what happened in [run 25973472831](https://github.com/akarras/ultros/actions/runs/25973472831/job/76349477440), where `rustc` died with `signal: 4, SIGILL` while compiling `js-sys`. `x86-64-v3` is the modern AMD64 baseline (AVX2/BMI2/FMA/F16C, Haswell+/Zen+), universal across CI runners, and gives up only minor scheduling hints vs `znver2` in practice.

## Test plan
- [ ] This PR's own Docker check turns green (validates both changes end-to-end)
- [ ] Verify the post-merge `push` build still publishes, signs, and uploads symbols
- [ ] Spot-check that local `cargo build` on the Threadripper still completes in roughly the same time (set `RUSTFLAGS="-C target-cpu=znver2"` locally if you want the old behavior back for dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)