### PR TITLE
🎨 Palette: Add aria_hidden=true to refresh icon in LiveSaleTicker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-05-14 - Added aria-label to max_purchase_price filter button
 **Learning:** Found that the button to remove the `max_purchase_price` filter chip in `analyzer.rs` was missing an `aria-label`, unlike the other filter removal buttons. This is an accessibility issue where screen readers wouldn't announce the purpose of the icon-only button.
 **Action:** Always verify that dynamically generated icon-only buttons (like inside a loop or conditional rendering block) have appropriate `aria-label` attributes.
+## 2026-05-21 - Prevent screen readers from reading decorative icons in buttons
+**Learning:** Found that when buttons have an icon next to visible text, sometimes the icon isn't hidden with `aria_hidden=true`. While this isn't an error, adding `aria_hidden=true` to the icon (since the button already has visible text) makes the screen reader experience smoother by preventing it from reading the decorative icon.
+**Action:** When inspecting buttons with both text and icons, consider adding `aria_hidden=true` to the icon component (if supported, e.g. the `Icon` component in this repo supports it) to avoid redundant or confusing announcements.

--- a/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
+++ b/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
@@ -170,7 +170,7 @@ pub fn LiveSaleTicker() -> impl IntoView {
                             retrigger.set(true);
                         }
                     >
-                        <Icon icon=i::BiRefreshRegular />
+                        <Icon icon=i::BiRefreshRegular aria_hidden=true />
                         {t!(i18n, refresh)}
                     </button>
                 </div>


### PR DESCRIPTION
Added `aria_hidden=true` to the refresh icon in `LiveSaleTicker` (`ultros-frontend/ultros-app/src/components/live_sale_ticker.rs`) to prevent screen readers from redundantly announcing the decorative icon. The button already contains the visible text "Refresh" (`{t!(i18n, refresh)}`), making the icon purely decorative.

---
*PR created automatically by Jules for task [15608093695884858991](https://jules.google.com/task/15608093695884858991) started by @akarras*