### PR TITLE
fix(error-reporting): make the beforeSend noise filter actually suppress the WebView/translate floods

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -1,0 +1,307 @@
+// Unit tests for the Sentry `beforeSend` noise filter defined in
+// ../ultros-frontend/ultros-app/src/error_filter.js.
+//
+// The filter source references `window` and `navigator` as free
+// identifiers. We load it by wrapping the source in
+// `new Function('window', 'navigator', src)` and invoking it with a fresh
+// fake `window` and a `navigator` carrying the User-Agent for the case.
+// That mirrors how the file runs in the browser (top-level globals) while
+// letting each case pick its own UA.
+//
+// Run with: node integration/error-filter.test.cjs
+//   (or: npm --prefix integration run test:error-filter)
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const FILTER_PATH = path.join(
+  __dirname,
+  "..",
+  "ultros-frontend",
+  "ultros-app",
+  "src",
+  "error_filter.js",
+);
+const SRC = fs.readFileSync(FILTER_PATH, "utf8");
+
+// Load the filter with a given UA and return its `shouldDrop` predicate.
+function loadFilter(userAgent) {
+  const win = {};
+  // eslint-disable-next-line no-new-func
+  const factory = new Function("window", "navigator", SRC);
+  factory(win, { userAgent: userAgent || "" });
+  assert.strictEqual(
+    typeof win.__ultrosShouldDropEvent,
+    "function",
+    "error_filter.js must define window.__ultrosShouldDropEvent",
+  );
+  return win.__ultrosShouldDropEvent;
+}
+
+// Real Chrome/112 WebView UA from GlitchTip issue #707's request payload.
+const FROZEN_CHROME_112 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36";
+// A current, non-frozen browser.
+const CURRENT_CHROME =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
+
+const HYDRATION_LOC =
+  "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/" +
+  "tachys-0.2.15/src/hydration.rs:227:9";
+
+function rustPanic(location, extra) {
+  return Object.assign(
+    {
+      contexts: { rust_panic: { location } },
+      exception: {
+        values: [
+          {
+            type: "RustWasmPanic",
+            value: "internal error: entered unreachable code",
+          },
+        ],
+      },
+    },
+    extra,
+  );
+}
+
+const cases = [
+  // ── Category 3: frozen-Chrome-112 translate-overlay hydration panic ──
+  // This is the #707 / #2775 / #4951 / #4905 cluster. The `browser` tag
+  // is derived server-side by GlitchTip from the UA, so it is ABSENT in
+  // the client-side beforeSend event — the only client-visible signal is
+  // the live navigator UA. No Chinese stability breadcrumb on this event.
+  {
+    name: "frozen Chrome 112 tachys hydration panic (no breadcrumb, no browser tag) is dropped",
+    ua: FROZEN_CHROME_112,
+    event: rustPanic(HYDRATION_LOC, {
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    }),
+    expectDrop: true,
+  },
+  {
+    name: "frozen Chrome 112 hydration panic via Chinese stability breadcrumb is dropped",
+    ua: FROZEN_CHROME_112,
+    event: rustPanic(HYDRATION_LOC, {
+      breadcrumbs: {
+        values: [{ category: "console", message: "检测页面稳定 ok" }],
+      },
+    }),
+    expectDrop: true,
+  },
+  {
+    name: "hydration panic on a CURRENT browser is preserved (real bugs still reach GlitchTip)",
+    ua: CURRENT_CHROME,
+    event: rustPanic(HYDRATION_LOC, {
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    }),
+    expectDrop: false,
+  },
+
+  // ── Category 1: WASM/bundle fetch aborts ──
+  {
+    name: 'TypeError "Failed to fetch dynamically imported module" of the pkg bundle is dropped',
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Failed to fetch dynamically imported module: " +
+              "https://ultros.app/pkg/c994ea6/ultros.js",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "dynamic import failure of the pkg bundle on the www host is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Failed to fetch dynamically imported module: " +
+              "https://www.ultros.app/pkg/c994ea6/ultros.js",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "bare Failed to fetch from a pkg-bundle stack frame is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Failed to fetch",
+            stacktrace: {
+              frames: [{ filename: "/pkg/c994ea6/ultros.js" }],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "WebAssembly compilation aborted is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "WebAssembly compilation aborted: aborted",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "dynamic import failure of a NON-pkg (third-party) module is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Failed to fetch dynamically imported module: " +
+              "https://cdn.example.com/widget.js",
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "bare Failed to fetch from an API call (non-pkg frame) is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Failed to fetch",
+            stacktrace: {
+              frames: [{ filename: "https://ultros.app/api/v1/listings" }],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+
+  // ── Category 2: injected document TypeError ──
+  {
+    name: "injected HTMLDocument.c document TypeError is dropped",
+    ua: FROZEN_CHROME_112,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Cannot read properties of undefined (reading 'document')",
+            stacktrace: { frames: [{ function: "HTMLDocument.c" }] },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+
+  // ── Category 4: empty (undefined/null) promise rejections ──
+  {
+    name: "Non-Error promise rejection with value undefined is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "UnhandledRejection",
+            value: "Non-Error promise rejection captured with value: undefined",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "Non-Error promise rejection with value null is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "UnhandledRejection",
+            value: "Non-Error promise rejection captured with value: null",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "Non-Error promise rejection carrying a real object is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "UnhandledRejection",
+            value:
+              "Non-Error promise rejection captured with value: [object Object]",
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+
+  // ── Genuine application errors must always survive ──
+  {
+    name: "a genuine application Error is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [{ type: "Error", value: "list rename failed: 500" }],
+      },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "an empty event never throws and is preserved",
+    ua: CURRENT_CHROME,
+    event: {},
+    expectDrop: false,
+  },
+];
+
+for (const c of cases) {
+  test(c.name, () => {
+    const shouldDrop = loadFilter(c.ua);
+    const dropped = shouldDrop(c.event) === true;
+    assert.strictEqual(
+      dropped,
+      c.expectDrop,
+      c.expectDrop
+        ? "expected this event to be dropped as noise"
+        : "expected this event to be PRESERVED (filter is over-suppressing)",
+    );
+  });
+}

--- a/integration/package.json
+++ b/integration/package.json
@@ -17,7 +17,8 @@
     "test:list-card-edit": "node ./list-card-edit.cjs",
     "test:list-view-rename": "node ./list-view-rename.cjs",
     "test:list-bulk-edit": "node ./list-bulk-edit.cjs",
-    "test:dashboard": "node ./dashboard.cjs"
+    "test:dashboard": "node ./dashboard.cjs",
+    "test:error-filter": "node --test ./error-filter.test.cjs"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -1,0 +1,204 @@
+// Sentry `beforeSend` noise filter for the Ultros browser client.
+//
+// Extracted into its own file (instead of living inline in the
+// `error_reporting_script` format! string in lib.rs) so it can be unit
+// tested with Node without standing up a browser — see
+// `integration/error-filter.test.cjs`. The file is `include_str!`'d back
+// into lib.rs and injected verbatim ahead of the Sentry `init`, where it
+// defines `window.__ultrosShouldDropEvent(event)`.
+//
+// It references `window` and `navigator` as free identifiers: in the
+// browser these are the globals; the test wraps the source in
+// `new Function('window', 'navigator', src)` so the same code runs with
+// injected stand-ins. Every predicate is wrapped in try/catch — a noise
+// filter must NEVER throw, or it would drop (or duplicate) real events.
+//
+// We drop several independent categories of unactionable noise:
+//
+//   1. WASM bundle fetch aborts — users navigating away during the
+//      streaming compile, ad blockers, corporate proxies. Two shapes:
+//      a bare "TypeError: Failed to fetch" from the wasm-bindgen glue,
+//      and the ESM-entry "Failed to fetch dynamically imported module:
+//      <pkg-url>" thrown when the module preload/import() of our own
+//      bundle aborts. GlitchTip issues #21, #2374, #2404, and the
+//      count=1 flood of #62xx "Failed to fetch dynamically imported
+//      module: .../pkg/<hash>/ultros.js".
+//   2. A "Cannot read properties of undefined (reading 'document')"
+//      TypeError thrown by an injected third-party script (Tencent QQ
+//      Browser / UC / WeChat in-app WebViews on frozen Chrome 112).
+//      GlitchTip issues #1, #7, #313, #770, #1047, #2776–#2812.
+//   3. tachys hydration `unreachable!()` panics at
+//      /tachys-*/src/hydration.rs:* triggered by the same population
+//      when an injected auto-translation overlay wraps text nodes in
+//      <font> elements before Leptos hydrates. Matched on the exact
+//      crates.io path AND a fingerprint of the injecting browser so
+//      legit hydration mismatches on current browsers still reach
+//      GlitchTip. Issues #678, #707, #770, #1307, #2277, #2775, #4951,
+//      #4905.
+//   4. "Non-Error promise rejection captured with value: undefined"
+//      (and the null variant) — Sentry's synthetic wrapper for a promise
+//      rejected with no reason. Zero diagnostic value (no message, no
+//      stack), overwhelmingly third-party (gtag / funding-choices / ads)
+//      or aborted fetches. The count=1 flood of #62xx "UnhandledRejection".
+(function () {
+  var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
+  var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
+  var ULTROS_INJECTOR_BREADCRUMB = "检测页面稳定";
+  // The frozen-Chrome-112 in-app WebView population (Tencent QQ / UC /
+  // WeChat) that injects the translation + page-stability overlays. Chrome
+  // 112 shipped April 2023; any live, self-updating browser is many majors
+  // past it, so matching the 112 UA targets the stuck WebViews without
+  // catching real users on current browsers.
+  var ULTROS_FROZEN_CHROME_RE = /\bChrome\/112\./;
+
+  // Live User-Agent. Read from `navigator` because the `browser`/`os` tags
+  // shown in GlitchTip are derived SERVER-SIDE from the request UA header
+  // and are NOT present on the event during client-side beforeSend.
+  function userAgent() {
+    try {
+      return (typeof navigator !== "undefined" && navigator.userAgent) || "";
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function firstException(event) {
+    return (
+      event &&
+      event.exception &&
+      event.exception.values &&
+      event.exception.values[0]
+    );
+  }
+
+  function isUltrosWasmFetchAbort(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex) return false;
+      if (ex.type !== "TypeError" || typeof ex.value !== "string") return false;
+
+      // "WebAssembly compilation aborted: ..." — always network/abort.
+      if (ex.value.indexOf("WebAssembly compilation aborted") === 0) {
+        return true;
+      }
+
+      // "TypeError: Failed to fetch" originating from the wasm-bindgen
+      // glue loading /pkg/<hash>/ultros.{js,wasm}.
+      if (ex.value === "Failed to fetch") {
+        var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+        for (var i = 0; i < frames.length; i++) {
+          var fname = frames[i] && frames[i].filename;
+          if (typeof fname === "string" && ULTROS_PKG_BUNDLE_RE.test(fname)) {
+            return true;
+          }
+        }
+      }
+
+      // "Failed to fetch dynamically imported module: <url>" — the ESM
+      // entry import() / modulepreload of our own bundle aborting. Unlike
+      // the bare "Failed to fetch" above, the pkg URL is carried in the
+      // message itself rather than a stack frame, so match the regex
+      // against the value. Scoped to /pkg/<hash>/ultros.{js,wasm} so a
+      // failed import of a genuine third-party module still reports.
+      if (
+        ex.value.indexOf("Failed to fetch dynamically imported module") === 0 &&
+        ULTROS_PKG_BUNDLE_RE.test(ex.value)
+      ) {
+        return true;
+      }
+    } catch (_) {
+      /* be defensive — never let the filter throw */
+    }
+    return false;
+  }
+
+  function isInjectedDocumentTypeError(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex) return false;
+      if (ex.type !== "TypeError") return false;
+      if (ex.value !== "Cannot read properties of undefined (reading 'document')")
+        return false;
+      var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+      if (frames.length !== 1) return false;
+      return frames[0] && frames[0].function === "HTMLDocument.c";
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
+  function isInjectedTachysHydrationPanic(event) {
+    try {
+      var ctx = event && event.contexts && event.contexts.rust_panic;
+      var loc = ctx && ctx.location;
+      if (typeof loc !== "string") return false;
+      if (loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") !== 0)
+        return false;
+      if (!ULTROS_TACHYS_HYDRATION_RE.test(loc)) return false;
+
+      // Second prong: only suppress when the third-party DOM mutation
+      // fingerprint is present. Either a breadcrumb from the page-stability
+      // detector, or the frozen Chrome 112 UA shared by the affected
+      // WebView population.
+      var crumbs =
+        (event.breadcrumbs && event.breadcrumbs.values) ||
+        event.breadcrumbs ||
+        [];
+      if (Array.isArray(crumbs)) {
+        for (var i = 0; i < crumbs.length; i++) {
+          var msg = crumbs[i] && crumbs[i].message;
+          if (
+            typeof msg === "string" &&
+            msg.indexOf(ULTROS_INJECTOR_BREADCRUMB) !== -1
+          ) {
+            return true;
+          }
+        }
+      }
+      // Server-derived tag, kept for any ingestion path that pre-populates
+      // it — but it is normally ABSENT during client-side beforeSend...
+      var tags = event.tags || {};
+      if (tags.browser === "Chrome 112.0.0") {
+        return true;
+      }
+      // ...so the live navigator UA is the signal that actually fires here.
+      if (ULTROS_FROZEN_CHROME_RE.test(userAgent())) {
+        return true;
+      }
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
+  function isEmptyPromiseRejection(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex || typeof ex.value !== "string") return false;
+      // Sentry's synthetic wrapper for a promise rejected with no reason.
+      // value: undefined / null carries no message and no stack — there is
+      // nothing to act on, and it is overwhelmingly third-party (gtag /
+      // funding-choices / ads) or an aborted fetch. Exact-match keeps it
+      // narrow: a rejection carrying a real value renders "with value: ..."
+      // and is preserved.
+      return (
+        ex.value ===
+          "Non-Error promise rejection captured with value: undefined" ||
+        ex.value === "Non-Error promise rejection captured with value: null"
+      );
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
+  window.__ultrosShouldDropEvent = function (event) {
+    return (
+      isUltrosWasmFetchAbort(event) ||
+      isInjectedDocumentTypeError(event) ||
+      isInjectedTachysHydrationPanic(event) ||
+      isEmptyPromiseRejection(event)
+    );
+  };
+})();

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -138,6 +138,9 @@ fn error_reporting_script() -> Option<String> {
         .unwrap_or_else(|_| "https://browser.sentry-cdn.com/10.52.0/bundle.min.js".to_string());
     let config = serde_json::to_string(&config).expect("Sentry config should serialize");
     let sdk_url = serde_json::to_string(&sdk_url).expect("SDK URL should serialize");
+    // The beforeSend noise filter, injected verbatim via the {filter_js}
+    // placeholder below. Lives in its own file so Node can unit-test it.
+    let filter_js = include_str!("error_filter.js");
 
     Some(format!(
         r#"(function(){{
@@ -161,106 +164,19 @@ fn error_reporting_script() -> Option<String> {
         }});
     }};
 
-    // Patterns for unactionable noise we drop in beforeSend. Three
-    // independent categories, each with its own narrow predicate:
-    //
-    // 1. WASM bundle fetch aborts from the Sentry SDK's global
-    //    unhandledrejection handler — users navigating away during the
-    //    streaming compile, ad blockers, corporate proxies. GlitchTip
-    //    issues #21 (~880 events), #2374, #2404.
-    // 2. A "Cannot read properties of undefined (reading 'document')"
-    //    TypeError thrown by an injected third-party script (Tencent QQ
-    //    Browser / UC / WeChat in-app WebViews on frozen Chrome 112).
-    //    Filename in the stack frame is the page URL so each affected
-    //    route becomes its own GlitchTip issue — hundreds of duplicates.
-    //    GlitchTip issues #1, #7, #313, #770, #1047, #2776–#2812.
-    // 3. tachys hydration `unreachable!()` panics at
-    //    /tachys-*/src/hydration.rs:* triggered by the same population
-    //    when the injected auto-translation overlay wraps text nodes in
-    //    <font> elements before Leptos hydrates. We match on the exact
-    //    crates.io path AND a fingerprint of the injecting browser
-    //    (Chinese console breadcrumb `检测页面稳定` or frozen
-    //    Chrome 112.0.0 UA) so legit hydration mismatches on current
-    //    browsers still reach GlitchTip. Issues #678, #707, #770, #1307,
-    //    #2277, #2775.
-    var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
-    var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
-    var ULTROS_INJECTOR_BREADCRUMB = "检测页面稳定";
-
-    function isUltrosWasmFetchAbort(event) {{
-        try {{
-            var ex = event && event.exception && event.exception.values && event.exception.values[0];
-            if (!ex) return false;
-
-            // "WebAssembly compilation aborted: ..." — always network/abort.
-            if (ex.type === "TypeError" && typeof ex.value === "string"
-                && ex.value.indexOf("WebAssembly compilation aborted") === 0) {{
-                return true;
-            }}
-
-            // "TypeError: Failed to fetch" originating from the wasm-bindgen
-            // glue loading /pkg/<hash>/ultros.{{js,wasm}}.
-            if (ex.type === "TypeError" && ex.value === "Failed to fetch") {{
-                var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
-                for (var i = 0; i < frames.length; i++) {{
-                    var fname = frames[i] && frames[i].filename;
-                    if (typeof fname === "string" && ULTROS_PKG_BUNDLE_RE.test(fname)) {{
-                        return true;
-                    }}
-                }}
-            }}
-        }} catch (_) {{ /* be defensive — never let the filter throw */ }}
-        return false;
-    }}
-
-    function isInjectedDocumentTypeError(event) {{
-        try {{
-            var ex = event && event.exception && event.exception.values && event.exception.values[0];
-            if (!ex) return false;
-            if (ex.type !== "TypeError") return false;
-            if (ex.value !== "Cannot read properties of undefined (reading 'document')") return false;
-            var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
-            if (frames.length !== 1) return false;
-            return frames[0] && frames[0].function === "HTMLDocument.c";
-        }} catch (_) {{ /* never let the filter throw */ }}
-        return false;
-    }}
-
-    function isInjectedTachysHydrationPanic(event) {{
-        try {{
-            var ctx = event && event.contexts && event.contexts.rust_panic;
-            var loc = ctx && ctx.location;
-            if (typeof loc !== "string") return false;
-            if (loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") !== 0) return false;
-            if (!ULTROS_TACHYS_HYDRATION_RE.test(loc)) return false;
-
-            // Second prong: only suppress when the third-party DOM
-            // mutation fingerprint is present. Either a breadcrumb from
-            // the page-stability detector, or the frozen Chrome 112 UA
-            // shared by the affected WebView population.
-            var crumbs = (event.breadcrumbs && event.breadcrumbs.values) || event.breadcrumbs || [];
-            if (Array.isArray(crumbs)) {{
-                for (var i = 0; i < crumbs.length; i++) {{
-                    var msg = crumbs[i] && crumbs[i].message;
-                    if (typeof msg === "string" && msg.indexOf(ULTROS_INJECTOR_BREADCRUMB) !== -1) {{
-                        return true;
-                    }}
-                }}
-            }}
-            var tags = event.tags || {{}};
-            if (tags.browser === "Chrome 112.0.0") {{
-                return true;
-            }}
-        }} catch (_) {{ /* never let the filter throw */ }}
-        return false;
-    }}
+    // Unactionable-noise filter. Defines window.__ultrosShouldDropEvent,
+    // which classifies WASM/bundle fetch aborts, injected-WebView document
+    // TypeErrors, injected-translation tachys hydration panics, and empty
+    // promise rejections. Extracted to error_filter.js so it can be unit
+    // tested with Node (see integration/error-filter.test.cjs); injected
+    // here verbatim. Its single braces are safe because it arrives as a
+    // format! argument value, not part of the format string literal.
+{filter_js}
 
     var existingBeforeSend = config && config.beforeSend;
     config = config || {{}};
     config.beforeSend = function(event, hint) {{
-        if (isUltrosWasmFetchAbort(event)
-            || isInjectedDocumentTypeError(event)
-            || isInjectedTachysHydrationPanic(event)) {{
+        if (window.__ultrosShouldDropEvent && window.__ultrosShouldDropEvent(event)) {{
             return null;
         }}
         if (typeof existingBeforeSend === "function") {{
@@ -627,5 +543,41 @@ fn SentryRouteTag() -> impl IntoView {
             let path = location.pathname.get();
             set_sentry_tag("route", &path);
         });
+    }
+}
+
+#[cfg(test)]
+mod error_filter_wiring {
+    /// The beforeSend noise filter is maintained in error_filter.js and
+    /// pulled into the reporting script via `include_str!`. The JS logic is
+    /// exercised by `integration/error-filter.test.cjs`; this test guards the
+    /// Rust↔JS contract — that the file is still compiled in and still carries
+    /// each predicate's load-bearing token. If someone deletes one of these,
+    /// the corresponding GlitchTip flood silently returns.
+    const FILTER_JS: &str = include_str!("error_filter.js");
+
+    #[test]
+    fn filter_defines_the_drop_predicate_called_by_before_send() {
+        assert!(
+            FILTER_JS.contains("window.__ultrosShouldDropEvent ="),
+            "error_filter.js must define the predicate beforeSend invokes",
+        );
+    }
+
+    #[test]
+    fn filter_keeps_each_noise_category_signal() {
+        // Category 1: bundle fetch aborts, incl. the dynamic-import variant.
+        assert!(FILTER_JS.contains("Failed to fetch dynamically imported module"));
+        assert!(FILTER_JS.contains("WebAssembly compilation aborted"));
+        // Category 2: injected-WebView document TypeError.
+        assert!(FILTER_JS.contains("HTMLDocument.c"));
+        // Category 3: frozen-Chrome-112 translate-overlay hydration panic.
+        // Must read the live UA (the browser tag is server-derived and absent
+        // in beforeSend), so the navigator read is the load-bearing part.
+        assert!(FILTER_JS.contains("ULTROS_FROZEN_CHROME_RE"));
+        assert!(FILTER_JS.contains("navigator.userAgent"));
+        assert!(FILTER_JS.contains("hydration.rs"));
+        // Category 4: empty promise rejections.
+        assert!(FILTER_JS.contains("Non-Error promise rejection captured with value: undefined"));
     }
 }


### PR DESCRIPTION
## What & why

GlitchTip triage. The top recurring errors on the board are a cluster of
`RustWasmPanic` hydration panics on `/items/jobset/<JOB>` — **#707 (×50)**,
**#2775 (×42)**, **#4951 (×11)**, **#4905 (×13)** — plus two count=1 floods that
create a brand-new issue every few minutes (**"Failed to fetch dynamically
imported module"** #6276/#6275/#6243/… and **"Non-Error promise rejection
captured with value: undefined"** #6273/#6272/…).

All three are *unactionable client/external noise* the app already tries to drop
in the Sentry `beforeSend` filter — but the filter was silently letting them
through.

### Root cause (the hydration cluster)

The `beforeSend` prong that suppresses the frozen-Chrome-112 in-app-WebView
population (Tencent QQ / UC / WeChat, whose injected auto-translation overlay
wraps text nodes in `<font>` and trips tachys' hydration walker at
`hydration.rs:227`) fingerprinted that population with:

```js
if (event.tags.browser === "Chrome 112.0.0") return true;
```

But `browser`/`os` tags are **derived server-side by GlitchTip from the request
User-Agent header** — they do **not** exist on the event at client-side
`beforeSend` time. I confirmed this from #707's latest event: it carries
`browser = Chrome 112.0.0` *and* `rust_panic.location =
tachys-0.2.15/src/hydration.rs:227` (so it *should* have been dropped) yet still
reached GlitchTip. The only client-visible signal that works is the
`检测页面稳定` breadcrumb prong — and this variant doesn't emit it, so it leaked.

## The fix (error-reporting only — no app behavior change)

Extracted the filter from the inline `error_reporting_script` `format!` string
into [`error_filter.js`](ultros-frontend/ultros-app/src/error_filter.js)
(`include_str!`'d back in) so it can be unit-tested, and:

1. **Frozen-Chrome-112 prong** now reads `navigator.userAgent` (regex
   `/\bChrome\/112\./`) instead of the absent server tag. The old tag check is
   kept as a harmless fallback. Chrome 112 shipped Apr 2023, so this targets the
   stuck WebViews without touching real users on current browsers — a hydration
   panic on a current browser is still reported (would be a real bug).
2. **Dynamic-import abort**: drop `TypeError: Failed to fetch dynamically
   imported module: …/pkg/<hash>/ultros.{js,wasm}` (ESM entry import of our own
   bundle aborting — navigation-away, ad blockers, CDN hiccups). Scoped to the
   pkg bundle, so a failed import of a genuine third-party module still reports.
3. **Empty promise rejections**: drop the exact `Non-Error promise rejection
   captured with value: undefined` / `… null` (Sentry's wrapper for a rejection
   with no reason — no message, no stack). A rejection carrying a real value
   still reports.

## Verification

- **Node unit test** [`integration/error-filter.test.cjs`](integration/error-filter.test.cjs)
  (`node --test`, 15 cases). Written test-first: the 3 leak repros went RED
  against the current filter, GREEN after the fix. Includes over-suppression
  guards proving these are **preserved**: a hydration panic on a current
  browser, a real app `Error`, a bare `Failed to fetch` from an API frame, a
  dynamic-import failure of a non-pkg module, and a rejection with a real value.
- **`cargo test -p ultros-app --lib error_filter_wiring`** — guards the Rust↔JS
  contract (file still `include_str!`'d, each predicate's load-bearing token
  present). 2/2 pass.
- `cargo fmt --all -- --check` clean. `cargo check -p ultros-app --lib` ✓.
  `cargo clippy -p ultros-app --all-targets -- -D warnings` clean. (Full-workspace
  clippy not run — no other crate changed; submodules were initialized to build.)

## Backlog triage actions for a human

I attempted to mark the now-source-suppressed cluster (#707, #2775, #4951,
#4905) as **ignored** in GlitchTip, but the write was blocked by the auto-mode
classifier (expected). Recommendation once this deploys:

- **Ignore/resolve** #707, #2775, #4951, #4905 — external injected-translation
  panics, now dropped at the source.
- The count=1 floods (#6276/#6273/…) get a unique fingerprint each time, so
  per-issue ignoring is whack-a-mole; this filter is the durable fix. The
  existing ones will age out.
- **Not addressed here:** #4 ("RuntimeError: unreachable", ×901) is the JS-level
  wasm-trap echo of these same panics *plus* an unrelated (already-fixed)
  spawn_local subset, so it's a mixed bag — left alone deliberately rather than
  broadly suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
