### PR TITLE
⚡ Bolt: Replace unnecessary Memo node with Signal::derive

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/welcome.rs
+++ b/ultros-frontend/ultros-app/src/routes/welcome.rs
@@ -21,7 +21,8 @@ pub fn Welcome() -> impl IntoView {
     let price_region = result_to_selector_read(price_region);
     let set_price_region = selector_to_setter_signal(set_price_region);
 
-    let has_homeworld = Memo::new(move |_| homeworld.with(|w| w.is_some()));
+    // ⚡ Bolt Optimization: Replace Memo::new with Signal::derive to remove reactive allocation overhead
+    let has_homeworld = Signal::derive(move || homeworld.with(|w| w.is_some()));
 
     view! {
         <div class="main-content p-6">


### PR DESCRIPTION
💡 What: Replaced `Memo::new` with `Signal::derive` in `ultros-frontend/ultros-app/src/routes/welcome.rs` for `has_homeworld`.
🎯 Why: In Leptos, `Memo` creates a new reactive node that incurs allocation overhead. The `has_homeworld` operation is a very cheap check (`homeworld.with(|w| w.is_some())`). Wrapping this in a reactive `Memo` creates unnecessary overhead because maintaining the memoization node is more expensive than simply recomputing the condition on demand. `Signal::derive` is a better fit for lightweight derivations and removes the reactive allocation overhead.
📊 Impact: Removes the allocation and tracking overhead of an unnecessary `Memo` node on component mount.
🔬 Measurement: Verify by running the application and observing no regressions in functionality on the welcome page, while having marginally lower memory and processing overhead.

---
*PR created automatically by Jules for task [15707746734913611672](https://jules.google.com/task/15707746734913611672) started by @akarras*