### PR TITLE
fix(relative-time): defer Utc::now() label until after hydration

### DIFF
--- a/ultros-frontend/ultros-app/src/components/relative_time.rs
+++ b/ultros-frontend/ultros-app/src/components/relative_time.rs
@@ -12,9 +12,33 @@ pub fn RelativeToNow(timestamp: NaiveDateTime) -> impl IntoView {
     // this could probably be moved to a global state so we just have one interval for every clock
     #[cfg(feature = "hydrate")]
     let UseIntervalReturn { counter, .. } = use_interval(1000);
+    // Defer the `Utc::now()`-based label until after hydration. SSR computes
+    // the label at server-render time; the client re-runs the memo during
+    // hydration with a `Utc::now()` that has advanced by network + render
+    // latency, so the SSR text ("5 seconds ago") and the first CSR render
+    // ("20 seconds ago") differ. Pure text-content differences are usually
+    // tolerated by tachys, but `timeago::Formatter` can flip across
+    // unit/format boundaries (e.g. "now" vs "1 second ago") which has
+    // historically been part of the `/item/<world>/<id>` and
+    // `/items/jobset/<JOB>` cluster cascades — same idiom as #725 (chart),
+    // #719 (item-explorer), #712 (home `RecentItems`).
+    //
+    // During the initial SSR + first CSR render we emit the absolute UTC
+    // timestamp (deterministic, identical on both sides). An `Effect` flips
+    // `hydrated` post-render — effects only fire on the client and only
+    // after the first render — and the memo re-runs with the real relative
+    // label. Users see the absolute timestamp for one frame, then it
+    // updates to the relative form.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
     let time_display = Memo::new(move |_| {
         #[cfg(feature = "hydrate")]
         let _counter = counter(); // just to make things tick
+        if !hydrated.get() {
+            return timestamp.format("%Y-%m-%d %H:%M UTC").to_string();
+        }
         let duration = Utc::now().naive_utc() - timestamp;
         duration
             .to_std()


### PR DESCRIPTION
## Summary
- **Concrete fix:** apply the same `hydrated`-flag pattern from #712/#719/#725/#728 to `RelativeToNow`. Each row of `SaleHistoryTable` and `ListingsTable` renders a `<RelativeToNow timestamp=…>`; the inner memo reads `Utc::now()` during render, which differs between SSR (server clock at render time) and the first CSR render (client clock seconds-to-minutes later). On item pages this is hundreds of timestamps that can each flip across a `timeago::Formatter` unit boundary during hydration.
- During SSR + the first CSR render we emit an absolute UTC string (deterministic, identical on both sides). An `Effect` flips `hydrated` post-render, then the memo re-runs with the real relative label.
- I don't claim this is THE root cause of the residual GlitchTip cluster — see triage notes below — but it is a real correctness bug on the same surface (`/item/<world>/<id>`, `/items/jobset/<JOB>`) and matches the established fix pattern.

## GlitchTip triage notes (BugSquash mcSquash run)

I dug through the current `RustWasmPanic: …` backlog (~52 issues, mostly `internal error: entered unreachable code` + paired `RefCell already borrowed` on `/item/<world>/<id>`). The two latest events on `ultros@51d31a9` (the current deploy, *after* #725 + #728 landed) — issues [`5261`](https://glitchtip.ultros.app/ultros/issues/5261) (`/item/51196`) and [`1307`](https://glitchtip.ultros.app/ultros/issues/1307) (`/items/jobset/SGE?dir=asc&page=29&sort=price`) — panic at **identical WASM offsets** (`wasm-function[5310]/[20035]/[32553]/[39081]/…`). That's strong evidence the residual panic is in **shared chrome** (AppShell / TopBar / SideNav / shared providers in `AppInner`), not in the route content. Both events:

- panic at `tachys-0.2.15/src/hydration.rs:227:9` → `failed_to_cast_text_node` in the release build (cursor expected a `Text` node but found something else),
- come from a Shanghai (`Asia/Shanghai`) user on Chrome 107/108 — i.e. consistent locale/timezone/browser profile across many events.

What I ruled out for this PR (with confidence):
- `ItemView` chart + `SalesInsights` — already deferred in #725.
- `ItemList` price-aware sort — already deferred in #719.
- `RecentItems` localStorage — already `delay_during_hydration(true)` in `recently_viewed.rs`.
- `tracked_data()` / xiv_gen data races — bootstrap awaits `populate_xiv_gen_data()` before `hydrate_body` ([`lib.rs:335`](ultros-frontend/ultros-client/src/lib.rs:335)).
- `UserMenu`'s `Resource::new(get_login)` — Leptos serialises the resolved value into the payload, so SSR and CSR see the same `Option<UserData>` during the first hydration render.

What I have *suspicions* about but couldn't pin down without symbolicated traces:
- The `AppInner` auto-locale-switch effect ([`lib.rs:475–490`](ultros-frontend/ultros-app/src/lib.rs:475)) calls `i18n.set_locale(cn)` for `GuessedRegion == "中国"` but does **not** call `reload_locale_data(new_locale)` — only the explicit `LanguagePicker.set_language` does. So after auto-switch, UI strings render in `cn` while `tracked_data()` keeps returning `en` rkyv data until the user manually changes language. This is a real divergence but should fire post-hydration (effects run after first render), so probably not the panic source.
- `UIText.RawText` ([`ui_text.rs:124–132`](ultros-frontend/ultros-app/src/components/ui_text.rs:124)) emits one text node + one `<br>` per line of text. If `item_description()` text length / line count ever differs between SSR and CSR (e.g. locale data swap), the dynamic child count changes. Hard to trigger without the locale mismatch above.
- Worth uploading symbol maps so a future stack trace can name the failing component directly.

### Recommendations (auto-mode can't write to GlitchTip, surfacing here)
After this PR lands you can drive the backlog down considerably by triaging these in GlitchTip:

1. **Ignore (won't-fix / browser-environment):**
   - [`#4165`](https://glitchtip.ultros.app/ultros/issues/4165) — `CompileError: invalid value type 'externref', enable with --experimental-wasm-reftypes` (4 events). Old browsers that don't support wasm reftypes; the wasm refuses to load. Not fixable in app code.
   - [`#2222`](https://glitchtip.ultros.app/ultros/issues/2222) — `AbortError: The operation was aborted` (3 events). Navigation-cancelled fetches; expected behaviour.
   - [`#5235`](https://glitchtip.ultros.app/ultros/issues/5235), [`#5232`](https://glitchtip.ultros.app/ultros/issues/5232) — `UnhandledRejection: Non-Error promise rejection captured with value: undefined`. Third-party (Google AdSense / analytics) noise with no actionable stack.
2. **Resolve as fixed-pending-deploy (verify after this lands):**
   - All the paired `RustWasmPanic` issues that hit `<SaleHistoryTable>` / `<ListingsTable>` *only* — they may stop firing once `RelativeToNow` stops emitting unstable text. Re-check after a deploy window before resolving the shared-chrome cluster.
3. **Keep open / dedupe:** the high-count anchors — [`#4`](https://glitchtip.ultros.app/ultros/issues/4) (533 events, `?` placeholder), [`#5147`](https://glitchtip.ultros.app/ultros/issues/5147) (53 events, post-deploy), [`#1307`](https://glitchtip.ultros.app/ultros/issues/1307) (34 events, SGE), [`#402`](https://glitchtip.ultros.app/ultros/issues/402) (25 events, RPR) — these are the canonical buckets; the dozens of single-event panics that share the same release + same panic message + adjacent `/item/<world>/<id>` filenames are duplicates and could be bulk-ignored once GlitchTip merges them.

## Test plan
- [ ] `cargo fmt --all -- --check` — clean (verified locally).
- [ ] `cargo clippy -p ultros-app --no-deps --all-targets -- -D warnings` — clean (verified locally).
- [ ] Smoke: load `/item/<world>/<id>` for an item with recent sales; confirm sale-history relative timestamps render as `YYYY-MM-DD HH:MM UTC` for one frame, then snap to "5 seconds ago" / "in 3 minutes" etc.
- [ ] Verify hydration warnings in browser console drop on a refresh of an item page (Shanghai-timezone repro ideally).
- [ ] After a deploy window, re-check whether new `RustWasmPanic` events on `/item/<world>/<id>` slow down. If they don't, that confirms my suspicion that the residual panic lives in shared chrome (likely the locale-switch path) and needs a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)