### PR TITLE
🛡️ Sentinel: [HIGH] Secure OAuth PKCE verifier cookie

### DIFF
--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -183,6 +183,8 @@ pub async fn begin_login(
     );
     let cookies = cookies.add(
         CookieBuilder::new("pkce_verifier", pkce_verifier.secret().clone())
+            .same_site(SameSite::Lax)
+            .secure(true)
             .http_only(true)
             .build(),
     );


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The OAuth `pkce_verifier` cookie lacked the `Secure` and `SameSite` flags.
🎯 **Impact:** Without `Secure`, the cookie could be transmitted over an unencrypted connection and intercepted. Without `SameSite`, the cookie could be vulnerable to some classes of cross-site request forgery attacks.
🔧 **Fix:** Added `.secure(true)` and `.same_site(SameSite::Lax)` to the `CookieBuilder` for `pkce_verifier` in `ultros/src/web/oauth.rs`.
✅ **Verification:** Verified that the cookie builder methods are correctly invoked with the right properties without breaking compilation or the login callback redirection mechanics.

---
*PR created automatically by Jules for task [14091970956675643782](https://jules.google.com/task/14091970956675643782) started by @akarras*