### PR TITLE
fix(related-items): defer recipe price/profit Suspense reads until post-hydration

### DIFF
--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -117,9 +117,28 @@ fn RecipePriceEstimate(recipe: &'static Recipe) -> impl IntoView {
     let (opts_cookie, _) = cookies.use_cookie_typed::<_, CraftOptions>(craft_options::COOKIE_NAME);
     let on_hand_map = use_context::<OnHandMap>();
 
+    // Defer the resource read until after the first client render so SSR and
+    // the initial CSR hydration both render the skeleton (the same shape as
+    // the Suspense fallback). Same idiom as #740 (cheapest-price), #732
+    // (source-callout), #730 (relative-time), #725 (chart cutoff), #719
+    // (item-explorer): `Resource::with()` does not subscribe-and-suspend the
+    // wrapping `<Suspense>`, so SSR sees the resource as pending and the body
+    // returns `None` while CSR receives the serialised resource and would
+    // immediately emit the populated `<span>`. The structural mismatch trips
+    // tachys' walker at `tachys-0.2.15/src/hydration.rs:227` and cascades
+    // into the `RefCell already borrowed` panic from the
+    // wasm-bindgen-futures executor.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+
     view! {
         <Suspense fallback=move || view! { <SingleLineSkeleton /> }>
             {move || {
+                if !hydrated.get() {
+                    return view! { <SingleLineSkeleton /> }.into_any();
+                }
                 cheapest_prices.read_listings.with(|prices| {
                     let prices = prices.as_ref()?.as_ref().ok()?;
                     let opts_value = opts_cookie.get().unwrap_or_default();
@@ -178,8 +197,8 @@ fn RecipePriceEstimate(recipe: &'static Recipe) -> impl IntoView {
                                 </span>
                             })}
                         </span>
-                    })
-                })
+                    }.into_any())
+                }).unwrap_or_else(|| ().into_any())
             }}
         </Suspense>
     }
@@ -266,6 +285,18 @@ fn Recipe(recipe: &'static Recipe, item_id: ItemId) -> impl IntoView {
     let is_target = ItemId(recipe.item_result) == item_id;
     let is_ingredient = IngredientsIter::new(recipe).any(|(i, _)| i == item_id);
 
+    // Defer the inner profit-chip Suspense's resource read until after the
+    // first client render — same idiom as #740 and `RecipePriceEstimate`
+    // above. `Resource::with()` does not subscribe-and-suspend, so SSR
+    // returns `None` (skeleton fallback) while CSR hydration sees the
+    // serialised resource and would otherwise emit the populated profit
+    // `<div>` immediately, tripping tachys' walker at
+    // `tachys-0.2.15/src/hydration.rs:227`.
+    let profit_hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        profit_hydrated.set(true);
+    });
+
     Some(view! {
         <div class="card p-4 sm:p-5 space-y-4 rounded-lg border border-brand-700/30 hover:shadow-lg hover:border-brand-500/50 transition-all min-w-0">
             <div class="flex flex-col gap-3 border-b border-brand-700/30 pb-3 lg:flex-row lg:items-center lg:justify-between">
@@ -316,6 +347,9 @@ fn Recipe(recipe: &'static Recipe, item_id: ItemId) -> impl IntoView {
                 // Profitability at a glance
                 <Suspense fallback=move || view! { <SingleLineSkeleton /> }>
                     {move || {
+                        if !profit_hydrated.get() {
+                            return view! { <SingleLineSkeleton /> }.into_any();
+                        }
                         use crate::global_state::cookies::Cookies;
                         use crate::global_state::craft_options::{self, CraftOptions};
                         let cookies = use_context::<Cookies>().unwrap();
@@ -378,8 +412,8 @@ fn Recipe(recipe: &'static Recipe, item_id: ItemId) -> impl IntoView {
                                         {profit_chip(t_string!(i18n, lq).to_string(), lq_sell.map(|p| p - lq.cost))}
                                     </div>
                                 </div>
-                            })
-                        })
+                            }.into_any())
+                        }).unwrap_or_else(|| ().into_any())
                     }}
                 </Suspense>
             </div>


### PR DESCRIPTION
## Summary

- `<RecipePriceEstimate>` and the inner profit-chip `<Suspense>` inside `<Recipe>` (both rendered under `<RelatedItems>` on `/item/<world>/<id>`) read `CheapestPrices.read_listings.with(...)` directly inside their Suspense body, returning structurally different shapes depending on whether the resource is resolved (`Some(<span>...</span>)` / `Some(<div>...</div>)` vs `None` vs the `<SingleLineSkeleton />` fallback).
- `Resource::with()` does NOT subscribe-and-suspend the wrapping `<Suspense>` (only `.read()` does — same gotcha as [#740](https://github.com/akarras/ultros/pull/740), [#732](https://github.com/akarras/ultros/pull/732), [#730](https://github.com/akarras/ultros/pull/730), [#725](https://github.com/akarras/ultros/pull/725), [#719](https://github.com/akarras/ultros/pull/719)), so SSR sees the resource as pending and renders the skeleton, while CSR hydration sees the deserialised resource and immediately tries to emit the populated chip. tachys hits `unreachable!()` at `tachys-0.2.15/src/hydration.rs:227`, then the wasm-bindgen-futures executor cascades into `js-sys/futures/task/singlethread.rs:142` `RefCell already borrowed`.
- Applies the same `Effect`-driven `hydrated` flag idiom as #740. SSR and the first CSR render both early-return `<SingleLineSkeleton />` (same shape as the Suspense fallback); a frame later the effect fires, the closure re-runs with the resolved listings, and the skeleton reactively swaps to the real chip.

This is the missed sibling fix to #740: that PR repaired `<CheapestPrice>` itself, but the same `.with()`-then-branch-shape pattern lives in `<RecipePriceEstimate>` (line 109 of `related_items.rs`) and the profit `<Suspense>` inside `<Recipe>` (line 317). Both still render on `/item/<world>/<id>` via `<RelatedItems>` → `<For>` over the first 5 recipes, so every item-page hit replays the original panic chain.

## GlitchTip evidence

Release `ultros@a737cce` (the deploy that includes #740) still shows paired `RustWasmPanic: internal error: entered unreachable code` + `RustWasmPanic: RefCell already borrowed` on `/item/<world>/<id>` — every issue from [5435](https://glitchtip.ultros.app/ultros/issues/5435) through [5479](https://glitchtip.ultros.app/ultros/issues/5479), each pair tagged `filename: /item/<world>/<id>`. Plus the long-running [#4](https://glitchtip.ultros.app/ultros/issues/4) (count 642), [#402](https://glitchtip.ultros.app/ultros/issues/402) (count 29), [#601](https://glitchtip.ultros.app/ultros/issues/601) (count 50), [#4924](https://glitchtip.ultros.app/ultros/issues/4924) (count 5), and [#5420](https://glitchtip.ultros.app/ultros/issues/5420) (count 27, `RuntimeError: unreachable`). The stack trace points to `tachys-0.2.15/src/hydration.rs:227:9` from `lib.rs:459 app run!` → `hydrating body` → panic, which is the post-hydration shape mismatch on the recipe panel.

These issues should self-resolve once the fix deploys and the next hourly sweep finds no fresh events.

## Test plan
- [ ] After deploy, verify GlitchTip stops receiving new `RustWasmPanic` events tagged `/item/<world>/<id>` on the new release hash.
- [ ] Spot-check `/item/Marilith/52628` and `/item/Coeurl/51200` (both panicked under release `a737cce`) — page loads cleanly without a console panic and the recipe profit/cost chips render.
- [ ] Spot-check an item with no recipe (e.g. a vendor-only item) to confirm `<Recipe>` short-circuits via `target_item = items.get(...)?` and the `profit_hydrated` effect path isn't taken.
- [ ] Spot-check an HQ-craftable item to confirm both HQ and LQ profit chips appear after hydration, with the savings/shards chips conditionally visible.

`cargo fmt --all -- --check` clean.
`cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)