### PR TITLE
fix(api): check HTTP status before deserializing SSR fetch responses (GlitchTip #2218) + backlog triage

### DIFF
--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -588,6 +588,39 @@ where
     }
 }
 
+/// Classify an internal-API response (HTTP status + body) into our
+/// [`AppResult`]. Split out of the SSR fetch helpers so the status check can't
+/// be skipped again — and so it's unit-testable without a live server.
+///
+/// * **Success status** — the body is the JSON-encoded `T`. (A handful of
+///   endpoints answer `200` with a [`JsonErrorWrapper`] instead; [`deserialize`]
+///   already unwraps those into the matching [`AppError`].)
+/// * **Non-success status** — the body is *never* a `T`. It's either the API's
+///   structured [`JsonErrorWrapper`] or a plain-text message — most commonly the
+///   analyzer's `503 "Still warming up with data, unable to serve requests."`
+///   during its post-deploy warm-up. Feeding that body to `serde_json` produces
+///   a misleading `expected value at line 1 column 1` error reported at error
+///   level — the noise behind GlitchTip issue 2218. We map the status
+///   explicitly instead, mirroring the server side (`ultros/src/web/error.rs`).
+#[cfg(feature = "ssr")]
+fn parse_internal_api_response<T>(status: reqwest::StatusCode, body: &str) -> AppResult<T>
+where
+    T: DeserializeOwned,
+{
+    if status.is_success() {
+        return deserialize(body);
+    }
+    // Preserve the API's structured error when it sent one...
+    if let Ok(JsonErrorWrapper::ApiError(api)) = serde_json::from_str::<JsonErrorWrapper>(body) {
+        return Err(AppError::ApiError(api));
+    }
+    // ...otherwise fall back to the plain-text body (e.g. the analyzer warm-up
+    // message). This is an error *response*, not malformed JSON.
+    Err(AppError::ApiError(
+        ultros_api_types::result::ApiError::Message(body.trim().to_string()),
+    ))
+}
+
 #[cfg(not(feature = "ssr"))]
 #[instrument(skip())]
 pub(crate) async fn delete_api<T>(path: &str) -> AppResult<T>
@@ -656,7 +689,7 @@ where
         new_map.insert(name, value);
     }
     let request = client.delete(&path).headers(new_map).build()?;
-    let json = client
+    let response = client
         .execute(request)
         .await
         .instrument(tracing::trace_span!("HTTP FETCH"))
@@ -664,10 +697,10 @@ where
         .map_err(|e| {
             error!("Response {e}. {path}");
             e
-        })?
-        .text()
-        .await?;
-    deserialize(&json)
+        })?;
+    let status = response.status();
+    let json = response.text().await?;
+    parse_internal_api_response(status, &json)
 }
 
 #[cfg(not(feature = "ssr"))]
@@ -740,17 +773,30 @@ where
         new_map.insert(name, value);
     }
     let request = client.get(&path).headers(new_map).build()?;
-    let json = client
+    let response = client
         .execute(request)
         .await
         .instrument(tracing::trace_span!("HTTP FETCH"))
         .into_inner()
         .inspect_err(|e| {
             error!(error = ?e, path, "Error doing leptos fetch");
-        })?
-        .text()
-        .await?;
-    deserialize(&json).inspect_err(|e| error!(error = ?e, path, json, "Error deserializing text"))
+        })?;
+    let status = response.status();
+    let json = response.text().await?;
+    parse_internal_api_response(status, &json).inspect_err(|e| {
+        // Only a *successful* response that fails to parse is a real bug worth
+        // error-level reporting (GlitchTip). A non-success status is an
+        // expected error response — notably the analyzer's transient 503
+        // warm-up right after a deploy (issue 2218) — so log those quietly to
+        // match the server side (`ultros/src/web/error.rs`).
+        if status.is_success() {
+            error!(error = ?e, path, json, "Error deserializing text");
+        } else if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+            tracing::debug!(error = ?e, %status, path, "Internal API warming up");
+        } else {
+            tracing::warn!(error = ?e, %status, path, "Internal API error response");
+        }
+    })
 }
 
 #[cfg(not(feature = "ssr"))]
@@ -857,4 +903,65 @@ where
 {
     // This really only will be called by clients- I think.
     unreachable!("patch_api should only be called on clients? I think...")
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod ssr_response_tests {
+    use super::parse_internal_api_response;
+    use crate::error::AppError;
+    use reqwest::StatusCode;
+    use ultros_api_types::result::{ApiError, JsonErrorWrapper};
+
+    /// Regression for GlitchTip issue 2218. The analyzer answers
+    /// `503 + "Still warming up with data, unable to serve requests."` (plain
+    /// text) during its post-deploy warm-up. The SSR fetch helper used to feed
+    /// that body straight into `serde_json`, producing a misleading
+    /// `AppError::Json("expected value at line 1 column 1")` logged at error
+    /// level. A non-success status must yield a real API error and must never
+    /// be classified as a JSON-deserialize failure.
+    #[test]
+    fn warmup_503_plaintext_is_not_a_json_error() {
+        let body = "Analyzer Error: Still warming up with data, unable to serve requests.";
+        let err = parse_internal_api_response::<i32>(StatusCode::SERVICE_UNAVAILABLE, body)
+            .expect_err("a 503 body must not parse as a value");
+        assert!(
+            !matches!(err, AppError::Json(_)),
+            "503 warm-up body must not be treated as malformed JSON, got {err:?}",
+        );
+        match err {
+            AppError::ApiError(ApiError::Message(msg)) => {
+                assert!(
+                    msg.contains("warming up"),
+                    "message should carry the body: {msg}"
+                );
+            }
+            other => panic!("expected ApiError::Message, got {other:?}"),
+        }
+    }
+
+    /// A structured error body (the API's `JsonErrorWrapper`) on a non-success
+    /// status must round-trip to the matching typed error, not a generic string.
+    #[test]
+    fn structured_error_body_is_preserved() {
+        let body = serde_json::to_string(&JsonErrorWrapper::ApiError(ApiError::NotFound)).unwrap();
+        let err = parse_internal_api_response::<i32>(StatusCode::NOT_FOUND, &body)
+            .expect_err("a 404 must be an error");
+        assert_eq!(err, AppError::ApiError(ApiError::NotFound));
+    }
+
+    /// The happy path still deserializes the body into `T` on a 2xx.
+    #[test]
+    fn success_body_deserializes_value() {
+        let value = parse_internal_api_response::<i32>(StatusCode::OK, "42").unwrap();
+        assert_eq!(value, 42);
+    }
+
+    /// A 2xx whose body fails to deserialize is the one case that *is* a real
+    /// bug — it must still surface as an error (so the caller error-logs it).
+    #[test]
+    fn success_body_with_garbage_is_an_error() {
+        let err = parse_internal_api_response::<i32>(StatusCode::OK, "not json")
+            .expect_err("garbage on a 200 is an error");
+        assert!(matches!(err, AppError::Json(_)), "got {err:?}");
+    }
 }


### PR DESCRIPTION
## Summary

Automated GlitchTip triage run (BugSquash McSquash IV). One reproducible, test-backed fix + a full triage of the current backlog.

### The fix — GlitchTip [#2218](https://glitchtip.ultros.app/ultros/issues/2218) "Error deserializing text" (86 events)

The SSR-side `fetch_api` / `delete_api` (`ultros-frontend/ultros-app/src/api.rs`) read the response body and fed it straight into `serde_json` **without ever inspecting the HTTP status** (reqwest doesn't error on non-2xx). When the analyzer answers `503 + "Analyzer Error: Still warming up with data, unable to serve requests."` (plain text) during its post-deploy warm-up window, that produced a misleading `AppError::Json("expected value at line 1 column 1")` logged at **error** level.

The server already classifies this as a *quiet, transient* 503 (`ultros/src/web/error.rs` — deliberately logged at `debug`, cites issues 5033/5034). The client undid that care. Now it mirrors the server:

- New `parse_internal_api_response(status, body)` helper: success → deserialize `T`; non-success → preserve the API's `JsonErrorWrapper`, else wrap the plain-text body as `ApiError::Message`. An error *response* is never misreported as malformed JSON.
- Non-success responses log quietly (503 warm-up → `debug`, other non-2xx → `warn`); error-level logging is kept only for a **2xx** body that fails to parse — the one case that's a real bug.
- 4 unit tests: 503 warm-up body, structured-error round-trip, 2xx happy path, 2xx-with-garbage.

**Verification** (`CARGO_TARGET_DIR` → main repo's warm target):
- `cargo test -p ultros-app ssr_response_tests` → **4 passed**
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p ultros-app --all-targets -- -D warnings` → clean
- Full `cargo test -p ultros-app` → 132 passed, 2 **pre-existing** failures in untouched files (see note below)

> Full-workspace clippy was **not** run — this change is confined to `ultros-app`, and the workspace lint drags in the backend `ultros` crate's ~10-min vendored-OpenSSL build. fmt-check covers the whole workspace; clippy covers the only crate touched.

---

## Backlog triage

GlitchTip ignore/resolve writes are blocked in this task's auto-mode, so these are **recommendations** for you to apply (UI batch). Issue counts/IDs are noisy because the wasm build reshuffles `wasm-function[N]` indices each release, spawning fresh IDs for the same bug.

### 1. Hydration panic family — *external interference, recommend IGNORE*
`RustWasmPanic: RefCell already borrowed` + `internal error: entered unreachable code` + `RuntimeError: unreachable`, on `/item/<world>/<id>` and `/items/jobset/<JOB>`. These arrive as **pairs** per page load; the `RefCell` panic is a `js-sys` executor cascade from the primary `tachys hydration.rs:227` mismatch.

Verified this run: the app code is **thoroughly gated** (`item_explorer.rs` has the `hydrated` Effect-gate, deterministic HashMap ordering, the OOB-pagination guard, stable-wrapper divs — all with regression tests); the `notranslate` trifecta from #751 is present in `lib.rs` (`translate="no"` + `class="notranslate"` + `<meta google notranslate>`); and the panic reporter already defers via `set_timeout(0)` to avoid re-entry. The cluster **predates** the recent #748/#753 reactivity PRs by 3 weeks, so those didn't cause it. Every sampled event is a Chinese-timezone browser (`Asia/Shanghai`) viewing the EN site — consistent with Chrome's Translate rewriting text nodes into `<font>` wrappers before hydration finishes (notranslate is a hint Chrome ignores on user-initiated translation). **Same bucket as adblock; not fixable in app code — do not add more gates.**

Representative IDs (high count): [#4](https://glitchtip.ultros.app/ultros/issues/4) (788), [#5758](https://glitchtip.ultros.app/ultros/issues/5758) (70), [#3005](https://glitchtip.ultros.app/ultros/issues/3005) (61), [#4911](https://glitchtip.ultros.app/ultros/issues/4911) (40), [#402](https://glitchtip.ultros.app/ultros/issues/402) (33), [#156](https://glitchtip.ultros.app/ultros/issues/156) (23), [#272](https://glitchtip.ultros.app/ultros/issues/272) (20), [#224](https://glitchtip.ultros.app/ultros/issues/224) (16), [#4863](https://glitchtip.ultros.app/ultros/issues/4863) (13), [#5911](https://glitchtip.ultros.app/ultros/issues/5911) (9), [#5002](https://glitchtip.ultros.app/ultros/issues/5002) (7) — plus the long tail of count-1 per-item/per-world IDs (5895–5923, etc.). All `/item/*` + `/items/jobset/*` `RustWasmPanic`/`RuntimeError: unreachable` issues belong to this family.

### 2. Local-dev noise — *not production impact, recommend IGNORE (or filter `environment=development` at the SDK)*
All tagged `environment: development`, `server_name: Bahamut`, single dev box. Suggest configuring the server GlitchTip/sentry SDK to drop `environment=development` events at source so these stop accumulating.
- [#2216](https://glitchtip.ultros.app/ultros/issues/2216) "Listing add failed" (177) — `Connection pool timed out` on cold dev startup (2.2s acquire). *Verified.*
- [#4881](https://glitchtip.ultros.app/ultros/issues/4881) "...recent_sale_history... subtree pointer out of bounds" (75) — corrupt/stale local rkyv analyzer cache (`analyzer_service.rs:525`). *Verified.*
- [#2214](https://glitchtip.ultros.app/ultros/issues/2214) "Error removing listings" (127), [#2217](https://glitchtip.ultros.app/ultros/issues/2217) "Error inserting sale." (142) — same dev box/startup contention (inferred; same env/server).

### 3. Third-party / transient — recommend IGNORE
- [#5318](https://glitchtip.ultros.app/ultros/issues/5318) "TypeError: window[eFuncName] is not a function" (`app.js`, 7) — injected by a browser extension, not our bundle.
- [#5906](https://glitchtip.ultros.app/ultros/issues/5906) "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok" (1) — transient wasm fetch failure (deploy race / stale cached HTML).

---

## ⚠️ Pre-existing test failures (NOT caused by this PR)
Surfaced while running the full suite; both live in files this PR doesn't touch:
- `routes::item_explorer::tests::test_job_filtering` — asserts job ID 43 is filtered out, but **beastmaster (ID 43) became a visible job in the 7.51 data bump (#750)**. Stale test.
- `routes::retainers::test::test_sort_order` — unrelated, also failing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)