### PR TITLE
⚡ Bolt: Replace unnecessary <For> components with collect_view()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,6 @@
 ## 2025-05-22 - Resolve N+1 Queries in Retainer Listings Lookup
 **Learning:** In `get_retainer_listings_for_discord_user`, the code used `futures::future::join_all` to issue concurrent `.find_related()` queries for retainers and their listings. This still results in N+1 database queries (or $1 + N \times 2$) because it sends independent SELECTs per iteration, even if concurrently.
 **Action:** Always combine `find_also_related` (to fetch parent and 1:1/N:1 child in a single query) and SeaORM's `load_many` (to fetch all 1:N relations for a collection of models in one batched query). This reduces the query pattern to exactly 2 queries regardless of the collection size, drastically cutting database roundtrips.
+## 2026-05-29 - Optimize Leptos <For> rendering in conditional blocks
+**Learning:** In Leptos, using `<For>` components inside conditionally rendered blocks (like `match` arms for `Resource` updates) that re-create the entire view adds unnecessary keyed reconciliation overhead. Furthermore, if the block captures an owned `Vec`, providing it to `each=move || vec.clone()` causes unnecessary cloning.
+**Action:** Use `vec.into_iter().map(...).collect_view()` instead of `<For>` when the entire list is recreated on update. This avoids diffing overhead and unnecessary array cloning.

--- a/ultros-frontend/ultros-app/src/components/alert_rules_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/alert_rules_panel.rs
@@ -152,10 +152,8 @@ pub fn AlertRulesPanel() -> impl IntoView {
                                             </tr>
                                         </thead>
                                         <tbody>
-                                            <For
-                                                each=move || rows.clone()
-                                                key=|a| a.id
-                                                children=move |a: Alert| {
+                                            // ⚡ Bolt Optimization: Using collect_view() instead of <For> to prevent unnecessary cloning of rows inside a conditional block that completely recreates the view.
+                                            {rows.into_iter().map(|a: Alert| {
                                                     // Display strings differ per trigger variant. List-scoped alerts
                                                     // don't carry a single item/world/hq — render those columns with
                                                     // the list id and "—" placeholders so the table stays uniform.
@@ -255,8 +253,7 @@ pub fn AlertRulesPanel() -> impl IntoView {
                                                             </td>
                                                         </tr>
                                                     }
-                                                }
-                                            />
+                                            }).collect_view()}
                                         </tbody>
                                     </table>
                                 </div>

--- a/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
@@ -113,10 +113,8 @@ pub fn EndpointsPanel() -> impl IntoView {
                     }.into_any(),
                     Ok(rows) => view! {
                         <ul class="divide-y">
-                            <For
-                                each=move || rows.clone()
-                                key=|e| e.id
-                                children=move |e: Endpoint| {
+                            // ⚡ Bolt Optimization: Using collect_view() instead of <For> to prevent unnecessary cloning of rows inside a conditional block that completely recreates the view.
+                            {rows.into_iter().map(|e: Endpoint| {
                                     // Sub-label shows the method, plus enough context for
                                     // Discord channels to identify which server/channel it is.
                                     // Falls back to the raw id for legacy rows that pre-date
@@ -184,8 +182,7 @@ pub fn EndpointsPanel() -> impl IntoView {
                                             </div>
                                         </li>
                                     }
-                                }
-                            />
+                            }).collect_view()}
                         </ul>
                     }.into_any(),
                     Err(e) => view! { <div class="text-red-500">{format!("{e}")}</div> }.into_any(),

--- a/ultros-frontend/ultros-app/src/components/history_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/history_panel.rs
@@ -58,8 +58,8 @@ pub fn HistoryPanel() -> impl IntoView {
                                 </tr>
                             </thead>
                             <tbody>
-                                <For each=move || rows.clone() key=|e| e.id
-                                    children=move |e: AlertEvent| {
+                                // ⚡ Bolt Optimization: Using collect_view() instead of <For> to prevent unnecessary cloning of rows inside a conditional block that completely recreates the view.
+                                {rows.into_iter().map(|e: AlertEvent| {
                                         let item_name = tracked_data().items.get(&ItemId(e.item_id))
                                             .map(|it| it.name.as_str().to_string())
                                             .unwrap_or_else(|| format!("Item {}", e.item_id));
@@ -88,8 +88,7 @@ pub fn HistoryPanel() -> impl IntoView {
                                                 </td>
                                             </tr>
                                         }
-                                    }
-                                />
+                                    }).collect_view()}
                             </tbody>
                         </table>
                     </div>

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -980,10 +980,8 @@ fn ActivityFeed(
                             Ok(rows) => {
                                 view! {
                                     <ol class="flex flex-col gap-2">
-                                        <For
-                                            each=move || rows.clone()
-                                            key=|activity| activity.id
-                                            children=move |activity| {
+                                        // ⚡ Bolt Optimization: Using collect_view() instead of <For> to prevent unnecessary cloning of rows inside a conditional block that completely recreates the view.
+                                        {rows.into_iter().map(|activity| {
                                                 view! {
                                                     <li class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] px-3 py-2">
                                                         <div class="text-sm font-semibold text-[color:var(--color-text)]">{activity.message}</div>
@@ -992,8 +990,7 @@ fn ActivityFeed(
                                                         </div>
                                                     </li>
                                                 }
-                                            }
-                                        />
+                                        }).collect_view()}
                                     </ol>
                                 }
                                     .into_any()


### PR DESCRIPTION
💡 What: Replaced `<For>` components with `.into_iter().map(...).collect_view()` in `history_panel`, `alert_rules_panel`, `endpoints_panel`, and `list_view`.
🎯 Why: `<For>` components provide keyed diffing for reactive lists. However, when placed inside a match block for a `Resource`, the entire view is recreated when the resource updates. The keyed reconciliation provides zero benefit while adding overhead. Furthermore, the original code used `each=move || rows.clone()`, unnecessarily cloning the entire array.
📊 Impact: Eliminates vector cloning and keyed diffing overhead on these components, resulting in faster rendering and less memory allocation when lists are updated.
🔬 Measurement: Profile the UI when loading these panels to observe reduced memory allocation and faster render times.

---
*PR created automatically by Jules for task [7331988410991844661](https://jules.google.com/task/7331988410991844661) started by @akarras*