### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in static file handler

### DIFF
--- a/ultros/src/web/static_files.rs
+++ b/ultros/src/web/static_files.rs
@@ -37,6 +37,11 @@ pub(crate) fn get_static_file(path: &str) -> Option<Vec<u8>> {
 }
 
 pub(crate) async fn get_file(path: &str) -> Result<impl IntoResponse + use<>, WebError> {
+    // Prevent path traversal attacks
+    if path.contains("..") || path.starts_with('/') || path.starts_with('\\') {
+        return Err(WebError::NotFound);
+    }
+
     let mime_type = mime_guess::from_path(path).first_or_text_plain();
     match get_static_file(path) {
         None => Ok(Response::builder()


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Path traversal was possible in the `/static/*` route handler (`get_file`) when run in debug mode or if `include_dir` behavior allows accessing outside files.
🎯 **Impact**: An attacker could potentially access arbitrary files outside of the configured static directory, possibly leading to source code disclosure or sensitive file leakage (e.g., config files, `.env` data).
🔧 **Fix**: Added explicit path validation in `get_file` to reject any paths containing `..` or starting with `/` or `\` before attempting to resolve them on the file system. It returns a standard 404 Not Found error via `WebError::NotFound`.
✅ **Verification**: Run `cargo check` and `cargo clippy`. It compiles properly, and tests pass. Tested edge cases ensuring `/static/../Cargo.toml` fails.

---
*PR created automatically by Jules for task [3888782193610429700](https://jules.google.com/task/3888782193610429700) started by @akarras*