### PR TITLE
fix(clickhouse): silence flush error spam when CH is unreachable (GlitchTip triage)

### DIFF
--- a/ultros-clickhouse/src/writer.rs
+++ b/ultros-clickhouse/src/writer.rs
@@ -125,11 +125,19 @@ impl Writer {
         }
     }
 
-    /// A Writer that swallows every row. Used by tests that construct an
-    /// `AnalyzerService` directly without standing up ClickHouse — the channel
-    /// is created and the receiver immediately dropped so every `send()`
-    /// returns `Err` and silently no-ops.
-    pub fn noop_for_tests() -> Self {
+    /// A Writer that swallows every row without spawning a flush task. Used in
+    /// two cases:
+    ///
+    /// 1. Tests that construct an `AnalyzerService` directly without standing
+    ///    up ClickHouse.
+    /// 2. Production startup when `ClickHouseClient::migrate` fails — wiring a
+    ///    real `spawn`ed writer would log a `ClickHouse flush failed` error
+    ///    every 5 seconds (and trip the sentry-tracing layer into reporting
+    ///    each one as a GlitchTip issue, see issue #5080).
+    ///
+    /// The channel is created and the receiver immediately dropped so every
+    /// `send()` returns `Err` and silently no-ops.
+    pub fn disabled() -> Self {
         let (tx, _rx) = mpsc::unbounded_channel::<SaleRow>();
         Self { tx }
     }

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -2077,7 +2077,7 @@ mod tests {
             recent_sale_history: Arc::new(recent_sale_history),
             cheapest_items: Arc::new(cheapest_items),
             initiated: Arc::new(AtomicBool::new(false)),
-            ch_writer: ultros_clickhouse::writer::Writer::noop_for_tests(),
+            ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
 
@@ -2123,7 +2123,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: new_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(false)),
-            ch_writer: ultros_clickhouse::writer::Writer::noop_for_tests(),
+            ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
         assert!(new_analyzer_service.try_restore_from_snapshot().await);
@@ -2149,7 +2149,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: dc_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(true)),
-            ch_writer: ultros_clickhouse::writer::Writer::noop_for_tests(),
+            ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
         // Serialize
@@ -2165,7 +2165,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: restore_dc_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(false)),
-            ch_writer: ultros_clickhouse::writer::Writer::noop_for_tests(),
+            ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
         assert!(

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -278,17 +278,27 @@ async fn main() -> Result<()> {
     // ClickHouse: analytical store. Migration is idempotent — re-running it on
     // every startup is fine. We log-and-continue on failure because PG is the
     // source of truth and the analyzer's RAM caches keep the snappy tools
-    // alive even if CH is unreachable.
+    // alive even if CH is unreachable. When migrate fails we wire a disabled
+    // writer (silently drops rows) and skip the rollup scheduler — otherwise
+    // the flush task would fire `ClickHouse flush failed` every 5s and the
+    // sentry-tracing layer would report each one as a separate issue (see
+    // GlitchTip #5080, ~1k events from a dev box without CH running).
     let ch_client = ultros_clickhouse::ClickHouseClient::from_env();
-    if let Err(e) = ch_client.migrate().await {
-        warn!("ClickHouse migrate failed; continuing without analytics writes: {e:?}");
-    }
-    let ch_writer = ultros_clickhouse::writer::Writer::spawn(ch_client.clone(), token.clone());
-
-    // Background scheduler that keeps item_stats_window + item_quality_score
-    // fresh. Runs an immediate seed pass on startup, then on independent
-    // cadences (1d every 15min, 7d hourly, 30d/90d every 6h, quality hourly).
-    ultros_clickhouse::rollups::spawn_scheduler(ch_client.clone(), token.clone());
+    let ch_writer = match ch_client.migrate().await {
+        Ok(()) => {
+            let writer = ultros_clickhouse::writer::Writer::spawn(ch_client.clone(), token.clone());
+            // Background scheduler that keeps item_stats_window +
+            // item_quality_score fresh. Runs an immediate seed pass on startup,
+            // then on independent cadences (1d every 15min, 7d hourly,
+            // 30d/90d every 6h, quality hourly).
+            ultros_clickhouse::rollups::spawn_scheduler(ch_client.clone(), token.clone());
+            writer
+        }
+        Err(e) => {
+            warn!("ClickHouse migrate failed; continuing without analytics writes: {e:?}");
+            ultros_clickhouse::writer::Writer::disabled()
+        }
+    };
 
     let analyzer_service = AnalyzerService::start_analyzer(
         db.clone(),


### PR DESCRIPTION
## Summary

**GlitchTip triage pass — BugSquash mcSquash the Bug the Fourth.**

This PR fixes the highest-volume issue in the GlitchTip backlog: [#5080 *ClickHouse flush failed*](https://glitchtip.ultros.app/ultros/issues/5080) and its sibling [#5079 *interval ClickHouse flush failed*](https://glitchtip.ultros.app/ultros/issues/5079), together ~1,050 events over the last 2 days.

### Root cause

When `ClickHouseClient::migrate()` fails at startup (the common case on a dev box without CH running on `127.0.0.1:8123`), [main.rs:283](ultros/src/main.rs) was logging a warning and *still* spawning the full `Writer::spawn` flush task and `rollups::spawn_scheduler`. Every 5 seconds the writer's `flush()` would hit the connection-refused error and `error!(\"ClickHouse flush failed\")` — and because the tracing pipeline includes `sentry_tracing::layer()`, every `error!` becomes a GlitchTip issue.

### Fix

- Renamed `Writer::noop_for_tests()` → `Writer::disabled()` and expanded the doc to cover both the test use case and the new production use case.
- In [main.rs](ultros/src/main.rs), gate `Writer::spawn` + the rollup scheduler behind a successful `migrate()`. On failure, install `Writer::disabled()` so the analyzer service still has a valid `Writer` to `send()` into — the sends silently drop, no flush task, no Sentry spam.
- Updated the four `analyzer_service.rs` test call sites to use the new name.

Behavior unchanged when CH is healthy. When CH is down at startup, analytics writes are dropped (same as before) but the error log every 5s is gone.

## Other findings (no code change)

### WASM hydration panics (~700+ events across multiple issue IDs)

[#4](https://glitchtip.ultros.app/ultros/issues/4) (501), [#3147](https://glitchtip.ultros.app/ultros/issues/3147) (57), [#4327](https://glitchtip.ultros.app/ultros/issues/4327) (30), [#707](https://glitchtip.ultros.app/ultros/issues/707) (47), and a long tail of per-URL groups (`/item/*`, `/items/jobset/*`, `/items/category/*`) all share the same primary panic:

```
panicked at tachys-0.2.15/src/hydration.rs:227:9: internal error: entered unreachable code
```

This is the same DOM-mismatch panic that the [`translate=\"no\"` workaround](ultros-frontend/ultros-app/src/lib.rs:320) was added to block when Google Translate triggered it. The remaining trigger looks like Google AdSense / Funding Choices DOM injection running *before* hydration completes — the breadcrumbs show ~2s of `pagead2.googlesyndication.com` + `fundingchoicesmessages.google.com` activity wedged between `\"fetching..\"` and `\"hydrating body\"`, with the panic firing immediately after `\"app run!\"`. The paired `RefCell already borrowed` panics are the known secondary effect already documented in [ultros-client/src/lib.rs:266](ultros-frontend/ultros-client/src/lib.rs:266).

**Recommended follow-up:** refactor the `<Ad>` component ([ultros-frontend/ultros-app/src/components/ad.rs](ultros-frontend/ultros-app/src/components/ad.rs)) so the AdSense `<script>` + `<ins>` markup is only injected *after* hydration completes (via an `Effect` + signal pattern, so SSR renders just an empty placeholder). Out of scope here because it risks breaking ad revenue without a browser smoke test.

### Recommended GlitchTip ignores (auto-mode blocked me from setting these)

I tried `mcp__glitchtip__glitchtip_bulk_set_issue_status` and the individual variant — both denied by the auto-mode classifier as external-system writes. Suggested ignores after reviewing the latest events:

| Issue | Title | Why ignore |
|---|---|---|
| [#4165](https://glitchtip.ultros.app/ultros/issues/4165) | `CompileError: invalid value type 'externref'` | Browser missing WASM reftypes — unfixable on our side |
| [#5103](https://glitchtip.ultros.app/ultros/issues/5103), [#5100](https://glitchtip.ultros.app/ultros/issues/5100), [#5087](https://glitchtip.ultros.app/ultros/issues/5087) | `TypeError: Failed to fetch dynamically imported module /pkg/<hash>/ultros.js` | Stale tab requesting old pkg path after deploy — standard SPA churn |
| [#5099](https://glitchtip.ultros.app/ultros/issues/5099) | `UnhandledRejection: Non-Error promise rejection captured with value: undefined` | Vague Sentry capture with no actionable payload, likely third-party JS |

### Resolved (no new events on current build)

| Issue | Last seen | Why |
|---|---|---|
| [#5067](https://glitchtip.ultros.app/ultros/issues/5067), [#5072](https://glitchtip.ultros.app/ultros/issues/5072) | 2026-05-18 | Both fingerprinted on the previous `993f3ca` build's wasm function offsets; superseded by current `45b3da1` builds |

### Dev-only noise (will largely disappear with this PR)

[#4881](https://glitchtip.ultros.app/ultros/issues/4881) (rkyv snapshot corruption), [#2218](https://glitchtip.ultros.app/ultros/issues/2218) (analyzer warm-up text bodies), [#5081–5086](https://glitchtip.ultros.app/ultros/issues/) (\"response failed\" / \"Returning web error\") are all tagged `environment: development, server_name: Bahamut`. They tend to fire alongside the ClickHouse spam during local dev sessions; reducing the dev-mode noise floor will make these easier to triage if any are real.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p ultros-clickhouse --all-targets -- -D warnings` clean (where the renamed method lives)
- [ ] CI clippy on `ultros` crate (verified on push)
- [ ] Manual: start the app with no ClickHouse running, confirm no `ClickHouse flush failed` errors arrive in GlitchTip
- [ ] Manual: start the app with ClickHouse running, confirm rollups still seed and refresh on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)