### PR TITLE
fix(home): visible degradation when market pulse fetch errors

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "市场交易额",
     "market_pulse_unit_volume": "24 小时成交数量",
     "market_pulse_vs_yesterday": "对比昨日",
+    "market_pulse_load_failed": "无法加载市场数据，请稍后重试",
     "market_movers_title": "市场风向",
     "market_movers_subtitle": "过去 24 小时热门商品",
     "market_movers_rising": "上涨",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "Marktvolumen",
     "market_pulse_unit_volume": "Stück gehandelt (24 h)",
     "market_pulse_vs_yesterday": "ggü. gestern",
+    "market_pulse_load_failed": "Marktdaten konnten nicht geladen werden — bitte erneut versuchen",
     "market_movers_title": "Marktbewegung",
     "market_movers_subtitle": "Top-Items der letzten 24 Stunden",
     "market_movers_rising": "Steigend",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "Market Volume",
     "market_pulse_unit_volume": "Units Traded (24h)",
     "market_pulse_vs_yesterday": "vs yesterday",
+    "market_pulse_load_failed": "Couldn't load market pulse — retry shortly",
     "market_movers_title": "Market movers",
     "market_movers_subtitle": "Top items in the last 24 hours",
     "market_movers_rising": "Rising",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "Volume de marché",
     "market_pulse_unit_volume": "Unités vendues (24 h)",
     "market_pulse_vs_yesterday": "vs hier",
+    "market_pulse_load_failed": "Impossible de charger les indicateurs — réessayez sous peu",
     "market_movers_title": "Mouvements du marché",
     "market_movers_subtitle": "Top objets sur les 24 dernières heures",
     "market_movers_rising": "En hausse",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "取引高",
     "market_pulse_unit_volume": "取引数量（24時間）",
     "market_pulse_vs_yesterday": "前日比",
+    "market_pulse_load_failed": "市場データを読み込めませんでした。しばらくしてからお試しください",
     "market_movers_title": "マーケット動向",
     "market_movers_subtitle": "過去24時間の注目アイテム",
     "market_movers_rising": "上昇",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "거래 금액",
     "market_pulse_unit_volume": "거래 수량 (24h)",
     "market_pulse_vs_yesterday": "어제 대비",
+    "market_pulse_load_failed": "시장 데이터를 불러올 수 없습니다. 잠시 후 다시 시도하세요",
     "market_movers_title": "시장 동향",
     "market_movers_subtitle": "최근 24시간 인기 아이템",
     "market_movers_rising": "상승",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -1097,6 +1097,7 @@
     "market_pulse_gil_volume": "市場交易額",
     "market_pulse_unit_volume": "24 小時成交數量",
     "market_pulse_vs_yesterday": "對比昨日",
+    "market_pulse_load_failed": "無法載入市場數據，請稍後重試",
     "market_movers_title": "市場風向",
     "market_movers_subtitle": "過去 24 小時熱門商品",
     "market_movers_rising": "上漲",

--- a/ultros-frontend/ultros-app/src/components/market_pulse.rs
+++ b/ultros-frontend/ultros-app/src/components/market_pulse.rs
@@ -101,8 +101,15 @@ pub fn MarketPulse(world: Signal<Option<String>>) -> impl IntoView {
                             </div>
                         }.into_any(),
                         // Server soft-fails CH errors to a zeroed DTO so this
-                        // branch only fires for hard errors (e.g. unknown world).
-                        Err(_) => view! { <div></div> }.into_any(),
+                        // branch only fires for hard errors (e.g. unknown world
+                        // or analyzer warming up after a fresh deploy). Render
+                        // a visible muted line at the same height as the loaded
+                        // strip so the layout doesn't shift when it recovers.
+                        Err(_) => view! {
+                            <div class="flex items-center justify-center h-[5.25rem] text-sm text-[color:var(--color-text-muted)]">
+                                {t!(i18n, market_pulse_load_failed)}
+                            </div>
+                        }.into_any(),
                     })
                 }}
             </Suspense>


### PR DESCRIPTION
## Summary
- Replace `MarketPulse`'s silent `<div></div>` error arm with a muted "Couldn't load market pulse — retry shortly" line at the same fixed height as the loaded strip.
- Adds i18n key `market_pulse_load_failed` to all 7 locales.

## Why
During the new ClickHouse analyzer's warmup window (or any hard fetch error — unknown world, network blip), `MarketPulse` was disappearing entirely from the dashboard with no signal to the user. With this change, users see something they can read, and the fixed height prevents a layout shift when the data comes back.

The other three home-page widgets (`MarketHeat`, `MarketMovers`, `TopOpportunity`) already render visible "no data" text on their empty/error paths, so they're acceptable as-is. Splitting their resources to distinguish error from empty would be a separate refactor.

## Scope notes
This does **not** address the prod hydration panic on the home page ([GlitchTip Issue 5063](https://glitchtip.ultros.app/ultros/issues/5063) — `tachys hydration.rs:163 unreachable`). That's a separate WASM-level failure that an `ErrorBoundary` wouldn't catch — investigation suggests the Greeting `Effect::new` in `home_page.rs:79-89` calling `js_sys::Date::new_0()` during the hydration walk is the leading suspect. Will spin that out separately if confirmed.

## Test plan
- [ ] Verify the dashboard renders the fallback message when `/api/v1/market_pulse/{world}` returns 503
- [ ] Verify no layout shift between fallback and loaded states
- [ ] Verify the fallback text appears in all 7 supported locales
- [ ] CI: `cargo fmt --all -- --check` passes (clippy was not run locally — submodule init blocked in environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)