### PR TITLE
fix(hydration): complete Google-Translate opt-out to stop translate-induced hydration crash

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -317,8 +317,19 @@ pub fn shell(options: LeptosOptions, bootstrap_script: String) -> impl IntoView 
     let error_reporting_script = error_reporting_script();
     view! {
         <!DOCTYPE html>
-        // `translate="no"` + `<meta name="google" content="notranslate">` block Chrome's Google Translate from rewriting text nodes into `<font>` wrappers before hydration, which trips `failed_to_cast_text_node` in tachys (panic at `tachys-0.2.11/src/hydration.rs:227`). App has its own locale switcher.
-        <html lang="en" translate="no" data-theme="dark" data-palette="violet">
+        // Chrome's Google Translate rewrites text nodes into `<font>` wrappers
+        // before hydration finishes, which shifts tachys' hydration cursor and
+        // trips `failed_to_cast_text_node` (panic at `hydration.rs:227`), then
+        // cascades into `RefCell already borrowed` in the wasm-bindgen-futures
+        // executor and kills the page. We opt out of translation with the full
+        // Google trifecta: `translate="no"` (W3C standard), `class="notranslate"`
+        // (Google's legacy signal — honored more reliably by older Chrome and the
+        // Translate extension, which under-honor the `translate` attribute), and
+        // `<meta name="google" content="notranslate">` below (suppresses the
+        // page-level translate prompt). The class is repeated on `<body>` because
+        // Translate walks the ancestor chain per text node. App has its own
+        // locale switcher, so we never want the browser translating our markup.
+        <html lang="en" translate="no" class="notranslate" data-theme="dark" data-palette="violet">
             <head>
                 <meta charset="utf-8" />
                 <meta name="google" content="notranslate" />
@@ -374,7 +385,7 @@ pub fn shell(options: LeptosOptions, bootstrap_script: String) -> impl IntoView 
     "window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-WYVZLM39M3');"
                 </script>
             </head>
-            <body>
+            <body translate="no" class="notranslate">
                 <App />
             </body>
         </html>


### PR DESCRIPTION
## What

Completes the Google-Translate opt-out on the SSR shell by adding `class="notranslate"` to `<html>` and `<body>` (the shell already had `translate="no"` + `<meta name="google" content="notranslate">`).

## Why — root-causing the dominant GlitchTip panic family

The biggest live cluster is the pair that keeps respawning on every release:

- `RustWasmPanic: internal error: entered unreachable code` — `tachys hydration.rs:227` (`failed_to_cast_text_node`)
- `RustWasmPanic: RefCell already borrowed` — `js-sys .../singlethread.rs:142` (the fatal cascade in the wasm-bindgen-futures executor)

on `/item/<world>/<id>` and `/items/jobset/<JOB>`. Representative issues on the current release `ad2ea5e`: [#4924](https://glitchtip.ultros.app/ultros/issues/4924), [#402](https://glitchtip.ultros.app/ultros/issues/402), [#5616](https://glitchtip.ultros.app/ultros/issues/5616), and the per-item-page pairs [#5731](https://glitchtip.ultros.app/ultros/issues/5731)/[#5732](https://glitchtip.ultros.app/ultros/issues/5732), [#5728](https://glitchtip.ultros.app/ultros/issues/5728)/[#5729](https://glitchtip.ultros.app/ultros/issues/5729), etc. The long-running cross-release aggregate is [#4](https://glitchtip.ultros.app/ultros/issues/4) (736 events).

I traced the actual event breadcrumbs (both halves of the pair share one trace: the `hydration.rs:227` unreachable fires first, then the executor re-enters its borrowed `RefCell`). Then I audited every component on both panicking routes:

- **All `read_listings` / resource-driven views are already correctly `hydrated`-gated** (`cheapest_price.rs`, `related_items.rs`, `item_view.rs`, `item_explorer.rs`, `sale_history_table.rs`, `job_set_card.rs` via `GilOrDash`). The `#712/#719/#725/#730/#732/#740/#742/#747` fixes are all in place and sound.
- The cleanest case nails it: `/items/jobset/RPR?page=45&sort=name` panics **with an empty item list** (page far out of range) and **name sort** (price gate irrelevant). That rules out every page-specific component — the only divergent text nodes left on that page are the shared-shell `t!(i18n, …)` strings.
- **Every captured event** is from a Chinese-locale browser (`timezone: Asia/Shanghai`) viewing the **English** site (`en.rkyv`, English page titles), frequently on **Chrome 104/105** (2022).

That is the textbook signature of **Chrome's Google Translate rewriting English text nodes into `<font>` wrappers before hydration finishes** — which shifts tachys' hydration cursor and trips `failed_to_cast_text_node`, then cascades into the fatal `RefCell already borrowed`. The dev who wrote the existing `translate="no"` mitigation already documented this exact failure mode in a comment in `lib.rs`. In other words: **this residual family is external client-side interference (like adblocked requests), not an app-code hydration bug.** The app's own components check out.

## The fix

The existing mitigation was missing the third, most-broadly-honored part of Google's opt-out trifecta:

| Signal | Before | After |
| --- | --- | --- |
| `translate="no"` (W3C standard) | ✅ on `<html>` | ✅ on `<html>` + `<body>` |
| `<meta name="google" content="notranslate">` | ✅ | ✅ |
| `class="notranslate"` (Google legacy signal) | ❌ | ✅ on `<html>` + `<body>` |

`class="notranslate"` is honored more reliably than the `translate` attribute by **older Chrome and the Google Translate extension** — exactly the user agents in these events — and Translate checks it per-text-node up the ancestor chain, so it's placed on both `<html>` and `<body>`. This extends the prevention strategy already chosen in this file rather than introducing a new one.

## Verification

- ✅ `cargo fmt --all -- --check` passes.
- ⚠️ Clippy / full build **not** run: this worktree needs recursive submodule init + a warm `CARGO_TARGET_DIR`, and the change is purely additive static HTML attributes inside a `view!` macro (no type/clippy surface). fmt-check is the appropriate gate here per `CLAUDE.md`.
- ⚠️ **Cannot be browser-verified in this environment** — reproducing requires a Chinese-locale Chrome 104/105 with Translate active against the live SSR app. This is a standard, low-risk hardening of the documented mitigation; if some users still manually force-translate, the residual is irreducibly external (see triage below).

## GlitchTip triage recommendations

The MCP ignore/resolve write is blocked by the auto-mode classifier, so surfacing here for one-click batch action in the UI:

**Ignore now — external / non-actionable (adblock-class):**
- [#5733](https://glitchtip.ultros.app/ultros/issues/5733) — `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok`. Stale-chunk/deploy-race or adblock/proxy blocking the `.wasm` fetch. External, transient.
- [#5730](https://glitchtip.ultros.app/ultros/issues/5730) — `UnhandledRejection: Non-Error promise rejection captured with value: undefined`. Non-actionable noise, typically third-party (ads/GA) scripts.

**Translation-induced hydration family — re-evaluate after this deploys:**
- [#4924](https://glitchtip.ultros.app/ultros/issues/4924), [#402](https://glitchtip.ultros.app/ultros/issues/402), [#5616](https://glitchtip.ultros.app/ultros/issues/5616) and the per-item RefCell/unreachable pairs ([#5731](https://glitchtip.ultros.app/ultros/issues/5731)/[#5732](https://glitchtip.ultros.app/ultros/issues/5732), [#5728](https://glitchtip.ultros.app/ultros/issues/5728)/[#5729](https://glitchtip.ultros.app/ultros/issues/5729), [#5726](https://glitchtip.ultros.app/ultros/issues/5726)/[#5727](https://glitchtip.ultros.app/ultros/issues/5727), [#5724](https://glitchtip.ultros.app/ultros/issues/5724)/[#5725](https://glitchtip.ultros.app/ultros/issues/5725), and the rest of the 5688–5732 run).
- These are keyed to release `ad2ea5e`; the next deploy gets a new `/pkg/<sha>/` so GlitchTip will spawn fresh IDs regardless. Recommend **resolve-in-next-release** for the `ad2ea5e` set, then watch whether the new build's `/item/*` + `/items/jobset/*` cluster shrinks. Whatever remains is users force-translating despite the opt-out — ignore as external, same bucket as adblock.
- [#4](https://glitchtip.ultros.app/ultros/issues/4) (736 events) is the cross-release `RuntimeError: unreachable` aggregate for this same family; leave open as the rolling signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
