### PR TITLE
⚡ Bolt: Optimize retainer undercut item lookup with batched queries

### DIFF
--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -196,6 +196,20 @@ impl UltrosDb {
         Ok(listings)
     }
 
+    pub async fn get_listings_for_world_items(
+        &self,
+        world: WorldId,
+        items: impl Iterator<Item = ItemId>,
+    ) -> Result<Vec<active_listing::Model>> {
+        use active_listing::*;
+        let listings = Entity::find()
+            .filter(Column::ItemId.is_in(items.map(|i| i.0)))
+            .filter(Column::WorldId.eq(world.0))
+            .all(&self.db)
+            .await?;
+        Ok(listings)
+    }
+
     #[instrument(skip(self))]
     pub async fn get_listings_for_items_in_worlds(
         &self,

--- a/ultros-db/src/retainers.rs
+++ b/ultros-db/src/retainers.rs
@@ -168,20 +168,40 @@ impl UltrosDb {
                 map.entry(world_id).or_default().push(item_id);
                 map
             });
-        // execute multiple queries for world item listings at once
-        let results =
-            futures::future::join_all(items_by_world.into_iter().flat_map(|(world, item_ids)| {
-                item_ids.into_iter().map(move |i| async move {
-                    (
-                        (world, i),
-                        self.get_listings_for_world(WorldId(world), ItemId(i)).await,
-                    )
-                })
-            }))
-            .await
-            .into_iter()
-            // Bolt optimization: collect results into a HashMap for O(1) lookup
-            .collect::<std::collections::HashMap<_, _>>();
+        // execute one query per world for all items in that world to avoid N+1 queries
+        let results_by_world = futures::future::join_all(items_by_world.into_iter().map(
+            |(world, item_ids)| async move {
+                let items = item_ids.iter().copied().map(ItemId);
+                let listings = self
+                    .get_listings_for_world_items(WorldId(world), items)
+                    .await;
+                (world, item_ids, listings)
+            },
+        ))
+        .await;
+
+        let mut results: HashMap<(i32, i32), Result<Vec<active_listing::Model>, _>> =
+            HashMap::new();
+        for (world, item_ids, listings_res) in results_by_world {
+            match listings_res {
+                Ok(listings) => {
+                    // pre-populate with empty vectors so items with 0 listings are handled correctly
+                    for item_id in item_ids {
+                        results.insert((world, item_id), Ok(Vec::new()));
+                    }
+                    for listing in listings {
+                        if let Some(Ok(vec)) = results.get_mut(&(world, listing.item_id)) {
+                            vec.push(listing);
+                        }
+                    }
+                }
+                Err(e) => {
+                    for item_id in item_ids {
+                        results.insert((world, item_id), Err(anyhow::anyhow!(e.to_string())));
+                    }
+                }
+            }
+        }
         // now filter the retainer queries down to just listings that beat our retainer's listings
         Ok(retainers
             .into_iter()


### PR DESCRIPTION
💡 **What**: Added `get_listings_for_world_items` using `Column::ItemId.is_in(items)` and refactored `get_retainer_undercut_items` to issue just 1 DB query per world instead of an N+1 query loop.
🎯 **Why**: Previously, when checking if a user's retainer items are undercut, the app fired independent DB queries for *every single item* on a retainer (resulting in `O(N)` queries where `N` is items). This scales extremely poorly when many retainers list multiple items.
📊 **Impact**: Reduces total queries for the endpoint from `O(W * I)` (worlds * items) to just `O(W)` (worlds). Typically just 1 or 2 queries instead of potentially 400.
🔬 **Measurement**: Inspect the execution time of `get_retainer_undercut_items` under load. Run test suite to verify no regressions in returned results structure.

---
*PR created automatically by Jules for task [11684770318158126592](https://jules.google.com/task/11684770318158126592) started by @akarras*