### PR TITLE
fix(chart): stop chrono::Local round-trip from shifting sale timestamps (GlitchTip triage)

### DIFF
--- a/ultros-frontend/ultros-app/src/components/price_history_chart.rs
+++ b/ultros-frontend/ultros-app/src/components/price_history_chart.rs
@@ -66,9 +66,13 @@ fn group_sales_by_level(
         let Some(result) = helper.lookup_selector(selector) else {
             continue;
         };
-        let Some(sold_date) = sale.sold_date.and_local_timezone(chrono::Local).single() else {
-            continue;
-        };
+        // `sold_date` is a naive UTC instant. `and_local_timezone(Local)`
+        // re-interprets it as local time, silently shifting by the viewer's
+        // UTC offset (8h on a Shanghai client, 0h on a UTC server). The
+        // downstream `.with_timezone(&Utc)` then bakes the wrong value into
+        // `SaleRow.ts`, producing SSR/CSR row sets that disagree and tripping
+        // tachys hydration at `hydration.rs:227`.
+        let sold_date = sale.sold_date.and_utc().with_timezone(&chrono::Local);
         groups
             .entry(selector)
             .or_insert_with(|| (result.get_name().to_string(), Vec::new()))


### PR DESCRIPTION
## Summary

- `group_sales_by_level` was reinterpreting `SaleHistory.sold_date` (a `NaiveDateTime` that semantically holds a **UTC** instant) as local time via `.and_local_timezone(chrono::Local).single()`. On a UTC server the offset is zero and SSR sees the right value; on a client in `Asia/Shanghai` (UTC+8) every `SaleRow.ts` is shifted by 8 hours.
- The downstream `.with_timezone(&chrono::Utc)` then bakes the wrong value into the chart's data rows, so the SVG chartistry emits differs between SSR and the first CSR hydration render. tachys' walker panics at [`tachys-0.2.15/src/hydration.rs:227`](https://docs.rs/tachys/0.2.15/src/tachys/hydration.rs.html#227) (`failed_to_cast_text_node` / `internal error: entered unreachable code`), which then cascades into `RefCell already borrowed` from `js-sys/futures/task/singlethread.rs:142`.

## GlitchTip cluster this targets

Post-[#725](https://github.com/akarras/ultros/pull/725) (which fixed the `Utc::now()` cutoff in `ChartWrapper.filtered_sales` and `SalesInsights`) the panic kept reappearing on the current deploy `a6db8bc`:

- [`5128`](https://glitchtip.ultros.app/ultros/issues/5128) — 3 events, request URL `/item/한국/52616`, browser timezone `Asia/Shanghai`. Same `tachys hydration.rs:227` trace as the pre-#725 cluster.
- [`5129`](https://glitchtip.ultros.app/ultros/issues/5129) / [`5130`](https://glitchtip.ultros.app/ultros/issues/5130) — `/item/Chaos/51200`, post-#725 build, same trace.
- [`5132`](https://glitchtip.ultros.app/ultros/issues/5132)–[`5140`](https://glitchtip.ultros.app/ultros/issues/5140) — assorted `/item/<world>/<id>` and worldless `/item/<id>` panics on `a6db8bc`, all in `Asia/Shanghai`.

The mismatch source moved from #725's filter cutoff into the chart's data layout. The fix here is the right shape to retire that follow-on cluster.

## Fix

```rust
// before
let Some(sold_date) = sale.sold_date.and_local_timezone(chrono::Local).single() else {
    continue;
};
// after
let sold_date = sale.sold_date.and_utc().with_timezone(&chrono::Local);
```

`.and_utc()` pins the instant correctly first, then projects to `Local` purely for the in-tuple display type. The later `.with_timezone(&Utc)` is now a lossless round-trip and `SaleRow.ts` is identical on SSR and CSR regardless of viewer timezone.

## Why I'm confident this matters even if the panic source is elsewhere

This is at minimum a **correctness bug** independent of hydration: every non-UTC viewer was seeing a chart whose timestamps were shifted by their UTC offset. The hydration-mismatch tie is a hypothesis, but the correctness fix stands on its own.

## CI

- `cargo fmt --all -- --check` ✓ clean.
- `cargo clippy --all-targets -- -D warnings` left running on the OpenSSL-vendored first build (Strawberry Perl + ~10 min openssl-src compile). The change is a one-line API swap inside an existing function; not expected to introduce clippy warnings. CI gate will confirm before merge.

## Recommended GlitchTip triage that auto-mode blocked

The agent's GlitchTip write permission was denied (matches the memory note `reference_glitchtip_triage_blocks.md`). Surfaced here so you can run the buttons:

**Mark ignored — third-party / browser-environment noise we cannot fix from app code:**
- [`5127`](https://glitchtip.ultros.app/ultros/issues/5127), [`5107`](https://glitchtip.ultros.app/ultros/issues/5107), [`5103`](https://glitchtip.ultros.app/ultros/issues/5103), [`5100`](https://glitchtip.ultros.app/ultros/issues/5100) — `TypeError: Failed to fetch dynamically imported module` (stale cached HTML pointing at a since-deployed `pkg/<hash>` directory).
- [`5112`](https://glitchtip.ultros.app/ultros/issues/5112) — `Could not download wasm module` (network / adblock).
- [`5111`](https://glitchtip.ultros.app/ultros/issues/5111), [`5110`](https://glitchtip.ultros.app/ultros/issues/5110), [`5109`](https://glitchtip.ultros.app/ultros/issues/5109) — `WebAssembly.compile: HTTP status code is not ok` (same root cause as the dynamic-import failures, different surface).
- [`4165`](https://glitchtip.ultros.app/ultros/issues/4165) — `CompileError: invalid value type 'externref', enable with --experimental-wasm-reftypes`. Old browser without wasm reference-types support. Cannot fix in app code.
- [`5099`](https://glitchtip.ultros.app/ultros/issues/5099) — `UnhandledRejection: Non-Error promise rejection captured with value: undefined`. Single event, no payload, no actionable trace.

**Mark resolved — already fixed in `main`:**
- [`5080`](https://glitchtip.ultros.app/ultros/issues/5080) — `ClickHouse flush failed`, 1005 events, last seen 2026-05-19. Resolved by [#722](https://github.com/akarras/ultros/pull/722) (`fix(clickhouse): silence flush error spam when CH is unreachable`, commit `545dc793`).
- [`3147`](https://glitchtip.ultros.app/ultros/issues/3147) — 57 events on `/`, the homepage `RefCell already borrowed` cluster. Resolved by [#712](https://github.com/akarras/ultros/pull/712).
- [`4327`](https://glitchtip.ultros.app/ultros/issues/4327) — 30 events on `/`, partner panic to 3147. Same fix.
- [`5104`](https://glitchtip.ultros.app/ultros/issues/5104) — 11 events on the pre-#725 build `cfb6a45`. Subsumed by #725 + this PR.
- [`4`](https://glitchtip.ultros.app/ultros/issues/4) — 506 events on `pkg/40f0fb13/ultros.wasm`, oldest live issue. Build hash is from a long-since-deployed release; nothing to do but resolve.

## Test plan

- [ ] Wait for CI's `cargo clippy --all-targets -- -D warnings` to pass.
- [ ] After merge + deploy: load `/item/3053` (worldless) and `/item/Light/52614` (world-bound) in Chrome with the devtools timezone forced to `Asia/Shanghai`; confirm no `tachys hydration.rs:227` panic in the console and the chart hydrates without an SVG flip.
- [ ] Verify in GlitchTip that the post-#725 `/item/...` cluster on `Asia/Shanghai` clients stops growing.
- [ ] Smoke the existing chart unit tests in `price_history_chart.rs::tests`: `grouping_collapses_*`, `bucket_quantities_*`, `bucket_seconds_scales_with_window`. The change doesn't touch group naming or bucket math, so they should all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)