### PR TITLE
fix(home): defer RecentItems localStorage read until after hydration

### DIFF
--- a/ultros-frontend/ultros-app/src/components/recently_viewed.rs
+++ b/ultros-frontend/ultros-app/src/components/recently_viewed.rs
@@ -7,7 +7,7 @@ use codee::string::JsonSerdeCodec;
 use leptos::leptos_dom::helpers::set_timeout;
 use leptos::prelude::*;
 use leptos_router::components::A;
-use leptos_use::storage::use_local_storage;
+use leptos_use::storage::{UseStorageOptions, use_local_storage_with_options};
 use ultros_api_types::icon_size::IconSize;
 use ultros_api_types::sparklines::{SparklineSeries, SparklinesRequest};
 use xiv_gen::ItemId;
@@ -25,8 +25,21 @@ pub struct RecentItems {
 
 impl RecentItems {
     pub fn new() -> Self {
+        // `delay_during_hydration` is required: without it leptos-use reads
+        // localStorage synchronously inside the component setup, which on the
+        // client races the still-running hydration. The CSR signal then holds
+        // a non-empty VecDeque while the SSR'd DOM was rendered with the
+        // empty default, so tachys' walker hits a different element shape at
+        // the `RecentlyViewed` slot and panics at `hydration.rs:163`
+        // (`failed_to_cast_element`). Deferring the storage read to the next
+        // animation frame lets hydration finish with matching shapes first,
+        // then the rail repopulates reactively. Drove the homepage panics
+        // (GlitchTip 3147 + 4327) and contributed to item-page cascades.
         let (read_signal, write_signal, _delete_fn) =
-            use_local_storage::<VecDeque<i32>, JsonSerdeCodec>("recently_viewed");
+            use_local_storage_with_options::<VecDeque<i32>, JsonSerdeCodec>(
+                "recently_viewed",
+                UseStorageOptions::default().delay_during_hydration(true),
+            );
         Self {
             read_signal,
             write_signal,


### PR DESCRIPTION
## Summary

`RecentItems::new()` (provided as global context in [lib.rs:486](ultros-frontend/ultros-app/src/lib.rs#L486), consumed by `RecentlyViewed` on home/item/history pages) called `use_local_storage` with default options. leptos-use's default is `delay_during_hydration: false`, so on the client the storage read runs synchronously inside component setup — while hydration is still walking the SSR'd DOM.

The signal then holds the user's persisted item queue, but the SSR side rendered with the empty default. The inner `{move || if ids.is_empty() { None } else { Some(rows) }}` slot in `RecentlyViewed` resolves to a different element shape on CSR than on SSR. tachys' walker hits the wrong node type and panics at `hydration.rs:163` (`failed_to_cast_element`), which then cascades into `RefCell already borrowed` once `wasm-bindgen-futures` re-enters its task queue.

Fix: switch to `use_local_storage_with_options(..., delay_during_hydration(true))` so the storage read is queued via `request_animation_frame` and runs **after** hydration completes. Same fix pattern as #696 (jobset price slot) and `6e77e5c3` (item-view confidence badge) — the disease is SSR/CSR element-shape divergence at a hydration boundary; the cure is to keep the source of divergence (localStorage) quiet until hydration finishes.

## GlitchTip impact

Should fix the homepage panic cluster:
- Issue 3147: `RustWasmPanic: RefCell already borrowed` on `/` — **49 events** in Firefox 150 / Win10 production
- Issue 4327: `internal error: entered unreachable code` on `/` — **22 events**, same trace
- Plus the per-item-page singleton cascades (`/item/*`, `/items/jobset/*`) that share the same root frame (tachys `hydration.rs:163` → `js-sys/futures/task/singlethread.rs:142`). `RecentlyViewed` is also mounted on the item-view detail page and `/history`, so the same hydration race fires anywhere `RecentItems::new()`'s default branches against persisted state.

## Test plan

- [x] `./check_ci.sh` passes (fmt + clippy --all-targets -D warnings)
- [x] Compiles for `--features hydrate --no-default-features` (WASM target)
- [ ] Manual check on staging: load `/` with a non-empty `recently_viewed` localStorage value in Firefox; confirm no `RustWasmPanic` / `RefCell already borrowed` events fire and the rail still populates within ~1 frame.
- [ ] Monitor GlitchTip 3147 / 4327 / 707 / 4913 event rates over the next 24h after deploy — should drop sharply if this was the dominant root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)