### PR TITLE
fix(web): keep analyzer warm-up 503 out of error logs (GlitchTip triage)

### DIFF
--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -30,10 +30,11 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tower::ServiceBuilder;
+use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::compression::predicate::{NotForContentType, SizeAbove};
 use tower_http::compression::{CompressionLayer, Predicate};
 use tower_http::trace::TraceLayer;
-use tracing::{debug, warn};
+use tracing::{Span, debug, warn};
 use ultros_api_types::list::{
     CreateInvite, CreateList, List, ListActivity, ListActivityKind, ListInvite, ListItem,
     ListSharedGroup, ListSharedUser, ListWithPermission, ShareListGroup, ShareListUser,
@@ -1543,7 +1544,31 @@ pub(crate) async fn start_web(state: WebState) {
         .with_state(state)
         .route_layer(middleware::from_fn(track_metrics))
         .layer(middleware::from_fn(redirect_legacy_book_host))
-        .layer(TraceLayer::new_for_http())
+        // tower-http's default `on_failure` logs every 5xx via `tracing::error!`,
+        // which the `sentry_tracing` layer turns into a GlitchTip issue. The
+        // analyzer service returns 503 during its warm-up window — those aren't
+        // bugs, just a transient startup state (see WebError::as_status_code and
+        // issues 5033/5034). Drop 503 to debug so it stays out of error logs.
+        .layer(TraceLayer::new_for_http().on_failure(
+            |class: ServerErrorsFailureClass, latency: Duration, _: &Span| match class {
+                ServerErrorsFailureClass::StatusCode(status)
+                    if status == hyper::StatusCode::SERVICE_UNAVAILABLE =>
+                {
+                    tracing::debug!(
+                        %status,
+                        ?latency,
+                        "response failed (likely warm-up)",
+                    );
+                }
+                _ => {
+                    tracing::error!(
+                        classification = %class,
+                        ?latency,
+                        "response failed",
+                    );
+                }
+            },
+        ))
         // Sentry/Glitchtip: bind a fresh Hub per request and decorate captured
         // events with HTTP context (method, URL, status). NewSentryLayer must
         // come before SentryHttpLayer; ServiceBuilder applies in declared

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -200,7 +200,13 @@ impl WebError {
 impl IntoResponse for WebError {
     fn into_response(self) -> Response {
         let status = self.as_status_code();
-        if status.is_server_error() {
+        // Analyzer warm-up (503) is an expected transient state at startup, not
+        // a real server bug. Keep it out of `tracing::error!` so the
+        // `sentry_tracing` layer doesn't capture it as a GlitchTip issue
+        // (see issues 5033/5034 — e2e harness racing the warm-up window).
+        let is_transient_warmup =
+            matches!(self, WebError::AnalyzerError(AnalyzerError::Uninitialized));
+        if status.is_server_error() && !is_transient_warmup {
             tracing::error!(error = %self, %status, "Returning web error");
         } else {
             tracing::debug!(error = %self, %status, "Returning web error");


### PR DESCRIPTION
## Summary

Two GlitchTip issues fire on every e2e run against a fresh server because the analyzer's startup window returns `503 Service Unavailable` and both log sites treat that as an error:

- **#5033** "Returning web error" (22 events) — `WebError::into_response` logs at `error!` whenever `status.is_server_error()` is true. Even though `as_status_code` already special-cases `AnalyzerError::Uninitialized` to 503, the log level doesn't follow.
- **#5034** "response failed" (22 events) — `TraceLayer::new_for_http()` uses tower-http's `DefaultOnFailure`, which also logs every 5xx at `error!`.

`sentry_tracing` pipes both to GlitchTip, so the same request lands as two issues. The e2e harness hitting `/api/v1/cheapest/<region>` mid-warm-up is the reliable trigger.

This PR downgrades **only** the analyzer-warmup-style 503 to `debug` at both sites:

- [ultros/src/web/error.rs](ultros/src/web/error.rs): skip the `error!` branch when the variant is `WebError::AnalyzerError(AnalyzerError::Uninitialized)`.
- [ultros/src/web.rs](ultros/src/web.rs): replace `TraceLayer::new_for_http()` with a custom `on_failure` that maps `ServerErrorsFailureClass::StatusCode(503)` to `debug!` and keeps the default `error!` for every other 5xx — so real 500s/502s still surface.

Other 503s (none today) would also be downgraded; 503 is "transient, retry" by convention. Anything wanting to fail loudly can return 500.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo check -p ultros --bin ultros` — clean.
- [ ] After deploy: confirm next e2e run on `Bahamut` produces no new events on issues #5033/#5034 (cross-check by hitting `/api/v1/cheapest/North-America` during the warm-up window).
- [ ] Sanity: a real 500 (e.g. trigger a panic in any handler) still fires `error!` and reaches GlitchTip.

GlitchTip references:
- https://glitchtip.ultros.app/ultros/issues/5033
- https://glitchtip.ultros.app/ultros/issues/5034

🤖 Generated with [Claude Code](https://claude.com/claude-code)