### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information exposure in error messages

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** OAuth `state` parameter generated during `begin_login` was ignored during `redirect` callback, allowing Cross-Site Request Forgery (CSRF).
 **Learning:** Even when using a mature library like `oauth2-rs`, the framework integration points are critical. The library provides `CsrfToken` helpers, but the application is responsible for persisting and validating them.
 **Prevention:** Always ensure that generated security tokens (CSRF, Nonce, PKCE) are statefully stored (e.g., via `HttpOnly` + `Secure` cookies or session store) during the initial request, and rigorously validated on the callback.
+## 2025-02-15 - Fix Information Exposure in Error Responses
+**Vulnerability:** Detailed error messages were exposed to users in API and web responses via `self.to_string()` and `format!("{self}")`, potentially leaking internal server details or logic.
+**Learning:** Returning `format!("{self}")` or `self.to_string()` directly in `into_response()` for `WebError` or `ApiError` exposes the full error text.
+**Prevention:** Mask errors going to the client as "Internal server error" for 5xx responses, while preserving original error logs server-side via `tracing::error!`.

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -131,9 +131,17 @@ impl ApiError {
                 Some(ListError::InviteExhausted) => ultros_api_types::result::ApiError::BadRequest(
                     "Invite has reached max uses".into(),
                 ),
-                None => ultros_api_types::result::ApiError::Message(self.to_string()),
+                None => {
+                    ultros_api_types::result::ApiError::Message("Internal server error".to_string())
+                }
             },
-            _ => ultros_api_types::result::ApiError::Message(self.to_string()),
+            _ => {
+                if self.as_status_code().is_server_error() {
+                    ultros_api_types::result::ApiError::Message("Internal server error".to_string())
+                } else {
+                    ultros_api_types::result::ApiError::Message(self.to_string())
+                }
+            }
         }
     }
 }
@@ -206,11 +214,18 @@ impl IntoResponse for WebError {
         // (see issues 5033/5034 — e2e harness racing the warm-up window).
         let is_transient_warmup =
             matches!(self, WebError::AnalyzerError(AnalyzerError::Uninitialized));
+
+        let message = if status.is_server_error() && !is_transient_warmup {
+            "Internal server error".to_string()
+        } else {
+            format!("{self}")
+        };
+
         if status.is_server_error() && !is_transient_warmup {
             tracing::error!(error = %self, %status, "Returning web error");
         } else {
             tracing::debug!(error = %self, %status, "Returning web error");
         }
-        (status, format!("{self}")).into_response()
+        (status, message).into_response()
     }
 }


### PR DESCRIPTION
Replaced specific error text with "Internal server error" for responses carrying 5xx status codes, while maintaining detailed logging.

---
*PR created automatically by Jules for task [3799123254642245799](https://jules.google.com/task/3799123254642245799) started by @akarras*