### PR TITLE
fix(job-set-detail): defer materials-total Suspense reads until post-hydration

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
+++ b/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
@@ -474,6 +474,30 @@ pub fn JobSetDetail() -> impl IntoView {
     });
     let has_materials = Memo::new(move |_| materials.get().is_some_and(|m| !m.is_empty()));
 
+    // Defer the price-resource-driven materials totals until after the first
+    // client render. The default-zone column reads the shared `CheapestPrices`
+    // `read_listings` resource and the home-world column reads
+    // `home_world_listings`, both via `.with()`/`.get()` — which (same gotcha
+    // as #740/#742) do NOT subscribe-and-suspend the wrapping `<Suspense>`. So
+    // SSR renders the body with the resource pending (`total`/`shard_total`
+    // both `None`, so the `match` arm collapses to `()`), while the first CSR
+    // hydration render sees the serialised/resolved resource and may emit the
+    // extra "with shards" `<div>`. That structural divergence trips tachys'
+    // walker at `tachys-0.2.15/src/hydration.rs:227` (`failed_to_cast_text_node`,
+    // the post-debug-strip `unreachable!()`) and cascades into the
+    // `RefCell already borrowed` panic from the wasm-bindgen-futures executor —
+    // the `/items/jobset/<JOB>/set/<ilvl>` mirror of the cluster #740
+    // (`<CheapestPrice>`) and #742 (`<RelatedItems>`) already fixed. An
+    // `Effect`-driven `hydrated` flag (effects run client-only, after the first
+    // render) makes SSR and the first CSR render both emit the Suspense-fallback
+    // shape, so the trees agree; a frame later the effect fires and the totals
+    // swap in reactively. The sibling `set_total` columns below only render a
+    // structurally-stable `<GilOrDash>`, so they don't need the gate.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+
     view! {
         <MetaTitle title=move || t_string!(i18n, job_set_detail_title).to_string().replace("%set%", &set_stem()) />
         <MetaDescription text=move || t_string!(i18n, job_set_detail_desc).to_string().replace("%set%", &set_stem()) />
@@ -595,6 +619,9 @@ pub fn JobSetDetail() -> impl IntoView {
                                     {
                                         let entries_for_total = entries_for_default;
                                         move || {
+                                            if !hydrated.get() {
+                                                return view! { <span class="text-[color:var(--color-text-muted)]">"…"</span> }.into_any();
+                                            }
                                             let entries = entries_for_total.clone();
                                             let total = default_zone_listings.and_then(|listings| {
                                                 listings.with(|data| match data {
@@ -634,6 +661,9 @@ pub fn JobSetDetail() -> impl IntoView {
                                     {
                                         let entries_for_total = entries_for_home;
                                         move || {
+                                            if !hydrated.get() {
+                                                return view! { <span class="text-[color:var(--color-text-muted)]">"…"</span> }.into_any();
+                                            }
                                             let entries = entries_for_total.clone();
                                             let total = home_world_listings
                                                 .get()


### PR DESCRIPTION
## Summary

Fixes a Leptos/tachys **hydration mismatch** on `/items/jobset/<JOB>/set/<ilvl>` — the `/set/` mirror of the same bug class already fixed for `<CheapestPrice>` (#740) and `<RelatedItems>` (#742).

The two "materials total" cards on the job-set detail page read price resources inside `<Suspense>` **without** a post-hydration gate:

| Card | Resource | Read via |
|------|----------|----------|
| Total (default zone) | `CheapestPrices.read_listings` | `.with()` |
| Total (home world) | `home_world_listings` | `.get()` |

As #740/#742 document, `Resource::with()`/`.get()` do **not** subscribe-and-suspend the wrapping `<Suspense>`. So:

- **SSR** renders the body with the resource *pending* → `total`/`shard_total` are both `None` → the `match (shard_total, total)` arm collapses to `().into_any()` (no "with shards" `<div>`).
- **First CSR hydration render** sees the serialised/resolved resource → `total`/`shard_total` may be `Some` → emits the extra `<div class="text-[11px]…">…<Gil/></div>`.

That structural divergence (a `<div>` that exists on the client but not in the SSR DOM) shifts tachys' hydration cursor and trips the walker at `tachys-0.2.15/src/hydration.rs:227` — `failed_to_cast_text_node`'s post-debug-strip `unreachable!()`. The wasm-bindgen-futures executor then cascades into the paired `js-sys/futures/task/singlethread.rs:142` `RefCell already borrowed` panic. These surface in GlitchTip as the **`RustWasmPanic: internal error: entered unreachable code`** + **`RustWasmPanic: RefCell already borrowed`** + **`RuntimeError: unreachable`** family.

## Fix

Same idiom as #719 / #725 / #730 / #732 / #740 / #742 — an `Effect`-driven `hydrated` flag (effects run client-only, after the first render). Both SSR and the first CSR render now early-return the Suspense-fallback shape (`<span>"…"</span>`), so the SSR DOM and the CSR view tree agree at the walker boundary regardless of resource state. A frame later the effect fires and the totals swap in reactively.

The sibling `set_total` columns below were left untouched — they only render a structurally-stable `<GilOrDash>` (always the same element shape, value patched reactively), so they can't diverge.

```rust
let hydrated = RwSignal::new(false);
Effect::new(move |_| { hydrated.set(true); });
// …in each materials-total Suspense body:
if !hydrated.get() {
    return view! { <span class="text-[color:var(--color-text-muted)]">"…"</span> }.into_any();
}
```

## How this was found

Triaged the GlitchTip backlog (dominated by this panic family on `/item/<world>/<id>` and `/items/jobset/<JOB>*`), confirmed the failure site is `hydration.rs:227` (text-node cast), then audited **every** `read_listings` consumer against the established `hydrated`-gate pattern:

| Consumer | Status |
|---|---|
| `cheapest_price.rs` `<CheapestPrice>` | gated ✓ (#740) |
| `related_items.rs` `RecipePriceEstimate` / `Recipe` profit | gated ✓ (#742) |
| `item_explorer.rs` `ItemList` price sort/filter | gated ✓ (#719) |
| `item_view.rs` `source_callout` recipe chip | gated ✓ (#732) |
| `job_set_card.rs` → `<GilOrDash>` | structurally stable ✓ |
| **`job_set_detail.rs` materials totals** | **un-gated ✗ → fixed here** |

## Verification

- `cargo fmt -p ultros-app -- --check` — **clean**.
- clippy / full build **not run locally**: the `ko` datamining nested submodule isn't initialised in this worktree, so `xiv-gen`'s build script can't run (`ko/Item.csv` missing). The change is a verbatim application of the existing pattern (identical constructs to `cheapest_price.rs`/`item_explorer.rs`, imports already satisfied by `leptos::prelude::*`), so I'm confident it compiles — but **CI should confirm clippy**.

## Backlog notes / recommendations (not actioned here)

- The highest-count buckets (issue 4 ·702, 601 ·51, 902 ·25, 4908 ·15, plus the fresh release-`0cd5891` flood 5566–5605) are on bare `/item/<world>/<id>` and `/items/jobset/<JOB>` pages. My static audit found those consumers **already gated** in HEAD. The continuing events are most likely (a) the broad GlitchTip fingerprint bucket ("unreachable panic on `<page>`") capturing pre-#740/#742-release stragglers, or (b) a residual that needs a **live SSR repro** to pin down. Recommend a one-off `./scripts/run_e2e.sh` style hydration check on a populated item page to confirm whether anything still diverges after this lands.
- **Likely-unresolvable / noise** (recommend marking *ignored* in GlitchTip): **5589** `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok` (failed `.wasm` fetch — adblock/CDN/network, not a code bug) and **5574** `UnhandledRejection: Non-Error promise rejection captured with value: undefined` (third-party/ad script). I could not mark these ignored from this autonomous run — the GlitchTip write tools are blocked in auto-mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
