### PR TITLE
Analyzer: visible-window lazy enrichment (fill Trend/Sales-day/Volume for all scrolled rows)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-analyzer-visible-window-enrichment.md
+++ b/docs/superpowers/plans/2026-06-06-analyzer-visible-window-enrichment.md
@@ -1,0 +1,645 @@
+# Analyzer Visible-Window Lazy Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the analyzer's fixed top-240/200 ROI enrichment cap with viewport-driven lazy fetching, so every row the user scrolls to gets its Trend / Sales-day / 30d-Volume, fetched in small batched requests that accumulate.
+
+**Architecture:** `VirtualScroller` gains an optional `visible_range` writeback signal. `AnalyzerTable` owns an accumulating `EnrichmentMaps` and a `requested` dedupe set; one debounced effect (generation-guard + `gloo` `TimeoutFuture`, mirroring `components/search_box.rs`) selects the visible-window keys from `sorted_data`, fetches them via the existing bulk endpoints, and merges results. Cells distinguish loading / no-data / value via a new `settled` set. The old eager fetch in the parent (`AnalyzerWorldView`) is deleted.
+
+**Tech Stack:** Rust, Leptos (reactive signals/effects/memos), `leptos` edition 2024, `gloo-timers` (futures), ClickHouse-backed `resale_quality` + `sparklines` HTTP endpoints (unchanged).
+
+**Design spec:** `docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md`
+
+---
+
+## Prerequisites (build/test environment)
+
+Building or testing `ultros-app` compiles the whole workspace under the default `ssr` feature, which needs the game-data submodule and (on Windows) a vendored-OpenSSL toolchain. Before running any `cargo`/`./check_ci.sh` command:
+
+- **Submodule:** `git submodule update --init --recursive --depth=1` (the `xiv-gen-db` build script reads `xiv-gen/ffxiv-datamining/`; non-recursive init is insufficient — `cn/ko/tc` CSVs live in nested submodules).
+- **Windows OpenSSL (vendored):** put Strawberry Perl + its C toolchain ahead of Git's MSYS Perl on PATH, e.g. from PowerShell:
+  `\$env:PATH = "C:\Strawberry\perl\bin;C:\Strawberry\c\bin;" + \$env:PATH` (Git Bash: prepend `/c/Strawberry/perl/bin:/c/Strawberry/c/bin:`).
+- **Worktree builds:** this repo is checked out as a git worktree under `.claude/worktrees/`. Point cargo at the main checkout's warm target dir to avoid a cold ~10-min rebuild: `export CARGO_TARGET_DIR=<main-repo>/target` (see AGENTS.md / project notes).
+
+CI's gate is `./check_ci.sh` = `cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings`. It does **not** run `cargo test`, but `--all-targets` compiles the test module, so tests must compile. Run `cargo test -p ultros-app` yourself to actually execute the unit tests added here.
+
+No new user-facing strings are introduced, so **no locale files change**.
+
+---
+
+## File Structure
+
+- `ultros-frontend/ultros-app/src/components/virtual_scroller.rs` — **modify.** Add one optional `visible_range: Option<RwSignal<(usize, usize)>>` prop and an effect that writes the rendered `(start, end)` when the prop is supplied. Purely additive; the 7 other call sites pass nothing and are unaffected.
+- `ultros-frontend/ultros-app/src/routes/analyzer.rs` — **modify.** (1) Extend `EnrichmentMaps` with a `settled` set + `is_settled`. (2) Add a pure, generic `visible_keys` helper + unit tests. (3) Move enrichment ownership into `AnalyzerTable`: accumulating signal, dedupe set, visible-range wiring, world-reset effect, debounced fetch effect. (4) Update the three enrichment cells for loading/no-data/value. (5) Delete the parent's eager fetch (`LocalResource`, `enrichment_signal`, the `enrichment` prop) and the now-dead `roi_for_rank`, `select_enrichment_keys`, `ENRICHMENT_BATCH_CAP`, `SPARKLINE_BATCH_CAP`.
+
+No other files change.
+
+---
+
+## Task 1: VirtualScroller — optional `visible_range` writeback prop
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/components/virtual_scroller.rs` (prop list ~line 56-68; after the `children_shown` memo ~line 148)
+
+This is a structural component change with no natural unit test; it is verified by compilation here and by the manual scroll check in Task 3. The other 7 `<VirtualScroller>` consumers do not pass the new optional prop, so they are unaffected.
+
+- [ ] **Step 1: Add the optional prop to the component signature**
+
+In the `#[component] pub fn VirtualScroller<...>(...)` argument list, add the new prop immediately after the existing `scroller_ref` prop:
+
+```rust
+    #[prop(optional)] scroller_ref: Option<NodeRef<leptos::html::Div>>,
+    /// Optional writeback of the rendered row range `(start, end)` (end
+    /// exclusive, includes overscan). Lets a parent fetch data only for
+    /// rows in view. When omitted, no extra work is done.
+    #[prop(optional, into)] visible_range: Option<RwSignal<(usize, usize)>>,
+) -> impl IntoView
+```
+
+- [ ] **Step 2: Write the range back whenever the rendered window changes**
+
+Right after the `children_shown` memo is defined (the block ending with `((effective_viewport / avg_row_height()).ceil() as u32).max(1) + render_ahead`), add:
+
+```rust
+    // Publish the rendered row range to an optional parent signal. `child_start`
+    // and `children_shown` already account for overscan and match the slice used
+    // by `virtual_children` below.
+    if let Some(range_sig) = visible_range {
+        Effect::new(move |_| {
+            let len = children_len();
+            if len == 0 {
+                range_sig.set((0, 0));
+            } else {
+                let start = (child_start() as usize).min(len - 1);
+                let end = (start + children_shown() as usize).min(len);
+                range_sig.set((start, end));
+            }
+        });
+    }
+```
+
+- [ ] **Step 3: Verify the crate still compiles (no consumer broke)**
+
+Run: `cargo check -p ultros-app`
+Expected: compiles with no errors. (The new prop is optional; existing `<VirtualScroller>` uses in `analyzer.rs`, `venture_analyzer.rs`, `recipe_analyzer.rs`, `leve_analyzer.rs`, `fc_crafting_analyzer.rs`, `scrip_sources.rs`, `vendor_resale.rs`, `search_box.rs` compile unchanged.)
+
+- [ ] **Step 4: Run the format + lint gate**
+
+Run: `./check_ci.sh`
+Expected: passes (fmt clean, clippy clean).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+git commit -m "feat(virtual-scroller): optional visible_range writeback prop
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `visible_keys` pure helper + unit tests (TDD)
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs` (add helper after `select_enrichment_keys` ~line 400; add tests inside the existing `#[cfg(test)] mod tests` ~line 1872)
+
+The helper is generic over the row type and a key extractor so it tests with plain `(i32, bool)` tuples — no `CalculatedProfitData` fixtures, no DOM. It is wired into the real fetch effect in Task 3 (which removes the temporary `#[allow(dead_code)]`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to the **existing** `mod tests` block in `analyzer.rs` (it already starts with `use super::*;`). Append them after the last existing test:
+
+```rust
+    #[test]
+    fn visible_keys_includes_window_and_margin() {
+        let data: Vec<(i32, bool)> = (0..100).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // rendered rows [40, 50), margin 5 => slice [35, 55)
+        let keys = visible_keys(&data, (40, 50), 5, &seen, |k| *k);
+        assert_eq!(keys.len(), 20);
+        assert_eq!(keys.first(), Some(&(35, false)));
+        assert_eq!(keys.last(), Some(&(54, false)));
+    }
+
+    #[test]
+    fn visible_keys_clamps_at_start_and_end() {
+        let data: Vec<(i32, bool)> = (0..10).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // lo = 2.saturating_sub(5) = 0 ; hi = (4 + 5).min(10) = 9 => slice [0, 9)
+        let keys = visible_keys(&data, (2, 4), 5, &seen, |k| *k);
+        assert_eq!(keys.first(), Some(&(0, false)));
+        assert_eq!(keys.last(), Some(&(8, false)));
+    }
+
+    #[test]
+    fn visible_keys_excludes_already_seen() {
+        let data: Vec<(i32, bool)> = (0..10).map(|i| (i, false)).collect();
+        let mut seen = std::collections::HashSet::new();
+        seen.insert((3, false));
+        seen.insert((5, false));
+        let keys = visible_keys(&data, (0, 10), 0, &seen, |k| *k);
+        assert_eq!(keys.len(), 8);
+        assert!(!keys.contains(&(3, false)));
+        assert!(!keys.contains(&(5, false)));
+    }
+
+    #[test]
+    fn visible_keys_empty_data_yields_empty() {
+        let data: Vec<(i32, bool)> = Vec::new();
+        let seen = std::collections::HashSet::new();
+        let keys = visible_keys(&data, (0, 0), 30, &seen, |k| *k);
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn visible_keys_out_of_range_yields_empty() {
+        let data: Vec<(i32, bool)> = (0..5).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // lo = 95, hi = (110 + 5).min(5) = 5 => get(95..5) is an invalid range => &[]
+        let keys = visible_keys(&data, (100, 110), 5, &seen, |k| *k);
+        assert!(keys.is_empty());
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail to compile**
+
+Run: `cargo test -p ultros-app visible_keys`
+Expected: FAIL — `cannot find function visible_keys in this scope` (the helper doesn't exist yet).
+
+- [ ] **Step 3: Implement the helper**
+
+Add this immediately after the `select_enrichment_keys` function (just before `#[component] fn PresetFilterButton`). The `#[allow(dead_code)]` is temporary — Task 3 wires this in and removes it.
+
+```rust
+/// Keys in the `[start - margin, end + margin)` slice of `data`, minus `seen`.
+/// Generic over the row type + a key extractor so it unit-tests with plain
+/// `(i32, bool)` fixtures — no `CalculatedProfitData` / DOM needed. Wired into
+/// the lazy-enrichment effect in `AnalyzerTable`.
+#[allow(dead_code)] // wired into the fetch effect in the same change set
+fn visible_keys<T>(
+    data: &[T],
+    range: (usize, usize),
+    margin: usize,
+    seen: &std::collections::HashSet<(i32, bool)>,
+    key_of: impl Fn(&T) -> (i32, bool),
+) -> Vec<(i32, bool)> {
+    let (start, end) = range;
+    let lo = start.saturating_sub(margin);
+    let hi = (end + margin).min(data.len());
+    data.get(lo..hi)
+        .unwrap_or(&[])
+        .iter()
+        .map(key_of)
+        .filter(|k| !seen.contains(k))
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p ultros-app visible_keys`
+Expected: PASS — 5 tests pass (`visible_keys_includes_window_and_margin`, `visible_keys_clamps_at_start_and_end`, `visible_keys_excludes_already_seen`, `visible_keys_empty_data_yields_empty`, `visible_keys_out_of_range_yields_empty`).
+
+- [ ] **Step 5: Run the format + lint gate**
+
+Run: `./check_ci.sh`
+Expected: passes. (`visible_keys` would warn as dead code, but `#[allow(dead_code)]` suppresses it for this task only.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs
+git commit -m "test(analyzer): add visible_keys window/margin/dedupe helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Move enrichment into `AnalyzerTable` (lazy visible-window fetch)
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/src/routes/analyzer.rs`
+
+This task swaps the data-fetch model. It is committed as one unit (the parent removal and child addition must land together to compile). Intermediate steps may not compile on their own; the compile gate is Step 11.
+
+- [ ] **Step 1: Add the `settled` set to `EnrichmentMaps` + an accessor**
+
+Replace the `EnrichmentMaps` struct (currently 3 fields → 2 fields; it has `quality` + `sparkline`) and its impl. Find:
+
+```rust
+#[derive(Clone, Debug, Default)]
+struct EnrichmentMaps {
+    quality: HashMap<(i32, bool), ResaleQualityRow>,
+    sparkline: HashMap<(i32, bool), Vec<u32>>,
+}
+
+impl EnrichmentMaps {
+    fn quality_for(&self, key: &(i32, bool)) -> Option<&ResaleQualityRow> {
+        self.quality.get(key)
+    }
+    fn sparkline_for(&self, key: &(i32, bool)) -> Option<&Vec<u32>> {
+        self.sparkline.get(key)
+    }
+}
+```
+
+Replace with:
+
+```rust
+#[derive(Clone, Debug, Default)]
+struct EnrichmentMaps {
+    quality: HashMap<(i32, bool), ResaleQualityRow>,
+    sparkline: HashMap<(i32, bool), Vec<u32>>,
+    /// Keys whose fetch has completed (with OR without data). Lets cells tell
+    /// "still loading" (absent) from "fetched, no CH data" (present, but no
+    /// entry in `quality` / `sparkline`).
+    settled: std::collections::HashSet<(i32, bool)>,
+}
+
+impl EnrichmentMaps {
+    fn quality_for(&self, key: &(i32, bool)) -> Option<&ResaleQualityRow> {
+        self.quality.get(key)
+    }
+    fn sparkline_for(&self, key: &(i32, bool)) -> Option<&Vec<u32>> {
+        self.sparkline.get(key)
+    }
+    fn is_settled(&self, key: &(i32, bool)) -> bool {
+        self.settled.contains(key)
+    }
+}
+```
+
+- [ ] **Step 2: Add imports + constants; drop the temporary `allow`**
+
+(a) Change the skeleton import (currently `skeleton::BoxSkeleton,`) to:
+
+```rust
+        skeleton::{BoxSkeleton, SingleLineSkeleton},
+```
+
+(b) Add the `TimeoutFuture` import near the top-of-file `use` statements (e.g. just after the `use chrono::...;` line):
+
+```rust
+use gloo_timers::future::TimeoutFuture;
+```
+
+(c) Remove the `#[allow(dead_code)] // wired into the fetch effect in the same change set` line above `fn visible_keys` (it is used for real now).
+
+(d) Add the tuning constants next to `visible_keys` (just above it):
+
+```rust
+/// Rows fetched above & below the rendered window, so enrichment lands just
+/// before a row scrolls into view. Keep small enough that
+/// `rendered (~26) + 2 * PREFETCH_MARGIN` stays well under the 200-item
+/// sparklines cap (no chunking needed).
+const PREFETCH_MARGIN: usize = 30;
+/// Debounce window for scroll-driven fetches (ms). Mirrors search_box.rs.
+const DEBOUNCE_MS: u32 = 150;
+```
+
+- [ ] **Step 3: Remove the `enrichment` prop from `AnalyzerTable`**
+
+In the `#[component] fn AnalyzerTable(...)` signature, delete this prop (the doc comment + the field):
+
+```rust
+    /// CH-backed per-row enrichment (quality band + sparkline). Empty
+    /// when the enrichment fetch is in flight or failed — the table
+    /// degrades gracefully to Pass-1 rendering.
+    enrichment: Signal<EnrichmentMaps>,
+```
+
+- [ ] **Step 4: Declare the accumulating `enrichment` signal before `sorted_data`**
+
+`sorted_data`'s suspicious-filter closure reads `enrichment`, so the signal must exist before it. Immediately before the `let sorted_data = Memo::new(move |_| {` line, add:
+
+```rust
+    // Accumulating CH enrichment (quality + sparkline + settled), grown by the
+    // visible-window fetch effect below; never wholesale-replaced (except on a
+    // world change). Cells + the suspicious filter read it reactively.
+    let enrichment = RwSignal::new(EnrichmentMaps::default());
+```
+
+- [ ] **Step 5: Add the fetch state + effects after `sorted_data`**
+
+`sorted_data` ends with `.collect::<Vec<(usize, CalculatedProfitData)>>()` followed by `});`. Immediately after that closing `});` (and before `view! {`), add:
+
+```rust
+    // --- Visible-window lazy enrichment -------------------------------------
+    // Dedupe / loop-breaker: keys we've already scheduled a fetch for. Non-
+    // reactive (StoredValue) on purpose — claiming a key must not retrigger the
+    // fetch effect.
+    let requested = StoredValue::new(std::collections::HashSet::<(i32, bool)>::new());
+    // Rendered row range published by the VirtualScroller (see view! below).
+    let visible_range = RwSignal::new((0usize, 0usize));
+    // Generation counter for debounce-with-cancellation (RwSignal, mirroring
+    // components/search_box.rs). `gen` is a reserved keyword in edition 2024.
+    let fetch_id = RwSignal::new(0u64);
+
+    // Reset accumulated enrichment when the world changes. Defense-in-depth: if
+    // the component is updated in place rather than remounted, another world's
+    // data must not leak.
+    Effect::new(move |_| {
+        let _ = world.get(); // subscribe: re-run on world change
+        enrichment.set(EnrichmentMaps::default());
+        requested.update_value(|s| s.clear());
+    });
+
+    // Select the visible-window keys (honoring the active sort/filter via
+    // sorted_data), debounce, fetch both batches, and merge — accumulating.
+    Effect::new(move |_| {
+        let range = visible_range.get(); // reactive: scroll
+        let keys = sorted_data.with(|data| {
+            requested.with_value(|seen| {
+                visible_keys(data, range, PREFETCH_MARGIN, seen, |(_, d)| {
+                    (d.inner.sale_summary.item_id, d.inner.sale_summary.hq)
+                })
+            })
+        });
+        if keys.is_empty() {
+            return;
+        }
+        fetch_id.update(|n| *n += 1);
+        let current_id = fetch_id.get_untracked();
+        let world_name = world.get_untracked();
+        leptos::task::spawn_local(async move {
+            TimeoutFuture::new(DEBOUNCE_MS).await; // debounce
+            if fetch_id.get_untracked() != current_id {
+                return; // superseded by a newer range
+            }
+            // Claim post-debounce so superseded generations never claim.
+            requested.update_value(|s| s.extend(keys.iter().copied()));
+            // window <= ~86 keys << 200 cap -> single batch, no chunking.
+            let (quality, sparklines) = futures::join!(
+                get_resale_quality(&world_name, keys.clone(), 30),
+                post_sparklines(
+                    &world_name,
+                    SparklinesRequest {
+                        items: keys.clone(),
+                        // 7 days; server caps at 168h. Matches prior behavior.
+                        hours: Some(168),
+                    },
+                ),
+            );
+            // Merge whatever succeeded and mark every fetched key settled
+            // (success OR error) so cells switch loading -> value / "—". On a CH
+            // blip the rows degrade to "—" (same as today) — no retry loop; a
+            // world change resets everything.
+            enrichment.update(|m| {
+                if let Ok(q) = &quality {
+                    m.quality
+                        .extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));
+                }
+                if let Ok(s) = &sparklines {
+                    m.sparkline
+                        .extend(s.series.iter().map(|r| ((r.item_id, r.hq), r.points.clone())));
+                }
+                m.settled.extend(keys.iter().copied());
+            });
+        });
+    });
+```
+
+- [ ] **Step 6: Wire `visible_range` into the `<VirtualScroller>`**
+
+In the `view!`, find the `<VirtualScroller` opening tag and add the prop right after `variable_height=false`:
+
+```rust
+                <VirtualScroller
+                        viewport_height=720.0
+                        row_height=40.0
+                        overscan=8
+                        header_height=56.0
+                        variable_height=false
+                        visible_range=visible_range
+```
+
+- [ ] **Step 7: Update the Trend cell for loading / no-data / value**
+
+Replace the `COL_TREND` cell block. Find:
+
+```rust
+                                            {move || visible_cols().contains(COL_TREND).then(|| {
+                                                let maps = enrichment.get();
+                                                let pts = maps.sparkline_for(&row_key).cloned().unwrap_or_default();
+                                                let pct = maps.quality_for(&row_key)
+                                                    .map(|q| {
+                                                        let vwap = q.vwap as f32;
+                                                        if vwap <= 0.0 {
+                                                            0.0
+                                                        } else {
+                                                            (row_cheapest_price as f32 - vwap) / vwap * 100.0
+                                                        }
+                                                    })
+                                                    .unwrap_or(0.0);
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[100px] hidden md:flex items-center justify-center">
+                                                        <Sparkline points=pts pct_change=pct />
+                                                    </div>
+                                                }
+                                            })}
+```
+
+Replace with:
+
+```rust
+                                            {move || visible_cols().contains(COL_TREND).then(|| {
+                                                let maps = enrichment.get();
+                                                let inner = if let Some(pts) = maps.sparkline_for(&row_key) {
+                                                    let pct = maps.quality_for(&row_key)
+                                                        .map(|q| {
+                                                            let vwap = q.vwap as f32;
+                                                            if vwap <= 0.0 {
+                                                                0.0
+                                                            } else {
+                                                                (row_cheapest_price as f32 - vwap) / vwap * 100.0
+                                                            }
+                                                        })
+                                                        .unwrap_or(0.0);
+                                                    view! { <Sparkline points=pts.clone() pct_change=pct /> }.into_any()
+                                                } else if maps.is_settled(&row_key) {
+                                                    // fetched, no series -> empty sparkline (prior behavior)
+                                                    view! { <Sparkline points=Vec::new() pct_change=0.0 /> }.into_any()
+                                                } else {
+                                                    view! { <SingleLineSkeleton /> }.into_any()
+                                                };
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[100px] hidden md:flex items-center justify-center">
+                                                        {inner}
+                                                    </div>
+                                                }
+                                            })}
+```
+
+- [ ] **Step 8: Update the Sales/day and 30d-Volume cells**
+
+Replace the `COL_SALES_PER_DAY` block. Find:
+
+```rust
+                                            {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| {
+                                                let text = enrichment.get()
+                                                    .quality_for(&row_key)
+                                                    .map(|q| format!("{:.1}", q.sales_per_day))
+                                                    .unwrap_or_else(|| "—".to_string());
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                                        {text}
+                                                    </div>
+                                                }
+                                            })}
+```
+
+Replace with:
+
+```rust
+                                            {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| {
+                                                let maps = enrichment.get();
+                                                let inner = match (maps.quality_for(&row_key), maps.is_settled(&row_key)) {
+                                                    (Some(q), _) => view! { {format!("{:.1}", q.sales_per_day)} }.into_any(),
+                                                    (None, true) => view! { "—" }.into_any(),
+                                                    (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
+                                                };
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                                        {inner}
+                                                    </div>
+                                                }
+                                            })}
+```
+
+Replace the `COL_VOLUME_30D` block. Find:
+
+```rust
+                                            {move || visible_cols().contains(COL_VOLUME_30D).then(|| {
+                                                let text = enrichment.get()
+                                                    .quality_for(&row_key)
+                                                    .map(|q| q.sample_size.to_string())
+                                                    .unwrap_or_else(|| "—".to_string());
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                                        {text}
+                                                    </div>
+                                                }
+                                            })}
+```
+
+Replace with:
+
+```rust
+                                            {move || visible_cols().contains(COL_VOLUME_30D).then(|| {
+                                                let maps = enrichment.get();
+                                                let inner = match (maps.quality_for(&row_key), maps.is_settled(&row_key)) {
+                                                    (Some(q), _) => view! { {q.sample_size.to_string()} }.into_any(),
+                                                    (None, true) => view! { "—" }.into_any(),
+                                                    (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
+                                                };
+                                                view! {
+                                                    <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                                        {inner}
+                                                    </div>
+                                                }
+                                            })}
+```
+
+- [ ] **Step 9: Delete the parent's eager fetch + the `enrichment` prop pass**
+
+(a) In `AnalyzerWorldView`, delete the entire eager-enrichment block — the three `*_for_enrichment` clones, the `LocalResource`, and the derived `enrichment_signal`. Find and remove:
+
+```rust
+    let sales_for_enrichment = sales.clone();
+    let world_cheapest_for_enrichment = world_cheapest_listings.clone();
+    let global_cheapest_for_enrichment = global_cheapest_listings.clone();
+    let enrichment = LocalResource::new(move || {
+        let world_name = world();
+        let sales_res = sales_for_enrichment.get();
+        let world_cheapest_res = world_cheapest_for_enrichment.get();
+        let global_cheapest_res = global_cheapest_for_enrichment.get();
+        let filter_outliers = filter_outliers().unwrap_or(false);
+        async move {
+            // ... entire async body ...
+        }
+    });
+    let enrichment_signal: Signal<EnrichmentMaps> =
+        Signal::derive(move || enrichment.get().unwrap_or_default());
+```
+
+(Delete from `let sales_for_enrichment = sales.clone();` through the end of the `enrichment_signal` `Signal::derive(...)` statement — i.e. the whole comment block at `// CH enrichment:` plus those bindings.)
+
+(b) In the `<AnalyzerTable .../>` usage, delete the prop line:
+
+```rust
+                                                    enrichment=enrichment_signal
+```
+
+- [ ] **Step 10: Delete the now-dead ranking helpers + caps**
+
+These were only used by the deleted `LocalResource`; clippy `-D warnings` will flag them as dead code. Remove:
+- the `ENRICHMENT_BATCH_CAP` const + its doc comment,
+- the `SPARKLINE_BATCH_CAP` const + its doc comment,
+- `fn roi_for_rank(...)` + its doc comment,
+- `fn select_enrichment_keys(...)` + its doc comment.
+
+(Keep `EnrichmentMaps`, `ProfitTable`, `get_resale_quality`, `post_sparklines`, `SparklinesRequest`, `ResaleQualityRow`, `ConfidenceBand` — all still used by the new `AnalyzerTable` code.)
+
+- [ ] **Step 11: Compile, lint, and run unit tests**
+
+Run: `cargo test -p ultros-app visible_keys`
+Expected: PASS — the 5 `visible_keys` tests still pass (helper unchanged).
+
+Run: `./check_ci.sh`
+Expected: passes — fmt clean; clippy clean (no dead-code warnings; the `#[allow(dead_code)]` from Task 2 is gone and `visible_keys` is now used). If clippy flags a leftover unused import or binding, remove it.
+
+- [ ] **Step 12: Manual browser verification**
+
+Run the SSR app locally (see project notes / `reference_ultros_local_browser_test`: jemalloc/MSVC build wall + `bin-features=[]` workaround, ClickHouse creds) and open the analyzer on a busy world (e.g. a high-traffic NA/EU world). Confirm:
+1. Top rows populate Trend / Sales-day / 30d-Volume on load (no separate eager pass needed).
+2. Scrolling down fills previously-blank rows; in-flight rows briefly show the thin `SingleLineSkeleton` pulse, then a value or `—`.
+3. The Network panel shows **small batched** `POST /api/v1/resale_quality/...` + `POST /api/v1/sparklines/...` per scroll-stop (~one pair), not one request per row.
+4. Scrolling back up does **not** re-issue requests for already-seen rows.
+5. Switching sort (ROI ↔ Profit ↔ Profit-per-day) keeps already-fetched values (no refetch storm), and newly-surfaced rows fetch.
+6. Switching world clears and refetches for the new world.
+
+(Rows with no ClickHouse rollup still show `—` for Sales-day / 30d-Volume — that's the separate, out-of-scope `item_stats_window` backfill coverage issue; Trend from `sales_hourly` should still populate.)
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add ultros-frontend/ultros-app/src/routes/analyzer.rs
+git commit -m "feat(analyzer): visible-window lazy enrichment
+
+Fetch Trend / Sales-day / 30d-Volume for rows in (and near) the viewport,
+accumulating as the user scrolls, instead of capping at the top 240/200 ROI
+rows. Reuses the existing bulk resale_quality + sparklines endpoints; debounced
+generation-guard fetch mirrors search_box.rs. Cells show a skeleton while in
+flight. Removes the parent eager-fetch path and the ROI ranking helpers.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (each spec section → task):
+- §1 VirtualScroller `visible_range` prop → Task 1. ✓
+- §2 `AnalyzerTable` ownership: `EnrichmentMaps.settled` → T3 S1; `visible_keys` helper → T2; state signals + reset effect + debounced fetch effect → T3 S4-S5; `visible_range` wiring → T3 S6; constants/imports → T3 S2. ✓
+- §3 Cell loading/no-data/value with `SingleLineSkeleton` → T3 S7-S8. ✓
+- §4 Caching/invalidation (world reset; sort/filter reuse) → T3 S5 (reset effect; reuse is inherent in `requested` + accumulating map). ✓
+- Removal of eager path (`LocalResource`, `enrichment_signal`, prop, `roi_for_rank`, `select_enrichment_keys`, two caps) → T3 S3, S9, S10. ✓
+- Testing (unit test for `visible_keys`; `./check_ci.sh`; manual scroll check) → T2 S1-S4, T3 S11-S12. ✓
+- Non-goals respected: no backend/API-type/locale changes in any task. ✓
+
+**2. Placeholder scan:** No "TBD"/"TODO"/"handle edge cases"/"similar to" — every code step shows full code; every test step shows assertions; every run step shows the command + expected result. ✓
+
+**3. Type consistency:**
+- `EnrichmentMaps` field `settled: std::collections::HashSet<(i32, bool)>` (T3 S1) is read via `is_settled` in cells (T3 S7-S8) and written via `m.settled.extend(...)` in the effect (T3 S5). ✓
+- `visible_keys<T>(data, range, margin, seen, key_of)` signature (T2 S3) matches the call in the effect (T3 S5), passing `|(_, d)| (d.inner.sale_summary.item_id, d.inner.sale_summary.hq)` against `sorted_data`'s `Vec<(usize, CalculatedProfitData)>`. ✓
+- `visible_range: RwSignal<(usize, usize)>` declared in `AnalyzerTable` (T3 S5), passed to the `visible_range` prop on `VirtualScroller` (T1 S1 prop type `Option<RwSignal<(usize, usize)>>`, `into`). ✓
+- `fetch_id: RwSignal<u64>` uses `.update(|n| *n += 1)` / `.get_untracked()` — matches `search_box.rs` precedent. ✓
+- Response field access matches api-types: `ResaleQualityResponse.rows` → `ResaleQualityRow { item_id, hq, sales_per_day, sample_size, vwap }`; `SparklinesResponse.series` → `SparklineSeries { item_id, hq, points }`. ✓
+- `get_resale_quality(&str, Vec<(i32,bool)>, u16)` and `post_sparklines(&str, SparklinesRequest)` signatures match `api.rs`. ✓
+
+**4. Edition-2024 / build gotchas covered:** `gen` keyword avoided (`fetch_id`); `gloo-timers` is a plain dep that compiles under `ssr`; `default = ["ssr"]` so `cargo test -p ultros-app` runs natively; submodule + Perl + `CARGO_TARGET_DIR` called out in Prerequisites. ✓
+
+No gaps found.

--- a/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
@@ -1,0 +1,287 @@
+# Analyzer visible-window lazy enrichment — design
+
+- **Date:** 2026-06-06
+- **Status:** Approved (ready for implementation plan)
+- **Area:** `ultros-frontend/ultros-app` (Flip Finder / analyzer)
+
+## Problem
+
+The analyzer table shows Trend (sparkline), Sales/day, and 30d Volume columns,
+but only the **top ~240 rows by ROI** ever get populated — everything below the
+cap renders `—`. On a busy world the table holds **thousands** of rows, so most
+of them are blank. The user wants every row the analyzer *shows them* to carry
+its enrichment, fetched efficiently.
+
+## Current behavior (baseline)
+
+The blanks are by design, not an N+1 query bug:
+
+- After building the in-memory profit table, the frontend enriches only the top
+  `ENRICHMENT_BATCH_CAP = 240` rows by ROI —
+  `select_enrichment_keys(profits, 240)` at `analyzer.rs:392`.
+- It fires **two batch calls** (`analyzer.rs:1479`, inside a `LocalResource` in
+  the parent `AnalyzerWorldView`):
+  - `get_resale_quality(world, top240, 30)` → Sales/day + 30d Volume +
+    confidence/launder flags, from ClickHouse `item_stats_window`.
+  - `post_sparklines(world, { items: top200, hours: 168 })` → Trend, from
+    `sales_hourly`. Sparklines uses a tighter `SPARKLINE_BATCH_CAP = 200`.
+- Rows below the cap render `—`. The caps exist only because the backend rejects
+  payloads above 250 / 200 items (`resale_quality.rs`, `movers.rs`).
+
+Two facts that make the fix tractable:
+
+1. **The backend already does true bulk queries** —
+   `WHERE (item_id,hq,world_id) IN (...)`, one ClickHouse query per batch, no
+   per-item loop (`ultros-clickhouse/src/queries.rs` `deep_scan_batch`,
+   `sparklines_batch`). The limit is purely the frontend cap + per-request size
+   ceiling.
+2. **Row order is fully determined by Pass-1 data.** The only sort modes are
+   `Roi` / `Profit` / `ProfitPerDay` (`analyzer.rs:617`), all computed from the
+   in-memory profit table. Nothing sorts or filters on enriched columns *except*
+   the "hide suspicious" filter (`analyzer.rs:599`). So the set of visible rows
+   and their order are known *before* enrichment — which is what makes
+   visible-window fetching viable.
+
+The table is virtualized: `viewport_height=720`, `row_height=40`, `overscan=8`
+→ ~26 rows mounted at once (`analyzer.rs:1051`). `sorted_data` collects **all**
+filtered rows with no `.take()` (`analyzer.rs:492`); the `VirtualScroller` just
+virtualizes them.
+
+## Goal
+
+Fetch Trend + Sales/day + 30d Volume (+ suspicious flag) for the rows currently
+in or near the viewport, accumulating results into one map as the user scrolls.
+Each scroll-stop fetches ~50–90 keys (one batch, under the 200/250 ceilings),
+scales to any world size, and never re-fetches a row it already holds.
+
+## Non-goals
+
+- No backend, API-type, or ClickHouse query changes (existing bulk endpoints
+  suffice).
+- No new sort/filter on enriched columns (visible-window deliberately does not
+  hold the full set in memory, so full-set sort/filter is not enabled here).
+- No locale changes — no new user-facing strings are introduced.
+- The prod `item_stats_window` backfill (~7% coverage) is **out of scope**: rows
+  ClickHouse has no rollup for stay blank regardless of fetch strategy. Trends
+  from `sales_hourly` are unaffected. Flagged separately as a data-population
+  action.
+
+## Design
+
+### 1. `VirtualScroller` — expose its visible range (additive, optional)
+
+File: `ultros-frontend/ultros-app/src/components/virtual_scroller.rs`
+
+Add one optional prop so the other 7 consumers are untouched:
+
+```rust
+#[prop(optional, into)] visible_range: Option<RwSignal<(usize, usize)>>,
+```
+
+When provided, an `Effect` writes `(start, end)` derived from the existing
+`child_start` / `children_shown` memos whenever they change:
+
+```rust
+if let Some(vr) = visible_range {
+    Effect::new(move |_| {
+        let start = (child_start() as usize).min(children_len().saturating_sub(1));
+        let end = (start + children_shown() as usize).min(children_len());
+        vr.set((start, end));
+    });
+}
+```
+
+No prop → no effect → zero behavior change for `venture_analyzer`,
+`recipe_analyzer`, `leve_analyzer`, `fc_crafting_analyzer`, `scrip_sources`,
+`vendor_resale`, `search_box`.
+
+The exposed range is the *rendered* range (includes the scroller's overscan).
+Any extra prefetch margin is applied consumer-side (keeps the scroller honest
+about what it actually renders).
+
+### 2. `AnalyzerTable` — own enrichment + orchestrate lazy fetch
+
+File: `ultros-frontend/ultros-app/src/routes/analyzer.rs`
+
+The enrichment fetch moves **out of the parent** (`AnalyzerWorldView`) and into
+`AnalyzerTable`, which already owns `sorted_data` and renders the
+`VirtualScroller`. The `enrichment` prop on `AnalyzerTable` is removed; the
+parent's `LocalResource` (currently `analyzer.rs:1441-1517`) and the
+`select_enrichment_keys` / `ENRICHMENT_BATCH_CAP` / `SPARKLINE_BATCH_CAP` machinery
+are deleted.
+
+State held in `AnalyzerTable`:
+
+```rust
+let enrichment = RwSignal::new(EnrichmentMaps::default()); // accumulates, never replaced
+let requested  = StoredValue::new(HashSet::<(i32, bool)>::new()); // dedupe + loop-breaker
+let visible_range = RwSignal::new((0usize, 0usize));
+```
+
+Wiring:
+
+- Pass `visible_range=visible_range` into `<VirtualScroller .../>`.
+- Debounce the range with leptos-use (`signal_debounced`, ~150 ms) so a fast
+  fling only fetches where scrolling settles. (`leptos-use` is already a
+  workspace dep; `gloo_timers::future::TimeoutFuture` — as used in
+  `search_box.rs` — is the fallback if a manual debounce reads cleaner.)
+- A `pending_keys` memo computes the keys to fetch:
+
+```rust
+const PREFETCH_MARGIN: usize = 30; // rows above & below the rendered window
+
+fn visible_keys(
+    data: &[(usize, CalculatedProfitData)],
+    range: (usize, usize),
+    margin: usize,
+    seen: &HashSet<(i32, bool)>,
+) -> Vec<(i32, bool)> {
+    let (start, end) = range;
+    let lo = start.saturating_sub(margin);
+    let hi = (end + margin).min(data.len());
+    data.get(lo..hi)
+        .unwrap_or(&[])
+        .iter()
+        .map(|(_, d)| (d.inner.sale_summary.item_id, d.inner.sale_summary.hq))
+        .filter(|k| !seen.contains(k))
+        .collect()
+}
+```
+
+`visible_keys` is a **pure free function** so it is unit-testable without a DOM.
+The `pending_keys` memo reads the debounced range + `sorted_data` + `requested`
+and calls it.
+
+- An `Effect` reacts to `pending_keys`: if non-empty, mark them requested
+  (optimistic dedupe), then `spawn_local` a fetch that joins both batch calls and
+  merges into `enrichment`:
+
+```rust
+Effect::new(move |_| {
+    let keys = pending_keys.get();
+    if keys.is_empty() { return; }
+    let world_name = world.get_untracked();
+    requested.update_value(|s| s.extend(keys.iter().copied()));
+    spawn_local(async move {
+        // chunk to <=200 (sparklines) / <=240 (quality); usually 1 chunk
+        let (quality, sparklines) = futures::join!(
+            get_resale_quality(&world_name, keys.clone(), 30),
+            post_sparklines(&world_name, SparklinesRequest { items: keys.clone(), hours: Some(168) }),
+        );
+        // Merge whatever succeeded into the accumulating map (mirrors the
+        // existing merge at analyzer.rs:1492-1509).
+        enrichment.update(|m| {
+            if let Ok(q) = &quality {
+                m.quality.extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));
+            }
+            if let Ok(s) = &sparklines {
+                m.sparkline.extend(s.series.iter().map(|r| ((r.item_id, r.hq), r.points.clone())));
+            }
+        });
+        // If a call failed, drop its keys from `requested` so revisiting retries.
+        if quality.is_err() || sparklines.is_err() {
+            requested.update_value(|s| keys.iter().for_each(|k| { s.remove(k); }));
+        }
+    });
+});
+```
+
+Defensive chunking keeps each request under the caps even with a tall viewport +
+margin; in practice ~26 + 2×30 ≈ 86 keys → one chunk.
+
+Fixed params preserved from today: `window_days = 30`, sparkline `hours = 168`.
+
+### 3. Cell rendering — loading vs. no-data
+
+Files/lines: Trend `analyzer.rs:1319`, Sales/day `analyzer.rs:1340`,
+30d Volume `analyzer.rs:1349`.
+
+Today every cell falls back to empty/`—` whether the row is loading or genuinely
+absent. Add an in-flight notion (a key is in `requested` but not yet in
+`enrichment`): render the already-imported `BoxSkeleton` for Trend and a dim
+placeholder for the number columns while in-flight, and `—` only once a fetch has
+completed with no data. This keeps fast scrolling reading as "loading", not
+"no data".
+
+### 4. Caching / invalidation
+
+- Reset `enrichment` + `requested` when **`world`** changes (enrichment is
+  world-specific; the underlying data resources reload anyway). An `Effect`
+  watching `world` clears both.
+- Sort/filter changes do **not** invalidate: switching ROI→Profit reuses
+  everything already fetched; only newly-visible items fetch. The fixed
+  window/hours mean no per-window cache key is needed.
+
+## Data flow
+
+```
+scroll → VirtualScroller updates child_start/children_shown
+       → visible_range RwSignal set (rendered range)
+       → signal_debounced(150ms)
+       → pending_keys memo = visible_keys(sorted_data, range, MARGIN, requested)
+       → Effect: mark requested, spawn_local fetch (join resale_quality + sparklines)
+       → enrichment.update(merge)
+       → cells re-read enrichment, render values (mounted rows only)
+```
+
+## Edge cases & wrinkles (handled)
+
+- **Suspicious-filter reflow** (`analyzer.rs:599-614`): a row kept while
+  unenriched can disappear once its data arrives and flags it
+  Unusable/high-launder, shifting rows. The prefetch margin means this mostly
+  happens off-screen (the row is enriched before it scrolls into view).
+  Decision: keep current **hide** semantics; switching to dim/mark would fully
+  remove reflow but is out of scope.
+- **Reactive loop** (enrichment update → `sorted_data` recompute, because the
+  suspicious filter reads enrichment → `pending_keys` recompute): the `requested`
+  set breaks it — already-requested keys are filtered out, so it converges after
+  one round per newly-visible set.
+- **Fetch failure:** failed keys are cleared from `requested` so revisiting the
+  rows retries, avoiding a permanent `—`.
+- **Initial mount:** the scroller's range effect runs on mount, setting
+  `visible_range` to `(0, ~26)`, which triggers the first fetch of the default
+  (top-ROI) view — so the default view fills without a separate eager path.
+  `AnalyzerTable` receives already-resolved data (it builds `ProfitTable::new`
+  synchronously at `analyzer.rs:429`), so keys are derivable at mount.
+
+## Side benefits
+
+- **Fixes a latent mismatch:** the current eager pass always ranks by ROI even
+  when the user sorts by Profit / Profit-per-day, enriching the wrong rows.
+  Reading `sorted_data` makes enrichment always match what is shown.
+- Lighter first paint (~50–90 keys vs. 240 + 200).
+- No row is permanently blank merely for being far down the list.
+
+## Testing
+
+- **Unit test** for `visible_keys` (range + margin clamping, dedupe vs. `seen`,
+  empty-data and out-of-bounds ranges) — pure function, no DOM.
+- `./check_ci.sh` — `cargo fmt --all -- --check` + `cargo clippy --all-targets
+  -- -D warnings` (CI gate per CLAUDE.md). Requires submodule init; if blocked,
+  at minimum run fmt-check and note clippy was skipped.
+- **Manual browser smoke** (per local-browser-testing notes): load the analyzer
+  on a busy world, scroll, and confirm (a) rows fill in progressively, (b) the
+  network panel shows small *batched* requests per scroll-stop (not per-row),
+  (c) already-seen rows do not refetch when scrolled back to, (d) the loading
+  shimmer shows for in-flight rows.
+
+## Files touched
+
+- `ultros-frontend/ultros-app/src/components/virtual_scroller.rs` — add optional
+  `visible_range` writeback prop + effect.
+- `ultros-frontend/ultros-app/src/routes/analyzer.rs` — move enrichment into
+  `AnalyzerTable`; add visible-window orchestration (debounced range →
+  `pending_keys` → fetch → accumulate); loading state in the three cells; remove
+  the eager top-N path (`select_enrichment_keys`, the two `*_BATCH_CAP` consts,
+  the parent `LocalResource`, the `enrichment` prop); extract testable
+  `visible_keys` helper.
+
+## Out of scope (flagged)
+
+- Prod `item_stats_window` backfill (`clickhouse_backfill` one-shot bin never
+  run; ~7% item coverage). Independent of fetch strategy; run to densify
+  Sales/day + 30d Volume coverage.
+- Enabling full-set sort/filter/export by enriched columns (would require holding
+  all rows' data in memory — the "fetch all up-front" alternative we did not
+  choose).
+- Switching the suspicious filter from hide to dim/mark.

--- a/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
@@ -141,11 +141,15 @@ Wiring:
 ```rust
 const PREFETCH_MARGIN: usize = 30; // rows above & below the rendered window
 
-fn visible_keys(
-    data: &[(usize, CalculatedProfitData)],
+/// Keys in the [start-margin, end+margin) slice of `data`, minus `seen`.
+/// Generic over the row type + key extractor so it unit-tests with plain
+/// `(i32, bool)` fixtures — no `CalculatedProfitData` / DOM needed.
+fn visible_keys<T>(
+    data: &[T],
     range: (usize, usize),
     margin: usize,
     seen: &std::collections::HashSet<(i32, bool)>,
+    key_of: impl Fn(&T) -> (i32, bool),
 ) -> Vec<(i32, bool)> {
     let (start, end) = range;
     let lo = start.saturating_sub(margin);
@@ -153,7 +157,7 @@ fn visible_keys(
     data.get(lo..hi)
         .unwrap_or(&[])
         .iter()
-        .map(|(_, d)| (d.inner.sale_summary.item_id, d.inner.sale_summary.hq))
+        .map(key_of)
         .filter(|k| !seen.contains(k))
         .collect()
 }
@@ -170,26 +174,33 @@ fn visible_keys(
 
 ```rust
 const DEBOUNCE_MS: u32 = 150;
-let gen = StoredValue::new(0u64);
+// Generation counter for debounce-with-cancellation, mirroring the proven
+// pattern in components/search_box.rs. (`gen` is a reserved keyword in Rust
+// edition 2024, so this is named `fetch_id`.)
+let fetch_id = RwSignal::new(0u64);
 
 Effect::new(move |_| {
     let range = visible_range.get();          // reactive: scroll
     let keys = sorted_data.with(|data| {      // reactive: sort / filter / enrichment
-        requested.with_value(|seen| visible_keys(data, range, PREFETCH_MARGIN, seen))
+        requested.with_value(|seen| {
+            visible_keys(data, range, PREFETCH_MARGIN, seen, |(_, d)| {
+                (d.inner.sale_summary.item_id, d.inner.sale_summary.hq)
+            })
+        })
     });
     if keys.is_empty() {
         return;
     }
-    gen.update_value(|g| *g += 1);
-    let my_gen = gen.get_value();
+    fetch_id.update(|n| *n += 1);
+    let current_id = fetch_id.get_untracked();
     let world_name = world.get_untracked();
     leptos::task::spawn_local(async move {
         TimeoutFuture::new(DEBOUNCE_MS).await;       // debounce
-        if gen.get_value() != my_gen {
+        if fetch_id.get_untracked() != current_id {
             return; // superseded by a newer range
         }
         requested.update_value(|s| s.extend(keys.iter().copied())); // claim post-debounce
-        // chunk to <=200 (sparklines) / <=240 (quality); usually one chunk
+        // window <= ~86 keys << 200 cap -> single batch (see PREFETCH_MARGIN note)
         let (quality, sparklines) = futures::join!(
             get_resale_quality(&world_name, keys.clone(), 30),
             post_sparklines(
@@ -218,8 +229,9 @@ Effect::new(move |_| {
 });
 ```
 
-Defensive chunking keeps each request under the caps even with a tall viewport +
-margin; in practice ~26 + 2×30 ≈ 86 keys → one chunk.
+The window is ~26 + 2×30 ≈ 86 keys — comfortably under the 200 / 250 caps — so
+keys are sent in a single batch (no chunking). If `PREFETCH_MARGIN` or the
+viewport ever grows enough to approach ~150 keys, add chunking to ≤200 / ≤240.
 
 Fixed params preserved from today: `window_days = 30`, sparkline `hours = 168`.
 

--- a/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-06-analyzer-visible-window-enrichment-design.md
@@ -110,22 +110,33 @@ parent's `LocalResource` (currently `analyzer.rs:1441-1517`) and the
 `select_enrichment_keys` / `ENRICHMENT_BATCH_CAP` / `SPARKLINE_BATCH_CAP` machinery
 are deleted.
 
+`EnrichmentMaps` (defined at `analyzer.rs:34`) gains a third field so cells can
+tell "still loading" from "fetched, no data":
+
+```rust
+#[derive(Clone, Debug, Default)]
+struct EnrichmentMaps {
+    quality: HashMap<(i32, bool), ResaleQualityRow>,
+    sparkline: HashMap<(i32, bool), Vec<u32>>,
+    settled: std::collections::HashSet<(i32, bool)>, // keys whose fetch completed (data or not)
+}
+```
+
 State held in `AnalyzerTable`:
 
 ```rust
-let enrichment = RwSignal::new(EnrichmentMaps::default()); // accumulates, never replaced
-let requested  = StoredValue::new(HashSet::<(i32, bool)>::new()); // dedupe + loop-breaker
+// Accumulating enrichment (quality + sparkline + settled); grown, never replaced.
+let enrichment = RwSignal::new(EnrichmentMaps::default());
+// Scheduled-set: keys we've already kicked a fetch for. Non-reactive
+// (StoredValue) — it's the dedupe + reactive-loop breaker, not UI state.
+let requested = StoredValue::new(std::collections::HashSet::<(i32, bool)>::new());
 let visible_range = RwSignal::new((0usize, 0usize));
 ```
 
 Wiring:
 
 - Pass `visible_range=visible_range` into `<VirtualScroller .../>`.
-- Debounce the range with leptos-use (`signal_debounced`, ~150 ms) so a fast
-  fling only fetches where scrolling settles. (`leptos-use` is already a
-  workspace dep; `gloo_timers::future::TimeoutFuture` — as used in
-  `search_box.rs` — is the fallback if a manual debounce reads cleaner.)
-- A `pending_keys` memo computes the keys to fetch:
+- The key selection is a **pure free function** (unit-testable without a DOM):
 
 ```rust
 const PREFETCH_MARGIN: usize = 30; // rows above & below the rendered window
@@ -134,7 +145,7 @@ fn visible_keys(
     data: &[(usize, CalculatedProfitData)],
     range: (usize, usize),
     margin: usize,
-    seen: &HashSet<(i32, bool)>,
+    seen: &std::collections::HashSet<(i32, bool)>,
 ) -> Vec<(i32, bool)> {
     let (start, end) = range;
     let lo = start.saturating_sub(margin);
@@ -148,40 +159,61 @@ fn visible_keys(
 }
 ```
 
-`visible_keys` is a **pure free function** so it is unit-testable without a DOM.
-The `pending_keys` memo reads the debounced range + `sorted_data` + `requested`
-and calls it.
-
-- An `Effect` reacts to `pending_keys`: if non-empty, mark them requested
-  (optimistic dedupe), then `spawn_local` a fetch that joins both batch calls and
-  merges into `enrichment`:
+- One `Effect` does selection + debounce + fetch + merge. It reads
+  `visible_range` and `sorted_data` reactively, and `requested` non-reactively
+  (so claiming a key doesn't retrigger the effect). Debounce uses a generation
+  guard + `gloo_timers::future::TimeoutFuture` — the same pattern `search_box.rs`
+  already uses — so a fast fling only fetches where it settles. (Chosen over
+  leptos-use's `signal_debounced`: the gloo-timer pattern is already proven here
+  and adds no new API surface.) Keys are claimed in `requested` *after* the
+  debounce, so superseded generations never claim.
 
 ```rust
+const DEBOUNCE_MS: u32 = 150;
+let gen = StoredValue::new(0u64);
+
 Effect::new(move |_| {
-    let keys = pending_keys.get();
-    if keys.is_empty() { return; }
+    let range = visible_range.get();          // reactive: scroll
+    let keys = sorted_data.with(|data| {      // reactive: sort / filter / enrichment
+        requested.with_value(|seen| visible_keys(data, range, PREFETCH_MARGIN, seen))
+    });
+    if keys.is_empty() {
+        return;
+    }
+    gen.update_value(|g| *g += 1);
+    let my_gen = gen.get_value();
     let world_name = world.get_untracked();
-    requested.update_value(|s| s.extend(keys.iter().copied()));
-    spawn_local(async move {
-        // chunk to <=200 (sparklines) / <=240 (quality); usually 1 chunk
+    leptos::task::spawn_local(async move {
+        TimeoutFuture::new(DEBOUNCE_MS).await;       // debounce
+        if gen.get_value() != my_gen {
+            return; // superseded by a newer range
+        }
+        requested.update_value(|s| s.extend(keys.iter().copied())); // claim post-debounce
+        // chunk to <=200 (sparklines) / <=240 (quality); usually one chunk
         let (quality, sparklines) = futures::join!(
             get_resale_quality(&world_name, keys.clone(), 30),
-            post_sparklines(&world_name, SparklinesRequest { items: keys.clone(), hours: Some(168) }),
+            post_sparklines(
+                &world_name,
+                SparklinesRequest { items: keys.clone(), hours: Some(168) },
+            ),
         );
-        // Merge whatever succeeded into the accumulating map (mirrors the
-        // existing merge at analyzer.rs:1492-1509).
+        // Merge whatever succeeded, and mark every fetched key `settled`
+        // (success OR error) so cells switch loading -> value / "—".
+        // Mirrors the existing merge at analyzer.rs:1492-1509.
         enrichment.update(|m| {
             if let Ok(q) = &quality {
-                m.quality.extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));
+                m.quality
+                    .extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));
             }
             if let Ok(s) = &sparklines {
-                m.sparkline.extend(s.series.iter().map(|r| ((r.item_id, r.hq), r.points.clone())));
+                m.sparkline
+                    .extend(s.series.iter().map(|r| ((r.item_id, r.hq), r.points.clone())));
             }
+            m.settled.extend(keys.iter().copied());
         });
-        // If a call failed, drop its keys from `requested` so revisiting retries.
-        if quality.is_err() || sparklines.is_err() {
-            requested.update_value(|s| keys.iter().for_each(|k| { s.remove(k); }));
-        }
+        // No per-key retry: keys stay in `requested`, so a CH blip degrades the
+        // rows to "—" (same as today) rather than refetch-looping. A world
+        // change resets everything (see §4).
     });
 });
 ```
@@ -197,11 +229,17 @@ Files/lines: Trend `analyzer.rs:1319`, Sales/day `analyzer.rs:1340`,
 30d Volume `analyzer.rs:1349`.
 
 Today every cell falls back to empty/`—` whether the row is loading or genuinely
-absent. Add an in-flight notion (a key is in `requested` but not yet in
-`enrichment`): render the already-imported `BoxSkeleton` for Trend and a dim
-placeholder for the number columns while in-flight, and `—` only once a fetch has
-completed with no data. This keeps fast scrolling reading as "loading", not
-"no data".
+absent. With the `settled` set, each of the three cells follows one rule (reading
+the already-subscribed `enrichment` signal):
+
+- key in `quality` / `sparkline` map → render the value (current behavior).
+- else if key in `settled` → render `—` (fetched, no CH data).
+- else → render `SingleLineSkeleton` (a thin themed pulse, `skeleton.rs:6`) — the
+  fetch is in flight.
+
+`SingleLineSkeleton` (not `BoxSkeleton`, which is a six-row block sized for a
+panel) is added to the existing `skeleton::{...}` import. This keeps fast
+scrolling reading as "loading", not "no data".
 
 ### 4. Caching / invalidation
 
@@ -217,11 +255,11 @@ completed with no data. This keeps fast scrolling reading as "loading", not
 ```
 scroll → VirtualScroller updates child_start/children_shown
        → visible_range RwSignal set (rendered range)
-       → signal_debounced(150ms)
-       → pending_keys memo = visible_keys(sorted_data, range, MARGIN, requested)
-       → Effect: mark requested, spawn_local fetch (join resale_quality + sparklines)
-       → enrichment.update(merge)
-       → cells re-read enrichment, render values (mounted rows only)
+       → Effect: keys = visible_keys(sorted_data, range, MARGIN, requested)
+       → debounce (gen guard + TimeoutFuture 150ms); latest generation wins
+       → claim keys in `requested`; join get_resale_quality + post_sparklines
+       → enrichment.update(merge data + mark keys settled)
+       → cells re-read enrichment → value / "—" / skeleton (mounted rows only)
 ```
 
 ## Edge cases & wrinkles (handled)
@@ -233,11 +271,14 @@ scroll → VirtualScroller updates child_start/children_shown
   Decision: keep current **hide** semantics; switching to dim/mark would fully
   remove reflow but is out of scope.
 - **Reactive loop** (enrichment update → `sorted_data` recompute, because the
-  suspicious filter reads enrichment → `pending_keys` recompute): the `requested`
-  set breaks it — already-requested keys are filtered out, so it converges after
-  one round per newly-visible set.
-- **Fetch failure:** failed keys are cleared from `requested` so revisiting the
-  rows retries, avoiding a permanent `—`.
+  suspicious filter reads enrichment → the fetch effect re-runs): the `requested`
+  set breaks it — already-claimed keys are filtered out by `visible_keys`, so the
+  recomputed key set is empty and the effect returns. Converges after one round
+  per newly-visible set.
+- **Fetch failure:** on completion (success *or* error) the fetched keys are
+  marked `settled` and kept in `requested`, so the rows render `—` (graceful
+  degradation, same as today's CH-outage behavior) with no refetch loop. A world
+  change clears `settled` + `requested`, allowing a fresh attempt.
 - **Initial mount:** the scroller's range effect runs on mount, setting
   `visible_range` to `(0, ~26)`, which triggers the first fetch of the default
   (top-ROI) view — so the default view fills without a separate eager path.

--- a/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+++ b/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
@@ -161,7 +161,7 @@ where
             if len == 0 {
                 range_sig.set((0, 0));
             } else {
-                let start = (child_start() as usize).min(len - 1);
+                let start = (child_start() as usize).min(len.saturating_sub(1));
                 let end = (start + children_shown() as usize).min(len);
                 range_sig.set((start, end));
             }

--- a/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+++ b/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
@@ -65,6 +65,11 @@ pub fn VirtualScroller<T, D, V, KF, K>(
     #[prop(optional)] variable_height: bool,
     #[prop(optional, into)] scroll_to_index: Option<Signal<Option<usize>>>,
     #[prop(optional)] scroller_ref: Option<NodeRef<leptos::html::Div>>,
+    /// Optional writeback of the rendered row range `(start, end)` (end
+    /// exclusive, includes overscan). Lets a parent fetch data only for
+    /// rows in view. When omitted, no extra work is done.
+    #[prop(optional, into)]
+    visible_range: Option<RwSignal<(usize, usize)>>,
 ) -> impl IntoView
 where
     D: Fn(T) -> V + 'static + Clone + Send,
@@ -146,6 +151,22 @@ where
     let children_shown = Memo::new(move |_| {
         ((effective_viewport / avg_row_height()).ceil() as u32).max(1) + render_ahead
     });
+
+    // Publish the rendered row range to an optional parent signal. `child_start`
+    // and `children_shown` already account for overscan and match the slice used
+    // by `virtual_children` below.
+    if let Some(range_sig) = visible_range {
+        Effect::new(move |_| {
+            let len = children_len();
+            if len == 0 {
+                range_sig.set((0, 0));
+            } else {
+                let start = (child_start() as usize).min(len - 1);
+                let end = (start + children_shown() as usize).min(len);
+                range_sig.set((start, end));
+            }
+        });
+    }
 
     // Scroll target into view when requested (moved after layout signals are defined)
     if let Some(scroll_sig) = scroll_to_index {

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -639,6 +639,11 @@ fn AnalyzerTable(
         let _ = world.get(); // subscribe: re-run on world change
         enrichment.set(EnrichmentMaps::default());
         requested.update_value(|s| s.clear());
+        // Invalidate any in-flight fetch from the previous world: bumping the
+        // generation makes it bail at the guard below before it claims keys,
+        // so a stale batch can't repopulate `requested` (which would strand
+        // those rows on the skeleton) or merge another world's data.
+        fetch_id.update(|n| *n += 1);
     });
 
     // Select the visible-window keys (honoring the active sort/filter via
@@ -660,11 +665,20 @@ fn AnalyzerTable(
         let world_name = world.get_untracked();
         leptos::task::spawn_local(async move {
             TimeoutFuture::new(DEBOUNCE_MS).await; // debounce
-            if fetch_id.get_untracked() != current_id {
-                return; // superseded by a newer range
+            // Past this await the component can be disposed (user navigated away
+            // / changed world), which disposes these signals. Every access here
+            // uses a `try_*` variant so touching a disposed signal returns
+            // quietly instead of panicking (RustWasmPanic / "unreachable").
+            if fetch_id.try_get_untracked() != Some(current_id) {
+                return; // superseded by a newer range, or component disposed
             }
             // Claim post-debounce so superseded generations never claim.
-            requested.update_value(|s| s.extend(keys.iter().copied()));
+            if requested
+                .try_update_value(|s| s.extend(keys.iter().copied()))
+                .is_none()
+            {
+                return; // component disposed
+            }
             // window <= ~86 keys << 200 cap -> single batch, no chunking.
             let (quality, sparklines) = futures::join!(
                 get_resale_quality(&world_name, keys.clone(), 30),
@@ -676,11 +690,20 @@ fn AnalyzerTable(
                     },
                 ),
             );
+            // The join above awaits the network, so the world may have changed
+            // (or the component been disposed) while this batch was in flight.
+            // Don't merge one world's enrichment into another's map (the
+            // world-change reset already cleared `requested`, so the new world
+            // refetches these keys). A disposed `world` signal yields None here,
+            // which also bails.
+            if world.try_get_untracked().as_deref() != Some(world_name.as_str()) {
+                return;
+            }
             // Merge whatever succeeded and mark every fetched key settled
             // (success OR error) so cells switch loading -> value / "—". On a CH
             // blip the rows degrade to "—" (same as today) — no retry loop; a
             // world change resets everything.
-            enrichment.update(|m| {
+            let _ = enrichment.try_update(|m| {
                 if let Ok(q) = &quality {
                     m.quality
                         .extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -399,6 +399,29 @@ fn select_enrichment_keys(profits: &ProfitTable, cap: usize) -> Vec<(i32, bool)>
         .collect()
 }
 
+/// Keys in the `[start - margin, end + margin)` slice of `data`, minus `seen`.
+/// Generic over the row type + a key extractor so it unit-tests with plain
+/// `(i32, bool)` fixtures — no `CalculatedProfitData` / DOM needed. Wired into
+/// the lazy-enrichment effect in `AnalyzerTable`.
+#[allow(dead_code)] // wired into the fetch effect in the same change set
+fn visible_keys<T>(
+    data: &[T],
+    range: (usize, usize),
+    margin: usize,
+    seen: &std::collections::HashSet<(i32, bool)>,
+    key_of: impl Fn(&T) -> (i32, bool),
+) -> Vec<(i32, bool)> {
+    let (start, end) = range;
+    let lo = start.saturating_sub(margin);
+    let hi = (end + margin).min(data.len());
+    data.get(lo..hi)
+        .unwrap_or(&[])
+        .iter()
+        .map(key_of)
+        .filter(|k| !seen.contains(k))
+        .collect()
+}
+
 #[component]
 fn PresetFilterButton(href: &'static str, #[prop(into)] label: String) -> impl IntoView {
     view! {
@@ -2136,5 +2159,55 @@ mod tests {
             select_enrichment_keys(&profits, 10),
             vec![(40000, false), (2, false)]
         );
+    }
+
+    #[test]
+    fn visible_keys_includes_window_and_margin() {
+        let data: Vec<(i32, bool)> = (0..100).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // rendered rows [40, 50), margin 5 => slice [35, 55)
+        let keys = visible_keys(&data, (40, 50), 5, &seen, |k| *k);
+        assert_eq!(keys.len(), 20);
+        assert_eq!(keys.first(), Some(&(35, false)));
+        assert_eq!(keys.last(), Some(&(54, false)));
+    }
+
+    #[test]
+    fn visible_keys_clamps_at_start_and_end() {
+        let data: Vec<(i32, bool)> = (0..10).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // lo = 2.saturating_sub(5) = 0 ; hi = (4 + 5).min(10) = 9 => slice [0, 9)
+        let keys = visible_keys(&data, (2, 4), 5, &seen, |k| *k);
+        assert_eq!(keys.first(), Some(&(0, false)));
+        assert_eq!(keys.last(), Some(&(8, false)));
+    }
+
+    #[test]
+    fn visible_keys_excludes_already_seen() {
+        let data: Vec<(i32, bool)> = (0..10).map(|i| (i, false)).collect();
+        let mut seen = std::collections::HashSet::new();
+        seen.insert((3, false));
+        seen.insert((5, false));
+        let keys = visible_keys(&data, (0, 10), 0, &seen, |k| *k);
+        assert_eq!(keys.len(), 8);
+        assert!(!keys.contains(&(3, false)));
+        assert!(!keys.contains(&(5, false)));
+    }
+
+    #[test]
+    fn visible_keys_empty_data_yields_empty() {
+        let data: Vec<(i32, bool)> = Vec::new();
+        let seen = std::collections::HashSet::new();
+        let keys = visible_keys(&data, (0, 0), 30, &seen, |k| *k);
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn visible_keys_out_of_range_yields_empty() {
+        let data: Vec<(i32, bool)> = (0..5).map(|i| (i, false)).collect();
+        let seen = std::collections::HashSet::new();
+        // lo = 95, hi = (110 + 5).min(5) = 5 => get(95..5) is an invalid range => &[]
+        let keys = visible_keys(&data, (100, 110), 5, &seen, |k| *k);
+        assert!(keys.is_empty());
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -11,7 +11,7 @@ use crate::{
         item_icon::*,
         meta::*,
         query_button::QueryButton,
-        skeleton::BoxSkeleton,
+        skeleton::{BoxSkeleton, SingleLineSkeleton},
         sparkline::Sparkline,
         toggle::Toggle,
         tool_help::*,
@@ -35,6 +35,10 @@ use ultros_api_types::{
 struct EnrichmentMaps {
     quality: HashMap<(i32, bool), ResaleQualityRow>,
     sparkline: HashMap<(i32, bool), Vec<u32>>,
+    /// Keys whose fetch has completed (with OR without data). Lets cells tell
+    /// "still loading" (absent) from "fetched, no CH data" (present, but no
+    /// entry in `quality` / `sparkline`).
+    settled: std::collections::HashSet<(i32, bool)>,
 }
 
 impl EnrichmentMaps {
@@ -44,17 +48,10 @@ impl EnrichmentMaps {
     fn sparkline_for(&self, key: &(i32, bool)) -> Option<&Vec<u32>> {
         self.sparkline.get(key)
     }
+    fn is_settled(&self, key: &(i32, bool)) -> bool {
+        self.settled.contains(key)
+    }
 }
-
-/// Cap on the batch size sent to `/api/v1/resale_quality`, which rejects
-/// payloads above 250; we stay under to leave headroom for serialization.
-const ENRICHMENT_BATCH_CAP: usize = 240;
-
-/// `/api/v1/sparklines` enforces a tighter cap than `resale_quality` —
-/// it rejects payloads above 200. Because `select_enrichment_keys` returns
-/// rows ROI-ranked, sending the first `SPARKLINE_BATCH_CAP` keys still
-/// covers the most-visible (highest-ROI) rows the table shows first.
-const SPARKLINE_BATCH_CAP: usize = 200;
 
 /// Stable URL IDs for optional columns. Required columns (HQ, Item,
 /// Profit, ROI, Buy Price) are not in this list — they always render.
@@ -109,6 +106,7 @@ fn serialize_visible_cols(visible: &std::collections::HashSet<&'static str>) -> 
         .join(",")
 }
 use chrono::{Duration, Utc};
+use gloo_timers::future::TimeoutFuture;
 use humantime::{format_duration, parse_duration};
 use icondata as i;
 use leptos::{either::Either, prelude::*, reactive::wrappers::write::SignalSetter};
@@ -366,44 +364,18 @@ impl ProfitTable {
     }
 }
 
-/// Post-tax ROI in integer percent for a profit row, mirroring the analyzer
-/// table's default (ROI) ranking so the enrichment pass requests the same rows
-/// the user sees first.
-fn roi_for_rank(p: &ProfitData) -> i32 {
-    let estimated = (p.estimated_sale_price as f32 * 0.95) as i32;
-    let profit = estimated - p.cheapest_price;
-    if p.cheapest_price > 0 {
-        ((profit as f32 / p.cheapest_price as f32) * 100.0) as i32
-    } else {
-        0
-    }
-}
-
-/// Choose the `(item_id, hq)` keys to send to the ClickHouse enrichment
-/// endpoints (`resale_quality` + `sparklines`), capped at `cap`.
-///
-/// The endpoints reject batches above ~250, but a busy world has thousands of
-/// recently-sold items — so we must enrich a subset, and it has to be the rows
-/// the table actually displays: the top opportunities by ROI (the default
-/// sort). The earlier implementation sorted by `item_id` and kept the lowest
-/// `cap`, which are low-level commodities that never rank as top flips — so
-/// every displayed (high-item_id) row missed the join and rendered "—" in the
-/// Sales/day, 30d Volume, and Trend columns.
-fn select_enrichment_keys(profits: &ProfitTable, cap: usize) -> Vec<(i32, bool)> {
-    let mut ranked: Vec<&Arc<ProfitData>> = profits.0.iter().collect();
-    ranked.sort_by_key(|p| Reverse(roi_for_rank(p)));
-    ranked
-        .into_iter()
-        .take(cap)
-        .map(|p| (p.sale_summary.item_id, p.sale_summary.hq))
-        .collect()
-}
+/// Rows fetched above & below the rendered window, so enrichment lands just
+/// before a row scrolls into view. Keep small enough that
+/// `rendered (~26) + 2 * PREFETCH_MARGIN` stays well under the 200-item
+/// sparklines cap (no chunking needed).
+const PREFETCH_MARGIN: usize = 30;
+/// Debounce window for scroll-driven fetches (ms). Mirrors search_box.rs.
+const DEBOUNCE_MS: u32 = 150;
 
 /// Keys in the `[start - margin, end + margin)` slice of `data`, minus `seen`.
 /// Generic over the row type + a key extractor so it unit-tests with plain
 /// `(i32, bool)` fixtures — no `CalculatedProfitData` / DOM needed. Wired into
 /// the lazy-enrichment effect in `AnalyzerTable`.
-#[allow(dead_code)] // wired into the fetch effect in the same change set
 fn visible_keys<T>(
     data: &[T],
     range: (usize, usize),
@@ -443,10 +415,6 @@ fn AnalyzerTable(
     worlds: Arc<WorldHelper>,
     world: Signal<String>,
     filter_outliers: bool,
-    /// CH-backed per-row enrichment (quality band + sparkline). Empty
-    /// when the enrichment fetch is in flight or failed — the table
-    /// degrades gracefully to Pass-1 rendering.
-    enrichment: Signal<EnrichmentMaps>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let profits = ProfitTable::new(
@@ -511,6 +479,11 @@ fn AnalyzerTable(
             .map(|d| format_duration(d).to_string())
             .unwrap_or("---".to_string())
     });
+
+    // Accumulating CH enrichment (quality + sparkline + settled), grown by the
+    // visible-window fetch effect below; never wholesale-replaced (except on a
+    // world change). Cells + the suspicious filter read it reactively.
+    let enrichment = RwSignal::new(EnrichmentMaps::default());
 
     let sorted_data = Memo::new(move |_| {
         let include_tax = tax_enabled().unwrap_or(true);
@@ -647,6 +620,83 @@ fn AnalyzerTable(
             .enumerate()
             .collect::<Vec<(usize, CalculatedProfitData)>>()
     });
+
+    // --- Visible-window lazy enrichment -------------------------------------
+    // Dedupe / loop-breaker: keys we've already scheduled a fetch for. Non-
+    // reactive (StoredValue) on purpose — claiming a key must not retrigger the
+    // fetch effect.
+    let requested = StoredValue::new(std::collections::HashSet::<(i32, bool)>::new());
+    // Rendered row range published by the VirtualScroller (see view! below).
+    let visible_range = RwSignal::new((0usize, 0usize));
+    // Generation counter for debounce-with-cancellation (RwSignal, mirroring
+    // components/search_box.rs). `gen` is a reserved keyword in edition 2024.
+    let fetch_id = RwSignal::new(0u64);
+
+    // Reset accumulated enrichment when the world changes. Defense-in-depth: if
+    // the component is updated in place rather than remounted, another world's
+    // data must not leak.
+    Effect::new(move |_| {
+        let _ = world.get(); // subscribe: re-run on world change
+        enrichment.set(EnrichmentMaps::default());
+        requested.update_value(|s| s.clear());
+    });
+
+    // Select the visible-window keys (honoring the active sort/filter via
+    // sorted_data), debounce, fetch both batches, and merge — accumulating.
+    Effect::new(move |_| {
+        let range = visible_range.get(); // reactive: scroll
+        let keys = sorted_data.with(|data| {
+            requested.with_value(|seen| {
+                visible_keys(data, range, PREFETCH_MARGIN, seen, |(_, d)| {
+                    (d.inner.sale_summary.item_id, d.inner.sale_summary.hq)
+                })
+            })
+        });
+        if keys.is_empty() {
+            return;
+        }
+        fetch_id.update(|n| *n += 1);
+        let current_id = fetch_id.get_untracked();
+        let world_name = world.get_untracked();
+        leptos::task::spawn_local(async move {
+            TimeoutFuture::new(DEBOUNCE_MS).await; // debounce
+            if fetch_id.get_untracked() != current_id {
+                return; // superseded by a newer range
+            }
+            // Claim post-debounce so superseded generations never claim.
+            requested.update_value(|s| s.extend(keys.iter().copied()));
+            // window <= ~86 keys << 200 cap -> single batch, no chunking.
+            let (quality, sparklines) = futures::join!(
+                get_resale_quality(&world_name, keys.clone(), 30),
+                post_sparklines(
+                    &world_name,
+                    SparklinesRequest {
+                        items: keys.clone(),
+                        hours: Some(168),
+                    },
+                ),
+            );
+            // Merge whatever succeeded and mark every fetched key settled
+            // (success OR error) so cells switch loading -> value / "—". On a CH
+            // blip the rows degrade to "—" (same as today) — no retry loop; a
+            // world change resets everything.
+            enrichment.update(|m| {
+                if let Ok(q) = &quality {
+                    m.quality
+                        .extend(q.rows.iter().map(|r| ((r.item_id, r.hq), r.clone())));
+                }
+                if let Ok(s) = &sparklines {
+                    m.sparkline.extend(
+                        s.series
+                            .iter()
+                            .map(|r| ((r.item_id, r.hq), r.points.clone())),
+                    );
+                }
+                m.settled.extend(keys.iter().copied());
+            });
+        });
+    });
+
     view! {
         <div class="flex flex-col gap-6">
             // Primary filter toolbar
@@ -1077,6 +1127,7 @@ fn AnalyzerTable(
                         overscan=8
                         header_height=56.0
                         variable_height=false
+                        visible_range=visible_range
                         header=view! {
                             <div class="flex flex-row items-center h-14 text-xs font-semibold uppercase tracking-wider text-[color:var(--color-text-muted)] border-b border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_8%,transparent)]" role="rowgroup">
                                 <div role="columnheader" class="w-[44px] px-2 text-center">
@@ -1339,42 +1390,53 @@ fn AnalyzerTable(
                                         view! {
                                             {move || visible_cols().contains(COL_TREND).then(|| {
                                                 let maps = enrichment.get();
-                                                let pts = maps.sparkline_for(&row_key).cloned().unwrap_or_default();
-                                                let pct = maps.quality_for(&row_key)
-                                                    .map(|q| {
-                                                        let vwap = q.vwap as f32;
-                                                        if vwap <= 0.0 {
-                                                            0.0
-                                                        } else {
-                                                            (row_cheapest_price as f32 - vwap) / vwap * 100.0
-                                                        }
-                                                    })
-                                                    .unwrap_or(0.0);
+                                                let inner = if let Some(pts) = maps.sparkline_for(&row_key) {
+                                                    let pct = maps.quality_for(&row_key)
+                                                        .map(|q| {
+                                                            let vwap = q.vwap as f32;
+                                                            if vwap <= 0.0 {
+                                                                0.0
+                                                            } else {
+                                                                (row_cheapest_price as f32 - vwap) / vwap * 100.0
+                                                            }
+                                                        })
+                                                        .unwrap_or(0.0);
+                                                    view! { <Sparkline points=pts.clone() pct_change=pct /> }.into_any()
+                                                } else if maps.is_settled(&row_key) {
+                                                    // fetched, no series -> empty sparkline (prior behavior)
+                                                    view! { <Sparkline points=Vec::new() pct_change=0.0 /> }.into_any()
+                                                } else {
+                                                    view! { <SingleLineSkeleton /> }.into_any()
+                                                };
                                                 view! {
                                                     <div role="cell" class="px-3 py-2 w-[100px] hidden md:flex items-center justify-center">
-                                                        <Sparkline points=pts pct_change=pct />
+                                                        {inner}
                                                     </div>
                                                 }
                                             })}
                                             {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| {
-                                                let text = enrichment.get()
-                                                    .quality_for(&row_key)
-                                                    .map(|q| format!("{:.1}", q.sales_per_day))
-                                                    .unwrap_or_else(|| "—".to_string());
+                                                let maps = enrichment.get();
+                                                let inner = match (maps.quality_for(&row_key), maps.is_settled(&row_key)) {
+                                                    (Some(q), _) => view! { {format!("{:.1}", q.sales_per_day)} }.into_any(),
+                                                    (None, true) => view! { "—" }.into_any(),
+                                                    (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
+                                                };
                                                 view! {
                                                     <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
-                                                        {text}
+                                                        {inner}
                                                     </div>
                                                 }
                                             })}
                                             {move || visible_cols().contains(COL_VOLUME_30D).then(|| {
-                                                let text = enrichment.get()
-                                                    .quality_for(&row_key)
-                                                    .map(|q| q.sample_size.to_string())
-                                                    .unwrap_or_else(|| "—".to_string());
+                                                let maps = enrichment.get();
+                                                let inner = match (maps.quality_for(&row_key), maps.is_settled(&row_key)) {
+                                                    (Some(q), _) => view! { {q.sample_size.to_string()} }.into_any(),
+                                                    (None, true) => view! { "—" }.into_any(),
+                                                    (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
+                                                };
                                                 view! {
                                                     <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
-                                                        {text}
+                                                        {inner}
                                                     </div>
                                                 }
                                             })}
@@ -1453,91 +1515,6 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     let (filter_outliers, set_filter_outliers) = query_signal::<bool>("filter-outliers");
     let connected_regions = &["Europe", "Japan", "North-America", "Oceania"];
     let query = use_query_map();
-
-    // CH enrichment: fetched once the sales resource resolves, in a
-    // single round-trip via the resale_quality + sparklines batch
-    // endpoints. Soft-fails silently — the page still renders Pass-1
-    // results with no chip when CH is unavailable.
-    let sales_for_enrichment = sales.clone();
-    let world_cheapest_for_enrichment = world_cheapest_listings.clone();
-    let global_cheapest_for_enrichment = global_cheapest_listings.clone();
-    let enrichment = LocalResource::new(move || {
-        let world_name = world();
-        let sales_res = sales_for_enrichment.get();
-        let world_cheapest_res = world_cheapest_for_enrichment.get();
-        let global_cheapest_res = global_cheapest_for_enrichment.get();
-        let filter_outliers = filter_outliers().unwrap_or(false);
-        async move {
-            if world_name.is_empty() {
-                return EnrichmentMaps::default();
-            }
-            let (Some(Ok(sales)), Some(Ok(world_cheapest)), Some(Ok(global_cheapest))) =
-                (sales_res, world_cheapest_res, global_cheapest_res)
-            else {
-                return EnrichmentMaps::default();
-            };
-            // Enrich the rows the table will actually show — the top
-            // opportunities by ROI (the default sort) — not the 240
-            // numerically-lowest item_ids, which are low-level commodities
-            // that never surface as top flips. Cross-region deals are omitted
-            // from this ranking pass (a default-off power feature); the ROI
-            // order still captures the rows shown by default.
-            let profits = ProfitTable::new(
-                sales,
-                global_cheapest,
-                world_cheapest,
-                Vec::new(),
-                filter_outliers,
-            );
-            let keys = select_enrichment_keys(&profits, ENRICHMENT_BATCH_CAP);
-            if keys.is_empty() {
-                return EnrichmentMaps::default();
-            }
-            // sparklines caps batches at 200 (tighter than resale_quality's
-            // 250); `keys` is ROI-ranked, so the first SPARKLINE_BATCH_CAP are
-            // the most-visible rows. Sending the full 240 here 400s the whole
-            // request and blanks the Trend column on any busy world.
-            let sparkline_keys: Vec<(i32, bool)> =
-                keys.iter().take(SPARKLINE_BATCH_CAP).copied().collect();
-            let (quality, sparklines) = futures::join!(
-                get_resale_quality(&world_name, keys.clone(), 30),
-                post_sparklines(
-                    &world_name,
-                    SparklinesRequest {
-                        items: sparkline_keys,
-                        // 7 days (server caps at 168h). 24h was too tight —
-                        // quiet items rendered as empty sparklines because a
-                        // single non-trade hour can sink the polyline.
-                        hours: Some(168),
-                    }
-                ),
-            );
-            let quality_map = quality
-                .ok()
-                .map(|r| {
-                    r.rows
-                        .into_iter()
-                        .map(|row| ((row.item_id, row.hq), row))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let sparkline_map = sparklines
-                .ok()
-                .map(|s| {
-                    s.series
-                        .into_iter()
-                        .map(|row| ((row.item_id, row.hq), row.points))
-                        .collect()
-                })
-                .unwrap_or_default();
-            EnrichmentMaps {
-                quality: quality_map,
-                sparkline: sparkline_map,
-            }
-        }
-    });
-    let enrichment_signal: Signal<EnrichmentMaps> =
-        Signal::derive(move || enrichment.get().unwrap_or_default());
 
     let enabled_regions = move || {
         let map = query();
@@ -1723,7 +1700,6 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                                                     worlds
                                                     world=world.into()
                                                     filter_outliers=filter_outliers().unwrap_or(false)
-                                                    enrichment=enrichment_signal
                                                 />
                                             },
                                         )
@@ -2098,67 +2074,6 @@ mod tests {
         let row = &table.0[0];
         assert_eq!(row.sale_summary.median_price, 1000);
         assert_eq!(row.estimated_sale_price, 1000);
-    }
-
-    #[test]
-    fn enrichment_selects_top_roi_rows_not_lowest_item_ids() {
-        use ultros_api_types::cheapest_listings::{CheapestListingItem, CheapestListings};
-        use ultros_api_types::recent_sales::RecentSales;
-
-        // A low-id commodity with no margin, and a high-id flip with a fat
-        // margin. The enrichment pass must pick the high-ROI flip — the rows
-        // the table shows first — not the numerically-lowest item_id. (The old
-        // `sort_unstable() + truncate()` would have picked item 2 instead,
-        // which is exactly why the columns were always blank in prod.)
-        let sales = RecentSales {
-            sales: vec![
-                sales_row(
-                    2,
-                    false,
-                    &[(100, 0), (100, 1), (100, 2), (100, 3), (100, 4), (100, 5)],
-                ),
-                sales_row(
-                    40000,
-                    false,
-                    &[
-                        (10000, 0),
-                        (10000, 1),
-                        (10000, 2),
-                        (10000, 3),
-                        (10000, 4),
-                        (10000, 5),
-                    ],
-                ),
-            ],
-        };
-        let region = CheapestListings {
-            cheapest_listings: vec![
-                CheapestListingItem {
-                    item_id: 2,
-                    hq: false,
-                    cheapest_price: 95,
-                    world_id: 42,
-                },
-                CheapestListingItem {
-                    item_id: 40000,
-                    hq: false,
-                    cheapest_price: 1000,
-                    world_id: 42,
-                },
-            ],
-        };
-        let world = CheapestListings {
-            cheapest_listings: vec![],
-        };
-        let profits = ProfitTable::new(sales, region, world, vec![], false);
-
-        // cap = 1 must yield the high-ROI flip, never the lowest item_id.
-        assert_eq!(select_enrichment_keys(&profits, 1), vec![(40000, false)]);
-        // Under a larger cap, both are present, ordered ROI-desc (flip first).
-        assert_eq!(
-            select_enrichment_keys(&profits, 10),
-            vec![(40000, false), (2, false)]
-        );
     }
 
     #[test]

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -2176,10 +2176,12 @@ mod tests {
     fn visible_keys_clamps_at_start_and_end() {
         let data: Vec<(i32, bool)> = (0..10).map(|i| (i, false)).collect();
         let seen = std::collections::HashSet::new();
-        // lo = 2.saturating_sub(5) = 0 ; hi = (4 + 5).min(10) = 9 => slice [0, 9)
-        let keys = visible_keys(&data, (2, 4), 5, &seen, |k| *k);
+        // start clamp: lo = 2.saturating_sub(5) = 0
+        // end clamp: hi = (8 + 5).min(10) = 10 (would be 13 unclamped) => slice [0, 10)
+        let keys = visible_keys(&data, (2, 8), 5, &seen, |k| *k);
+        assert_eq!(keys.len(), 10);
         assert_eq!(keys.first(), Some(&(0, false)));
-        assert_eq!(keys.last(), Some(&(8, false)));
+        assert_eq!(keys.last(), Some(&(9, false)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replaces the analyzer's fixed **top-240/200 ROI enrichment cap** with **viewport-driven lazy fetching**. Trend, Sales/day, and 30d Volume are now fetched for the rows in (and near) the viewport and **accumulate as you scroll**, so every row you scroll to gets enriched — not just the top ~240. Scales to thousands of items with small per-scroll ClickHouse load.
- `VirtualScroller` gains an optional `visible_range` writeback prop. `AnalyzerTable` owns an accumulating `EnrichmentMaps` (plus a `settled` set so cells show loading-skeleton / "—" / value) and a **debounced generation-guard fetch effect** (mirrors `components/search_box.rs`) that reuses the existing bulk `resale_quality` + `sparklines` endpoints. The eager `LocalResource` path and the dead ROI-ranking helpers (`select_enrichment_keys`, `roi_for_rank`, the two batch caps) are removed.
- **Frontend-only** — no backend, API-type, or locale changes. Also fixes a latent bug: the old eager pass always ranked by ROI even when sorting by Profit / Profit-per-day, so it enriched the wrong rows; reading `sorted_data` now matches what's shown.

Design spec + implementation plan included under `docs/superpowers/`.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p ultros-app --all-targets -- -D warnings` clean
- [x] New `visible_keys` unit tests pass (window / margin / clamp / dedupe / out-of-range)
- [ ] Full-workspace CI (clippy + fmt) green
- [ ] **In-browser on a busy world:** rows fill progressively while scrolling; Network shows small *batched* `resale_quality` + `sparklines` per scroll-stop (not per-row); scrolling back up does not refetch; switching sort reuses fetched data; switching world refetches
- [ ] _(Separate / pre-existing)_ Sales/day + 30d Volume stay blank for items with no ClickHouse `item_stats_window` rollup — run the `clickhouse_backfill` one-shot to densify (out of scope here)

> Note: the 2 failing unit tests on this branch (`test_job_filtering`, `test_sort_order`) are **pre-existing on `main`** and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)