### PR TITLE
🛡️ Sentry: Add HeatBand::from_pct unit test

### DIFF
--- a/ultros-api-types/src/market_heat.rs
+++ b/ultros-api-types/src/market_heat.rs
@@ -61,3 +61,32 @@ pub struct MarketHeatResponse {
     pub world_id: i32,
     pub categories: Vec<CategoryHeat>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_heat_band_from_pct() {
+        // NoData when item_count is 0, regardless of pct
+        assert_eq!(HeatBand::from_pct(10.0, 0), HeatBand::NoData);
+        assert_eq!(HeatBand::from_pct(-10.0, 0), HeatBand::NoData);
+
+        // Hot: pct > 5.0
+        assert_eq!(HeatBand::from_pct(5.1, 1), HeatBand::Hot);
+        assert_eq!(HeatBand::from_pct(10.0, 1), HeatBand::Hot);
+
+        // Warm: 1.0 < pct <= 5.0
+        assert_eq!(HeatBand::from_pct(5.0, 1), HeatBand::Warm);
+        assert_eq!(HeatBand::from_pct(1.1, 1), HeatBand::Warm);
+
+        // Stable: -1.0 < pct <= 1.0
+        assert_eq!(HeatBand::from_pct(1.0, 1), HeatBand::Stable);
+        assert_eq!(HeatBand::from_pct(0.0, 1), HeatBand::Stable);
+        assert_eq!(HeatBand::from_pct(-0.9, 1), HeatBand::Stable);
+
+        // Cool: pct <= -1.0
+        assert_eq!(HeatBand::from_pct(-1.0, 1), HeatBand::Cool);
+        assert_eq!(HeatBand::from_pct(-5.0, 1), HeatBand::Cool);
+    }
+}


### PR DESCRIPTION
💡 What: Implemented a comprehensive unit test for `HeatBand::from_pct` in `ultros-api-types/src/market_heat.rs`.

🎯 Why: To ensure the correct boundary evaluation for volume-weighted price change categorizations (Hot, Warm, Stable, Cool, NoData).

📊 Impact: The logic calculating `HeatBand` given percentage change and item count in `ultros-api-types/src/market_heat.rs` is now completely covered by a dedicated unit test.

🔬 Verification: Run `cargo test -p ultros-api-types` to execute the specific tests for this api-types crate.

---
*PR created automatically by Jules for task [14007176844189355797](https://jules.google.com/task/14007176844189355797) started by @akarras*