### PR TITLE
fix(analyzer): enrich displayed top-ROI rows, not the lowest item_ids

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -361,6 +361,39 @@ impl ProfitTable {
     }
 }
 
+/// Post-tax ROI in integer percent for a profit row, mirroring the analyzer
+/// table's default (ROI) ranking so the enrichment pass requests the same rows
+/// the user sees first.
+fn roi_for_rank(p: &ProfitData) -> i32 {
+    let estimated = (p.estimated_sale_price as f32 * 0.95) as i32;
+    let profit = estimated - p.cheapest_price;
+    if p.cheapest_price > 0 {
+        ((profit as f32 / p.cheapest_price as f32) * 100.0) as i32
+    } else {
+        0
+    }
+}
+
+/// Choose the `(item_id, hq)` keys to send to the ClickHouse enrichment
+/// endpoints (`resale_quality` + `sparklines`), capped at `cap`.
+///
+/// The endpoints reject batches above ~250, but a busy world has thousands of
+/// recently-sold items — so we must enrich a subset, and it has to be the rows
+/// the table actually displays: the top opportunities by ROI (the default
+/// sort). The earlier implementation sorted by `item_id` and kept the lowest
+/// `cap`, which are low-level commodities that never rank as top flips — so
+/// every displayed (high-item_id) row missed the join and rendered "—" in the
+/// Sales/day, 30d Volume, and Trend columns.
+fn select_enrichment_keys(profits: &ProfitTable, cap: usize) -> Vec<(i32, bool)> {
+    let mut ranked: Vec<&Arc<ProfitData>> = profits.0.iter().collect();
+    ranked.sort_by_key(|p| Reverse(roi_for_rank(p)));
+    ranked
+        .into_iter()
+        .take(cap)
+        .map(|p| (p.sale_summary.item_id, p.sale_summary.hq))
+        .collect()
+}
+
 #[component]
 fn PresetFilterButton(href: &'static str, #[prop(into)] label: String) -> impl IntoView {
     view! {
@@ -1398,21 +1431,37 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     // endpoints. Soft-fails silently — the page still renders Pass-1
     // results with no chip when CH is unavailable.
     let sales_for_enrichment = sales.clone();
+    let world_cheapest_for_enrichment = world_cheapest_listings.clone();
+    let global_cheapest_for_enrichment = global_cheapest_listings.clone();
     let enrichment = LocalResource::new(move || {
         let world_name = world();
         let sales_res = sales_for_enrichment.get();
+        let world_cheapest_res = world_cheapest_for_enrichment.get();
+        let global_cheapest_res = global_cheapest_for_enrichment.get();
+        let filter_outliers = filter_outliers().unwrap_or(false);
         async move {
             if world_name.is_empty() {
                 return EnrichmentMaps::default();
             }
-            let Some(Ok(sales)) = sales_res else {
+            let (Some(Ok(sales)), Some(Ok(world_cheapest)), Some(Ok(global_cheapest))) =
+                (sales_res, world_cheapest_res, global_cheapest_res)
+            else {
                 return EnrichmentMaps::default();
             };
-            let mut keys: Vec<(i32, bool)> =
-                sales.sales.iter().map(|s| (s.item_id, s.hq)).collect();
-            keys.sort_unstable();
-            keys.dedup();
-            keys.truncate(ENRICHMENT_BATCH_CAP);
+            // Enrich the rows the table will actually show — the top
+            // opportunities by ROI (the default sort) — not the 240
+            // numerically-lowest item_ids, which are low-level commodities
+            // that never surface as top flips. Cross-region deals are omitted
+            // from this ranking pass (a default-off power feature); the ROI
+            // order still captures the rows shown by default.
+            let profits = ProfitTable::new(
+                sales,
+                global_cheapest,
+                world_cheapest,
+                Vec::new(),
+                filter_outliers,
+            );
+            let keys = select_enrichment_keys(&profits, ENRICHMENT_BATCH_CAP);
             if keys.is_empty() {
                 return EnrichmentMaps::default();
             }
@@ -2015,5 +2064,66 @@ mod tests {
         let row = &table.0[0];
         assert_eq!(row.sale_summary.median_price, 1000);
         assert_eq!(row.estimated_sale_price, 1000);
+    }
+
+    #[test]
+    fn enrichment_selects_top_roi_rows_not_lowest_item_ids() {
+        use ultros_api_types::cheapest_listings::{CheapestListingItem, CheapestListings};
+        use ultros_api_types::recent_sales::RecentSales;
+
+        // A low-id commodity with no margin, and a high-id flip with a fat
+        // margin. The enrichment pass must pick the high-ROI flip — the rows
+        // the table shows first — not the numerically-lowest item_id. (The old
+        // `sort_unstable() + truncate()` would have picked item 2 instead,
+        // which is exactly why the columns were always blank in prod.)
+        let sales = RecentSales {
+            sales: vec![
+                sales_row(
+                    2,
+                    false,
+                    &[(100, 0), (100, 1), (100, 2), (100, 3), (100, 4), (100, 5)],
+                ),
+                sales_row(
+                    40000,
+                    false,
+                    &[
+                        (10000, 0),
+                        (10000, 1),
+                        (10000, 2),
+                        (10000, 3),
+                        (10000, 4),
+                        (10000, 5),
+                    ],
+                ),
+            ],
+        };
+        let region = CheapestListings {
+            cheapest_listings: vec![
+                CheapestListingItem {
+                    item_id: 2,
+                    hq: false,
+                    cheapest_price: 95,
+                    world_id: 42,
+                },
+                CheapestListingItem {
+                    item_id: 40000,
+                    hq: false,
+                    cheapest_price: 1000,
+                    world_id: 42,
+                },
+            ],
+        };
+        let world = CheapestListings {
+            cheapest_listings: vec![],
+        };
+        let profits = ProfitTable::new(sales, region, world, vec![], false);
+
+        // cap = 1 must yield the high-ROI flip, never the lowest item_id.
+        assert_eq!(select_enrichment_keys(&profits, 1), vec![(40000, false)]);
+        // Under a larger cap, both are present, ordered ROI-desc (flip first).
+        assert_eq!(
+            select_enrichment_keys(&profits, 10),
+            vec![(40000, false), (2, false)]
+        );
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -46,10 +46,15 @@ impl EnrichmentMaps {
     }
 }
 
-/// Cap on the batch size sent to `/api/v1/resale_quality` and
-/// `/api/v1/sparklines`. Both endpoints reject payloads above ~250; we
-/// stay safely under to leave headroom for serialization overhead.
+/// Cap on the batch size sent to `/api/v1/resale_quality`, which rejects
+/// payloads above 250; we stay under to leave headroom for serialization.
 const ENRICHMENT_BATCH_CAP: usize = 240;
+
+/// `/api/v1/sparklines` enforces a tighter cap than `resale_quality` —
+/// it rejects payloads above 200. Because `select_enrichment_keys` returns
+/// rows ROI-ranked, sending the first `SPARKLINE_BATCH_CAP` keys still
+/// covers the most-visible (highest-ROI) rows the table shows first.
+const SPARKLINE_BATCH_CAP: usize = 200;
 
 /// Stable URL IDs for optional columns. Required columns (HQ, Item,
 /// Profit, ROI, Buy Price) are not in this list — they always render.
@@ -1465,12 +1470,18 @@ pub fn AnalyzerWorldView() -> impl IntoView {
             if keys.is_empty() {
                 return EnrichmentMaps::default();
             }
+            // sparklines caps batches at 200 (tighter than resale_quality's
+            // 250); `keys` is ROI-ranked, so the first SPARKLINE_BATCH_CAP are
+            // the most-visible rows. Sending the full 240 here 400s the whole
+            // request and blanks the Trend column on any busy world.
+            let sparkline_keys: Vec<(i32, bool)> =
+                keys.iter().take(SPARKLINE_BATCH_CAP).copied().collect();
             let (quality, sparklines) = futures::join!(
                 get_resale_quality(&world_name, keys.clone(), 30),
                 post_sparklines(
                     &world_name,
                     SparklinesRequest {
-                        items: keys.clone(),
+                        items: sparkline_keys,
                         // 7 days (server caps at 168h). 24h was too tight —
                         // quiet items rendered as empty sparklines because a
                         // single non-trade hour can sink the polyline.


### PR DESCRIPTION
## Problem
The Flip Finder (analyzer) **Sales/day**, **30d Volume**, and **Trend** columns are always blank in prod.

## Root cause — frontend, not the data pipeline
The enrichment fetch chose which items to look up by sorting *every* recently-sold item by `item_id` and truncating to the 240-item endpoint cap. On a busy world that means it requested the **240 numerically-lowest item_ids** (shards / low-level mats), while the table displays the **highest-ROI flips** (high item_ids). Every displayed row missed the `resale_quality` / `sparklines` join and rendered `—`. `LAST SOLD` kept working because it's Pass-1 sale data, not enrichment — matching the reported symptom.

Confirmed live against `ultros.app` / Gilgamesh:
- `recentSales` returns **16,725** distinct item_ids (2–52,712); the FE only ever requested **2–2,202**.
- `resale_quality` returns valid rows for the items it *is* asked about — so the backend, the rollup, and the ClickHouse query were all fine.

## Fix
- New pure `select_enrichment_keys(profits, cap)` ranks the profit table by **post-tax ROI** (the table's default sort) and takes the top `cap`, so enrichment requests the rows the user actually sees.
- The enrichment `LocalResource` now builds that ranked profit table from the cheapest-listings resources. With cross-region off (the default) it's the *identical* profit table the table renders, so the top-240 match exactly.
- Unit test `enrichment_selects_top_roi_rows_not_lowest_item_ids` locks in the corrected behavior (fails against the old id-sort).

## Verification
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓ (full workspace)
- `cargo test -p ultros-app routes::analyzer::tests` → **8/8 pass**

## Follow-ups (not in this PR)
- **ClickHouse coverage (the bigger lever):** `item_stats_window` (window=30) covers only ~7% of traded items in prod because the one-shot `clickhouse_backfill` binary has never been run (it isn't wired into startup). Until it runs, columns only populate for the ~7% of items that already have CH data. We discussed an env-gated startup backfill (`CLICKHOUSE_BACKFILL_START_YEAR`) that would ride a normal Docker redeploy — deferred for now.
- Enrichment ranks by ROI only; deep-scrolling under a Profit / Profit-per-day sort won't enrich beyond the top-240-by-ROI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
