### PR TITLE
🎨 Palette: Fix `aria_label` typos to ensure accessibility on Lists page buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-05-14 - Added aria-label to max_purchase_price filter button
 **Learning:** Found that the button to remove the `max_purchase_price` filter chip in `analyzer.rs` was missing an `aria-label`, unlike the other filter removal buttons. This is an accessibility issue where screen readers wouldn't announce the purpose of the icon-only button.
 **Action:** Always verify that dynamically generated icon-only buttons (like inside a loop or conditional rendering block) have appropriate `aria-label` attributes.
+## 2026-05-19 - Fixed typo in aria-label attributes
+**Learning:** In Leptos, HTML attributes should use hyphens, such as `aria-label`, not underscores (`aria_label`). Using an underscore creates a custom attribute that is not recognized by screen readers, rendering icon-only buttons inaccessible.
+**Action:** When adding or reviewing accessibility attributes in Leptos `view!` macros, verify that standard HTML attribute naming conventions (like hyphens) are used, instead of Rust-style snake_case, unless using `attr:aria-label`.

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -259,13 +259,13 @@ fn ListCard(
                                 <div class="flex items-center gap-1">
                                     <Show when=move || { permission >= ListPermission::Owner }>
                                         <Tooltip tooltip_text=Signal::derive(move || "Share list".to_string())>
-                                            <button class="btn-ghost btn-sm text-gray-400 hover:text-white" on:click=move |_| set_share_open(true) aria_label="Share list">
+                                            <button class="btn-ghost btn-sm text-gray-400 hover:text-white" on:click=move |_| set_share_open(true) aria-label="Share list">
                                                 <Icon icon=i::BiShareAltRegular />
                                             </button>
                                         </Tooltip>
                                     </Show>
                                     <Tooltip tooltip_text=Signal::derive(move || t_string!(i18n, edit_list).to_string())>
-                                        <button class="btn-ghost btn-sm text-gray-400 hover:text-white" on:click=move |_| set_is_edit(true) aria_label=move || t_string!(i18n, edit_list).to_string()>
+                                        <button class="btn-ghost btn-sm text-gray-400 hover:text-white" on:click=move |_| set_is_edit(true) aria-label=move || t_string!(i18n, edit_list).to_string()>
                                             <Icon icon=i::BsPencilFill />
                                         </button>
                                     </Tooltip>


### PR DESCRIPTION
💡 What: Fixed the `aria_label` attribute typo on two icon-only buttons ("Share list" and "Edit list") in `ultros-frontend/ultros-app/src/routes/lists.rs`, replacing it with `aria-label`.
🎯 Why: Leptos renders `aria_label` as a custom attribute `aria_label="X"` in HTML rather than the standard `aria-label`. Screen readers require the standard hyphenated attribute to properly announce icon-only buttons.
📸 Before/After: Visuals are unchanged. The HTML output correctly shows `<button aria-label="Share list" ...>` instead of `<button aria_label="Share list" ...>`.
♿ Accessibility: Ensures that users navigating via screen reader are accurately informed of the actions associated with the "Share" and "Edit" icon-only buttons on the Lists page.

---
*PR created automatically by Jules for task [6326514746478549323](https://jules.google.com/task/6326514746478549323) started by @akarras*