### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/ultros-api-types/src/trends.rs
+++ b/ultros-api-types/src/trends.rs
@@ -126,18 +126,48 @@ mod tests {
     #[test]
     fn test_confidence_band_serialization_deserialization() {
         // Test serialization to lowercase string
-        assert_eq!(serde_json::to_string(&ConfidenceBand::Unknown).unwrap(), "\"unknown\"");
-        assert_eq!(serde_json::to_string(&ConfidenceBand::High).unwrap(), "\"high\"");
-        assert_eq!(serde_json::to_string(&ConfidenceBand::Medium).unwrap(), "\"medium\"");
-        assert_eq!(serde_json::to_string(&ConfidenceBand::Low).unwrap(), "\"low\"");
-        assert_eq!(serde_json::to_string(&ConfidenceBand::Unusable).unwrap(), "\"unusable\"");
+        assert_eq!(
+            serde_json::to_string(&ConfidenceBand::Unknown).unwrap(),
+            "\"unknown\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConfidenceBand::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConfidenceBand::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConfidenceBand::Low).unwrap(),
+            "\"low\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ConfidenceBand::Unusable).unwrap(),
+            "\"unusable\""
+        );
 
         // Test deserialization from lowercase string
-        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"unknown\"").unwrap(), ConfidenceBand::Unknown);
-        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"high\"").unwrap(), ConfidenceBand::High);
-        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"medium\"").unwrap(), ConfidenceBand::Medium);
-        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"low\"").unwrap(), ConfidenceBand::Low);
-        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"unusable\"").unwrap(), ConfidenceBand::Unusable);
+        assert_eq!(
+            serde_json::from_str::<ConfidenceBand>("\"unknown\"").unwrap(),
+            ConfidenceBand::Unknown
+        );
+        assert_eq!(
+            serde_json::from_str::<ConfidenceBand>("\"high\"").unwrap(),
+            ConfidenceBand::High
+        );
+        assert_eq!(
+            serde_json::from_str::<ConfidenceBand>("\"medium\"").unwrap(),
+            ConfidenceBand::Medium
+        );
+        assert_eq!(
+            serde_json::from_str::<ConfidenceBand>("\"low\"").unwrap(),
+            ConfidenceBand::Low
+        );
+        assert_eq!(
+            serde_json::from_str::<ConfidenceBand>("\"unusable\"").unwrap(),
+            ConfidenceBand::Unusable
+        );
 
         // Test default value
         let default_band: ConfidenceBand = Default::default();

--- a/ultros-api-types/src/trends.rs
+++ b/ultros-api-types/src/trends.rs
@@ -118,3 +118,29 @@ pub struct TrendsData {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub falling_price: Vec<TrendItem>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_confidence_band_serialization_deserialization() {
+        // Test serialization to lowercase string
+        assert_eq!(serde_json::to_string(&ConfidenceBand::Unknown).unwrap(), "\"unknown\"");
+        assert_eq!(serde_json::to_string(&ConfidenceBand::High).unwrap(), "\"high\"");
+        assert_eq!(serde_json::to_string(&ConfidenceBand::Medium).unwrap(), "\"medium\"");
+        assert_eq!(serde_json::to_string(&ConfidenceBand::Low).unwrap(), "\"low\"");
+        assert_eq!(serde_json::to_string(&ConfidenceBand::Unusable).unwrap(), "\"unusable\"");
+
+        // Test deserialization from lowercase string
+        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"unknown\"").unwrap(), ConfidenceBand::Unknown);
+        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"high\"").unwrap(), ConfidenceBand::High);
+        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"medium\"").unwrap(), ConfidenceBand::Medium);
+        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"low\"").unwrap(), ConfidenceBand::Low);
+        assert_eq!(serde_json::from_str::<ConfidenceBand>("\"unusable\"").unwrap(), ConfidenceBand::Unusable);
+
+        // Test default value
+        let default_band: ConfidenceBand = Default::default();
+        assert_eq!(default_band, ConfidenceBand::Unknown);
+    }
+}


### PR DESCRIPTION
💡 What: Added unit tests for the `ConfidenceBand` enum serialization and deserialization in `ultros-api-types/src/trends.rs`.
🎯 Why: Ensuring the exact JSON string representation of confidence bands (lowercase strings) remains stable is critical for backwards compatibility. If these variants were ever renamed or their serialization behavior altered accidentally, it would break older clients attempting to parse API payloads. 
📊 Impact: Full coverage for `ConfidenceBand` serde behavior and default value creation.
🔬 Verification: Run `cargo test --package ultros-api-types` to execute the new test suite.

---
*PR created automatically by Jules for task [17178737699360643863](https://jules.google.com/task/17178737699360643863) started by @akarras*