### PR TITLE
⚡ Bolt: Replace Memo::new with Signal::derive in ItemIcon

### DIFF
--- a/ultros-frontend/ultros-app/src/components/item_icon.rs
+++ b/ultros-frontend/ultros-app/src/components/item_icon.rs
@@ -9,11 +9,11 @@ pub fn ItemIcon(
     icon_size: IconSize,
     #[prop(optional)] loading: &'static str,
 ) -> impl IntoView {
-    // ⚡ Bolt Optimization: Memoize map lookups
-    // `valid_search_category` and `item_name` are used in multiple reactive contexts
-    // inside the `view!`. By using `Memo::new`, we only perform the `HashMap` lookup
-    // when `item_id` changes, rather than on every reactive update (like when `failed_item` triggers).
-    let valid_search_category = Memo::new(move |_| {
+    // ⚡ Bolt Optimization: Replace Memo::new with Signal::derive
+    // `valid_search_category` and `item_name` are simple map lookups.
+    // Creating reactive `Memo` nodes for these O(1) derivations carries overhead
+    // that exceeds the cost of recomputing them.
+    let valid_search_category = Signal::derive(move || {
         tracked_data()
             .items
             .get(&ItemId(item_id()))
@@ -21,7 +21,7 @@ pub fn ItemIcon(
             .unwrap_or_default()
     });
 
-    let item_name = Memo::new(move |_| {
+    let item_name = Signal::derive(move || {
         tracked_data()
             .items
             .get(&ItemId(item_id()))


### PR DESCRIPTION
⚡ Bolt: Replace Memo::new with Signal::derive in ItemIcon for map lookups

💡 What:
Replaced `Memo::new` with `Signal::derive` for `valid_search_category` and `item_name` in `ItemIcon`.

🎯 Why:
The operations being performed are very fast (simple struct field access after an O(1) hash map lookup). Creating reactive `Memo` nodes for these O(1) derivations carries overhead that exceeds the cost of recomputing them. `Signal::derive` avoids the extra overhead associated with full memoization (heap allocation and equality checking).

📊 Impact:
Reduces reactive overhead and memory allocation, especially noticeable when rendering large lists with many `ItemIcon` components.

🔬 Measurement:
This improves component rendering performance by avoiding unnecessary reactive node creation. Verification is done through observing reduced memory allocation and observing standard Leptos best practices.

---
*PR created automatically by Jules for task [10936615573712710147](https://jules.google.com/task/10936615573712710147) started by @akarras*