### PR TITLE
⚡ Bolt: Optimize reactive overhead in Clipboard component

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,6 @@
 ## 2026-05-29 - Optimize Leptos <For> rendering in conditional blocks
 **Learning:** In Leptos, using `<For>` components inside conditionally rendered blocks (like `match` arms for `Resource` updates) that re-create the entire view adds unnecessary keyed reconciliation overhead. Furthermore, if the block captures an owned `Vec`, providing it to `each=move || vec.clone()` causes unnecessary cloning.
 **Action:** Use `vec.into_iter().map(...).collect_view()` instead of `<For>` when the entire list is recreated on update. This avoids diffing overhead and unnecessary array cloning.
+## 2025-05-29 - Avoid `Memo::new` for trivial signal gets and equality checks
+**Learning:** Found a component (`Clipboard`) using `Memo::new` to wrap a simple `clipboard_text()` getter, as well as an equality check `clipboard_text() == last_copied_text()` and a boolean branch to pick an icon. Creating reactive `Memo` nodes carries an overhead (tracking dependencies, memory allocation, equality checking). For purely O(1) instantaneous operations, this overhead is much larger than the operation being "memoized".
+**Action:** Replace `Memo::new` and `Signal::derive` with regular closures (`move || ...`) for trivial operations like getter calls, comparisons, and conditional returns. Save `Memo` for when the computation actually takes longer than the reactive system overhead.

--- a/ultros-frontend/ultros-app/src/components/clipboard.rs
+++ b/ultros-frontend/ultros-app/src/components/clipboard.rs
@@ -9,13 +9,17 @@ use leptos::prelude::*;
 pub fn Clipboard(#[prop(into)] clipboard_text: Signal<String>) -> impl IntoView {
     let last_copied_text = use_context::<GlobalLastCopiedText>().unwrap();
     let toasts = use_toast();
-    let clipboard_text = Memo::new(move |_| clipboard_text());
-    let copied = Memo::new(move |_| {
+    // ⚡ Bolt Optimization: Removed `Memo::new` for cheap operations
+    // `clipboard_text` is just a signal get, `copied` is simple string equality,
+    // and `icon` is a cheap branch. Creating reactive `Memo` nodes for these
+    // O(1) derivations carries overhead that exceeds the cost of recomputing them.
+    let get_clipboard_text = move || clipboard_text();
+    let copied = move || {
         last_copied_text.0()
-            .map(|t| clipboard_text() == t)
+            .map(|t| get_clipboard_text() == t)
             .unwrap_or_default()
-    });
-    let icon = Memo::new(move |_| {
+    };
+    let icon = Signal::derive(move || {
         if !copied() {
             i::BsClipboard2Fill
         } else {
@@ -25,7 +29,7 @@ pub fn Clipboard(#[prop(into)] clipboard_text: Signal<String>) -> impl IntoView 
 
     let tooltip_text = Signal::derive(move || {
         if !copied() {
-            format!("Copy '{}' to clipboard", clipboard_text())
+            format!("Copy '{}' to clipboard", get_clipboard_text())
         } else {
             "Text copied!".to_string()
         }
@@ -37,9 +41,9 @@ pub fn Clipboard(#[prop(into)] clipboard_text: Signal<String>) -> impl IntoView 
             class="clipboard cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-ring)] rounded"
             aria-label=move || {
                 if !copied() {
-                    format!("Copy {} to clipboard", clipboard_text())
+                    format!("Copy {} to clipboard", get_clipboard_text())
                 } else {
-                    format!("Copied {} to clipboard", clipboard_text())
+                    format!("Copied {} to clipboard", get_clipboard_text())
                 }
             }
             on:click=move |e| {


### PR DESCRIPTION
💡 What: Replaced `Memo::new` with simple closures and `Signal::derive` for basic string equality checks, signal gets, and boolean branching in the `Clipboard` component.
🎯 Why: `Memo::new` allocates a new reactive node, tracks dependencies, and performs equality checks. For O(1) instantaneous operations, this reactive overhead is much larger than the operation itself.
📊 Impact: Reduces reactive graph memory usage and dependency tracking overhead when clipboard components are rendered.
🔬 Measurement: Verify by interacting with clipboard icons; functionality remains perfectly identical but with fewer reactive nodes in the Leptos graph.

---
*PR created automatically by Jules for task [1640255386962297178](https://jules.google.com/task/1640255386962297178) started by @akarras*