### PR TITLE
fix(item-view): defer Utc::now() filtering to stop hydration panic (GlitchTip triage)

### DIFF
--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -359,7 +359,29 @@ fn WindowStats(#[prop(into)] sales: Signal<SalesWindow>) -> impl IntoView {
 #[component]
 pub fn SalesInsights(sales: Signal<Vec<SaleHistory>>) -> impl IntoView {
     let i18n = use_i18n();
-    let sales = Memo::new(move |_| sales.with(|sales| SalesSummaryData::new(sales)));
+    // `SalesSummaryData::new` reads `Utc::now()`, which is non-deterministic
+    // across SSR (server clock at render time) and CSR (client clock at
+    // hydration). For items with sales right at the day/month window edge,
+    // `past_day` / `month` can flip between Some and None across the two
+    // renders, which in turn flips `class:hidden` on the wrapper div below.
+    // Pair that with the matching deferred-cutoff in `ChartWrapper` and the
+    // whole sale-history half of `/item/<world>/<id>` stays structurally
+    // stable through hydration. Effect flips `hydrated` post-render (client
+    // only), then the memo re-runs with the real summary data.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+    let sales = Memo::new(move |_| {
+        if hydrated.get() {
+            sales.with(|sales| SalesSummaryData::new(sales))
+        } else {
+            SalesSummaryData {
+                past_day: None,
+                month: None,
+            }
+        }
+    });
     let day_sales = Memo::new(move |_| sales.with(|s| s.past_day.clone()).unwrap_or_default());
     let month_sales = Memo::new(move |_| sales.with(|s| s.month.clone()).unwrap_or_default());
     view! {

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -616,6 +616,27 @@ pub fn ChartWrapper(
         set_extended_error.set(None);
     });
 
+    // Defer the `Utc::now()`-based date cutoff in `filtered_sales` until after
+    // hydration. SSR computes the cutoff at server-render time; the client
+    // re-runs the same memo during hydration but with a `Utc::now()` that has
+    // advanced by network + render latency (seconds, sometimes more on slow
+    // connections). For items with sales clustered near the 30/7/90-day
+    // boundary this flips:
+    //   - the `is_empty()` branch (text fallback vs `<PriceHistoryChart>`),
+    //   - the chart's internal `rows.is_empty()` branch,
+    // both of which choose structurally different DOM. tachys' walker then
+    // panics at `hydration.rs:163`/`:227` (`internal error: entered
+    // unreachable code`), and the wasm-bindgen-futures executor cascades into
+    // `RefCell already borrowed` — that's the `/item/<world>/<id>` cluster
+    // in GlitchTip (issues 5104, 5095/5096, 5097/5098, 5106, 5108, 5113-5122,
+    // …). Same idiom as #719 (`item-explorer`) and #712 (`home`): an
+    // `Effect`-driven flag that flips post-hydration so SSR and the first
+    // CSR render agree.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+
     /* moved into Transition branch to avoid reading resource outside Suspense/Transition */
 
     view! {
@@ -657,8 +678,12 @@ pub fn ChartWrapper(
                         if hq_only() {
                             sales.retain(|s| s.hq);
                         }
+                        // Skip the time-based cutoff during the first (SSR-matching)
+                        // render so the count/shape matches the SSR DOM exactly.
+                        // The effect above flips `hydrated` to true a frame later,
+                        // and this memo re-runs with the real cutoff applied.
                         let days = days_range();
-                        if days > 0 {
+                        if days > 0 && hydrated.get() {
                             let cutoff = (Utc::now() - TimeDelta::days(days as i64)).naive_utc();
                             sales.retain(|s| s.sold_date >= cutoff);
                         }


### PR DESCRIPTION
## Summary

`/item/<world>/<id>` is the last big cluster of `RustWasmPanic` /
`RuntimeError: unreachable` events in GlitchTip — issue **5104** is still
firing on `cfb6a45` (today's deploy), and the supporting RefCell-borrow
duplicates (5095/5096, 5097/5098, 5106, 5108, 5113–5122 etc.) all share
the same trace shape. The panic location is **`tachys-0.2.15/src/hydration.rs:227`**
(`internal error: entered unreachable code`), which is the same structural
hydration-mismatch family the team already fixed for home (#712),
jobset (#693, #696), and item-explorer (#719).

### Root cause

`ChartWrapper.filtered_sales` and `SalesInsights` both call `Utc::now()`
during render:

```rust
let cutoff = (Utc::now() - TimeDelta::days(days as i64)).naive_utc();
sales.retain(|s| s.sold_date >= cutoff);
```
```rust
SalesSummaryData::new(sales)   // → uses Utc::now() to bucket past_day / month
```

SSR computes the cutoff at server time T₀. The client re-runs the same
memos during hydration at T₁ (T₀ plus network + parse + wasm load — easily
seconds). For sales clustered at the day/month boundary that's enough to
move them in or out of the window, which flips both:

- `if filtered_sales.is_empty() { text } else { <PriceHistoryChart/> }` —
  picks structurally different DOM, and tachys panics walking the cursor;
- `class:hidden=move || past_day.is_none()` on the insights panels —
  attribute-level mismatch that compounds the inconsistency.

The wasm-bindgen-futures executor then cascades into
`RefCell already borrowed` from the *same* trace (`js-sys-0.3.98/src/futures/task/singlethread.rs:142`),
which is why every event in this cluster comes in as a pair.

### Fix

Mirror the post-hydration pattern from **#719** and **#712**:

```rust
let hydrated = RwSignal::new(false);
Effect::new(move |_| { hydrated.set(true); });
```

`Effect::new` only runs on the client, only **after** the first render.
SSR and the first CSR render both see `hydrated == false`, so:

- `filtered_sales` skips the date filter (same shape as SSR),
- `SalesInsights` treats `past_day` / `month` as `None` (same `class:hidden` as SSR).

A frame later the effect fires, the memos re-run with real `Utc::now()`,
and the chart / insights reactively re-shape — by which point hydration
is done and tachys is no longer walking.

GlitchTip issues this should close (all `/item/*` panics):
- [5104](https://glitchtip.ultros.app/ultros/issues/5104) — `RuntimeError: unreachable` on `cfb6a45`, 11 events
- [5122](https://glitchtip.ultros.app/ultros/issues/5122), [5121](https://glitchtip.ultros.app/ultros/issues/5121) — `/item/Light/52619`
- [5120](https://glitchtip.ultros.app/ultros/issues/5120), [5119](https://glitchtip.ultros.app/ultros/issues/5119) — `/item/Light/52614`
- [5118](https://glitchtip.ultros.app/ultros/issues/5118), [5117](https://glitchtip.ultros.app/ultros/issues/5117) — `/item/Japan/51205`
- [5116](https://glitchtip.ultros.app/ultros/issues/5116), [5115](https://glitchtip.ultros.app/ultros/issues/5115) — `/item/Chaos/52619`
- [5114](https://glitchtip.ultros.app/ultros/issues/5114), [5113](https://glitchtip.ultros.app/ultros/issues/5113) — `/item/迦樓羅/1823`
- [5108](https://glitchtip.ultros.app/ultros/issues/5108) — `/item/Alexander/42008`
- [5106](https://glitchtip.ultros.app/ultros/issues/5106), [5105](https://glitchtip.ultros.app/ultros/issues/5105) — `/item/伊弗利特/3`
- [5098](https://glitchtip.ultros.app/ultros/issues/5098), [5097](https://glitchtip.ultros.app/ultros/issues/5097) — `/item/Europe/52338`
- [5096](https://glitchtip.ultros.app/ultros/issues/5096), [5095](https://glitchtip.ultros.app/ultros/issues/5095) — `/item/2`
- [5092](https://glitchtip.ultros.app/ultros/issues/5092), [5091](https://glitchtip.ultros.app/ultros/issues/5091) — `/item/Carbuncle/2655`

Once verified post-deploy these can be bulk-resolved in GlitchTip (the
automated triage agent can't make write calls — flagging for manual
follow-up per the team's GlitchTip workflow). The `/items/category/*`
events 5090, 5093, 5094 were already addressed by #719; if any
re-appear post-deploy they likely point at a third hydration source.

## Test plan

- [ ] `cargo fmt --all -- --check` (passed locally)
- [ ] `cargo clippy -p ultros-app --all-targets --no-deps -- -D warnings` (passed locally; full workspace clippy not run — submodule init needed and the changes are scoped to `ultros-app`)
- [ ] Manual: load `/item/Light/52619`, `/item/Light/52614`, `/item/Japan/51205` — confirm chart renders without console panic on first paint
- [ ] Manual: load same items with each `days_range` (7/30/90/All) and `hq_only` toggle — confirm chart still updates correctly post-hydration
- [ ] Watch GlitchTip for new `RustWasmPanic` / `RuntimeError: unreachable` events on `/item/*` over ~24h after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)