### PR TITLE
⚡ Bolt: Eliminate N+1 queries in get_lists endpoints

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2025-05-22 - Resolve N+1 Queries in Retainer Listings Lookup
 **Learning:** In `get_retainer_listings_for_discord_user`, the code used `futures::future::join_all` to issue concurrent `.find_related()` queries for retainers and their listings. This still results in N+1 database queries (or $1 + N \times 2$) because it sends independent SELECTs per iteration, even if concurrently.
 **Action:** Always combine `find_also_related` (to fetch parent and 1:1/N:1 child in a single query) and SeaORM's `load_many` (to fetch all 1:N relations for a collection of models in one batched query). This reduces the query pattern to exactly 2 queries regardless of the collection size, drastically cutting database roundtrips.
+
+## 2026-05-13 - Optimize `get_lists_for_user` list fetch
+**Learning:** Found an N+1 query issue masquerading as `get_lists_for_user` in the `web.rs` endpoint. The code loaded `get_lists_for_user` returning just lists, and then iterated over them to call `get_permission` on each, which issued up to 3 queries each.
+**Action:** Always fetch associated data like permissions directly in the same query by using `.select_also` or similar methods on the `Entity` when fetching a collection. Changed `get_lists_for_user` to return `(list::Model, ListPermission)` avoiding the loop of `get_permission` queries.

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,10 @@
+--- ultros/src/web.rs
++++ ultros/src/web.rs
+@@ -501,6 +501,7 @@
+     Ok(())
+ }
+
++#[allow(clippy::result_large_err)]
+ pub(crate) async fn get_lists(
+     State(db): State<UltrosDb>,
+     user: AuthDiscordUser,

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -223,38 +223,57 @@ impl UltrosDb {
         Ok(())
     }
 
-    pub async fn get_lists_for_user(&self, discord_user: i64) -> Result<Vec<list::Model>> {
-        // This should probably also include lists shared with the user
+    pub async fn get_lists_for_user(
+        &self,
+        discord_user: i64,
+    ) -> Result<Vec<(list::Model, ListPermission)>> {
         let owned_lists = list::Entity::find()
             .filter(list::Column::Owner.eq(discord_user))
             .all(&self.db)
-            .await?;
+            .await?
+            .into_iter()
+            .map(|l| (l, ListPermission::Owner));
 
-        let shared_lists = list::Entity::find()
-            .inner_join(list_shared_user::Entity)
-            .filter(list_shared_user::Column::UserId.eq(discord_user))
-            .all(&self.db)
-            .await?;
+        let shared_lists: Vec<(list::Model, Option<list_shared_user::Model>)> =
+            list::Entity::find()
+                .inner_join(list_shared_user::Entity)
+                .filter(list_shared_user::Column::UserId.eq(discord_user))
+                .select_also(list_shared_user::Entity)
+                .all(&self.db)
+                .await?;
+        let shared_lists = shared_lists
+            .into_iter()
+            .filter_map(|(l, su)| su.map(|su| (l, ListPermission::from(su.permission))));
 
-        let group_lists = list::Entity::find()
-            .inner_join(list_shared_group::Entity)
-            .join(
-                JoinType::InnerJoin,
-                list_shared_group::Relation::UserGroup.def(),
-            )
-            .join(
-                JoinType::InnerJoin,
-                user_group::Relation::UserGroupMember.def(),
-            )
-            .filter(user_group_member::Column::UserId.eq(discord_user))
-            .all(&self.db)
-            .await?;
+        let group_lists: Vec<(list::Model, Option<list_shared_group::Model>)> =
+            list::Entity::find()
+                .inner_join(list_shared_group::Entity)
+                .join(
+                    JoinType::InnerJoin,
+                    list_shared_group::Relation::UserGroup.def(),
+                )
+                .join(
+                    JoinType::InnerJoin,
+                    user_group::Relation::UserGroupMember.def(),
+                )
+                .filter(user_group_member::Column::UserId.eq(discord_user))
+                .select_also(list_shared_group::Entity)
+                .all(&self.db)
+                .await?;
+        let group_lists = group_lists
+            .into_iter()
+            .filter_map(|(l, sg)| sg.map(|sg| (l, ListPermission::from(sg.permission))));
 
-        let mut all_lists = owned_lists;
-        all_lists.extend(shared_lists);
-        all_lists.extend(group_lists);
-        all_lists.sort_by_key(|l| l.id);
-        all_lists.dedup_by_key(|l| l.id);
+        let mut map = std::collections::HashMap::new();
+        for (l, p) in owned_lists.chain(shared_lists).chain(group_lists) {
+            let entry = map.entry(l.id).or_insert((l.clone(), p));
+            if p > entry.1 {
+                entry.1 = p;
+            }
+        }
+
+        let mut all_lists = map.into_values().collect::<Vec<_>>();
+        all_lists.sort_by_key(|(l, _)| l.id);
 
         Ok(all_lists)
     }

--- a/ultros/src/discord/ffxiv/lists.rs
+++ b/ultros/src/discord/ffxiv/lists.rs
@@ -68,8 +68,7 @@ pub(crate) async fn show_lists(ctx: Context<'_>) -> Result<(), Error> {
         .await?;
     let lists = ctx.data().db.get_lists_for_user(user.id).await?;
     let mut names = Vec::with_capacity(lists.len());
-    for list in lists {
-        let permission = ctx.data().db.get_permission(list.id, user.id).await?;
+    for (list, permission) in lists {
         names.push(format!("{} ({})", list.name, permission_name(permission)));
     }
     let names = names.join("\n");
@@ -95,8 +94,8 @@ async fn autocomplete_list_name(
         .await
         .unwrap_or_default()
         .into_iter()
-        .filter(move |l| l.name.to_ascii_lowercase().contains(&partial))
-        .map(|l| poise::serenity_prelude::AutocompleteChoice::new(l.name.clone(), l.name))
+        .filter(move |(l, _)| l.name.to_ascii_lowercase().contains(&partial))
+        .map(|(l, _)| poise::serenity_prelude::AutocompleteChoice::new(l.name.clone(), l.name))
 }
 
 async fn autocomplete_item_name_global(

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -503,23 +503,17 @@ pub(crate) async fn get_lists(
     State(db): State<UltrosDb>,
     user: AuthDiscordUser,
 ) -> Result<Json<Vec<ListWithPermission>>, ApiError> {
-    let lists = try_join_all(
-        db.get_lists_for_user(user.id as i64)
-            .await?
-            .into_iter()
-            .map(|list| {
-                let db = db.clone();
-                let user_id = user.id as i64;
-                async move {
-                    let permission = db.get_permission(list.id, user_id).await?;
-                    Ok::<_, ApiError>(ListWithPermission {
-                        list: List::try_from(list)?,
-                        permission,
-                    })
-                }
-            }),
-    )
-    .await?;
+    let lists = db
+        .get_lists_for_user(user.id as i64)
+        .await?
+        .into_iter()
+        .map(|(list, permission)| {
+            Ok::<_, ApiError>(ListWithPermission {
+                list: List::try_from(list)?,
+                permission,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(Json(lists))
 }
 

--- a/ultros/src/web.rs.orig
+++ b/ultros/src/web.rs.orig
@@ -499,7 +499,6 @@ pub(crate) async fn unclaim_retainer(
     Ok(())
 }
 
-#[allow(clippy::result_large_err)]
 pub(crate) async fn get_lists(
     State(db): State<UltrosDb>,
     user: AuthDiscordUser,


### PR DESCRIPTION
⚡ Bolt: Eliminate N+1 queries in get_lists endpoints

💡 What: Modified `get_lists_for_user` to use `.select_also()` to load ListPermission in the same query.
🎯 Why: In `web.rs` and the discord commands, the codebase fetched lists and then performed an N+1 query loop to fetch the user's permission for each list via `get_permission()`.
📊 Impact: Reduces list endpoint database queries from 3 + (N * up to 3) to exactly 3 constant queries.
🔬 Measurement: Verify through database logs or response timings when rendering a user's lists with a large quantity of lists.

---
*PR created automatically by Jules for task [14467608017552486337](https://jules.google.com/task/14467608017552486337) started by @akarras*