### PR TITLE
fix(home): stop tachys hydration panic from localStorage-fed RecentlyViewed

### DIFF
--- a/ultros-frontend/ultros-app/src/components/recently_viewed.rs
+++ b/ultros-frontend/ultros-app/src/components/recently_viewed.rs
@@ -135,8 +135,18 @@ pub fn RecentlyViewed() -> impl IntoView {
     let (homeworld, _) = use_home_world();
     // Limit to top 8 to keep the rail focused. The /history page is the
     // overflow surface for everything older.
-    let recent_top: Signal<Vec<i32>> =
-        Signal::derive(move || items.with(|q| q.iter().take(8).copied().collect()));
+    //
+    // `items` is backed by `use_local_storage`, which returns the empty
+    // default on SSR but reads localStorage synchronously on the client.
+    // Driving the view directly off it would render zero rows on the
+    // server but N rows during the client's first walk — tachys would
+    // step into elements that aren't there and panic at hydration.rs:163.
+    // Hold `recent_top` at its SSR-shape value (empty) until an Effect
+    // fires post-hydration, then mirror the storage value into it.
+    let recent_top: RwSignal<Vec<i32>> = RwSignal::new(Vec::new());
+    Effect::new(move |_| {
+        recent_top.set(items.with(|q| q.iter().take(8).copied().collect()));
+    });
     let world_name: Signal<Option<String>> =
         Signal::derive(move || homeworld.with(|w| w.as_ref().map(|w| w.name.clone())));
 


### PR DESCRIPTION
## Summary

- `RecentlyViewed` read its item list via `use_local_storage`, which returns the empty default on SSR but reads `localStorage` synchronously on the client. For a returning user with cached items, SSR rendered zero rows while the client's first hydration walk wanted N `<TrackedRow>`s. Tachys walked into elements that weren't there and panicked at `tachys-0.2.15/src/hydration.rs:163` ("entered unreachable code"); the secondary `RefCell already borrowed` came from the js-sys executor re-entering during the panic-reporter callback.
- Hold `recent_top` at its SSR-shape value (an empty `RwSignal`) and mirror storage into it from an `Effect`. Effects don't run on SSR, so the server and the first client render produce identical DOM. After hydration settles the Effect fires once, sets the real list, and the rows mount reactively. Same shape as the existing pattern in `live_sale_ticker.rs:48`.

## GlitchTip impact

Both issues at filename `/`, both last-seen within minutes of the commit:

- [#4327](https://glitchtip.ultros.app/ultros/issues/4327) `RustWasmPanic: internal error: entered unreachable code` — 25 events
- [#3147](https://glitchtip.ultros.app/ultros/issues/3147) `RustWasmPanic: RefCell already borrowed` — 52 events
- [#5067](https://glitchtip.ultros.app/ultros/issues/5067) `RuntimeError: unreachable executed` (un-symbolicated paired event) — 29 events

The panic location traced cleanly to `tachys-0.2.15/src/hydration.rs:163:9` via the `rust_panic` context tag on every event. (Note: similar `unreachable executed` panics on `/items/jobset/*` and `/item/*` are likely the same *class* of bug — localStorage- or cookie-driven render diverging from SSR — but were not touched by this PR. Worth a follow-up audit.)

## Test plan

- [x] `./check_ci.sh` clean (`cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings`)
- [x] Local repro with `cargo leptos serve` on Windows: prime `localStorage.setItem('recently_viewed', JSON.stringify([1675, 5057, 12321, 33198, 19999, 28000, 39000, 41001]))`, hard-reload `/`, and confirm:
  - Console shows the full hydrate sequence (`hydrate mode - hydrating` → `fetching..` → `hydrating body` → `app run!`) and stops clean — no `hydration.rs:163` panic, no `RefCell already borrowed`, no `RuntimeError: unreachable`.
  - All 8 `<TrackedRow>` rows mount correctly post-hydration (UX preserved).

Verified against the same prod release commit (`993f3ca`) whose hydration trace ran `app run!` → panic immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)