### PR TITLE
fix(item-explorer): stop hydration panic on /items/jobset & /items/category

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -433,10 +433,47 @@ fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView
     let listings_resource = cheapest_prices.read_listings;
     let (price_zone, _) = get_price_zone();
 
+    // Defer the price-based filter + sort until after hydration.
+    //
+    // `sorted_items` previously read `listings_resource.get()` directly. On
+    // SSR that resource is `None` at render time (the wrapping `<Suspense>`
+    // never suspends — `.get()` doesn't subscribe-and-suspend the way
+    // `.read()` does), so the SSR HTML reflects the ilvl fallback with NO
+    // price filter applied. On the client, Leptos serialises the resolved
+    // resource into the payload so `listings_resource.get()` returns
+    // `Some(map)` immediately during hydration — which would make the first
+    // CSR render apply the price filter (dropping items without listings)
+    // AND sort by price. The resulting `<For>` children then mismatch the
+    // SSR DOM in both count and order, and tachys' walker panics at
+    // `hydration.rs:163`/`:195` (`failed_to_cast_element`). That's the
+    // `?sort=price`/`?page=N` cluster in GlitchTip — issues 707
+    // (`/items/jobset/DNC?page=7&sort=price`, 47 events), 156
+    // (`/items/jobset/NIN?page=21&sort=price`, 18 events), 4951+5002
+    // (`RefCell already borrowed` cascades from the same trace), plus the
+    // category-page mirrors (4968/4969 on Dancer's Arms etc.).
+    //
+    // Gate the price map behind a signal that defaults to `false` and
+    // flips to `true` from an `Effect` — `Effect::new` runs only on the
+    // client (same idiom as `WasmLoadingIndicator`), and only AFTER the
+    // initial view is rendered. So the SSR render and the first CSR
+    // hydration render both see `hydrated == false`, both fall back to
+    // the ilvl sort with all items included, and shapes/positions match.
+    // A frame later the effect fires, the memo re-runs with the real
+    // price map, and the `<For>` reactively reorders/filters — by which
+    // point hydration is finished and tachys is no longer walking.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+
     let sorted_items = Memo::new(move |_| {
         let direction = direction().unwrap_or(SortDirection::Desc);
         let item_property = sort().unwrap_or(ItemSortOption::ItemLevel);
-        let price_map = listings_resource.get().and_then(|r| r.ok());
+        let price_map = if hydrated.get() {
+            listings_resource.get().and_then(|r| r.ok())
+        } else {
+            None
+        };
         items()
             .into_iter()
             .filter(|(id, _)| {


### PR DESCRIPTION
## Summary
- Defers price-aware filter/sort in `ItemList` until **after hydration** to fix the `?sort=price`/`?page=N` cluster of tachys hydration panics.
- The wrapping `<Suspense>` never suspended on `listings_resource` because `.get()` doesn't subscribe-and-suspend. SSR rendered with `price_map = None` (ilvl fallback, all items). CSR's first hydration render saw `Some(map)` from Leptos's serialized payload (price filter + price sort), producing different children at every position. tachys panicked at `hydration.rs:163`/`:195` (`failed_to_cast_element`) and `wasm-bindgen-futures` cascaded into `RefCell already borrowed`.
- Fix uses the same `Effect`-only-runs-on-client idiom as `WasmLoadingIndicator` (https://github.com/akarras/ultros/blob/main/ultros-frontend/ultros-app/src/components/wasm_loading_indicator.rs): a signal that flips to `true` from an `Effect`, gating consumption of the resource. Both SSR and the initial CSR render see `hydrated == false` and use the ilvl fallback; a frame later the effect fires and the memo recomputes.

## GlitchTip issues addressed
Latest events on release `18e6fa6` (i.e. after the #712 homepage fix had deployed) — so this is a distinct hydration source from the `RecentItems` localStorage race.

- [#707](https://glitchtip.ultros.app/ultros/issues/707) — `RustWasmPanic: internal error: entered unreachable code` on `/items/jobset/DNC?page=7&sort=price` — **47 events**
- [#156](https://glitchtip.ultros.app/ultros/issues/156) — same panic on `/items/jobset/NIN?page=21&sort=price` — **18 events**
- [#4951](https://glitchtip.ultros.app/ultros/issues/4951) — `RefCell already borrowed` cascade on `/items/jobset/DNC` — **8 events**
- [#5002](https://glitchtip.ultros.app/ultros/issues/5002) — `RefCell already borrowed` cascade on `/items/jobset/NIN` — **2 events**
- [#4968](https://glitchtip.ultros.app/ultros/issues/4968), [#4969](https://glitchtip.ultros.app/ultros/issues/4969) — category-page mirror on `/items/category/Dancer's Arms`
- [#5089](https://glitchtip.ultros.app/ultros/issues/5089), [#5090](https://glitchtip.ultros.app/ultros/issues/5090) — category-page mirror on `/items/category/Red Mage's Arms`

Same hydration-mismatch family as #696 (jobset price-slot element shape), #712 (`RecentItems` localStorage), #6e77e5c3 (item-view confidence badge `LocalResource`).

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] After deploy: confirm GlitchTip issue 707 stops accumulating events on release > `cb6a31fb` (no new `tachys::hydration::failed_to_cast_element` panics on `/items/jobset/*?sort=price&page=*`)
- [ ] Smoke-test in browser: visit `/items/jobset/DNC?sort=price` and `?sort=price&page=2`, confirm:
  - No WASM console errors
  - Items render and reorder to price-desc after a frame
  - Pagination remains correct after sort flip
- [ ] Smoke-test `/items/category/Dancer's%20Arms?sort=price` for parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)