### PR TITLE
fix(cheapest-price): defer resource read until post-hydration

### DIFF
--- a/ultros-frontend/ultros-app/src/components/cheapest_price.rs
+++ b/ultros-frontend/ultros-app/src/components/cheapest_price.rs
@@ -8,7 +8,35 @@ use crate::{
 };
 use ultros_api_types::world_helper::AnySelector;
 
-/// Always shows the lowest price
+/// Always shows the lowest price.
+///
+/// Defers reading the `cheapest_prices` resource until after hydration. The
+/// `Suspense` fallback (`<SingleLineSkeleton />`) is the only shape that's
+/// safe to ship through SSR + first-render CSR for this component: SSR uses
+/// `.with()` (not `.read()`), which does NOT subscribe-and-suspend the
+/// wrapping Suspense, so the SSR pass renders the fallback with the resource
+/// in pending state. The client side serialises the resolved resource into
+/// the payload, so the first CSR render of the body would otherwise see
+/// `Some(map)` immediately during hydration — swapping the SSR'd
+/// `<SingleLineSkeleton />` for either a `<div>` (item has a listing) or
+/// nothing (no listing). The shape divergence drives tachys' walker into
+/// `failed_to_cast_text_node` at `tachys-0.2.15/src/hydration.rs:227`
+/// (the post-debug-strip `unreachable!()` — see the long-running
+/// `/items/jobset/<JOB>` and `/item/<world>/<id>` clusters in GlitchTip
+/// including issues 4 (count 622), 5277, 2388, 4962, 156, 5002, 224, 5392,
+/// 2541, 5030, 1306, 4910, 4889, 5391, 5360, 5359, plus the per-item-page
+/// pairs 5413/5414, 5411/5412, 5409/5410, 5407/5408, 5405/5406, 5403/5404,
+/// 5401/5402, 5399/5400, 5397/5398, 5395/5396, 5393/5394, 5389/5390,
+/// 5387/5388, 5385/5386, 5383/5384 etc.). The wasm-bindgen-futures executor
+/// then cascades into `RefCell already borrowed` from the same trace, which
+/// is what surfaces as the secondary issue in each pair.
+///
+/// Same idiom as #730 (relative-time), #732 (source-callout recipe chip),
+/// #725 (chart), #719 (item-explorer price sort), #712 (RecentItems): an
+/// `Effect`-driven `hydrated` flag (effects run client-only, after the
+/// initial view is rendered) so SSR and the first CSR render both render
+/// the skeleton, shapes match, and a frame later the effect fires and the
+/// closure re-runs with the resolved listings.
 #[component]
 pub fn CheapestPrice(
     item_id: ItemId,
@@ -17,11 +45,18 @@ pub fn CheapestPrice(
 ) -> impl IntoView {
     let i18n = use_i18n();
     let cheapest = use_context::<CheapestPrices>().unwrap().read_listings;
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
     view! {
         <Suspense fallback=move || {
             view! { <SingleLineSkeleton /> }
         }>
             {move || {
+                if !hydrated.get() {
+                    return view! { <SingleLineSkeleton /> }.into_any();
+                }
                 cheapest
                     .with(|data| {
                         data.as_ref()
@@ -65,6 +100,7 @@ pub fn CheapestPrice(
                                     })
                             })
                     })
+                    .unwrap_or_else(|| ().into_any())
             }}
         </Suspense>
     }


### PR DESCRIPTION
## Summary

- `<CheapestPrice>` is rendered in dozens of slots across `/items/jobset/<JOB>`, `/items/jobset/<JOB>/set/<ilvl>`, and `/item/<world>/<id>`. Each instance reads `cheapest_prices.read_listings.with(...)` inside a `<Suspense>` body. Because `Resource::with()` does NOT subscribe-and-suspend the wrapping `<Suspense>`, SSR can ship the skeleton fallback while CSR's first hydration render sees the serialised resource and emits a `<div>` (or `None`) instead. That shape divergence drives tachys' walker into `failed_to_cast_text_node` at `tachys-0.2.15/src/hydration.rs:227`, and the wasm-bindgen-futures executor then cascades into `js-sys/futures/task/singlethread.rs:142` `RefCell already borrowed`.
- This is the same root cause family addressed by #719, #725, #730, #732 — but for `<CheapestPrice>` specifically, which is the highest-volume offender across the affected routes.
- Fix: an `Effect`-driven `hydrated` flag (effects run client-only, only after the first render) so SSR and the initial CSR hydration render both early-return the skeleton. A frame later the effect fires, the closure re-runs with the resolved listings, and the skeleton reactively swaps to the price tile (or to nothing when no listing exists).

## GlitchTip issues this should resolve

Latest events all reproduce on release `1956745` (current HEAD, post-#732). The `internal error: entered unreachable code` and the paired `RefCell already borrowed` issues for the same trace:

- `/items/jobset/<JOB>` cluster: [#4](https://glitchtip.ultros.app/ultros/issues/4) (count 622, oldest mirror), [#5277](https://glitchtip.ultros.app/ultros/issues/5277) (31), [#2388](https://glitchtip.ultros.app/ultros/issues/2388) (26), [#4962](https://glitchtip.ultros.app/ultros/issues/4962), [#156](https://glitchtip.ultros.app/ultros/issues/156) (20), [#5002](https://glitchtip.ultros.app/ultros/issues/5002), [#224](https://glitchtip.ultros.app/ultros/issues/224) (15), [#5392](https://glitchtip.ultros.app/ultros/issues/5392), [#2541](https://glitchtip.ultros.app/ultros/issues/2541) (10), [#5030](https://glitchtip.ultros.app/ultros/issues/5030), [#1306](https://glitchtip.ultros.app/ultros/issues/1306), [#4910](https://glitchtip.ultros.app/ultros/issues/4910), [#4889](https://glitchtip.ultros.app/ultros/issues/4889), [#5391](https://glitchtip.ultros.app/ultros/issues/5391), [#5360](https://glitchtip.ultros.app/ultros/issues/5360), [#5359](https://glitchtip.ultros.app/ultros/issues/5359).
- `/item/<world>/<id>` cluster (per-item-page pairs): 5413/5414, 5411/5412, 5409/5410, 5407/5408, 5405/5406, 5403/5404, 5401/5402, 5399/5400, 5397/5398, 5395/5396, 5393/5394, 5389/5390, 5387/5388, 5385/5386, 5383/5384, etc.

### Separately worth marking ignored (auto-mode blocks ignore/resolve calls)

- [#5318](https://glitchtip.ultros.app/ultros/issues/5318) `TypeError: window[eFuncName] is not a function` from `app.js`. The breadcrumbs show a Chinese scraping bot's console output (`检测稳定结束，停止观察，开始抓取` — "stability detection ended, start scraping") and the stack lives entirely in `app.js`, which Ultros does not serve. This is third-party injection noise. Recommend setting status to `ignored` manually in GlitchTip.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] After deploy, watch the GlitchTip clusters above to confirm new event volume stops on the deploy release. If new events appear on the deploy release with a `:227` panic, look for another `Resource::with(...)`-inside-Suspense site we missed (related candidates: `JobSetCard.totals`, `ChartWrapper.item_stats_resource` callsite, but those use shape-stable wrappers already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)