### PR TITLE
feat: interactive price chart + sparklines on ultros_charts (removes leptos-chartistry)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,19 +4441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leptos-chartistry"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777b6bb2100427b4e5f6c64ec659a27c253b69f4a78ccd58f4bcc5d39c6dcffb"
-dependencies = [
- "chrono",
- "leptos",
- "leptos-use",
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "leptos-use"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9782,7 +9769,6 @@ dependencies = [
  "itertools",
  "js-sys",
  "leptos",
- "leptos-chartistry",
  "leptos-use",
  "leptos_axum",
  "leptos_hotkeys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9822,6 +9822,7 @@ dependencies = [
  "chrono",
  "image",
  "itertools",
+ "leptos",
  "resvg",
  "ultros-api-types",
  "ultros-xiv-icons",

--- a/docs/superpowers/plans/2026-06-09-ultros-charts-pr2-web-chart.md
+++ b/docs/superpowers/plans/2026-06-09-ultros-charts-pr2-web-chart.md
@@ -1,0 +1,1755 @@
+# ultros_charts PR 2 — Web Price Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the item-page price-history chart from the ultros_charts scene graph with full interactivity (crosshair, tooltip, legend, toggles), and remove leptos-chartistry from the workspace.
+
+**Architecture:** The core gains `build_price_history_chart` returning a `PriceChartModel` (the existing `Scene` plus a `HoverModel` of bucket positions/values, series metadata, and stats). A new `leptos` feature in ultros-charts renders any `Scene` as SVG view nodes (`scene_view`). The app's `price_history_chart.rs` shrinks to wiring: it builds the model in a memo (responsive width, viewer-timezone labels via a post-hydration offset signal — the established hydration-gate pattern), embeds `scene_view`, and adds the hover overlay, HTML tooltip, controls, stats strip, and legend with the existing i18n keys. Spec: `docs/superpowers/specs/2026-06-09-ultros-charts-design.md`.
+
+**Tech Stack:** Rust edition 2024, leptos 0.8 (workspace, nightly feature), leptos-use (`use_element_bounding`), chrono. No new third-party deps.
+
+---
+
+## Context for the implementer
+
+- Workspace root: `C:\Users\chw11\code\ultros`. PR 1 already landed: `ultros-frontend/ultros-charts` is the scene-graph crate (36 tests; `charts/price_history.rs` builds the `Scene`, `svg.rs` serializes it for the server PNG path in `ultros/src/web/item_card.rs` — that path must keep working untouched).
+- The current web chart is `ultros-frontend/ultros-app/src/components/price_history_chart.rs` (~1050 lines on leptos-chartistry). Its only instantiation is `ultros-frontend/ultros-app/src/routes/item_view.rs` (ChartWrapper, which owns the 7/30/90/All window selector, the outlier-filter toggle, and the `hydrated`-gated time cutoff — **item_view.rs does not change in this PR**; the component props stay identical).
+- **Hydration safety is a hard requirement.** This codebase has a history of tachys `hydration.rs:227` panics from SSR/CSR divergence. The rules this plan follows: anything viewer-dependent (timezone, measured container width) starts at a deterministic default (offset 0 / width 960) for both SSR and first client render, and only changes via `Effect`/leptos-use signals after hydration. Do not introduce `Local::now()`/`Utc::now()`/measurements into the initial render path.
+- **i18n:** this PR introduces NO new user-visible strings — every label reuses existing keys (`chart_toggle_market_avg`, `chart_legend_trend`, `chart_legend_quantity`, `chart_legend_market_avg`, `chart_color_*`, `chart_stat_*`, `chart_no_sales_in_window`, `chart_aria_label`, `chart_range_*`). If you find yourself adding a new string, STOP: per CLAUDE.md it must be added to all 7 locale files with real translations — report it instead of improvising.
+- Tests per task: `cargo test -p ultros-charts` (fast). Full `./check_ci.sh` only at the end.
+- The working tree has unrelated dirt (`.jules/palette.md`, `.mcp.json`, the universalis-assets submodule pointer). NEVER `git add -A`; stage explicit paths. Commit messages end with `-m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"`.
+- Branch for this PR: `ultros-charts-web` (created in Task 1).
+
+### Task 1: Grouping levels in core
+
+The web chart lets the user override the grouping level (Region/Datacenter/World); the core currently only auto-picks. Move the level-based grouping (and the scope-based availability rule) from the app into `data/grouping.rs`, refactoring `group_sales_by_scope` to be the auto wrapper.
+
+**Files:**
+- Modify: `ultros-frontend/ultros-charts/src/data/grouping.rs`
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git checkout -b ultros-charts-web
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to the test module in `data/grouping.rs`:
+
+```rust
+    #[test]
+    fn explicit_level_overrides_auto() {
+        // Sales on one DC would auto-group by world; force datacenter level.
+        let sales = vec![sale(100, 1, 1, ts(0)), sale(200, 1, 2, ts(10))];
+        let series = group_sales_by_level(&world_helper(), &sales, GroupLevel::Datacenter);
+        assert_eq!(names(&series), vec!["Aether"]);
+        assert_eq!(series[0].points.len(), 2);
+        let series = group_sales_by_level(&world_helper(), &sales, GroupLevel::Region);
+        assert_eq!(names(&series), vec!["North-America"]);
+    }
+
+    #[test]
+    fn auto_level_matches_scope_cascade() {
+        let h = world_helper();
+        // one DC → world level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 2, ts(0))]),
+            GroupLevel::World
+        );
+        // two DCs, one region → datacenter level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 3, ts(0))]),
+            GroupLevel::Datacenter
+        );
+        // two regions → region level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 4, ts(0))]),
+            GroupLevel::Region
+        );
+    }
+
+    #[test]
+    fn available_levels_follow_the_viewed_scope() {
+        let h = world_helper();
+        assert_eq!(available_group_levels(&h, "Gilgamesh"), vec![GroupLevel::World]);
+        assert_eq!(
+            available_group_levels(&h, "Aether"),
+            vec![GroupLevel::Datacenter, GroupLevel::World]
+        );
+        assert_eq!(
+            available_group_levels(&h, "North-America"),
+            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+        );
+        assert_eq!(
+            available_group_levels(&h, "Not A Scope"),
+            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+        );
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo test -p ultros-charts grouping`
+Expected: FAIL to compile (`GroupLevel` etc. not found).
+
+- [ ] **Step 4: Write the implementation**
+
+In `data/grouping.rs`, add below the `Series` struct (new imports: `std::collections::BTreeMap`):
+
+```rust
+/// Which level of the world hierarchy to roll sales up to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GroupLevel {
+    Region,
+    Datacenter,
+    World,
+}
+
+impl GroupLevel {
+    /// Stable identifier (list keys / debugging); user-facing names come
+    /// from the app's i18n layer.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Region => "Region",
+            Self::Datacenter => "Datacenter",
+            Self::World => "World",
+        }
+    }
+}
+
+/// Group sales at an explicit hierarchy level. Sales whose world id isn't in
+/// the helper are dropped. Series sort by name; points by timestamp.
+pub fn group_sales_by_level(
+    world_helper: &WorldHelper,
+    sales: &[SaleHistory],
+    level: GroupLevel,
+) -> Vec<Series> {
+    let mut groups = BTreeMap::<AnySelector, Series>::new();
+    for sale in sales {
+        let Some(world) = world_helper
+            .lookup_selector(AnySelector::World(sale.world_id))
+            .and_then(|r| r.as_world())
+        else {
+            continue;
+        };
+        let selector = match level {
+            GroupLevel::World => AnySelector::World(world.id),
+            GroupLevel::Datacenter => AnySelector::Datacenter(world.datacenter_id),
+            GroupLevel::Region => {
+                let Some(datacenter) = world_helper
+                    .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                    .and_then(|r| r.as_datacenter())
+                else {
+                    continue;
+                };
+                AnySelector::Region(datacenter.region_id)
+            }
+        };
+        let Some(result) = world_helper.lookup_selector(selector) else {
+            continue;
+        };
+        groups
+            .entry(selector)
+            .or_insert_with(|| Series {
+                name: result.get_name().to_string(),
+                points: Vec::new(),
+            })
+            .points
+            .push(SalePoint {
+                ts: sale.sold_date,
+                price: sale.price_per_item,
+                quantity: sale.quantity,
+            });
+    }
+    let mut series: Vec<Series> = groups
+        .into_values()
+        .sorted_by_cached_key(|series| series.name.clone())
+        .collect();
+    for series in &mut series {
+        series.points.sort_by_key(|p| p.ts);
+    }
+    series
+}
+
+/// The narrowest level that still yields multiple groups — the old
+/// `group_sales_by_scope` cascade.
+pub fn auto_group_level(world_helper: &WorldHelper, sales: &[SaleHistory]) -> GroupLevel {
+    let world_ids: HashSet<_> = sales
+        .iter()
+        .map(|s| AnySelector::World(s.world_id))
+        .collect();
+    let datacenters: HashSet<_> = world_ids
+        .iter()
+        .flat_map(|world| {
+            world_helper
+                .lookup_selector(*world)
+                .and_then(|s| s.as_world())
+                .map(|w| AnySelector::Datacenter(w.datacenter_id))
+        })
+        .collect();
+    let regions: HashSet<_> = datacenters
+        .iter()
+        .flat_map(|dc| {
+            world_helper
+                .lookup_selector(*dc)
+                .and_then(|dc| dc.as_datacenter())
+                .map(|dc| AnySelector::Region(dc.region_id))
+        })
+        .collect();
+    if datacenters.len() <= 1 {
+        GroupLevel::World
+    } else if regions.len() <= 1 {
+        GroupLevel::Datacenter
+    } else {
+        GroupLevel::Region
+    }
+}
+
+/// Which grouping levels make sense for the scope page being viewed —
+/// ported from the web UI (a world page only offers World; a DC page offers
+/// DC + World; a region page or unknown scope offers everything).
+pub fn available_group_levels(world_helper: &WorldHelper, scope_name: &str) -> Vec<GroupLevel> {
+    match world_helper.lookup_world_by_name(scope_name) {
+        Some(result) if result.as_world().is_some() => vec![GroupLevel::World],
+        Some(result) if result.as_datacenter().is_some() => {
+            vec![GroupLevel::Datacenter, GroupLevel::World]
+        }
+        _ => vec![
+            GroupLevel::Region,
+            GroupLevel::Datacenter,
+            GroupLevel::World,
+        ],
+    }
+}
+```
+
+Then REPLACE the existing `group_sales_by_scope` and DELETE the now-unused private `series_for` helper:
+
+```rust
+/// Auto-picked grouping (the PNG path): the narrowest level that still
+/// yields multiple groups.
+pub fn group_sales_by_scope(world_helper: &WorldHelper, sales: &[SaleHistory]) -> Vec<Series> {
+    group_sales_by_level(world_helper, sales, auto_group_level(world_helper, sales))
+}
+```
+
+(Note: the old region-page arm matched `result.as_region().is_some()` separately; since the fallback arm returns the same vec, the match above folds them — behavior is identical.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p ultros-charts`
+Expected: PASS — all pre-existing grouping tests (including `unknown_worlds_are_dropped` and the scope-cascade tests) must still pass against the refactored implementation, plus the 3 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultros-frontend/ultros-charts/src/data/grouping.rs
+git commit -m "feat(charts): explicit grouping levels and scope-based availability" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 2: PriceChartModel — hover data, stats, label offset
+
+**Files:**
+- Modify: `ultros-frontend/ultros-charts/src/charts/price_history.rs`
+- Modify: `ultros-frontend/ultros-charts/src/scale.rs` (ticks signature gains a label offset)
+- Modify: `ultros-frontend/ultros-charts/src/data/buckets.rs` (volume from SalePoints, so hidden series drop out of the volume lane too)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the test module of `charts/price_history.rs`:
+
+```rust
+    #[test]
+    fn model_exposes_hover_buckets_series_and_stats() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
+        assert_eq!(model.series.len(), 2);
+        assert!(!model.hover.buckets.is_empty());
+        for bucket in &model.hover.buckets {
+            assert_eq!(bucket.series_values.len(), 2);
+            assert!(!bucket.label.is_empty());
+        }
+        // sorted by x
+        assert!(
+            model
+                .hover
+                .buckets
+                .windows(2)
+                .all(|w| w[0].x <= w[1].x)
+        );
+        let stats = model.stats.expect("stats for non-empty sales");
+        assert_eq!(stats.n, 20);
+        assert!(stats.min <= stats.max);
+        assert!(stats.market_average.is_some());
+    }
+
+    #[test]
+    fn nearest_index_snaps_to_the_closest_bucket() {
+        let hover = HoverModel {
+            plot_top: 0.0,
+            plot_bottom: 100.0,
+            buckets: [10.0_f32, 20.0, 30.0]
+                .iter()
+                .map(|x| HoverBucket {
+                    x: *x,
+                    label: String::new(),
+                    series_values: Vec::new(),
+                    volume: 0,
+                })
+                .collect(),
+        };
+        assert_eq!(hover.nearest_index(-5.0), Some(0));
+        assert_eq!(hover.nearest_index(14.0), Some(0));
+        assert_eq!(hover.nearest_index(16.0), Some(1));
+        assert_eq!(hover.nearest_index(99.0), Some(2));
+        let empty = HoverModel {
+            plot_top: 0.0,
+            plot_bottom: 0.0,
+            buckets: Vec::new(),
+        };
+        assert_eq!(empty.nearest_index(10.0), None);
+    }
+
+    #[test]
+    fn scene_function_delegates_to_the_model() {
+        let scene =
+            build_price_history_scene(&world_helper(), &two_world_sales(), &PriceChartOptions::default());
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
+        assert_eq!(scene, model.scene);
+    }
+
+    #[test]
+    fn hidden_series_are_excluded_from_drawing_but_kept_in_metadata() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions {
+                hidden_series: vec!["Gilgamesh".to_string()],
+                ..Default::default()
+            },
+        );
+        // Both series stay in metadata (the legend needs the hidden one to
+        // offer un-hiding), flagged appropriately.
+        assert_eq!(model.series.len(), 2);
+        assert!(model.series.iter().any(|s| s.hidden));
+        assert!(model.series.iter().any(|s| !s.hidden));
+        // Only the visible series draws — and a single visible series gets
+        // the area fill.
+        let polylines = model
+            .scene
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Polyline { .. }))
+            .count();
+        assert_eq!(polylines, 1);
+        let areas = model
+            .scene
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Area { .. }))
+            .count();
+        assert_eq!(areas, 1);
+        // Hover keeps full-length series_values with None at the hidden slot
+        // (series sort by name: Adamantoise=0, Gilgamesh=1).
+        for bucket in &model.hover.buckets {
+            assert_eq!(bucket.series_values.len(), 2);
+            assert!(bucket.series_values[1].is_none());
+        }
+    }
+
+    #[test]
+    fn hiding_every_series_yields_the_no_data_card_but_keeps_metadata() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions {
+                hidden_series: vec!["Gilgamesh".to_string(), "Adamantoise".to_string()],
+                ..Default::default()
+            },
+        );
+        assert!(model.hover.buckets.is_empty());
+        assert_eq!(model.series.len(), 2, "legend must still offer un-hiding");
+    }
+
+    #[test]
+    fn empty_sales_yield_empty_model_with_no_data_scene() {
+        let model =
+            build_price_history_chart(&world_helper(), &[], &PriceChartOptions::default());
+        assert!(model.hover.buckets.is_empty());
+        assert!(model.stats.is_none());
+        assert!(model.scene.nodes.iter().any(
+            |n| matches!(n, Node::Text { content, .. } if content == "No recent sales")
+        ));
+    }
+```
+
+And to the test module of `scale.rs`:
+
+```rust
+    #[test]
+    fn tick_labels_shift_with_offset_but_positions_do_not() {
+        let scale = TimeScale::new(ts(1_700_000_000), ts(1_700_000_000 + 2 * 3600), (0.0, 100.0));
+        let utc = scale.ticks(6, 0);
+        let shifted = scale.ticks(6, 60);
+        assert_eq!(utc.len(), shifted.len());
+        assert_eq!(utc[0].ts, shifted[0].ts);
+        assert_ne!(utc[0].label, shifted[0].label);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p ultros-charts`
+Expected: FAIL to compile.
+
+- [ ] **Step 3: Change the TimeScale ticks signature**
+
+In `scale.rs`: add `TimeDelta` to the chrono import, and change `ticks` to:
+
+```rust
+    /// At most `target` ticks aligned to step boundaries. `label_offset_minutes`
+    /// shifts the LABEL text only (viewer-local display); tick positions stay
+    /// UTC-aligned so SSR and client geometry agree.
+    pub fn ticks(&self, target: usize, label_offset_minutes: i32) -> Vec<TimeTick> {
+        let span = self.end - self.start;
+        let step = TIME_STEPS
+            .iter()
+            .copied()
+            .find(|step| span / step <= target as i64)
+            .unwrap_or(365 * DAY);
+        let format = if step < HOUR {
+            "%H:%M"
+        } else if step < DAY {
+            "%m-%d %H:%M"
+        } else if step < 30 * DAY {
+            "%m-%d"
+        } else {
+            "%Y-%m"
+        };
+        let mut tick = self.start.div_euclid(step) * step;
+        if tick < self.start {
+            tick += step;
+        }
+        let mut out = Vec::new();
+        while tick <= self.end {
+            if let Some(ts) = chrono::DateTime::from_timestamp(tick, 0) {
+                let ts = ts.naive_utc();
+                let display = ts + TimeDelta::minutes(label_offset_minutes as i64);
+                out.push(TimeTick {
+                    ts,
+                    label: display.format(format).to_string(),
+                });
+            }
+            tick += step;
+        }
+        out
+    }
+```
+
+Update the two existing `ticks(6)` calls in scale.rs's tests to `ticks(6, 0)`.
+
+- [ ] **Step 4: Extend charts/price_history.rs**
+
+New imports at the top of the file:
+
+```rust
+use std::collections::BTreeMap;
+```
+
+and extend the existing import lines: add `NaiveDateTime` is NOT needed; add `Color` to the `crate::scene` import, `median, vwap` (replacing the lone `vwap`) on `crate::data::stats`, and replace the grouping import with:
+
+```rust
+use crate::data::grouping::{GroupLevel, auto_group_level, group_sales_by_level};
+```
+
+Add to `PriceChartOptions` (and its `Default`: `group_level: None, utc_offset_minutes: 0`):
+
+```rust
+    /// Grouping level for series; `None` = pick automatically from the data
+    /// scope (what the PNG path wants).
+    pub group_level: Option<GroupLevel>,
+    /// Shift applied to axis/tooltip LABELS so the browser can show
+    /// viewer-local times. Bucket boundaries and geometry stay UTC-aligned;
+    /// keep 0 for SSR and PNG so server and first client render agree.
+    pub utc_offset_minutes: i32,
+    /// Series names the user hid via the legend. They stay in the model's
+    /// `series` metadata (flagged `hidden`) but draw nothing, feed no hover
+    /// values, and don't influence the axes.
+    pub hidden_series: Vec<String>,
+```
+
+(Default adds `hidden_series: Vec::new()`.)
+
+Add the model types above `build_price_history_chart`:
+
+```rust
+#[derive(Clone, Debug, PartialEq)]
+pub struct SeriesInfo {
+    pub name: String,
+    pub color: Color,
+    /// True when the user hid this series via the legend; it stays listed so
+    /// the legend can offer un-hiding.
+    pub hidden: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChartStats {
+    pub n: usize,
+    pub market_average: Option<i32>,
+    pub median: Option<i32>,
+    pub min: i32,
+    pub max: i32,
+}
+
+/// One hoverable time bucket: pixel x of the bucket center, a display label
+/// (already offset to viewer time), per-series `(y_px, vwap)` (None where a
+/// series has no sales in the bucket), and total volume.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HoverBucket {
+    pub x: f32,
+    pub label: String,
+    pub series_values: Vec<Option<(f32, f64)>>,
+    pub volume: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HoverModel {
+    /// Vertical extent for the crosshair line.
+    pub plot_top: f32,
+    pub plot_bottom: f32,
+    /// Sorted by x ascending.
+    pub buckets: Vec<HoverBucket>,
+}
+
+impl HoverModel {
+    /// Index of the bucket whose center is closest to pixel `x`.
+    pub fn nearest_index(&self, x: f32) -> Option<usize> {
+        if self.buckets.is_empty() {
+            return None;
+        }
+        let i = self.buckets.partition_point(|b| b.x < x);
+        if i == 0 {
+            return Some(0);
+        }
+        if i >= self.buckets.len() {
+            return Some(self.buckets.len() - 1);
+        }
+        if (x - self.buckets[i - 1].x) <= (self.buckets[i].x - x) {
+            Some(i - 1)
+        } else {
+            Some(i)
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PriceChartModel {
+    pub scene: Scene,
+    pub hover: HoverModel,
+    pub series: Vec<SeriesInfo>,
+    pub stats: Option<ChartStats>,
+    /// The level actually used (resolves `group_level: None`).
+    pub group_level: GroupLevel,
+}
+```
+
+Rename `build_price_history_scene` to `build_price_history_chart` returning `PriceChartModel`, then add a thin delegate so the PNG path (`item_card.rs`, `png_smoke.rs`, the example) compiles unchanged:
+
+```rust
+pub fn build_price_history_scene(
+    world_helper: &WorldHelper,
+    sales: &[SaleHistory],
+    options: &PriceChartOptions,
+) -> Scene {
+    build_price_history_chart(world_helper, sales, options).scene
+}
+```
+
+Inside `build_price_history_chart`, make these changes to the existing body:
+
+a) Grouping — replace the `group_sales_by_scope` call. Colors index the FULL series list so a series keeps its color while hidden, and `all_points` (which drives the axes, stats, and overlays) iterates only visible series:
+
+```rust
+    let level = options
+        .group_level
+        .unwrap_or_else(|| auto_group_level(world_helper, &sales));
+    let series = group_sales_by_level(world_helper, &sales, level);
+    let is_hidden = |name: &str| options.hidden_series.iter().any(|h| h == name);
+    let series_info: Vec<SeriesInfo> = series
+        .iter()
+        .enumerate()
+        .map(|(index, group)| SeriesInfo {
+            name: group.name.clone(),
+            color: theme.palette[index % theme.palette.len()],
+            hidden: is_hidden(&group.name),
+        })
+        .collect();
+    let all_points = || {
+        series
+            .iter()
+            .filter(|s| !is_hidden(&s.name))
+            .flat_map(|s| s.points.iter())
+    };
+    let visible_count = series.iter().filter(|s| !is_hidden(&s.name)).count();
+```
+
+(This REPLACES the existing `let all_points = ...` closure — delete the old one.)
+
+b) The empty-data early return becomes:
+
+```rust
+    let Some((first_ts, last_ts)) = all_points().map(|p| p.ts).minmax().into_option() else {
+        scene.nodes.push(Node::Text {
+            x: options.width / 2.0,
+            y: options.height / 2.0,
+            content: "No recent sales".to_string(),
+            size: 22.0,
+            color: theme.text_muted,
+            anchor: TextAnchor::Middle,
+            bold: false,
+        });
+        return PriceChartModel {
+            scene,
+            hover: HoverModel {
+                plot_top: 0.0,
+                plot_bottom: 0.0,
+                buckets: Vec::new(),
+            },
+            series: series_info,
+            stats: None,
+            group_level: level,
+        };
+    };
+```
+
+c) After `(min_price, max_price)` is computed, build the stats:
+
+```rust
+    let stats = {
+        let prices: Vec<i32> = all_points().map(|p| p.price).collect();
+        let pairs: Vec<(i32, i32)> = all_points().map(|p| (p.price, p.quantity)).collect();
+        Some(ChartStats {
+            n: prices.len(),
+            market_average: vwap(&pairs),
+            median: median(&prices),
+            min: min_price,
+            max: max_price,
+        })
+    };
+```
+
+d) The x-tick loop adapts its density to the width and passes the offset:
+
+```rust
+    let x_tick_target = ((options.width / 150.0) as usize).clamp(3, 8);
+    for tick in time.ticks(x_tick_target, options.utc_offset_minutes) {
+```
+
+(960px keeps the current 6 ticks.)
+
+e) Volume buckets move OUT of the `if options.show_volume` block (they feed hover regardless) and now aggregate the VISIBLE series' points instead of the raw sales (so hidden series drop out of the volume lane, and unknown-world sales — already absent from every series — no longer sneak into volume). First add to `data/buckets.rs`:
+
+```rust
+/// Total quantity per bucket over grouped sale points (the chart feeds the
+/// visible series' points here so hidden series don't count).
+pub fn volume_buckets_from_points<'a>(
+    points: impl Iterator<Item = &'a SalePoint>,
+    bucket_secs: i64,
+) -> Vec<VolumeBucket> {
+    if bucket_secs <= 0 {
+        return Vec::new();
+    }
+    let mut sums: BTreeMap<i64, i64> = BTreeMap::new();
+    for point in points {
+        let bucket = point.ts.and_utc().timestamp().div_euclid(bucket_secs) * bucket_secs;
+        *sums.entry(bucket).or_default() += point.quantity as i64;
+    }
+    sums.into_iter()
+        .filter_map(|(bucket, quantity)| {
+            chrono::DateTime::from_timestamp(bucket, 0).map(|ts| VolumeBucket {
+                ts: ts.naive_utc(),
+                quantity,
+            })
+        })
+        .collect()
+}
+```
+
+DELETE the old `volume_buckets` (its only caller was this chart) and rewrite its test to the new function:
+
+```rust
+    #[test]
+    fn volume_buckets_sum_quantities() {
+        let points = vec![
+            SalePoint { ts: ts(0), price: 100, quantity: 2 },
+            SalePoint { ts: ts(60), price: 100, quantity: 3 },
+            SalePoint { ts: ts(86_400), price: 100, quantity: 5 },
+        ];
+        let buckets = volume_buckets_from_points(points.iter(), 86_400);
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0].quantity, 5);
+        assert_eq!(buckets[1].quantity, 5);
+    }
+```
+
+Then in the chart (the `use crate::data::buckets::...` import swaps `volume_buckets` for `volume_buckets_from_points`):
+
+```rust
+    let volumes = volume_buckets_from_points(all_points(), bucket_secs);
+    if options.show_volume {
+        if let Some(max_volume) = volumes.iter().map(|v| v.quantity).max() {
+            // ... existing bar-drawing code unchanged ...
+        }
+    }
+```
+
+f) The VWAP-line loop skips hidden series and fills a hover map; the raw-dots loop above it gets the same `if series_info[index].hidden { continue; }` guard. Replace the line loop with:
+
+```rust
+    let mut hover_map: BTreeMap<i64, Vec<Option<(f32, f64)>>> = BTreeMap::new();
+    for (index, group) in series.iter().enumerate() {
+        if series_info[index].hidden {
+            continue;
+        }
+        let color = series_color(index);
+        let buckets = vwap_buckets(&group.points, bucket_secs);
+        for point in &buckets {
+            // key by bucket START so it aligns with the volume buckets
+            let key = point.ts.and_utc().timestamp() - bucket_secs / 2;
+            hover_map.entry(key).or_insert_with(|| vec![None; series.len()])[index] =
+                Some((price.scale(point.vwap), point.vwap));
+        }
+        let line: Vec<(f32, f32)> = buckets
+            .into_iter()
+            .map(|p| (time.scale(p.ts), price.scale(p.vwap)))
+            .collect();
+        if line.len() > 1 {
+            if visible_count == 1 {
+                scene.nodes.push(Node::Area {
+                    points: line.clone(),
+                    baseline_y: price_bottom,
+                    fill: color.with_alpha(0.08),
+                });
+            }
+            scene.nodes.push(Node::Polyline {
+                points: line,
+                stroke: Stroke {
+                    color,
+                    width: 2.0,
+                    dash: None,
+                },
+            });
+        }
+    }
+```
+
+(Note `visible_count == 1` replaces the old `series.len() == 1` for the area fill, and the legend block near the end keeps using the full `series` list — hidden chips must still render in the PNG legend? No: the PNG path never sets `hidden_series`, so the legend block is unaffected; leave it untouched.)
+
+g) At the end of the function (after the title/legend block), assemble and return:
+
+```rust
+    let mut volume_by_bucket: BTreeMap<i64, i64> = volumes
+        .iter()
+        .map(|v| (v.ts.and_utc().timestamp(), v.quantity))
+        .collect();
+    let label_format = if bucket_secs < 86_400 {
+        "%m-%d %H:%M"
+    } else {
+        "%Y-%m-%d"
+    };
+    let hover_buckets: Vec<HoverBucket> = hover_map
+        .into_iter()
+        .filter_map(|(start, series_values)| {
+            let center = chrono::DateTime::from_timestamp(start + bucket_secs / 2, 0)?.naive_utc();
+            let display = center + TimeDelta::minutes(options.utc_offset_minutes as i64);
+            Some(HoverBucket {
+                x: time.scale(center),
+                label: display.format(label_format).to_string(),
+                series_values,
+                volume: volume_by_bucket.remove(&start).unwrap_or(0),
+            })
+        })
+        .collect();
+
+    PriceChartModel {
+        scene,
+        hover: HoverModel {
+            plot_top,
+            plot_bottom,
+            buckets: hover_buckets,
+        },
+        series: series_info,
+        stats,
+        group_level: level,
+    }
+```
+
+(The `series_color` closure and everything else stays as is. `TimeDelta` is already imported in this file from PR 1.)
+
+- [ ] **Step 5: Run the full crate tests**
+
+Run: `cargo test -p ultros-charts --features image`
+Expected: PASS — all existing tests (including png_smoke and the structural scene tests) plus the 5 new ones. The scene snapshot behavior must be unchanged: `scene_function_delegates_to_the_model` plus the untouched `renders_lines_dots_volume_and_labels` prove it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultros-frontend/ultros-charts/src/charts/price_history.rs ultros-frontend/ultros-charts/src/scale.rs
+git commit -m "feat(charts): PriceChartModel with hover buckets, stats, and label offset" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: `leptos` feature — scene_view renderer
+
+**Files:**
+- Modify: `ultros-frontend/ultros-charts/Cargo.toml`
+- Modify: `ultros-frontend/ultros-charts/src/svg.rs` (share two helpers)
+- Create: `ultros-frontend/ultros-charts/src/components.rs`
+- Modify: `ultros-frontend/ultros-charts/src/lib.rs`
+
+- [ ] **Step 1: Wire the feature**
+
+In `ultros-frontend/ultros-charts/Cargo.toml`:
+
+```toml
+[features]
+image = ["dep:ultros-xiv-icons", "dep:image", "dep:base64"]
+leptos = ["dep:leptos"]
+```
+
+Add to `[dependencies]`:
+
+```toml
+leptos = { workspace = true, optional = true }
+```
+
+Add to `[dev-dependencies]` (SSR rendering for the unit test; feature-unified only for this crate's tests):
+
+```toml
+leptos = { workspace = true, features = ["ssr"] }
+```
+
+- [ ] **Step 2: Share the geometry serializers**
+
+In `svg.rs`: change `fn points_attr` to `pub(crate) fn points_attr`, and extract the Area path construction into a shared helper (replace the body of the `Node::Area` match arm to use it):
+
+```rust
+/// Path data for a filled area: the polyline plus a closing run along the
+/// baseline. `None` for fewer than 2 points.
+pub(crate) fn area_path_d(points: &[(f32, f32)], baseline_y: f32) -> Option<String> {
+    if points.len() < 2 {
+        return None;
+    }
+    let mut d = String::new();
+    for (i, (x, y)) in points.iter().enumerate() {
+        let _ = write!(d, "{}{x:.1} {y:.1}", if i == 0 { "M" } else { "L" });
+    }
+    let first_x = points[0].0;
+    let last_x = points[points.len() - 1].0;
+    let _ = write!(d, "L{last_x:.1} {baseline_y:.1}L{first_x:.1} {baseline_y:.1}Z");
+    Some(d)
+}
+```
+
+New Area arm in `scene_to_svg`:
+
+```rust
+            Node::Area {
+                points,
+                baseline_y,
+                fill,
+            } => {
+                let Some(d) = area_path_d(points, *baseline_y) else {
+                    continue;
+                };
+                let _ = write!(out, r#"<path d="{d}""#);
+                push_fill(&mut out, fill);
+                out.push_str("/>");
+            }
+```
+
+Run `cargo test -p ultros-charts svg` — the existing serializer tests must still pass byte-for-byte.
+
+- [ ] **Step 3: Write the failing component test**
+
+Create `src/components.rs` with only the test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scene::{Color, Node, Scene, Stroke, TextAnchor};
+    use leptos::prelude::*;
+
+    #[test]
+    fn renders_scene_nodes_as_svg_markup() {
+        let scene = Scene {
+            width: 100.0,
+            height: 50.0,
+            background: Some(Color::hex("#202124")),
+            font_family: "sans-serif".to_string(),
+            nodes: vec![
+                Node::Circle {
+                    cx: 5.0,
+                    cy: 5.0,
+                    r: 2.0,
+                    fill: Color::rgb(9, 9, 9).with_alpha(0.5),
+                },
+                Node::Polyline {
+                    points: vec![(0.0, 0.0), (5.0, 5.0)],
+                    stroke: Stroke {
+                        color: Color::rgb(0, 0, 255),
+                        width: 2.0,
+                        dash: Some((2.0, 4.0)),
+                    },
+                },
+                Node::Area {
+                    points: vec![(0.0, 10.0), (5.0, 5.0)],
+                    baseline_y: 20.0,
+                    fill: Color::rgb(1, 2, 3),
+                },
+                Node::Text {
+                    x: 1.0,
+                    y: 1.0,
+                    content: "hi".to_string(),
+                    size: 13.0,
+                    color: Color::rgb(0, 0, 0),
+                    anchor: TextAnchor::Middle,
+                    bold: true,
+                },
+            ],
+        };
+        let html = scene_view(&scene).to_html();
+        assert!(html.contains("<rect"), "background rect: {html}");
+        assert!(html.contains("rgba(9,9,9,0.500)"));
+        assert!(html.contains("<polyline"));
+        assert!(html.contains("stroke-dasharray=\"2.0 4.0\""));
+        assert!(html.contains("<path"));
+        assert!(html.contains("text-anchor=\"middle\""));
+        assert!(html.contains(">hi</text>"));
+    }
+}
+```
+
+Add to `lib.rs` (below the icon block):
+
+```rust
+#[cfg(feature = "leptos")]
+pub mod components;
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cargo test -p ultros-charts --features leptos components`
+Expected: FAIL to compile (`scene_view` missing).
+
+- [ ] **Step 5: Write the implementation**
+
+Prepend to `components.rs`:
+
+```rust
+//! Leptos renderer over [`Scene`] — the browser counterpart of [`crate::svg`].
+//!
+//! [`scene_view`] maps display-list nodes to SVG view nodes. It renders a
+//! snapshot of the scene; reactivity comes from the caller rebuilding the
+//! scene inside a memo/closure. Hover layers are drawn by the app on top.
+
+use leptos::prelude::*;
+
+use crate::scene::{Color, Node, Scene, Stroke, TextAnchor};
+use crate::svg::{area_path_d, points_attr};
+
+/// CSS color string. Browsers accept `rgba()`, so unlike the resvg-bound
+/// serializer this needs no separate `*-opacity` attributes.
+pub fn color_attr(c: &Color) -> String {
+    if c.a >= 1.0 {
+        format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)
+    } else {
+        format!("rgba({},{},{},{:.3})", c.r, c.g, c.b, c.a)
+    }
+}
+
+fn px(v: f32) -> String {
+    format!("{v:.1}")
+}
+
+fn dash_attr(stroke: &Stroke) -> Option<String> {
+    stroke.dash.map(|(dash, gap)| format!("{dash:.1} {gap:.1}"))
+}
+
+/// Render the scene's nodes (plus its background) as SVG children. Embed
+/// inside an `<svg viewBox="0 0 {scene.width} {scene.height}">`.
+pub fn scene_view(scene: &Scene) -> impl IntoView {
+    let background = scene.background.as_ref().map(|bg| {
+        view! {
+            <rect x="0" y="0" width=px(scene.width) height=px(scene.height) fill=color_attr(bg) />
+        }
+    });
+    let nodes = scene.nodes.iter().map(node_view).collect_view();
+    view! {
+        {background}
+        <g font-family=scene.font_family.clone()>{nodes}</g>
+    }
+}
+
+fn node_view(node: &Node) -> AnyView {
+    match node {
+        Node::Rect {
+            x,
+            y,
+            width,
+            height,
+            rx,
+            fill,
+        } => view! {
+            <rect
+                x=px(*x)
+                y=px(*y)
+                width=px(*width)
+                height=px(*height)
+                rx=(*rx > 0.0).then(|| px(*rx))
+                fill=color_attr(fill)
+            />
+        }
+        .into_any(),
+        Node::Line {
+            x1,
+            y1,
+            x2,
+            y2,
+            stroke,
+        } => view! {
+            <line
+                x1=px(*x1)
+                y1=px(*y1)
+                x2=px(*x2)
+                y2=px(*y2)
+                stroke=color_attr(&stroke.color)
+                stroke-width=px(stroke.width)
+                stroke-linecap="round"
+                stroke-dasharray=dash_attr(stroke)
+            />
+        }
+        .into_any(),
+        Node::Polyline { points, stroke } => view! {
+            <polyline
+                points=points_attr(points)
+                fill="none"
+                stroke=color_attr(&stroke.color)
+                stroke-width=px(stroke.width)
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-dasharray=dash_attr(stroke)
+            />
+        }
+        .into_any(),
+        Node::Area {
+            points,
+            baseline_y,
+            fill,
+        } => match area_path_d(points, *baseline_y) {
+            Some(d) => view! { <path d=d fill=color_attr(fill) /> }.into_any(),
+            None => ().into_any(),
+        },
+        Node::Circle { cx, cy, r, fill } => view! {
+            <circle cx=px(*cx) cy=px(*cy) r=px(*r) fill=color_attr(fill) />
+        }
+        .into_any(),
+        Node::Text {
+            x,
+            y,
+            content,
+            size,
+            color,
+            anchor,
+            bold,
+        } => {
+            let anchor = match anchor {
+                TextAnchor::Start => "start",
+                TextAnchor::Middle => "middle",
+                TextAnchor::End => "end",
+            };
+            view! {
+                <text
+                    x=px(*x)
+                    y=px(*y)
+                    font-size=px(*size)
+                    text-anchor=anchor
+                    font-weight=bold.then_some("bold")
+                    fill=color_attr(color)
+                >
+                    {content.clone()}
+                </text>
+            }
+            .into_any()
+        }
+        Node::Image {
+            x,
+            y,
+            width,
+            height,
+            href,
+        } => view! {
+            <image x=px(*x) y=px(*y) width=px(*width) height=px(*height) href=href.clone() />
+        }
+        .into_any(),
+    }
+}
+```
+
+If `().into_any()` doesn't satisfy the type checker on this leptos version, use `view! { <g></g> }.into_any()` for the empty-Area arm and note it.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test -p ultros-charts --features leptos` and then `cargo test -p ultros-charts --features image` (the non-leptos config must stay green).
+Expected: PASS both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ultros-frontend/ultros-charts/Cargo.toml ultros-frontend/ultros-charts/src/components.rs ultros-frontend/ultros-charts/src/svg.rs ultros-frontend/ultros-charts/src/lib.rs Cargo.lock
+git commit -m "feat(charts): leptos feature with scene_view SVG renderer" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 4: Rewrite the app component, remove leptos-chartistry
+
+**Files:**
+- Modify: `ultros-frontend/ultros-app/Cargo.toml`
+- Rewrite: `ultros-frontend/ultros-app/src/components/price_history_chart.rs`
+- Maybe modify: `style/tailwind.css` (remove chartistry-only CSS)
+- DO NOT TOUCH: `ultros-frontend/ultros-app/src/routes/item_view.rs` (props are unchanged), any locale file.
+
+- [ ] **Step 1: Cargo changes**
+
+In `ultros-frontend/ultros-app/Cargo.toml`: delete the `leptos-chartistry = "0.2.3"` line and change the ultros-charts dep to:
+
+```toml
+ultros-charts = { path = "../ultros-charts", features = ["leptos"] }
+```
+
+- [ ] **Step 2: Rewrite price_history_chart.rs**
+
+Replace the entire file. The controls/markup below intentionally reproduce the current UI (same classes, same i18n keys); the chartistry plumbing, the `CATEGORY_PALETTE` const, the local `ColorBy` enum, the duplicated math helpers (`vwap`/`median`/`iqr_band`/`short_number`/`bucket_quantities`/`quantity_bucket_seconds`/`x_axis_periods`/`group_sales_by_level`), the `marker_css` `<style>` hack, and the in-file tests (their coverage moved to ultros-charts in Tasks 1–2) all go away.
+
+```rust
+use leptos::prelude::*;
+use leptos_use::{UseElementBoundingReturn, use_element_bounding};
+use ultros_api_types::SaleHistory;
+use ultros_charts::charts::price_history::{
+    ChartStats, PriceChartModel, PriceChartOptions, build_price_history_chart,
+};
+use ultros_charts::components::{color_attr, scene_view};
+use ultros_charts::data::grouping::{GroupLevel, available_group_levels};
+use ultros_charts::scale::short_number;
+use ultros_charts::theme::Theme;
+
+use crate::global_state::LocalWorldData;
+use crate::i18n::{t, t_string, use_i18n};
+
+fn px(v: f32) -> String {
+    format!("{v:.1}")
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+#[component]
+fn StatsStrip(stats: Signal<Option<ChartStats>>) -> impl IntoView {
+    let i18n = use_i18n();
+    view! {
+        {move || {
+            stats
+                .get()
+                .map(|s| {
+                    let n_label = t_string!(i18n, chart_stat_n_sales)
+                        .to_string()
+                        .replace("{n}", &s.n.to_string());
+                    let market_average_label =
+                        t_string!(i18n, chart_stat_market_avg).to_string();
+                    let median_label = t_string!(i18n, chart_stat_median).to_string();
+                    let min_label = t_string!(i18n, chart_stat_min).to_string();
+                    let max_label = t_string!(i18n, chart_stat_max).to_string();
+                    view! {
+                        <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums text-[color:var(--color-text)]/70 mb-3">
+                            <span>{n_label}</span>
+                            {s
+                                .market_average
+                                .map(|v| {
+                                    view! {
+                                        <span>
+                                            {market_average_label.clone()} " " {short_number(v)}
+                                        </span>
+                                    }
+                                })}
+                            {s
+                                .median
+                                .map(|v| {
+                                    view! {
+                                        <span>
+                                            {median_label} " " {short_number(v)}
+                                        </span>
+                                    }
+                                })}
+                            <span>{min_label} " " {short_number(s.min)}</span>
+                            <span>{max_label} " " {short_number(s.max)}</span>
+                        </div>
+                    }
+                        .into_any()
+                })
+        }}
+    }
+}
+
+#[component]
+fn ChartOverlayToggle(
+    label: String,
+    #[prop(into)] checked: Signal<bool>,
+    set_checked: WriteSignal<bool>,
+) -> impl IntoView {
+    view! {
+        <label
+            class=move || {
+                [
+                    "inline-flex cursor-pointer select-none items-center gap-1.5 rounded-md border px-2.5 py-1 transition-colors",
+                    if checked.get() {
+                        "border-brand-500/60 bg-brand-700/30 text-brand-100"
+                    } else {
+                        "border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,_var(--color-text)_4%,_transparent)] text-[color:var(--color-text-muted)]"
+                    },
+                ]
+                    .join(" ")
+            }
+        >
+            <input
+                class="sr-only"
+                type="checkbox"
+                prop:checked=checked
+                on:change=move |event| set_checked.set(event_target_checked(&event))
+            />
+            <span
+                class=move || {
+                    [
+                        "h-2 w-2 rounded-full",
+                        if checked.get() { "bg-brand-300" } else { "bg-[color:var(--color-text-muted)]/45" },
+                    ]
+                        .join(" ")
+                }
+            ></span>
+            {label}
+        </label>
+    }
+}
+
+#[component]
+fn ColorByControl(
+    #[prop(into)] options: Signal<Vec<GroupLevel>>,
+    #[prop(into)] selected: Signal<GroupLevel>,
+    set_selected: WriteSignal<GroupLevel>,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    view! {
+        <Show when=move || options.with(|options| options.len() > 1)>
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+                <span class="font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                    {t!(i18n, chart_color_by)}
+                </span>
+                <div class="inline-flex overflow-hidden rounded-md border border-[color:var(--color-outline)]">
+                <For
+                    each=move || options.get()
+                    key=|option| option.label()
+                    children=move |option| {
+                        view! {
+                            <button
+                                type="button"
+                                class=move || {
+                                    let active = selected.get() == option;
+                                    [
+                                        "border-l border-[color:var(--color-outline)] px-2.5 py-1 transition-colors first:border-l-0",
+                                        if active {
+                                            "bg-brand-600/30 text-brand-100"
+                                        } else {
+                                            "bg-[color:color-mix(in_srgb,_var(--color-text)_4%,_transparent)] text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)]"
+                                        },
+                                    ]
+                                        .join(" ")
+                                }
+                                on:click=move |_| set_selected.set(option)
+                            >
+                                {match option {
+                                    GroupLevel::Region => t_string!(i18n, chart_color_region).to_string(),
+                                    GroupLevel::Datacenter => t_string!(i18n, chart_color_datacenter).to_string(),
+                                    GroupLevel::World => t_string!(i18n, chart_color_world).to_string(),
+                                }}
+                            </button>
+                        }
+                    }
+                />
+                </div>
+            </div>
+        </Show>
+    }
+}
+
+/// Crosshair + per-series dots at the hovered bucket. Lives INSIDE the
+/// chart's `<svg>` so it shares the viewBox coordinate space.
+#[component]
+fn HoverLayer(
+    model: Memo<PriceChartModel>,
+    hover_index: RwSignal<Option<usize>>,
+) -> impl IntoView {
+    move || {
+        hover_index.get().and_then(|i| {
+            model.with(|m| {
+                let bucket = m.hover.buckets.get(i)?;
+                let dots = bucket
+                    .series_values
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(series_index, value)| {
+                        let (y, _) = (*value)?;
+                        let color = m.series.get(series_index)?.color;
+                        Some(view! {
+                            <circle
+                                cx=px(bucket.x)
+                                cy=px(y)
+                                r="4"
+                                fill=color_attr(&color)
+                                stroke="#16131f"
+                                stroke-width="1.5"
+                            />
+                        })
+                    })
+                    .collect_view();
+                Some(view! {
+                    <g class="pointer-events-none">
+                        <line
+                            x1=px(bucket.x)
+                            y1=px(m.hover.plot_top)
+                            x2=px(bucket.x)
+                            y2=px(m.hover.plot_bottom)
+                            stroke="#9ca3af"
+                            stroke-opacity="0.45"
+                            stroke-width="1"
+                        />
+                        {dots}
+                    </g>
+                })
+            })
+        })
+    }
+}
+
+/// HTML tooltip positioned over the chart container; flips to the left of
+/// the crosshair past the midpoint so it never clips on the right edge.
+#[component]
+fn HoverTooltip(
+    model: Memo<PriceChartModel>,
+    hover_index: RwSignal<Option<usize>>,
+    #[prop(into)] show_quantity: Signal<bool>,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    move || {
+        hover_index.get().and_then(|i| {
+            model.with(|m| {
+                let bucket = m.hover.buckets.get(i)?.clone();
+                let series = m.series.clone();
+                let left_pct = (bucket.x / m.scene.width * 100.0).clamp(0.0, 100.0);
+                let style = if left_pct > 55.0 {
+                    format!("left:calc({left_pct:.1}% - 12px);transform:translateX(-100%)")
+                } else {
+                    format!("left:calc({left_pct:.1}% + 12px)")
+                };
+                Some(view! {
+                    <div
+                        class="pointer-events-none absolute top-2 z-10 min-w-36 rounded-md border border-[color:var(--color-outline)] bg-violet-950/95 px-3 py-2 text-xs shadow-lg"
+                        style=style
+                    >
+                        <div class="mb-1 font-semibold text-[color:var(--color-text)]">
+                            {bucket.label.clone()}
+                        </div>
+                        {series
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(series_index, info)| {
+                                let (_, vwap) =
+                                    bucket.series_values.get(series_index).copied().flatten()?;
+                                Some(view! {
+                                    <div class="flex items-center justify-between gap-3">
+                                        <span class="inline-flex items-center gap-1.5">
+                                            <span
+                                                class="inline-block h-2 w-2 rounded-full"
+                                                style:background-color=color_attr(&info.color)
+                                            ></span>
+                                            <span class="text-[color:var(--color-text-muted)]">
+                                                {info.name.clone()}
+                                            </span>
+                                        </span>
+                                        <span class="tabular-nums text-[color:var(--color-text)]">
+                                            {short_number(vwap.round() as i32)}
+                                        </span>
+                                    </div>
+                                })
+                            })
+                            .collect_view()}
+                        {show_quantity
+                            .get()
+                            .then(|| {
+                                view! {
+                                    <div class="mt-1 flex items-center justify-between gap-3 border-t border-[color:var(--color-outline)]/60 pt-1">
+                                        <span class="text-[color:var(--color-text-muted)]">
+                                            {t!(i18n, chart_legend_quantity)}
+                                        </span>
+                                        <span class="tabular-nums text-[color:var(--color-text)]">
+                                            {bucket.volume}
+                                        </span>
+                                    </div>
+                                }
+                            })}
+                    </div>
+                })
+            })
+        })
+    }
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+#[component]
+pub fn PriceHistoryChart(
+    #[prop(into)] sales: Signal<Vec<SaleHistory>>,
+    #[prop(into)] filter_outliers: Signal<bool>,
+    #[prop(into)] scope_name: Signal<String>,
+    /// Selected days window from the parent (7 / 30 / 90 / 0 for All).
+    #[prop(into)]
+    days_range: Signal<i32>,
+) -> impl IntoView {
+    let local_world_data = use_context::<LocalWorldData>().unwrap();
+    let helper = local_world_data.0.unwrap();
+    let i18n = use_i18n();
+    let (show_market_average, set_show_market_average) = signal(true);
+    let (show_trend, set_show_trend) = signal(false);
+    let (show_quantity, set_show_quantity) = signal(false);
+    let (color_by, set_color_by) = signal(GroupLevel::World);
+    // Series the user hid by clicking legend chips. Stored as a sorted Vec so
+    // the model memo's PartialEq sees a stable value.
+    let hidden_series = RwSignal::new(Vec::<String>::new());
+
+    // Viewer timezone for axis/tooltip LABELS only. SSR and the first client
+    // render agree on 0 (UTC); this effect shifts the labels after hydration
+    // — same idea as ChartWrapper's `hydrated` gate, so tachys never sees
+    // divergent markup. Bucketing/geometry are timezone-independent.
+    let utc_offset = RwSignal::new(0i32);
+    Effect::new(move |_| {
+        utc_offset.set(chrono::Local::now().offset().local_minus_utc() / 60);
+    });
+
+    // Responsive: rebuild the scene at the measured container width so text
+    // renders at natural size instead of scaling down. Unmeasured (SSR and
+    // first client render) falls back to 960, and leptos-use only updates
+    // the signal post-mount — hydration-safe for the same reason as above.
+    let container = NodeRef::<leptos::html::Div>::new();
+    let UseElementBoundingReturn {
+        left: container_left,
+        width: container_width,
+        ..
+    } = use_element_bounding(container);
+
+    let helper_for_options = helper.clone();
+    let color_by_options =
+        Memo::new(move |_| available_group_levels(&helper_for_options, &scope_name.get()));
+    let effective_color_by = Memo::new(move |_| {
+        let selected = color_by.get();
+        let options = color_by_options.get();
+        if options.contains(&selected) {
+            selected
+        } else {
+            *options.last().unwrap_or(&GroupLevel::World)
+        }
+    });
+
+    let helper_for_model = helper.clone();
+    let model = Memo::new(move |_| {
+        let sales = sales.get();
+        let measured = container_width.get() as f32;
+        let width = if measured > 0.0 {
+            measured.clamp(320.0, 1600.0)
+        } else {
+            960.0
+        };
+        let height = (width * 0.56).clamp(300.0, 540.0);
+        build_price_history_chart(
+            &helper_for_model,
+            &sales,
+            &PriceChartOptions {
+                width,
+                height,
+                remove_outliers: filter_outliers.get(),
+                show_market_average: show_market_average.get(),
+                show_trendline: show_trend.get(),
+                show_volume: show_quantity.get(),
+                show_legend: false,
+                title: None,
+                icon_data_uri: None,
+                days_range: Some(days_range.get()),
+                group_level: Some(effective_color_by.get()),
+                utc_offset_minutes: utc_offset.get(),
+                hidden_series: hidden_series.get(),
+                theme: Theme::site(),
+            },
+        )
+    });
+
+    let stats = Signal::derive(move || model.with(|m| m.stats.clone()));
+    let hover_index = RwSignal::new(None::<usize>);
+
+    let on_pointer_move = move |evt: web_sys::PointerEvent| {
+        let width = container_width.get_untracked();
+        if width <= 0.0 {
+            return;
+        }
+        let x_css = evt.client_x() as f64 - container_left.get_untracked();
+        let index = model.with_untracked(|m| {
+            m.hover
+                .nearest_index((x_css / width) as f32 * m.scene.width)
+        });
+        hover_index.set(index);
+    };
+
+    view! {
+        <div class="flex flex-col gap-3">
+            <StatsStrip stats=stats />
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_toggle_market_avg).to_string()
+                    checked=show_market_average
+                    set_checked=set_show_market_average
+                />
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_legend_trend).to_string()
+                    checked=show_trend
+                    set_checked=set_show_trend
+                />
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_legend_quantity).to_string()
+                    checked=show_quantity
+                    set_checked=set_show_quantity
+                />
+            </div>
+            <ColorByControl options=color_by_options selected=effective_color_by set_selected=set_color_by />
+            <div
+                role="img"
+                aria-label=move || {
+                    let n = stats.get().map(|s| s.n).unwrap_or(0);
+                    let (from, to) = model.with(|m| {
+                        (
+                            m.hover.buckets.first().map(|b| b.label.clone()).unwrap_or_default(),
+                            m.hover.buckets.last().map(|b| b.label.clone()).unwrap_or_default(),
+                        )
+                    });
+                    t_string!(i18n, chart_aria_label)
+                        .to_string()
+                        .replace("{n}", &n.to_string())
+                        .replace("{from}", &from)
+                        .replace("{to}", &to)
+                }
+                class="price-history-chart relative w-full overflow-visible"
+                node_ref=container
+                on:pointermove=on_pointer_move
+                on:pointerleave=move |_| hover_index.set(None)
+            >
+                {move || {
+                    let m = model.get();
+                    if m.hover.buckets.is_empty() {
+                        let msg = t_string!(i18n, chart_no_sales_in_window).to_string();
+                        return view! {
+                            <div class="flex items-center justify-center w-full h-full text-[color:var(--color-text)]/60 text-sm">
+                                {msg}
+                            </div>
+                        }
+                            .into_any();
+                    }
+                    view! {
+                        <svg
+                            class="block w-full h-auto"
+                            viewBox=format!("0 0 {:.0} {:.0}", m.scene.width, m.scene.height)
+                            preserveAspectRatio="xMidYMid meet"
+                        >
+                            {scene_view(&m.scene)}
+                            <HoverLayer model=model hover_index=hover_index />
+                        </svg>
+                    }
+                        .into_any()
+                }}
+                <HoverTooltip model=model hover_index=hover_index show_quantity=show_quantity />
+            </div>
+            {move || {
+                let m = model.get();
+                (!m.series.is_empty())
+                    .then(|| {
+                        let toggleable = m.series.len() > 1;
+                        view! {
+                            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
+                                {m
+                                    .series
+                                    .iter()
+                                    .map(|info| {
+                                        let name = info.name.clone();
+                                        let toggle_name = info.name.clone();
+                                        let hidden = info.hidden;
+                                        view! {
+                                            <button
+                                                type="button"
+                                                disabled=!toggleable
+                                                class=[
+                                                    "inline-flex items-center gap-1.5 transition-opacity",
+                                                    if toggleable { "cursor-pointer" } else { "cursor-default" },
+                                                    if hidden { "opacity-40 line-through" } else { "" },
+                                                ]
+                                                    .join(" ")
+                                                on:click=move |_| {
+                                                    if !toggleable {
+                                                        return;
+                                                    }
+                                                    hidden_series
+                                                        .update(|hidden_list| {
+                                                            if let Some(pos) = hidden_list
+                                                                .iter()
+                                                                .position(|n| n == &toggle_name)
+                                                            {
+                                                                hidden_list.remove(pos);
+                                                            } else {
+                                                                hidden_list.push(toggle_name.clone());
+                                                                hidden_list.sort();
+                                                            }
+                                                        });
+                                                }
+                                            >
+                                                <span
+                                                    class="h-2.5 w-2.5 rounded-full ring-1 ring-blue-100/70"
+                                                    style:background-color=color_attr(&info.color)
+                                                ></span>
+                                                {name}
+                                            </button>
+                                        }
+                                    })
+                                    .collect_view()}
+                                {show_market_average
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-0.5 w-5 bg-[#facc15]"></span>
+                                                {t!(i18n, chart_legend_market_avg)}
+                                            </span>
+                                        }
+                                    })}
+                                {show_trend
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-0.5 w-5 bg-[#94a3b8]"></span>
+                                                {t!(i18n, chart_legend_trend)}
+                                            </span>
+                                        }
+                                    })}
+                                {show_quantity
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-2.5 w-3 rounded-sm bg-[#22c55e]"></span>
+                                                {t!(i18n, chart_legend_quantity)}
+                                            </span>
+                                        }
+                                    })}
+                            </div>
+                        }
+                    })
+            }}
+        </div>
+    }
+}
+```
+
+Implementation notes (compile-fix latitude, report anything you change):
+- `web_sys::PointerEvent` — ultros-app's web-sys already lists the `PointerEvent` feature under both ssr and hydrate.
+- If `LocalWorldData`'s field access differs from `local_world_data.0.unwrap()`, copy exactly what the OLD file did at its line 309–310 (you're replacing that file; read it first).
+- The tooltip surface uses `bg-violet-950/95`; if a chart-adjacent surface class exists in `components/tooltip.rs`'s popup, prefer matching that instead — check it and pick the closer match, noting your choice.
+- If `For`'s `key=|option| option.label()` displeases the type checker, use `key=|option| *option` (GroupLevel is Copy+Eq+Hash if you add `Hash` to its derives in core — fine to do, note it).
+
+- [ ] **Step 3: Remove chartistry CSS**
+
+Search `style/tailwind.css` (and `ultros/static/main.css` if present) for `chartistry` / `_chartistry_` / `price-history-chart`. Remove rules that exist solely to style chartistry internals (e.g., `._chartistry_*` selectors). KEEP any rule for `.price-history-chart` itself if it does general layout. Report what you removed.
+
+- [ ] **Step 4: Compile both targets**
+
+```powershell
+cargo check -p ultros-app
+cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown
+```
+
+Both must pass. (The first compiles the ssr default; the second is the WASM client. The wasm32 target is installed — cargo-leptos builds use it.) Fix compile errors minimally; anything structural, stop and report.
+
+- [ ] **Step 5: Run the charts crate tests once more**
+
+Run: `cargo test -p ultros-charts --features "image leptos"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ultros-frontend/ultros-app/Cargo.toml ultros-frontend/ultros-app/src/components/price_history_chart.rs Cargo.lock
+# plus style/tailwind.css if modified
+git commit -m "feat: render the item-page price chart from ultros_charts, drop leptos-chartistry" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Verify chartistry is gone: `rg -i chartistry -g '*.rs' -g '*.toml'` → no hits; Cargo.lock no longer lists `leptos-chartistry` after the check builds.
+
+### Task 5: Browser verification (controller-driven checkpoint)
+
+This task is performed by the CONTROLLER with the chrome-devtools MCP, not a subagent. Bring up the app locally (see `docs/superpowers/plans/...` is not needed — use the documented local-run procedure / `./scripts/run_e2e.sh` with a reused `$BASE_URL` if a server is already running). Then on an item page with sales data:
+
+- [ ] Chart renders (VWAP lines + dots + grid + axis labels), stats strip shows, legend chips correct.
+- [ ] Hover: crosshair + dots + tooltip follow the pointer; tooltip flips sides past the midpoint; leaves cleanly on pointerleave.
+- [ ] Toggles: market avg / trend / quantity redraw correctly; quantity adds the volume lane; Color-by switches series on a DC/region scope.
+- [ ] Legend chips: clicking hides/shows a series (dimmed + line-through while hidden, axes rescale); hiding everything leaves the legend visible so it can be undone.
+- [ ] Window selector (7/30/90/All) still drives the chart; outlier toggle works.
+- [ ] No hydration panic in the console on first load (check console for `hydration` / `unreachable`).
+- [ ] Axis labels show local time after load (offset effect fired) without any flash-of-wrong-markup warnings.
+- [ ] Screenshot desktop + a ~400px-wide emulated viewport (responsive rebuild).
+
+Fixes found here go through small follow-up commits.
+
+### Task 6: CI gate + PR
+
+- [ ] **Step 1:** `cargo fmt --all -- --check` (autofix with `cargo fmt --all` + commit only branch-touched files).
+- [ ] **Step 2:** `cargo clippy --all-targets -- -D warnings` (Strawberry Perl PATH prefix; rerun on timeout — cache resumes). Fix findings in branch-touched files properly; commit.
+- [ ] **Step 3:** Push and open the PR:
+
+```bash
+git push -u origin ultros-charts-web
+gh pr create --title "feat: interactive item-page price chart on ultros_charts (removes leptos-chartistry)" --body "PR 2 of 3 for the ultros_charts rewrite (spec: docs/superpowers/specs/2026-06-09-ultros-charts-design.md).
+
+- ultros-charts: PriceChartModel (hover buckets + stats + series metadata), explicit grouping levels, viewer-timezone label offset, and a new \`leptos\` feature rendering any Scene as SVG view nodes
+- ultros-app: price_history_chart.rs rewritten from ~1050 lines of chartistry plumbing to wiring over the shared model — crosshair + tooltip + toggles preserved with the same i18n keys (no new strings), legend chips now hide/show series, responsive scene rebuild at measured width
+- leptos-chartistry removed from the workspace
+- Hydration safety: timezone offset and container width start at deterministic defaults (UTC / 960px) for SSR + first client render and shift via post-hydration effects — same pattern as the existing hydrated gates
+- The server PNG path (Discord/item card) is untouched: build_price_history_scene delegates to the new model builder, golden behavior covered by existing tests
+
+PR 3 (interactive sparklines) follows.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Out of scope (PR 3)
+
+Interactive `<Sparkline>` (hover dot + micro-tooltip), gap-interpolation port into `data/`, migration of Market Movers / Continue Tracking / Trends / Analyzer, deletion of `sparkline.rs`.

--- a/docs/superpowers/plans/2026-06-09-ultros-charts-pr3-sparklines.md
+++ b/docs/superpowers/plans/2026-06-09-ultros-charts-pr3-sparklines.md
@@ -1,0 +1,361 @@
+# ultros_charts PR 3 — Interactive Sparklines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move sparkline math into ultros_charts and add hover interactivity (dot + micro-tooltip) to the app's `<Sparkline>`, with zero call-site changes.
+
+**Architecture:** Core gains `data/interpolate.rs` (the gap-interpolation, moved verbatim with its tests) and `charts/sparkline.rs` (`build_sparkline` → `SparklineModel`: scaled vertices, interpolated values, trend color, nearest-index hover math). The app's `sparkline.rs` becomes a thin interactive renderer over the model: same polyline by construction, plus a pointer-driven dot and a tooltip showing the value and "Nh ago". Two NEW i18n keys (all 7 locales). Per user instruction this lands on the existing `ultros-charts-web` branch as part of one combined PR.
+
+**Note:** This was originally scoped as PR 3 of the spec (docs/superpowers/specs/2026-06-09-ultros-charts-design.md); the user requested it be folded into the web-chart PR.
+
+---
+
+## Context for the implementer
+
+- Branch `ultros-charts-web` (checked out). The crate already has `scene::Color`, `components::color_attr` (leptos feature), `scale::short_number`.
+- The current component is `ultros-frontend/ultros-app/src/components/sparkline.rs` (~190 lines incl. `interpolate_gaps` + 4 tests). Call sites (UNCHANGED — prop-compatible): market_movers.rs, recently_viewed.rs, trends.rs, analyzer.rs. All sparkline series are hourly VWAP.
+- **i18n:** exactly two new keys, `sparkline_now` and `sparkline_hours_ago` — they MUST be added to ALL 7 locale files (`ultros-frontend/ultros-app/locales/{en,fr,de,ja,cn,ko,tc}.json`, flat structure, place near the `chart_*` keys) with the translations given below. Use the `t_string!(...).replace("{n}", ...)` pattern like `chart_stat_n_sales`.
+- A `cargo leptos serve` watcher may be running — coordinate with the controller; run `cargo test -p ultros-charts` only when told the target lock is free.
+- NEVER `git add -A`. Commit messages end with the Co-Authored-By trailer.
+
+### Task 1: Core sparkline model
+
+**Files:**
+- Create: `ultros-frontend/ultros-charts/src/data/interpolate.rs`
+- Create: `ultros-frontend/ultros-charts/src/charts/sparkline.rs`
+- Modify: `ultros-frontend/ultros-charts/src/data/mod.rs` (+ `pub mod interpolate;`), `src/charts/mod.rs` (+ `pub mod sparkline;`)
+
+- [ ] **Step 1:** Create `data/interpolate.rs` by MOVING `interpolate_gaps` and its 4 tests verbatim from the app's `sparkline.rs` (lines ~115–190), making the function `pub` and adapting the doc comment's first line to module context. Do not change the algorithm.
+
+- [ ] **Step 2:** Write the failing tests in `charts/sparkline.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scales_min_to_bottom_and_max_to_top_inset() {
+        let m = build_sparkline(&[100, 200], 1.0, 80.0, 24.0);
+        assert_eq!(m.points.len(), 2);
+        assert_eq!(m.points[0], (0.0, 22.0)); // min → height - inset
+        assert_eq!(m.points[1], (80.0, 2.0)); // max → inset
+        assert_eq!(m.values, vec![100.0, 200.0]);
+    }
+
+    #[test]
+    fn all_zero_series_is_empty() {
+        let m = build_sparkline(&[0, 0, 0], 0.0, 80.0, 24.0);
+        assert!(m.is_empty());
+        let m = build_sparkline(&[], 0.0, 80.0, 24.0);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn trend_color_follows_pct_change() {
+        use crate::scene::Color;
+        assert_eq!(build_sparkline(&[1, 2], 5.0, 80.0, 24.0).color, Color::hex("#34d399"));
+        assert_eq!(build_sparkline(&[1, 2], -5.0, 80.0, 24.0).color, Color::hex("#f87171"));
+        assert_eq!(build_sparkline(&[1, 2], 0.0, 80.0, 24.0).color, Color::hex("#94a3b8"));
+    }
+
+    #[test]
+    fn nearest_index_snaps_and_clamps() {
+        let m = build_sparkline(&[10, 20, 30], 0.0, 80.0, 24.0); // step = 40
+        assert_eq!(m.nearest_index(-10.0), Some(0));
+        assert_eq!(m.nearest_index(15.0), Some(0));
+        assert_eq!(m.nearest_index(25.0), Some(1));
+        assert_eq!(m.nearest_index(999.0), Some(2));
+        assert_eq!(build_sparkline(&[], 0.0, 80.0, 24.0).nearest_index(10.0), None);
+    }
+}
+```
+
+- [ ] **Step 3:** Run `cargo test -p ultros-charts sparkline` — expect compile failure.
+
+- [ ] **Step 4:** Implement (prepend to `charts/sparkline.rs`):
+
+```rust
+//! Geometry for the tiny inline sparklines (Market Movers, Continue
+//! Tracking, Trends, Analyzer). Same visual rules as the old hand-rolled
+//! component: 2px vertical inset, min→bottom / max→top scaling, gap
+//! interpolation across quiet hours, single trend color.
+
+use crate::data::interpolate::interpolate_gaps;
+use crate::scene::Color;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SparklineModel {
+    pub width: f32,
+    pub height: f32,
+    /// Scaled polyline vertices; empty for an empty/all-zero series.
+    pub points: Vec<(f32, f32)>,
+    /// Interpolated values aligned with `points` (tooltip content).
+    pub values: Vec<f32>,
+    /// Trend color: emerald up, red down, slate flat.
+    pub color: Color,
+}
+
+impl SparklineModel {
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+
+    /// Nearest sample index for pixel `x` (viewBox units).
+    pub fn nearest_index(&self, x: f32) -> Option<usize> {
+        if self.points.is_empty() {
+            return None;
+        }
+        if self.points.len() == 1 {
+            return Some(0);
+        }
+        let step = self.width / (self.points.len() as f32 - 1.0);
+        let index = (x / step).round() as i64;
+        Some(index.clamp(0, self.points.len() as i64 - 1) as usize)
+    }
+}
+
+fn trend_color(pct_change: f32) -> Color {
+    if pct_change > 0.0 {
+        Color::hex("#34d399")
+    } else if pct_change < 0.0 {
+        Color::hex("#f87171")
+    } else {
+        Color::hex("#94a3b8")
+    }
+}
+
+pub fn build_sparkline(raw: &[u32], pct_change: f32, width: f32, height: f32) -> SparklineModel {
+    let filled = interpolate_gaps(raw);
+    let color = trend_color(pct_change);
+    if filled.iter().all(|&v| v == 0.0) {
+        return SparklineModel {
+            width,
+            height,
+            points: Vec::new(),
+            values: Vec::new(),
+            color,
+        };
+    }
+    let (min, max) = filled
+        .iter()
+        .copied()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    let span = (max - min).max(1.0);
+    let inset = 2.0;
+    let usable_h = height - inset * 2.0;
+    let n = filled.len();
+    let step = if n > 1 { width / (n as f32 - 1.0) } else { 0.0 };
+    let points = filled
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (i as f32 * step, inset + (1.0 - (v - min) / span) * usable_h))
+        .collect();
+    SparklineModel {
+        width,
+        height,
+        points,
+        values: filled,
+        color,
+    }
+}
+```
+
+- [ ] **Step 5:** `cargo test -p ultros-charts` — all pass (interpolate tests moved + 4 new sparkline tests).
+
+- [ ] **Step 6:** Commit:
+
+```bash
+git add ultros-frontend/ultros-charts/src/data/interpolate.rs ultros-frontend/ultros-charts/src/data/mod.rs ultros-frontend/ultros-charts/src/charts/sparkline.rs ultros-frontend/ultros-charts/src/charts/mod.rs
+git commit -m "feat(charts): sparkline model with gap interpolation and hover math" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 2: Interactive app component + i18n keys
+
+**Files:**
+- Rewrite: `ultros-frontend/ultros-app/src/components/sparkline.rs`
+- Modify: ALL 7 of `ultros-frontend/ultros-app/locales/{en,fr,de,ja,cn,ko,tc}.json`
+
+- [ ] **Step 1:** Add the two keys to every locale file (flat JSON, near the `chart_*` keys):
+
+| locale | `sparkline_hours_ago` | `sparkline_now` |
+|---|---|---|
+| en | `"{n}h ago"` | `"now"` |
+| fr | `"il y a {n} h"` | `"maintenant"` |
+| de | `"vor {n} Std."` | `"jetzt"` |
+| ja | `"{n}時間前"` | `"現在"` |
+| cn | `"{n}小时前"` | `"现在"` |
+| ko | `"{n}시간 전"` | `"지금"` |
+| tc | `"{n}小時前"` | `"現在"` |
+
+- [ ] **Step 2:** Replace `sparkline.rs` wholesale:
+
+```rust
+//! Inline SVG sparkline for the Market Movers list and other surfaces that
+//! want a 24h price trace next to each row.
+//!
+//! Geometry/coloring live in `ultros_charts::charts::sparkline`; this
+//! component adds the interactive layer: nothing renders until hover, then
+//! a dot on the trace and a micro-tooltip with the value and how long ago
+//! that sample was. Sparkline series are hourly VWAP, oldest first.
+
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+
+use ultros_charts::charts::sparkline::build_sparkline;
+use ultros_charts::components::color_attr;
+use ultros_charts::scale::short_number;
+
+use crate::i18n::{t_string, use_i18n};
+
+#[component]
+pub fn Sparkline(
+    /// VWAP series, oldest first. Zeros mean "no trade in this hour" and are
+    /// interpolated across.
+    points: Vec<u32>,
+    /// Drives stroke color. Pass the API's `pct_change_24h`.
+    #[prop(default = 0.0)]
+    pct_change: f32,
+    /// Pixel width of the rendered sparkline. Default 80.
+    #[prop(default = 80)]
+    width: u32,
+    /// Pixel height. Default 24.
+    #[prop(default = 24)]
+    height: u32,
+    /// Hours represented by one point step (all current feeds are hourly).
+    #[prop(default = 1)]
+    hours_per_point: u32,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    let model = build_sparkline(&points, pct_change, width as f32, height as f32);
+
+    // Empty / all-zero series → render nothing rather than a flat line at
+    // the bottom. The page typically shows the price as text anyway.
+    if model.is_empty() {
+        return view! { <span class="inline-block w-20 h-6" /> }.into_any();
+    }
+
+    let path: String = model
+        .points
+        .iter()
+        .map(|(x, y)| format!("{x:.1},{y:.1}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let stroke = color_attr(&model.color);
+    let model = StoredValue::new(model);
+    let hover = RwSignal::new(None::<usize>);
+
+    let on_pointer_move = move |evt: web_sys::PointerEvent| {
+        let Some(target) = evt
+            .current_target()
+            .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+        else {
+            return;
+        };
+        let rect = target.get_bounding_client_rect();
+        if rect.width() <= 0.0 {
+            return;
+        }
+        let x_css = evt.client_x() as f64 - rect.left();
+        let index =
+            model.with_value(|m| m.nearest_index((x_css / rect.width()) as f32 * m.width));
+        hover.set(index);
+    };
+
+    view! {
+        <span
+            class="relative inline-block align-middle"
+            on:pointermove=on_pointer_move
+            on:pointerleave=move |_| hover.set(None)
+        >
+            <svg
+                width=width
+                height=height
+                viewBox=format!("0 0 {width} {height}")
+                class="block"
+                aria-hidden="true"
+            >
+                <polyline
+                    fill="none"
+                    stroke=stroke
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    points=path
+                />
+                {move || {
+                    hover
+                        .get()
+                        .and_then(|i| {
+                            model
+                                .with_value(|m| {
+                                    let (x, y) = *m.points.get(i)?;
+                                    Some(view! {
+                                        <circle
+                                            cx=format!("{x:.1}")
+                                            cy=format!("{y:.1}")
+                                            r="2.5"
+                                            fill=color_attr(&m.color)
+                                        />
+                                    })
+                                })
+                        })
+                }}
+            </svg>
+            {move || {
+                hover
+                    .get()
+                    .and_then(|i| {
+                        model
+                            .with_value(|m| {
+                                let value = *m.values.get(i)?;
+                                let steps_back = (m.values.len() - 1 - i) as u32 * hours_per_point;
+                                let when = if steps_back == 0 {
+                                    t_string!(i18n, sparkline_now).to_string()
+                                } else {
+                                    t_string!(i18n, sparkline_hours_ago)
+                                        .to_string()
+                                        .replace("{n}", &steps_back.to_string())
+                                };
+                                let left_pct = if m.points.len() > 1 {
+                                    i as f32 / (m.points.len() as f32 - 1.0) * 100.0
+                                } else {
+                                    50.0
+                                };
+                                let style = if left_pct > 50.0 {
+                                    format!("left:{left_pct:.0}%;transform:translate(-100%,-100%)")
+                                } else {
+                                    format!("left:{left_pct:.0}%;transform:translateY(-100%)")
+                                };
+                                Some(view! {
+                                    <span
+                                        class="pointer-events-none absolute top-0 z-20 whitespace-nowrap rounded border border-[color:var(--color-outline)] bg-violet-950/95 px-1.5 py-0.5 text-[10px] tabular-nums text-[color:var(--color-text)] shadow"
+                                        style=style
+                                    >
+                                        {format!("{} · {}", short_number(value.round() as i32), when)}
+                                    </span>
+                                })
+                            })
+                    })
+            }}
+        </span>
+    }
+    .into_any()
+}
+```
+
+(The old `interpolate_gaps` + tests are GONE from this file — they moved to core in Task 1. If `wasm_bindgen::JsCast` needs a different import path or `client_x()` typing differs, match what `price_history_chart.rs` does — it compiled with the identical pattern.)
+
+- [ ] **Step 3:** Compile gates:
+  - `cargo check -p ultros-app`
+  - `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown`
+  - Confirm no call site needed changes: `rg "Sparkline" ultros-frontend/ultros-app/src --type rust -l` and check each still passes only existing props.
+
+- [ ] **Step 4:** Commit:
+
+```bash
+git add ultros-frontend/ultros-app/src/components/sparkline.rs ultros-frontend/ultros-app/locales
+git commit -m "feat: interactive sparklines (hover dot + value/time micro-tooltip)" -m "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -216,41 +216,6 @@
     border-color: var(--color-outline);
 }
 
-/* leptos-chartistry emits inline SVG/HTML; scope theme fixes to price charts. */
-.price-history-chart ._chartistry {
-    width: 100% !important;
-    height: 100% !important;
-    color: var(--color-text);
-}
-
-.price-history-chart ._chartistry svg {
-    width: 100%;
-    height: 100%;
-}
-
-.price-history-chart ._chartistry_tick_label text,
-.price-history-chart ._chartistry_rotated_label text {
-    fill: var(--color-text-muted);
-}
-
-.price-history-chart ._chartistry_line:has(> ._chartistry_line_markers circle) > path {
-    stroke: transparent;
-}
-
-.price-history-chart ._chartistry_tooltip {
-    background-color: var(--color-background-elevated) !important;
-    color: var(--color-text) !important;
-    border-color: var(--color-outline-strong) !important;
-    border-radius: 0.5rem;
-    box-shadow:
-        0 18px 45px rgba(0, 0, 0, 0.35),
-        0 0 0 1px color-mix(in srgb, var(--brand-ring) 18%, transparent);
-    pointer-events: none;
-}
-
-.price-history-chart ._chartistry_tooltip h2 {
-    color: var(--brand-fg);
-}
 
 /* Runtime-swappable brand palettes */
 :root[data-palette="violet"],

--- a/ultros-frontend/ultros-app/Cargo.toml
+++ b/ultros-frontend/ultros-app/Cargo.toml
@@ -65,8 +65,7 @@ js-sys = { version = "0.3", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 tracing = "0.1"
 serde_json = { workspace = true }
-ultros-charts = { path = "../ultros-charts" }
-leptos-chartistry = "0.2.3"
+ultros-charts = { path = "../ultros-charts", features = ["leptos"] }
 icondata.workspace = true
 gloo-timers = { version = "0.4.0", features = ["futures"] }
 cfg-if.workspace = true

--- a/ultros-frontend/ultros-app/Cargo.toml
+++ b/ultros-frontend/ultros-app/Cargo.toml
@@ -29,6 +29,7 @@ web-sys = { version = "0.3", optional = true, features = [
     "HtmlElement",
     "HtmlDocument",
     "Document",
+    "DomRect",
     "Element",
     "PointerEvent",
     "WebSocket",

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30天",
     "chart_range_all": "全部",
     "chart_aria_label": "{from} 到 {to} 之间 {n} 笔销售的散点图",
+    "sparkline_hours_ago": "{n}小时前",
+    "sparkline_now": "现在",
     "retainers_edit_title": "编辑雇员",
     "retainers_title": "雇员",
     "retainers_unassigned": "未分配",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30T",
     "chart_range_all": "Alle",
     "chart_aria_label": "Streudiagramm mit {n} Verkäufen zwischen {from} und {to}",
+    "sparkline_hours_ago": "vor {n} Std.",
+    "sparkline_now": "jetzt",
     "retainers_edit_title": "Gehilfen bearbeiten",
     "retainers_title": "Gehilfen",
     "retainers_unassigned": "Nicht zugewiesen",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30d",
     "chart_range_all": "All",
     "chart_aria_label": "Scatter plot of {n} sales between {from} and {to}",
+    "sparkline_hours_ago": "{n}h ago",
+    "sparkline_now": "now",
     "retainers_edit_title": "Edit Retainers",
     "retainers_title": "Retainers",
     "retainers_unassigned": "Unassigned",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30j",
     "chart_range_all": "Tout",
     "chart_aria_label": "Nuage de points de {n} ventes entre {from} et {to}",
+    "sparkline_hours_ago": "il y a {n} h",
+    "sparkline_now": "maintenant",
     "retainers_edit_title": "Modifier les servants",
     "retainers_title": "Servants",
     "retainers_unassigned": "Non assigné",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30日",
     "chart_range_all": "すべて",
     "chart_aria_label": "{from} から {to} までの {n} 件の販売を示す散布図",
+    "sparkline_hours_ago": "{n}時間前",
+    "sparkline_now": "現在",
     "retainers_edit_title": "リテイナーを編集",
     "retainers_title": "リテイナー",
     "retainers_unassigned": "未割り当て",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30일",
     "chart_range_all": "전체",
     "chart_aria_label": "{from}부터 {to}까지의 {n}건 판매를 보여 주는 산점도",
+    "sparkline_hours_ago": "{n}시간 전",
+    "sparkline_now": "지금",
     "retainers_edit_title": "친구상인 편집",
     "retainers_title": "친구상인",
     "retainers_unassigned": "미지정",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -537,6 +537,8 @@
     "chart_range_30d": "30天",
     "chart_range_all": "全部",
     "chart_aria_label": "{from} 到 {to} 之間 {n} 筆銷售的散點圖",
+    "sparkline_hours_ago": "{n}小時前",
+    "sparkline_now": "現在",
     "retainers_edit_title": "編輯雇員",
     "retainers_title": "雇員",
     "retainers_unassigned": "未指派",

--- a/ultros-frontend/ultros-app/src/components/price_history_chart.rs
+++ b/ultros-frontend/ultros-app/src/components/price_history_chart.rs
@@ -1,243 +1,19 @@
-use std::collections::BTreeMap;
-
 use leptos::prelude::*;
-use leptos_chartistry::*;
+use leptos_use::{UseElementBoundingReturn, use_element_bounding};
 use ultros_api_types::SaleHistory;
-use ultros_api_types::world_helper::AnySelector;
+use ultros_charts::charts::price_history::{
+    ChartStats, PriceChartModel, PriceChartOptions, build_price_history_chart,
+};
+use ultros_charts::components::{color_attr, scene_view};
+use ultros_charts::data::grouping::{GroupLevel, available_group_levels};
+use ultros_charts::scale::short_number;
+use ultros_charts::theme::Theme;
 
 use crate::global_state::LocalWorldData;
 use crate::i18n::{t, t_string, use_i18n};
 
-type SeriesPoints = Vec<(chrono::DateTime<chrono::Local>, i32, i32)>;
-
-const CATEGORY_PALETTE: [&str; 12] = [
-    "#60a5fa", "#f97316", "#34d399", "#a78bfa", "#fb7185", "#facc15", "#22d3ee", "#c084fc",
-    "#4ade80", "#f472b6", "#94a3b8", "#fdba74",
-];
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum ColorBy {
-    Region,
-    Datacenter,
-    World,
-}
-
-impl ColorBy {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Region => "Region",
-            Self::Datacenter => "Datacenter",
-            Self::World => "World",
-        }
-    }
-}
-
-/// Roll sales up by a chosen world hierarchy level for colouring the scatter points.
-fn group_sales_by_level(
-    helper: &ultros_api_types::world_helper::WorldHelper,
-    sales: &[SaleHistory],
-    color_by: ColorBy,
-) -> Vec<(String, SeriesPoints)> {
-    use itertools::Itertools;
-
-    let mut groups = BTreeMap::<AnySelector, (String, SeriesPoints)>::new();
-    for sale in sales {
-        let world = match helper
-            .lookup_selector(AnySelector::World(sale.world_id))
-            .and_then(|result| result.as_world())
-        {
-            Some(world) => world,
-            None => continue,
-        };
-        let selector = match color_by {
-            ColorBy::World => AnySelector::World(world.id),
-            ColorBy::Datacenter => AnySelector::Datacenter(world.datacenter_id),
-            ColorBy::Region => {
-                let datacenter = match helper
-                    .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
-                    .and_then(|result| result.as_datacenter())
-                {
-                    Some(datacenter) => datacenter,
-                    None => continue,
-                };
-                AnySelector::Region(datacenter.region_id)
-            }
-        };
-        let Some(result) = helper.lookup_selector(selector) else {
-            continue;
-        };
-        // `sold_date` is a naive UTC instant. `and_local_timezone(Local)`
-        // re-interprets it as local time, silently shifting by the viewer's
-        // UTC offset (8h on a Shanghai client, 0h on a UTC server). The
-        // downstream `.with_timezone(&Utc)` then bakes the wrong value into
-        // `SaleRow.ts`, producing SSR/CSR row sets that disagree and tripping
-        // tachys hydration at `hydration.rs:227`.
-        let sold_date = sale.sold_date.and_utc().with_timezone(&chrono::Local);
-        groups
-            .entry(selector)
-            .or_insert_with(|| (result.get_name().to_string(), Vec::new()))
-            .1
-            .push((sold_date, sale.price_per_item, sale.quantity));
-    }
-
-    groups
-        .into_values()
-        .sorted_by_cached_key(|(name, _)| name.clone())
-        .collect()
-}
-
-/// Volume-weighted average price. Returns None if the input is empty or total qty is 0.
-fn vwap(prices_and_qty: &[(i32, i32)]) -> Option<i32> {
-    let (num, den) = prices_and_qty
-        .iter()
-        .fold((0i64, 0i64), |(n, d), (price, qty)| {
-            (n + (*price as i64) * (*qty as i64), d + (*qty as i64))
-        });
-    if den == 0 {
-        return None;
-    }
-    Some((num / den) as i32)
-}
-
-/// Median price. For even counts, returns the integer mean of the two middle values.
-fn median(prices: &[i32]) -> Option<i32> {
-    if prices.is_empty() {
-        return None;
-    }
-    let mut sorted: Vec<i32> = prices.to_vec();
-    sorted.sort_unstable();
-    let n = sorted.len();
-    if n % 2 == 1 {
-        Some(sorted[n / 2])
-    } else {
-        Some((sorted[n / 2 - 1] + sorted[n / 2]) / 2)
-    }
-}
-
-/// IQR-based outlier band, matching the existing logic in `ultros-charts`.
-/// Returns (min, max) where min = Q1 - 2.5*IQR, max = Q3 + 2.5*IQR.
-/// Returns None for samples smaller than 10.
-fn iqr_band(prices: &[i32]) -> Option<(i32, i32)> {
-    if prices.len() < 10 {
-        return None;
-    }
-    let mut sorted: Vec<i32> = prices.to_vec();
-    sorted.sort_unstable();
-    let q1_idx = sorted.len() / 4;
-    let q3_idx = sorted.len() - q1_idx;
-    let q1 = *sorted.get(q1_idx)?;
-    let q3 = *sorted.get(q3_idx)?;
-    let widened = ((q3 - q1) as f32 * 2.5) as i32;
-    Some((q1 - widened, q3 + widened))
-}
-
-/// Format an integer price using K/mil shortening, same rules as the plotters chart.
-fn short_number(value: i32) -> String {
-    match value {
-        1_000_000.. => format!("{:.2}mil", value as f32 / 1_000_000.0),
-        1_000..=999_999 => format!("{:.2}K", value as f32 / 1_000.0),
-        _ => value.to_string(),
-    }
-}
-
-/// Computed statistics for the stats strip.
-#[derive(Clone, Debug, PartialEq)]
-struct ChartStats {
-    n: usize,
-    market_average_val: Option<i32>,
-    median_val: Option<i32>,
-    min_val: i32,
-    max_val: i32,
-}
-
-/// One row in the flat chartistry data Vec.
-/// Each row represents a single sale event. Series that don't have a point
-/// for this row carry f64::NAN, which chartistry skips when `skip_missing()`
-/// is set on the tooltip.
-#[derive(Clone, Debug, PartialEq)]
-struct SaleRow {
-    /// Sale timestamp, used as the X axis. chartistry's built-in `DateTime<Utc>`
-    /// `Tick` impl automatically formats labels as dates.
-    ts: chrono::DateTime<chrono::Utc>,
-    /// Price per item (f64 for chartistry).
-    price: f64,
-    /// The colour/category series this sale belongs to.
-    group_index: usize,
-    /// Quantity-weighted average price overlay (constant across all rows, or NAN).
-    market_average_y: f64,
-    /// Least-squares trendline value at this row's timestamp (or NAN).
-    trend_y: f64,
-}
-
-/// Aggregated quantity for a time bucket. The quantity sub-chart renders these
-/// as one bar per bucket so bars stay visible even when sales cluster in time.
-#[derive(Clone, Debug, PartialEq)]
-struct QuantityBucket {
-    ts: chrono::DateTime<chrono::Utc>,
-    quantity: f64,
-}
-
-/// Pick a bucket size (in seconds) for the quantity histogram based on the
-/// active days window. `days_range == 0` means "all" — fall back to the data span.
-fn quantity_bucket_seconds(days_range: i32, data_span_days: i64) -> i64 {
-    const HOUR: i64 = 3_600;
-    const DAY: i64 = 86_400;
-    const WEEK: i64 = DAY * 7;
-    let effective_days = if days_range > 0 {
-        days_range as i64
-    } else {
-        data_span_days.max(1)
-    };
-    match effective_days {
-        ..=2 => HOUR,
-        3..=10 => 6 * HOUR,
-        11..=45 => DAY,
-        46..=120 => DAY,
-        121..=400 => WEEK,
-        _ => DAY * 30,
-    }
-}
-
-/// Bucket sales by `bucket_secs`, summing quantities into each bucket. Buckets
-/// are aligned to absolute timestamps (UTC) so they line up with calendar boundaries
-/// for day/week/month sizes.
-fn bucket_quantities(sales: &[SaleHistory], bucket_secs: i64) -> Vec<QuantityBucket> {
-    if bucket_secs <= 0 || sales.is_empty() {
-        return Vec::new();
-    }
-    let mut sums: BTreeMap<i64, i64> = BTreeMap::new();
-    for s in sales {
-        let ts = s.sold_date.and_utc().timestamp();
-        let bucket = (ts.div_euclid(bucket_secs)) * bucket_secs;
-        *sums.entry(bucket).or_default() += s.quantity as i64;
-    }
-    sums.into_iter()
-        .filter_map(|(ts, q)| {
-            chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0).map(|dt| QuantityBucket {
-                ts: dt,
-                quantity: q as f64,
-            })
-        })
-        .collect()
-}
-
-/// Choose tick `Period`s for the X axis based on the selected window. Chartistry
-/// will pick the densest period that still fits the available width, so we pass
-/// a small set bracketing the expected scale rather than a single period.
-fn x_axis_periods(days_range: i32, data_span_days: i64) -> Vec<Period> {
-    let effective_days = if days_range > 0 {
-        days_range as i64
-    } else {
-        data_span_days.max(1)
-    };
-    match effective_days {
-        ..=2 => vec![Period::Hour, Period::Day],
-        3..=10 => vec![Period::Day, Period::Hour],
-        11..=45 => vec![Period::Day, Period::Month],
-        46..=120 => vec![Period::Day, Period::Month],
-        121..=400 => vec![Period::Month, Period::Day],
-        _ => vec![Period::Month, Period::Year],
-    }
+fn px(v: f32) -> String {
+    format!("{v:.1}")
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -262,7 +38,7 @@ fn StatsStrip(stats: Signal<Option<ChartStats>>) -> impl IntoView {
                         <div class="flex flex-wrap gap-x-4 gap-y-1 text-sm tabular-nums text-[color:var(--color-text)]/70 mb-3">
                             <span>{n_label}</span>
                             {s
-                                .market_average_val
+                                .market_average
                                 .map(|v| {
                                     view! {
                                         <span>
@@ -271,7 +47,7 @@ fn StatsStrip(stats: Signal<Option<ChartStats>>) -> impl IntoView {
                                     }
                                 })}
                             {s
-                                .median_val
+                                .median
                                 .map(|v| {
                                     view! {
                                         <span>
@@ -279,465 +55,14 @@ fn StatsStrip(stats: Signal<Option<ChartStats>>) -> impl IntoView {
                                         </span>
                                     }
                                 })}
-                            <span>{min_label} " " {short_number(s.min_val)}</span>
-                            <span>{max_label} " " {short_number(s.max_val)}</span>
+                            <span>{min_label} " " {short_number(s.min)}</span>
+                            <span>{max_label} " " {short_number(s.max)}</span>
                         </div>
                     }
                         .into_any()
                 })
         }}
     }
-}
-
-// ── Main component ────────────────────────────────────────────────────────────
-
-#[component]
-pub fn PriceHistoryChart(
-    #[prop(into)] sales: Signal<Vec<SaleHistory>>,
-    #[prop(into)] filter_outliers: Signal<bool>,
-    #[prop(into)] scope_name: Signal<String>,
-    /// Selected days window from the parent (7 / 30 / 90 / 0 for All).
-    /// Used to size quantity buckets and pick X-axis tick periods.
-    #[prop(into)]
-    days_range: Signal<i32>,
-) -> impl IntoView {
-    // Implementation uses leptos-chartistry 0.2 for axes/overlays. Sales stay in
-    // one dense series because sparse category series produce misleading tooltip
-    // rows and NaN path warnings; marker colours are applied from the grouping
-    // metadata after chartistry renders the circles.
-
-    let local_world_data = use_context::<LocalWorldData>().unwrap();
-    let helper = local_world_data.0.unwrap();
-    let i18n = use_i18n();
-    let (show_market_average, set_show_market_average) = signal(true);
-    let (show_trend, set_show_trend) = signal(false);
-    let (show_quantity, set_show_quantity) = signal(false);
-    let (color_by, set_color_by) = signal(ColorBy::World);
-
-    // Optional IQR outlier filter applied to the incoming (pre-filtered) sales.
-    let filtered = Memo::new(move |_| {
-        let base = sales.get();
-        if !filter_outliers.get() {
-            return base;
-        }
-        let prices: Vec<i32> = base.iter().map(|s| s.price_per_item).collect();
-        match iqr_band(&prices) {
-            Some((lo, hi)) => base
-                .into_iter()
-                .filter(|s| s.price_per_item >= lo && s.price_per_item <= hi)
-                .collect(),
-            None => base,
-        }
-    });
-
-    let helper_for_color_options = helper.clone();
-    let color_by_options = Memo::new(move |_| {
-        match helper_for_color_options.lookup_world_by_name(&scope_name.get()) {
-            Some(result) if result.as_world().is_some() => vec![ColorBy::World],
-            Some(result) if result.as_datacenter().is_some() => {
-                vec![ColorBy::Datacenter, ColorBy::World]
-            }
-            Some(result) if result.as_region().is_some() => {
-                vec![ColorBy::Region, ColorBy::Datacenter, ColorBy::World]
-            }
-            _ => vec![ColorBy::Region, ColorBy::Datacenter, ColorBy::World],
-        }
-    });
-
-    let effective_color_by = Memo::new(move |_| {
-        let selected = color_by.get();
-        let options = color_by_options.get();
-        if options.contains(&selected) {
-            selected
-        } else {
-            *options.last().unwrap_or(&ColorBy::World)
-        }
-    });
-
-    // Stats computed from the sales currently visible in the chart.
-    let stats = Memo::new(move |_| {
-        let data = filtered.get();
-        if data.is_empty() {
-            return None;
-        }
-        let prices: Vec<i32> = data.iter().map(|s| s.price_per_item).collect();
-        let pq: Vec<(i32, i32)> = data
-            .iter()
-            .map(|s| (s.price_per_item, s.quantity))
-            .collect();
-        let min_val = *prices.iter().min().unwrap();
-        let max_val = *prices.iter().max().unwrap();
-        Some(ChartStats {
-            n: data.len(),
-            market_average_val: vwap(&pq),
-            median_val: median(&prices),
-            min_val,
-            max_val,
-        })
-    });
-
-    // Group by locale and build flat row vec for chartistry.
-    // We produce a derived signal so chartistry's `data` prop stays reactive.
-    // Series names come from group_sales_by_locale; order is stable (sorted).
-    let helper_clone = helper.clone();
-    let chart_data = Memo::new(move |_| {
-        let data = filtered.get();
-        let groups = group_sales_by_level(&helper_clone, &data, effective_color_by.get());
-        if groups.is_empty() || data.is_empty() {
-            return (vec![], vec![]);
-        }
-        // series_names: stable order (already sorted by group_sales_by_locale)
-        let series_names: Vec<String> = groups.iter().map(|(n, _)| n.clone()).collect();
-
-        // Flatten all points into (ts, price, qty). Chartistry does not skip
-        // sparse series before building ranges, so keep the sales as one
-        // contiguous scatter series and use locale names only for the legend.
-        let mut flat: Vec<(chrono::DateTime<chrono::Utc>, usize, f64, i32)> = groups
-            .iter()
-            .enumerate()
-            .flat_map(|(group_index, (_, points))| {
-                points.iter().map(move |(dt, price, qty)| {
-                    let utc = dt.with_timezone(&chrono::Utc);
-                    (utc, group_index, *price as f64, *qty)
-                })
-            })
-            .collect();
-        // Sort by timestamp so chartistry's line renderer doesn't cross itself
-        flat.sort_by(|a, b| a.0.cmp(&b.0));
-
-        // ── Overlay computations ──────────────────────────────────────────
-
-        // Market average (from filtered, same as stats strip). This is a
-        // quantity-weighted average, but the UI avoids market-jargon labels.
-        let pq_filtered: Vec<(i32, i32)> = data
-            .iter()
-            .map(|s| (s.price_per_item, s.quantity))
-            .collect();
-        let market_average_val = vwap(&pq_filtered).map(|v| v as f64).unwrap_or(f64::NAN);
-
-        // Trendline via least-squares on (ts_secs, price) from filtered set
-        // y = b + m*x  where x = timestamp in seconds
-        let trend_points: Vec<(f64, f64)> = flat
-            .iter()
-            .map(|(ts, _, price, _)| (ts.timestamp() as f64, *price))
-            .collect();
-        let n = trend_points.len() as f64;
-        let (sum_x, sum_y, sum_xx, sum_xy) = trend_points.iter().fold(
-            (0.0f64, 0.0f64, 0.0f64, 0.0f64),
-            |(sx, sy, sxx, sxy), (x, y)| (sx + x, sy + y, sxx + x * x, sxy + x * y),
-        );
-        let denom = n * sum_xx - sum_x * sum_x;
-        let (trend_m, trend_b) = if denom.abs() > f64::EPSILON {
-            let m = (n * sum_xy - sum_x * sum_y) / denom;
-            let b = (sum_y - m * sum_x) / n;
-            (m, b)
-        } else {
-            (f64::NAN, f64::NAN)
-        };
-
-        // ── Build rows ────────────────────────────────────────────────────
-        let mut rows: Vec<SaleRow> = Vec::with_capacity(flat.len());
-        for (ts, group_index, price, _qty) in flat {
-            let trend_y = if trend_m.is_nan() || trend_b.is_nan() {
-                f64::NAN
-            } else {
-                trend_b + trend_m * ts.timestamp() as f64
-            };
-            rows.push(SaleRow {
-                ts,
-                price,
-                group_index,
-                market_average_y: market_average_val,
-                trend_y,
-            });
-        }
-        (series_names, rows)
-    });
-
-    // Bucketed quantity data. Per-sale bars produce zero-width slivers when sales
-    // cluster, so we aggregate into time buckets sized to the visible window.
-    let quantity_data = Memo::new(move |_| {
-        let data = filtered.get();
-        if data.is_empty() {
-            return (Vec::<QuantityBucket>::new(), 86_400i64);
-        }
-        let min_ts = data
-            .iter()
-            .map(|s| s.sold_date.and_utc().timestamp())
-            .min()
-            .unwrap_or(0);
-        let max_ts = data
-            .iter()
-            .map(|s| s.sold_date.and_utc().timestamp())
-            .max()
-            .unwrap_or(0);
-        let span_days = ((max_ts - min_ts) / 86_400).max(0);
-        let bucket_secs = quantity_bucket_seconds(days_range.get(), span_days);
-        (bucket_quantities(&data, bucket_secs), bucket_secs)
-    });
-
-    // X-axis tick periods sized to the visible window.
-    let x_periods = Memo::new(move |_| {
-        let data = filtered.get();
-        let span_days = if data.is_empty() {
-            0
-        } else {
-            let min_ts = data
-                .iter()
-                .map(|s| s.sold_date.and_utc().timestamp())
-                .min()
-                .unwrap_or(0);
-            let max_ts = data
-                .iter()
-                .map(|s| s.sold_date.and_utc().timestamp())
-                .max()
-                .unwrap_or(0);
-            (max_ts - min_ts) / 86_400
-        };
-        x_axis_periods(days_range.get(), span_days)
-    });
-
-    view! {
-        <div class="flex flex-col gap-3">
-            <StatsStrip stats=stats.into() />
-            <div class="flex flex-wrap items-center gap-2 text-xs">
-                <ChartOverlayToggle
-                    label=t_string!(i18n, chart_toggle_market_avg).to_string()
-                    checked=show_market_average
-                    set_checked=set_show_market_average
-                />
-                <ChartOverlayToggle
-                    label=t_string!(i18n, chart_legend_trend).to_string()
-                    checked=show_trend
-                    set_checked=set_show_trend
-                />
-                <ChartOverlayToggle
-                    label=t_string!(i18n, chart_legend_quantity).to_string()
-                    checked=show_quantity
-                    set_checked=set_show_quantity
-                />
-            </div>
-            <ColorByControl options=color_by_options selected=effective_color_by set_selected=set_color_by />
-            <div
-                role="img"
-                aria-label=move || {
-                    let n = stats.get().map(|s| s.n).unwrap_or(0);
-                    t_string!(i18n, chart_aria_label)
-                        .to_string()
-                        .replace("{n}", &n.to_string())
-                        .replace("{from}", "")
-                        .replace("{to}", "")
-                }
-                class="price-history-chart w-full overflow-visible"
-            >
-                {move || {
-                    let (series_names, rows) = chart_data.get();
-                    if rows.is_empty() {
-                        let msg = t_string!(i18n, chart_no_sales_in_window).to_string();
-                        view! {
-                            <div class="flex items-center justify-center w-full h-full text-[color:var(--color-text)]/60 text-sm">
-                                {msg}
-                            </div>
-                        }
-                            .into_any()
-                    } else {
-                        let marker_css = rows
-                            .iter()
-                            .enumerate()
-                            .map(|(index, row)| {
-                                let colour = CATEGORY_PALETTE[row.group_index % CATEGORY_PALETTE.len()];
-                                format!(
-                                    ".price-history-chart ._chartistry_line_markers circle:nth-of-type({}){{fill:{colour};}}",
-                                    index + 1
-                                )
-                            })
-                            .collect::<String>();
-
-                        let sales_colour: Colour = "#60a5fa"
-                            .parse()
-                            .unwrap_or(Colour::from_rgb(96, 165, 250));
-                        let mut reactive_series = Series::new(|row: &SaleRow| row.ts).line(
-                            Line::new(|row: &SaleRow| row.price)
-                                .with_name(t_string!(i18n, chart_legend_sales).to_string())
-                                .with_width(1.0)
-                                .with_colour(sales_colour)
-                                .with_interpolation(Interpolation::Linear)
-                                .with_marker(
-                                    Marker::from_shape(MarkerShape::Circle)
-                                        .with_colour(sales_colour)
-                                        .with_border(
-                                            "#dbeafe"
-                                                .parse()
-                                                .unwrap_or(Colour::from_rgb(219, 234, 254)),
-                                        )
-                                        .with_border_width(0.8)
-                                        .with_scale(1.1),
-                                ),
-                        );
-
-                        // ── Overlay lines ─────────────────────────────────────────────
-                        if show_market_average.get() {
-                            reactive_series = reactive_series.line(
-                                Line::new(|r: &SaleRow| r.market_average_y)
-                                    .with_name(t_string!(i18n, chart_legend_market_avg).to_string())
-                                    .with_width(2.0)
-                                    .with_interpolation(Interpolation::Linear)
-                                    .with_colour(
-                                        "#facc15"
-                                            .parse()
-                                            .unwrap_or(Colour::from_rgb(250, 204, 21)),
-                                    ),
-                            );
-                        }
-                        if show_trend.get() {
-                            reactive_series = reactive_series.line(
-                                Line::new(|r: &SaleRow| r.trend_y)
-                                    .with_name(t_string!(i18n, chart_legend_trend).to_string())
-                                    .with_width(1.5)
-                                    .with_interpolation(Interpolation::Linear)
-                                    .with_colour(
-                                        "#94a3b8"
-                                            .parse()
-                                            .unwrap_or(Colour::from_rgb(148, 163, 184)),
-                                    ),
-                            );
-                        }
-
-                        let aspect_ratio = AspectRatio::from_inner_ratio(800.0, 450.0);
-                        // X-axis: scale tick periods to the visible window so 7d shows hours/days,
-                        // 30d shows days, etc. The tooltip uses long format for unambiguous dates.
-                        let periods = x_periods.get();
-                        let x_axis_labels = TickLabels::from_generator(
-                            Timestamps::<chrono::Utc>::from_periods(periods.as_slice()),
-                        );
-                        let x_tooltip_labels = TickLabels::from_generator(
-                            Timestamps::<chrono::Utc>::default().with_long_format(),
-                        );
-                        let y_tooltip = TickLabels::aligned_floats()
-                            .with_format(|v: &f64, _state| short_number(*v as i32));
-                        let tooltip = Tooltip::new(
-                            TooltipPlacement::LeftCursor,
-                            x_tooltip_labels,
-                            y_tooltip,
-                        )
-                        .skip_missing(true)
-                        .with_cursor_distance(14.0);
-                        // Y-axis formatter: reuse short_number style for f64 prices.
-                        let y_labels = TickLabels::aligned_floats()
-                            .with_min_chars(7)
-                            .with_format(|v: &f64, _state| short_number(*v as i32));
-                        let grid_colour: Colour = "#3f3a4a"
-                            .parse()
-                            .unwrap_or(Colour::from_rgb(63, 58, 74));
-                        view! {
-                            <div class="flex flex-col gap-2">
-                                <style>{marker_css}</style>
-                                <Chart
-                                    aspect_ratio=aspect_ratio
-                                    font_height=12.0
-                                    font_width=7.0
-                                    series=reactive_series
-                                    data=rows.clone()
-                                    bottom=vec![x_axis_labels.into_edge()]
-                                    left=vec![y_labels.into_edge()]
-                                    inner=vec![
-                                        XGridLine::default().with_colour(grid_colour).into_inner(),
-                                        YGridLine::default().with_colour(grid_colour).into_inner(),
-                                    ]
-                                    tooltip=tooltip
-                                />
-                                {show_quantity.get().then(|| {
-                                    let (buckets, _bucket_secs) = quantity_data.get();
-                                    if buckets.is_empty() {
-                                        return ().into_any();
-                                    }
-                                    let q_periods = x_periods.get();
-                                    let quantity_colour: Colour = "#22c55e"
-                                        .parse()
-                                        .unwrap_or(Colour::from_rgb(34, 197, 94));
-                                    let quantity_series = Series::new(|b: &QuantityBucket| b.ts)
-                                        .bar(
-                                            Bar::new(|b: &QuantityBucket| b.quantity)
-                                                .with_name(t_string!(i18n, chart_legend_quantity).to_string())
-                                                .with_colour(quantity_colour)
-                                                .with_placement(BarPlacement::Zero)
-                                                .with_gap(0.1),
-                                        );
-                                    let quantity_labels = TickLabels::aligned_floats()
-                                        .with_min_chars(3)
-                                        .with_format(|v: &f64, _state| (*v as i32).to_string());
-                                    let quantity_x_axis = TickLabels::from_generator(
-                                        Timestamps::<chrono::Utc>::from_periods(q_periods.as_slice()),
-                                    );
-                                    let quantity_x_tooltip = TickLabels::from_generator(
-                                        Timestamps::<chrono::Utc>::default().with_long_format(),
-                                    );
-                                    let quantity_tooltip = Tooltip::new(
-                                        TooltipPlacement::LeftCursor,
-                                        quantity_x_tooltip,
-                                        quantity_labels.clone(),
-                                    )
-                                    .with_cursor_distance(14.0);
-                                    view! {
-                                        <div class="border-t border-[color:var(--color-outline)]/70 pt-2 mt-2">
-                                            <Chart
-                                                aspect_ratio=AspectRatio::from_inner_ratio(800.0, 120.0)
-                                                font_height=10.0
-                                                font_width=6.0
-                                                series=quantity_series
-                                                data=buckets
-                                                bottom=vec![quantity_x_axis.into_edge()]
-                                                left=vec![quantity_labels.into_edge()]
-                                                inner=vec![
-                                                    XGridLine::default().with_colour(grid_colour).into_inner(),
-                                                    YGridLine::default().with_colour(grid_colour).into_inner(),
-                                                ]
-                                                tooltip=quantity_tooltip
-                                            />
-                                        </div>
-                                    }.into_any()
-                                })}
-                                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
-                                    {series_names.iter().enumerate().map(|(index, name)| {
-                                        let colour = CATEGORY_PALETTE[index % CATEGORY_PALETTE.len()];
-                                        view! {
-                                            <span class="inline-flex items-center gap-1.5">
-                                                <span
-                                                    class="h-2.5 w-2.5 rounded-full ring-1 ring-blue-100/70"
-                                                    style:background-color=colour
-                                                ></span>
-                                                {name.clone()}
-                                            </span>
-                                        }
-                                    }).collect_view()}
-                                    {show_market_average.get().then(|| view! {
-                                        <span class="inline-flex items-center gap-1.5">
-                                            <span class="h-0.5 w-5 bg-[#facc15]"></span>
-                                            {t!(i18n, chart_legend_market_avg)}
-                                        </span>
-                                    })}
-                                    {show_trend.get().then(|| view! {
-                                        <span class="inline-flex items-center gap-1.5">
-                                            <span class="h-0.5 w-5 bg-[#94a3b8]"></span>
-                                            {t!(i18n, chart_legend_trend)}
-                                        </span>
-                                    })}
-                                    {show_quantity.get().then(|| view! {
-                                        <span class="inline-flex items-center gap-1.5">
-                                            <span class="h-2.5 w-3 rounded-sm bg-[#22c55e]"></span>
-                                            {t!(i18n, chart_legend_quantity)}
-                                        </span>
-                                    })}
-                                </div>
-                            </div>
-                        }
-                            .into_any()
-                    }
-                }}
-            </div>
-        </div>
-    }
-    .into_any()
 }
 
 #[component]
@@ -782,9 +107,9 @@ fn ChartOverlayToggle(
 
 #[component]
 fn ColorByControl(
-    #[prop(into)] options: Signal<Vec<ColorBy>>,
-    #[prop(into)] selected: Signal<ColorBy>,
-    set_selected: WriteSignal<ColorBy>,
+    #[prop(into)] options: Signal<Vec<GroupLevel>>,
+    #[prop(into)] selected: Signal<GroupLevel>,
+    set_selected: WriteSignal<GroupLevel>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     view! {
@@ -816,9 +141,9 @@ fn ColorByControl(
                                 on:click=move |_| set_selected.set(option)
                             >
                                 {match option {
-                                    ColorBy::Region => t_string!(i18n, chart_color_region).to_string(),
-                                    ColorBy::Datacenter => t_string!(i18n, chart_color_datacenter).to_string(),
-                                    ColorBy::World => t_string!(i18n, chart_color_world).to_string(),
+                                    GroupLevel::Region => t_string!(i18n, chart_color_region).to_string(),
+                                    GroupLevel::Datacenter => t_string!(i18n, chart_color_datacenter).to_string(),
+                                    GroupLevel::World => t_string!(i18n, chart_color_world).to_string(),
                                 }}
                             </button>
                         }
@@ -830,222 +155,383 @@ fn ColorByControl(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::TimeZone;
-    use ultros_api_types::world::{Datacenter, Region, World, WorldData};
-    use ultros_api_types::world_helper::WorldHelper;
-
-    fn test_world_helper() -> WorldHelper {
-        // Two regions; region 1 has two DCs; DC 10 has two worlds, DC 11 has one, DC 20 (region 2) has one.
-        let world_data = WorldData {
-            regions: vec![
-                Region {
-                    id: 1,
-                    name: "North-America".into(),
-                    datacenters: vec![
-                        Datacenter {
-                            id: 10,
-                            name: "Aether".into(),
-                            region_id: 1,
-                            worlds: vec![
-                                World {
-                                    id: 100,
-                                    name: "Gilgamesh".into(),
-                                    datacenter_id: 10,
-                                },
-                                World {
-                                    id: 101,
-                                    name: "Adamantoise".into(),
-                                    datacenter_id: 10,
-                                },
-                            ],
-                        },
-                        Datacenter {
-                            id: 11,
-                            name: "Crystal".into(),
-                            region_id: 1,
-                            worlds: vec![World {
-                                id: 102,
-                                name: "Balmung".into(),
-                                datacenter_id: 11,
-                            }],
-                        },
-                    ],
-                },
-                Region {
-                    id: 2,
-                    name: "Europe".into(),
-                    datacenters: vec![Datacenter {
-                        id: 20,
-                        name: "Light".into(),
-                        region_id: 2,
-                        worlds: vec![World {
-                            id: 200,
-                            name: "Phoenix".into(),
-                            datacenter_id: 20,
-                        }],
-                    }],
-                },
-            ],
-        };
-        WorldHelper::from(world_data)
-    }
-
-    fn sale(world_id: i32, price: i32, qty: i32, ts: i64) -> SaleHistory {
-        SaleHistory {
-            id: 0,
-            quantity: qty,
-            price_per_item: price,
-            buying_character_id: 0,
-            hq: false,
-            sold_item_id: 1,
-            sold_date: chrono::Utc.timestamp_opt(ts, 0).unwrap().naive_utc(),
-            world_id,
-            buyer_name: None,
-        }
-    }
-
-    #[test]
-    fn grouping_collapses_to_world_when_one_dc() {
-        let helper = test_world_helper();
-        // Both sales are on worlds inside Aether (DC 10) → one DC → group by world.
-        let sales = vec![sale(100, 1000, 1, 0), sale(101, 1100, 1, 1)];
-        let series = group_sales_by_level(&helper, &sales, ColorBy::World);
-        let names: Vec<_> = series.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains(&"Gilgamesh"));
-        assert!(names.contains(&"Adamantoise"));
-    }
-
-    #[test]
-    fn grouping_collapses_to_dc_when_one_region() {
-        let helper = test_world_helper();
-        // Two DCs (Aether, Crystal) both in NA → one region → group by DC.
-        let sales = vec![sale(100, 1000, 1, 0), sale(102, 1100, 1, 1)];
-        let series = group_sales_by_level(&helper, &sales, ColorBy::Datacenter);
-        let names: Vec<_> = series.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains(&"Aether"));
-        assert!(names.contains(&"Crystal"));
-    }
-
-    #[test]
-    fn grouping_collapses_to_region_when_multiple_regions() {
-        let helper = test_world_helper();
-        // Worlds from two regions → group by region.
-        let sales = vec![sale(100, 1000, 1, 0), sale(200, 1100, 1, 1)];
-        let series = group_sales_by_level(&helper, &sales, ColorBy::Region);
-        let names: Vec<_> = series.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains(&"North-America"));
-        assert!(names.contains(&"Europe"));
-    }
-
-    #[test]
-    fn vwap_weights_by_quantity() {
-        let prices = vec![(100, 1), (200, 9)];
-        assert_eq!(vwap(&prices), Some(190));
-    }
-
-    #[test]
-    fn vwap_returns_none_for_empty() {
-        assert_eq!(vwap(&[]), None);
-    }
-
-    #[test]
-    fn vwap_returns_none_when_total_qty_zero() {
-        let prices = vec![(100, 0), (200, 0)];
-        assert_eq!(vwap(&prices), None);
-    }
-
-    #[test]
-    fn median_of_odd_count() {
-        let prices = vec![300, 100, 200];
-        assert_eq!(median(&prices), Some(200));
-    }
-
-    #[test]
-    fn median_of_even_count_averages_middle_two() {
-        let prices = vec![400, 100, 300, 200];
-        assert_eq!(median(&prices), Some(250));
-    }
-
-    #[test]
-    fn median_returns_none_for_empty() {
-        assert_eq!(median(&[]), None);
-    }
-
-    #[test]
-    fn iqr_band_returns_none_for_small_samples() {
-        let prices: Vec<i32> = (0..9).collect();
-        assert_eq!(iqr_band(&prices), None);
-    }
-
-    #[test]
-    fn iqr_band_widens_with_25x_multiplier() {
-        let prices: Vec<i32> = (0..20).collect();
-        assert_eq!(iqr_band(&prices), Some((-20, 40)));
-    }
-
-    #[test]
-    fn bucket_seconds_scales_with_window() {
-        // 7d window → 6h buckets (~28 bars max)
-        assert_eq!(quantity_bucket_seconds(7, 7), 6 * 3_600);
-        // 30d window → daily
-        assert_eq!(quantity_bucket_seconds(30, 30), 86_400);
-        // 90d window → still daily
-        assert_eq!(quantity_bucket_seconds(90, 90), 86_400);
-        // "All" with multi-year span → weekly
-        assert_eq!(quantity_bucket_seconds(0, 365), 86_400 * 7);
-    }
-
-    #[test]
-    fn bucket_quantities_sums_within_same_day_bucket() {
-        // Three sales of qty 5 within an hour all land in one daily bucket.
-        let day_start_ts = 1_700_000_000i64 - (1_700_000_000 % 86_400);
-        let sales = vec![
-            sale(100, 1000, 5, day_start_ts + 60),
-            sale(100, 1100, 5, day_start_ts + 600),
-            sale(100, 1050, 5, day_start_ts + 3_500),
-        ];
-        let buckets = bucket_quantities(&sales, 86_400);
-        assert_eq!(buckets.len(), 1);
-        assert_eq!(buckets[0].quantity, 15.0);
-    }
-
-    #[test]
-    fn bucket_quantities_separates_across_buckets() {
-        let sales = vec![sale(100, 1000, 3, 0), sale(100, 1000, 7, 86_400 + 60)];
-        let buckets = bucket_quantities(&sales, 86_400);
-        assert_eq!(buckets.len(), 2);
-        assert_eq!(buckets[0].quantity, 3.0);
-        assert_eq!(buckets[1].quantity, 7.0);
-    }
-
-    #[test]
-    fn x_axis_periods_for_short_window_includes_day_or_hour() {
-        let periods = x_axis_periods(7, 7);
-        assert!(periods.contains(&Period::Day) || periods.contains(&Period::Hour));
-    }
-
-    #[test]
-    fn x_axis_periods_for_all_falls_back_to_month_year() {
-        let periods = x_axis_periods(0, 500);
-        assert!(periods.contains(&Period::Month) || periods.contains(&Period::Year));
+/// Crosshair + per-series dots at the hovered bucket. Lives INSIDE the
+/// chart's `<svg>` so it shares the viewBox coordinate space.
+#[component]
+fn HoverLayer(
+    model: Memo<PriceChartModel>,
+    hover_index: RwSignal<Option<usize>>,
+) -> impl IntoView {
+    move || {
+        hover_index.get().and_then(|i| {
+            model.with(|m| {
+                let bucket = m.hover.buckets.get(i)?;
+                let dots = bucket
+                    .series_values
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(series_index, value)| {
+                        let (y, _) = (*value)?;
+                        let color = m.series.get(series_index)?.color;
+                        Some(view! {
+                            <circle
+                                cx=px(bucket.x)
+                                cy=px(y)
+                                r="4"
+                                fill=color_attr(&color)
+                                stroke="#16131f"
+                                stroke-width="1.5"
+                            />
+                        })
+                    })
+                    .collect_view();
+                Some(view! {
+                    <g class="pointer-events-none">
+                        <line
+                            x1=px(bucket.x)
+                            y1=px(m.hover.plot_top)
+                            x2=px(bucket.x)
+                            y2=px(m.hover.plot_bottom)
+                            stroke="#9ca3af"
+                            stroke-opacity="0.45"
+                            stroke-width="1"
+                        />
+                        {dots}
+                    </g>
+                })
+            })
+        })
     }
 }
 
-#[cfg(test)]
-mod test_formatters {
-    use super::*;
+/// HTML tooltip positioned over the chart container; flips to the left of
+/// the crosshair past the midpoint so it never clips on the right edge.
+#[component]
+fn HoverTooltip(
+    model: Memo<PriceChartModel>,
+    hover_index: RwSignal<Option<usize>>,
+    #[prop(into)] show_quantity: Signal<bool>,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    move || {
+        hover_index.get().and_then(|i| {
+            model.with(|m| {
+                let bucket = m.hover.buckets.get(i)?.clone();
+                let series = m.series.clone();
+                let left_pct = (bucket.x / m.scene.width * 100.0).clamp(0.0, 100.0);
+                let style = if left_pct > 55.0 {
+                    format!("left:calc({left_pct:.1}% - 12px);transform:translateX(-100%)")
+                } else {
+                    format!("left:calc({left_pct:.1}% + 12px)")
+                };
+                Some(view! {
+                    <div
+                        class="pointer-events-none absolute top-2 z-10 min-w-36 rounded-md border border-[color:var(--color-outline)] bg-violet-950/95 px-3 py-2 text-xs shadow-lg"
+                        style=style
+                    >
+                        <div class="mb-1 font-semibold text-[color:var(--color-text)]">
+                            {bucket.label.clone()}
+                        </div>
+                        {series
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(series_index, info)| {
+                                let (_, vwap) =
+                                    bucket.series_values.get(series_index).copied().flatten()?;
+                                Some(view! {
+                                    <div class="flex items-center justify-between gap-3">
+                                        <span class="inline-flex items-center gap-1.5">
+                                            <span
+                                                class="inline-block h-2 w-2 rounded-full"
+                                                style:background-color=color_attr(&info.color)
+                                            ></span>
+                                            <span class="text-[color:var(--color-text-muted)]">
+                                                {info.name.clone()}
+                                            </span>
+                                        </span>
+                                        <span class="tabular-nums text-[color:var(--color-text)]">
+                                            {short_number(vwap.round() as i32)}
+                                        </span>
+                                    </div>
+                                })
+                            })
+                            .collect_view()}
+                        {show_quantity
+                            .get()
+                            .then(|| {
+                                view! {
+                                    <div class="mt-1 flex items-center justify-between gap-3 border-t border-[color:var(--color-outline)]/60 pt-1">
+                                        <span class="text-[color:var(--color-text-muted)]">
+                                            {t!(i18n, chart_legend_quantity)}
+                                        </span>
+                                        <span class="tabular-nums text-[color:var(--color-text)]">
+                                            {bucket.volume}
+                                        </span>
+                                    </div>
+                                }
+                            })}
+                    </div>
+                })
+            })
+        })
+    }
+}
 
-    #[test]
-    fn test_short_number() {
-        assert_eq!(short_number(0), "0");
-        assert_eq!(short_number(999), "999");
-        assert_eq!(short_number(1000), "1.00K");
-        assert_eq!(short_number(1500), "1.50K");
-        assert_eq!(short_number(999_999), "1000.00K");
-        assert_eq!(short_number(1_000_000), "1.00mil");
-        assert_eq!(short_number(1_500_000), "1.50mil");
+// ── Main component ────────────────────────────────────────────────────────────
+
+#[component]
+pub fn PriceHistoryChart(
+    #[prop(into)] sales: Signal<Vec<SaleHistory>>,
+    #[prop(into)] filter_outliers: Signal<bool>,
+    #[prop(into)] scope_name: Signal<String>,
+    /// Selected days window from the parent (7 / 30 / 90 / 0 for All).
+    #[prop(into)]
+    days_range: Signal<i32>,
+) -> impl IntoView {
+    let local_world_data = use_context::<LocalWorldData>().unwrap();
+    let helper = local_world_data.0.unwrap();
+    let i18n = use_i18n();
+    let (show_market_average, set_show_market_average) = signal(true);
+    let (show_trend, set_show_trend) = signal(false);
+    let (show_quantity, set_show_quantity) = signal(false);
+    let (color_by, set_color_by) = signal(GroupLevel::World);
+    // Series the user hid by clicking legend chips. Stored as a sorted Vec so
+    // the model memo's PartialEq sees a stable value.
+    let hidden_series = RwSignal::new(Vec::<String>::new());
+
+    // Viewer timezone for axis/tooltip LABELS only. SSR and the first client
+    // render agree on 0 (UTC); this effect shifts the labels after hydration
+    // — same idea as ChartWrapper's `hydrated` gate, so tachys never sees
+    // divergent markup. Bucketing/geometry are timezone-independent.
+    let utc_offset = RwSignal::new(0i32);
+    Effect::new(move |_| {
+        utc_offset.set(chrono::Local::now().offset().local_minus_utc() / 60);
+    });
+
+    // Responsive: rebuild the scene at the measured container width so text
+    // renders at natural size instead of scaling down. Unmeasured (SSR and
+    // first client render) falls back to 960, and leptos-use only updates
+    // the signal post-mount — hydration-safe for the same reason as above.
+    let container = NodeRef::<leptos::html::Div>::new();
+    let UseElementBoundingReturn {
+        left: container_left,
+        width: container_width,
+        ..
+    } = use_element_bounding(container);
+
+    let helper_for_options = helper.clone();
+    let color_by_options =
+        Memo::new(move |_| available_group_levels(&helper_for_options, &scope_name.get()));
+    let effective_color_by = Memo::new(move |_| {
+        let selected = color_by.get();
+        let options = color_by_options.get();
+        if options.contains(&selected) {
+            selected
+        } else {
+            *options.last().unwrap_or(&GroupLevel::World)
+        }
+    });
+
+    let helper_for_model = helper.clone();
+    let model = Memo::new(move |_| {
+        let sales = sales.get();
+        let measured = container_width.get() as f32;
+        let width = if measured > 0.0 {
+            measured.clamp(320.0, 1600.0)
+        } else {
+            960.0
+        };
+        let height = (width * 0.56).clamp(300.0, 540.0);
+        build_price_history_chart(
+            &helper_for_model,
+            &sales,
+            &PriceChartOptions {
+                width,
+                height,
+                remove_outliers: filter_outliers.get(),
+                show_market_average: show_market_average.get(),
+                show_trendline: show_trend.get(),
+                show_volume: show_quantity.get(),
+                show_legend: false,
+                title: None,
+                icon_data_uri: None,
+                days_range: Some(days_range.get()),
+                group_level: Some(effective_color_by.get()),
+                utc_offset_minutes: utc_offset.get(),
+                hidden_series: hidden_series.get(),
+                theme: Theme::site(),
+            },
+        )
+    });
+
+    let stats = Signal::derive(move || model.with(|m| m.stats.clone()));
+    let hover_index = RwSignal::new(None::<usize>);
+
+    let on_pointer_move = move |evt: web_sys::PointerEvent| {
+        let width = container_width.get_untracked();
+        if width <= 0.0 {
+            return;
+        }
+        let x_css = evt.client_x() as f64 - container_left.get_untracked();
+        let index = model.with_untracked(|m| {
+            m.hover
+                .nearest_index((x_css / width) as f32 * m.scene.width)
+        });
+        hover_index.set(index);
+    };
+
+    view! {
+        <div class="flex flex-col gap-3">
+            <StatsStrip stats=stats />
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_toggle_market_avg).to_string()
+                    checked=show_market_average
+                    set_checked=set_show_market_average
+                />
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_legend_trend).to_string()
+                    checked=show_trend
+                    set_checked=set_show_trend
+                />
+                <ChartOverlayToggle
+                    label=t_string!(i18n, chart_legend_quantity).to_string()
+                    checked=show_quantity
+                    set_checked=set_show_quantity
+                />
+            </div>
+            <ColorByControl options=color_by_options selected=effective_color_by set_selected=set_color_by />
+            <div
+                role="img"
+                aria-label=move || {
+                    let n = stats.get().map(|s| s.n).unwrap_or(0);
+                    let (from, to) = model.with(|m| {
+                        (
+                            m.hover.buckets.first().map(|b| b.label.clone()).unwrap_or_default(),
+                            m.hover.buckets.last().map(|b| b.label.clone()).unwrap_or_default(),
+                        )
+                    });
+                    t_string!(i18n, chart_aria_label)
+                        .to_string()
+                        .replace("{n}", &n.to_string())
+                        .replace("{from}", &from)
+                        .replace("{to}", &to)
+                }
+                class="price-history-chart relative w-full overflow-visible"
+                node_ref=container
+                on:pointermove=on_pointer_move
+                on:pointerleave=move |_| hover_index.set(None)
+            >
+                {move || {
+                    let m = model.get();
+                    if m.hover.buckets.is_empty() {
+                        let msg = t_string!(i18n, chart_no_sales_in_window).to_string();
+                        return view! {
+                            <div class="flex items-center justify-center w-full h-full text-[color:var(--color-text)]/60 text-sm">
+                                {msg}
+                            </div>
+                        }
+                            .into_any();
+                    }
+                    view! {
+                        <svg
+                            class="block w-full h-auto"
+                            viewBox=format!("0 0 {:.0} {:.0}", m.scene.width, m.scene.height)
+                            preserveAspectRatio="xMidYMid meet"
+                        >
+                            {scene_view(&m.scene)}
+                            <HoverLayer model=model hover_index=hover_index />
+                        </svg>
+                    }
+                        .into_any()
+                }}
+                <HoverTooltip model=model hover_index=hover_index show_quantity=show_quantity />
+            </div>
+            {move || {
+                let m = model.get();
+                (!m.series.is_empty())
+                    .then(|| {
+                        let toggleable = m.series.len() > 1;
+                        view! {
+                            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[color:var(--color-text-muted)]">
+                                {m
+                                    .series
+                                    .iter()
+                                    .map(|info| {
+                                        let name = info.name.clone();
+                                        let toggle_name = info.name.clone();
+                                        let hidden = info.hidden;
+                                        view! {
+                                            <button
+                                                type="button"
+                                                disabled=!toggleable
+                                                class=[
+                                                    "inline-flex items-center gap-1.5 transition-opacity",
+                                                    if toggleable { "cursor-pointer" } else { "cursor-default" },
+                                                    if hidden { "opacity-40 line-through" } else { "" },
+                                                ]
+                                                    .join(" ")
+                                                on:click=move |_| {
+                                                    if !toggleable {
+                                                        return;
+                                                    }
+                                                    hidden_series
+                                                        .update(|hidden_list| {
+                                                            if let Some(pos) = hidden_list
+                                                                .iter()
+                                                                .position(|n| n == &toggle_name)
+                                                            {
+                                                                hidden_list.remove(pos);
+                                                            } else {
+                                                                hidden_list.push(toggle_name.clone());
+                                                                hidden_list.sort();
+                                                            }
+                                                        });
+                                                }
+                                            >
+                                                <span
+                                                    class="h-2.5 w-2.5 rounded-full ring-1 ring-blue-100/70"
+                                                    style:background-color=color_attr(&info.color)
+                                                ></span>
+                                                {name}
+                                            </button>
+                                        }
+                                    })
+                                    .collect_view()}
+                                {show_market_average
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-0.5 w-5 bg-[#facc15]"></span>
+                                                {t!(i18n, chart_legend_market_avg)}
+                                            </span>
+                                        }
+                                    })}
+                                {show_trend
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-0.5 w-5 bg-[#94a3b8]"></span>
+                                                {t!(i18n, chart_legend_trend)}
+                                            </span>
+                                        }
+                                    })}
+                                {show_quantity
+                                    .get()
+                                    .then(|| {
+                                        view! {
+                                            <span class="inline-flex items-center gap-1.5">
+                                                <span class="h-2.5 w-3 rounded-sm bg-[#22c55e]"></span>
+                                                {t!(i18n, chart_legend_quantity)}
+                                            </span>
+                                        }
+                                    })}
+                            </div>
+                        }
+                    })
+            }}
+        </div>
     }
 }

--- a/ultros-frontend/ultros-app/src/components/price_history_chart.rs
+++ b/ultros-frontend/ultros-app/src/components/price_history_chart.rs
@@ -158,10 +158,7 @@ fn ColorByControl(
 /// Crosshair + per-series dots at the hovered bucket. Lives INSIDE the
 /// chart's `<svg>` so it shares the viewBox coordinate space.
 #[component]
-fn HoverLayer(
-    model: Memo<PriceChartModel>,
-    hover_index: RwSignal<Option<usize>>,
-) -> impl IntoView {
+fn HoverLayer(model: Memo<PriceChartModel>, hover_index: RwSignal<Option<usize>>) -> impl IntoView {
     move || {
         hover_index.get().and_then(|i| {
             model.with(|m| {

--- a/ultros-frontend/ultros-app/src/components/price_history_chart.rs
+++ b/ultros-frontend/ultros-app/src/components/price_history_chart.rs
@@ -1,5 +1,5 @@
 use leptos::prelude::*;
-use leptos_use::{UseElementBoundingReturn, use_element_bounding};
+use leptos_use::{UseElementSizeReturn, use_element_size};
 use ultros_api_types::SaleHistory;
 use ultros_charts::charts::price_history::{
     ChartStats, PriceChartModel, PriceChartOptions, build_price_history_chart,
@@ -312,12 +312,13 @@ pub fn PriceHistoryChart(
     // renders at natural size instead of scaling down. Unmeasured (SSR and
     // first client render) falls back to 960, and leptos-use only updates
     // the signal post-mount — hydration-safe for the same reason as above.
+    // use_element_size is ResizeObserver-only (no scroll listener), so page
+    // scroll does not trigger model rebuilds.
     let container = NodeRef::<leptos::html::Div>::new();
-    let UseElementBoundingReturn {
-        left: container_left,
+    let UseElementSizeReturn {
         width: container_width,
         ..
-    } = use_element_bounding(container);
+    } = use_element_size(container);
 
     let helper_for_options = helper.clone();
     let color_by_options =
@@ -332,15 +333,22 @@ pub fn PriceHistoryChart(
         }
     });
 
+    // Quantise measured width to 16 px steps so resize-dragging doesn't
+    // rebuild the full multi-thousand-node scene on every pixel change.
+    // Memo's PartialEq deduplicates sub-step changes automatically.
+    let chart_width = Memo::new(move |_| {
+        let measured = container_width.get() as f32;
+        if measured > 0.0 {
+            ((measured / 16.0).round() * 16.0).clamp(320.0, 1600.0)
+        } else {
+            960.0
+        }
+    });
+
     let helper_for_model = helper.clone();
     let model = Memo::new(move |_| {
         let sales = sales.get();
-        let measured = container_width.get() as f32;
-        let width = if measured > 0.0 {
-            measured.clamp(320.0, 1600.0)
-        } else {
-            960.0
-        };
+        let width = chart_width.get();
         let height = (width * 0.56).clamp(300.0, 540.0);
         build_price_history_chart(
             &helper_for_model,
@@ -367,15 +375,29 @@ pub fn PriceHistoryChart(
     let stats = Signal::derive(move || model.with(|m| m.stats.clone()));
     let hover_index = RwSignal::new(None::<usize>);
 
+    // Clear stale hover state whenever the model is rebuilt (e.g. after a
+    // window resize snaps to a new quantised width or the data changes).
+    Effect::new(move |_| {
+        model.track();
+        hover_index.set(None);
+    });
+
     let on_pointer_move = move |evt: web_sys::PointerEvent| {
-        let width = container_width.get_untracked();
-        if width <= 0.0 {
+        use web_sys::wasm_bindgen::JsCast;
+        let Some(target) = evt
+            .current_target()
+            .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+        else {
+            return;
+        };
+        let rect = target.get_bounding_client_rect();
+        if rect.width() <= 0.0 {
             return;
         }
-        let x_css = evt.client_x() as f64 - container_left.get_untracked();
+        let x_css = evt.client_x() - rect.left();
         let index = model.with_untracked(|m| {
             m.hover
-                .nearest_index((x_css / width) as f32 * m.scene.width)
+                .nearest_index((x_css / rect.width()) as f32 * m.scene.width)
         });
         hover_index.set(index);
     };

--- a/ultros-frontend/ultros-app/src/components/sparkline.rs
+++ b/ultros-frontend/ultros-app/src/components/sparkline.rs
@@ -1,32 +1,23 @@
 //! Inline SVG sparkline for the Market Movers list and other surfaces that
 //! want a 24h price trace next to each row.
 //!
-//! Design rules (informed by the dashboard mockup):
-//!   - Tiny: ~80×24 px so it fits comfortably in a table row.
-//!   - Color by net trend, not per-segment. Polyline gradient is overkill
-//!     for the visual signal we want; a single green/red trace reads
-//!     instantly without distracting from the row's text.
-//!   - Skip axes, labels, tooltips. At this size they're glyphs, not
-//!     charts — the page already has the price and pct change as text.
+//! Geometry/coloring live in `ultros_charts::charts::sparkline`; this
+//! component adds the interactive layer: nothing renders until hover, then
+//! a dot on the trace and a micro-tooltip with the value and how long ago
+//! that sample was. Sparkline series are hourly VWAP, oldest first.
 
 use leptos::prelude::*;
 
-/// Render an SVG polyline from the given points.
-///
-/// `points` is the raw VWAP series (frontend gets `Vec<u32>`). We rescale
-/// to fit the viewport, mapping the minimum value to the bottom edge and
-/// the maximum to the top edge. Zeros (gaps with no trade) are treated
-/// as bridging — we interpolate between the surrounding non-zero values
-/// rather than dropping to baseline. That keeps the trend line honest
-/// instead of showing a misleading dive every time a quiet hour appears.
-///
-/// `pct_change` is the up/down indicator that drives the stroke color:
-/// positive = emerald, negative = red, zero/none = muted neutral.
+use ultros_charts::charts::sparkline::build_sparkline;
+use ultros_charts::components::color_attr;
+use ultros_charts::scale::short_number;
+
+use crate::i18n::{t_string, use_i18n};
+
 #[component]
 pub fn Sparkline(
-    /// VWAP series, oldest first. Length 8-48 typical; we don't impose a
-    /// hard cap. Zeros mean "no trade in this hour" and are interpolated
-    /// across.
+    /// VWAP series, oldest first. Zeros mean "no trade in this hour" and are
+    /// interpolated across.
     points: Vec<u32>,
     /// Drives stroke color. Pass the API's `pct_change_24h`.
     #[prop(default = 0.0)]
@@ -37,154 +28,124 @@ pub fn Sparkline(
     /// Pixel height. Default 24.
     #[prop(default = 24)]
     height: u32,
+    /// Hours represented by one point step (all current feeds are hourly).
+    #[prop(default = 1)]
+    hours_per_point: u32,
 ) -> impl IntoView {
-    // Fill in gaps so the polyline doesn't dive to zero on quiet hours.
-    let filled = interpolate_gaps(&points);
+    let i18n = use_i18n();
+    let model = build_sparkline(&points, pct_change, width as f32, height as f32);
 
     // Empty / all-zero series → render nothing rather than a flat line at
     // the bottom. The page typically shows the price as text anyway.
-    if filled.iter().all(|&v| v == 0.0) {
+    if model.is_empty() {
         return view! { <span class="inline-block w-20 h-6" /> }.into_any();
     }
 
-    let (min, max) = filled
+    let path: String = model
+        .points
         .iter()
-        .copied()
-        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), v| {
-            (lo.min(v), hi.max(v))
-        });
-    let span = (max - min).max(1.0);
-
-    // 2px inset on top/bottom so the stroke isn't clipped at the edges.
-    let inset = 2.0;
-    let usable_h = height as f32 - inset * 2.0;
-    let n = filled.len();
-    let step = if n > 1 {
-        width as f32 / (n as f32 - 1.0)
-    } else {
-        0.0
-    };
-
-    let path: String = filled
-        .iter()
-        .enumerate()
-        .map(|(i, &v)| {
-            let x = i as f32 * step;
-            // Higher value → smaller y (SVG coord origin top-left).
-            let y = inset + (1.0 - (v - min) / span) * usable_h;
-            format!("{x:.1},{y:.1}")
-        })
+        .map(|(x, y)| format!("{x:.1},{y:.1}"))
         .collect::<Vec<_>>()
         .join(" ");
+    let stroke = color_attr(&model.color);
+    let model = StoredValue::new(model);
+    let hover = RwSignal::new(None::<usize>);
 
-    let stroke = if pct_change > 0.0 {
-        // emerald-400
-        "#34d399"
-    } else if pct_change < 0.0 {
-        // red-400
-        "#f87171"
-    } else {
-        // var(--color-text-muted) fallback; SVG can't take CSS var directly
-        // in `stroke=`, so we use currentColor and let the parent CSS
-        // class set color. Caller-side we don't bother — neutral grey
-        // looks fine.
-        "#94a3b8"
+    let on_pointer_move = move |evt: web_sys::PointerEvent| {
+        use web_sys::wasm_bindgen::JsCast;
+        let Some(target) = evt
+            .current_target()
+            .and_then(|t| t.dyn_into::<web_sys::Element>().ok())
+        else {
+            return;
+        };
+        let rect = target.get_bounding_client_rect();
+        if rect.width() <= 0.0 {
+            return;
+        }
+        let x_css = evt.client_x() - rect.left();
+        let index =
+            model.with_value(|m| m.nearest_index((x_css / rect.width()) as f32 * m.width));
+        hover.set(index);
     };
 
     view! {
-        <svg
-            width=width
-            height=height
-            viewBox=format!("0 0 {width} {height}")
-            class="inline-block align-middle"
-            aria-hidden="true"
+        <span
+            class="relative inline-block align-middle"
+            on:pointermove=on_pointer_move
+            on:pointerleave=move |_| hover.set(None)
         >
-            <polyline
-                fill="none"
-                stroke=stroke
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                points=path
-            />
-        </svg>
+            <svg
+                width=width
+                height=height
+                viewBox=format!("0 0 {width} {height}")
+                class="block"
+                aria-hidden="true"
+            >
+                <polyline
+                    fill="none"
+                    stroke=stroke
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    points=path
+                />
+                {move || {
+                    hover
+                        .get()
+                        .and_then(|i| {
+                            model
+                                .with_value(|m| {
+                                    let (x, y) = *m.points.get(i)?;
+                                    Some(view! {
+                                        <circle
+                                            cx=format!("{x:.1}")
+                                            cy=format!("{y:.1}")
+                                            r="2.5"
+                                            fill=color_attr(&m.color)
+                                        />
+                                    })
+                                })
+                        })
+                }}
+            </svg>
+            {move || {
+                hover
+                    .get()
+                    .and_then(|i| {
+                        model
+                            .with_value(|m| {
+                                let value = *m.values.get(i)?;
+                                let steps_back = (m.values.len() - 1 - i) as u32 * hours_per_point;
+                                let when = if steps_back == 0 {
+                                    t_string!(i18n, sparkline_now).to_string()
+                                } else {
+                                    t_string!(i18n, sparkline_hours_ago)
+                                        .to_string()
+                                        .replace("{n}", &steps_back.to_string())
+                                };
+                                let left_pct = if m.points.len() > 1 {
+                                    i as f32 / (m.points.len() as f32 - 1.0) * 100.0
+                                } else {
+                                    50.0
+                                };
+                                let style = if left_pct > 50.0 {
+                                    format!("left:{left_pct:.0}%;transform:translate(-100%,-100%)")
+                                } else {
+                                    format!("left:{left_pct:.0}%;transform:translateY(-100%)")
+                                };
+                                Some(view! {
+                                    <span
+                                        class="pointer-events-none absolute top-0 z-20 whitespace-nowrap rounded border border-[color:var(--color-outline)] bg-violet-950/95 px-1.5 py-0.5 text-[10px] tabular-nums text-[color:var(--color-text)] shadow"
+                                        style=style
+                                    >
+                                        {format!("{} · {}", short_number(value.round() as i32), when)}
+                                    </span>
+                                })
+                            })
+                    })
+            }}
+        </span>
     }
     .into_any()
-}
-
-/// Replace each zero in the series with a linear interpolation between
-/// the surrounding non-zero values. Leading/trailing zeros are clamped to
-/// the nearest non-zero. If the whole series is zero, returns zeros.
-fn interpolate_gaps(raw: &[u32]) -> Vec<f32> {
-    let n = raw.len();
-    let mut out: Vec<f32> = raw.iter().map(|&v| v as f32).collect();
-
-    // Pass 1: anchor positions of non-zero values.
-    let positions: Vec<usize> = raw
-        .iter()
-        .enumerate()
-        .filter_map(|(i, &v)| if v > 0 { Some(i) } else { None })
-        .collect();
-
-    if positions.is_empty() {
-        return out;
-    }
-
-    // Leading zeros: pin to first non-zero.
-    let first = positions[0];
-    for o in out.iter_mut().take(first) {
-        *o = raw[first] as f32;
-    }
-    // Trailing zeros: pin to last non-zero.
-    let last = *positions.last().unwrap();
-    for o in out.iter_mut().take(n).skip(last + 1) {
-        *o = raw[last] as f32;
-    }
-
-    // Internal gaps: linear interp between consecutive anchors.
-    for w in positions.windows(2) {
-        let (a, b) = (w[0], w[1]);
-        if b - a <= 1 {
-            continue;
-        }
-        let va = raw[a] as f32;
-        let vb = raw[b] as f32;
-        let gap = (b - a) as f32;
-        for k in 1..(b - a) {
-            let t = k as f32 / gap;
-            out[a + k] = va + (vb - va) * t;
-        }
-    }
-
-    out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn interpolate_fills_leading_and_trailing_zeros() {
-        let out = interpolate_gaps(&[0, 0, 10, 20, 0, 0]);
-        assert_eq!(out, vec![10.0, 10.0, 10.0, 20.0, 20.0, 20.0]);
-    }
-
-    #[test]
-    fn interpolate_bridges_internal_gap_linearly() {
-        // 100 at idx 0, 200 at idx 4 → 125, 150, 175 between
-        let out = interpolate_gaps(&[100, 0, 0, 0, 200]);
-        assert_eq!(out, vec![100.0, 125.0, 150.0, 175.0, 200.0]);
-    }
-
-    #[test]
-    fn interpolate_all_zeros_stays_zero() {
-        let out = interpolate_gaps(&[0, 0, 0]);
-        assert_eq!(out, vec![0.0, 0.0, 0.0]);
-    }
-
-    #[test]
-    fn interpolate_passthrough_when_no_gaps() {
-        let out = interpolate_gaps(&[10, 20, 30]);
-        assert_eq!(out, vec![10.0, 20.0, 30.0]);
-    }
 }

--- a/ultros-frontend/ultros-app/src/components/sparkline.rs
+++ b/ultros-frontend/ultros-app/src/components/sparkline.rs
@@ -64,8 +64,7 @@ pub fn Sparkline(
             return;
         }
         let x_css = evt.client_x() - rect.left();
-        let index =
-            model.with_value(|m| m.nearest_index((x_css / rect.width()) as f32 * m.width));
+        let index = model.with_value(|m| m.nearest_index((x_css / rect.width()) as f32 * m.width));
         hover.set(index);
     };
 

--- a/ultros-frontend/ultros-charts/Cargo.toml
+++ b/ultros-frontend/ultros-charts/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [features]
 image = ["dep:ultros-xiv-icons", "dep:image", "dep:base64"]
+leptos = ["dep:leptos"]
 
 [dependencies]
 ultros-api-types = { path = "../../ultros-api-types" }
@@ -16,7 +17,9 @@ itertools.workspace = true
 ultros-xiv-icons = { path = "../ultros-xiv-icons", optional = true }
 image = { workspace = true, optional = true }
 base64 = { version = "0.22", optional = true }
+leptos = { workspace = true, optional = true }
 
 [dev-dependencies]
 resvg = "0.47.0"
 image = { workspace = true }
+leptos = { workspace = true, features = ["ssr"] }

--- a/ultros-frontend/ultros-charts/src/charts/mod.rs
+++ b/ultros-frontend/ultros-charts/src/charts/mod.rs
@@ -1,1 +1,2 @@
 pub mod price_history;
+pub mod sparkline;

--- a/ultros-frontend/ultros-charts/src/charts/price_history.rs
+++ b/ultros-frontend/ultros-charts/src/charts/price_history.rs
@@ -4,19 +4,20 @@
 //! web chart (PR 2) can never drift apart.
 
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 use chrono::TimeDelta;
 use itertools::Itertools;
 use ultros_api_types::SaleHistory;
 use ultros_api_types::world_helper::WorldHelper;
 
-use crate::data::buckets::{bucket_seconds, volume_buckets, vwap_buckets};
-use crate::data::grouping::group_sales_by_scope;
+use crate::data::buckets::{bucket_seconds, volume_buckets_from_points, vwap_buckets};
+use crate::data::grouping::{GroupLevel, auto_group_level, group_sales_by_level};
 use crate::data::outliers::filter_outliers;
-use crate::data::stats::vwap;
+use crate::data::stats::{median, vwap};
 use crate::data::trend::least_squares;
 use crate::scale::{LinearScale, TimeScale, short_number};
-use crate::scene::{Node, Scene, Stroke, TextAnchor};
+use crate::scene::{Color, Node, Scene, Stroke, TextAnchor};
 use crate::theme::Theme;
 
 #[derive(Clone, Debug)]
@@ -37,6 +38,17 @@ pub struct PriceChartOptions {
     pub icon_data_uri: Option<String>,
     /// User-selected day window (7/30/90); `None`/0 = derive from data span.
     pub days_range: Option<i32>,
+    /// Grouping level for series; `None` = pick automatically from the data
+    /// scope (what the PNG path wants).
+    pub group_level: Option<GroupLevel>,
+    /// Shift applied to axis/tooltip LABELS so the browser can show
+    /// viewer-local times. Bucket boundaries and geometry stay UTC-aligned;
+    /// keep 0 for SSR and PNG so server and first client render agree.
+    pub utc_offset_minutes: i32,
+    /// Series names the user hid via the legend. They stay in the model's
+    /// `series` metadata (flagged `hidden`) but draw nothing, feed no hover
+    /// values, and don't influence the axes.
+    pub hidden_series: Vec<String>,
     pub theme: Theme,
 }
 
@@ -53,6 +65,9 @@ impl Default for PriceChartOptions {
             title: None,
             icon_data_uri: None,
             days_range: None,
+            group_level: None,
+            utc_offset_minutes: 0,
+            hidden_series: Vec::new(),
             theme: Theme::dark_card(),
         }
     }
@@ -81,11 +96,80 @@ fn clip_segment_to_band(
     Some((point_at(t0), point_at(t1)))
 }
 
-pub fn build_price_history_scene(
+#[derive(Clone, Debug, PartialEq)]
+pub struct SeriesInfo {
+    pub name: String,
+    pub color: Color,
+    /// True when the user hid this series via the legend; it stays listed so
+    /// the legend can offer un-hiding.
+    pub hidden: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ChartStats {
+    pub n: usize,
+    pub market_average: Option<i32>,
+    pub median: Option<i32>,
+    pub min: i32,
+    pub max: i32,
+}
+
+/// One hoverable time bucket: pixel x of the bucket center, a display label
+/// (already offset to viewer time), per-series `(y_px, vwap)` (None where a
+/// series has no sales in the bucket), and total volume.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HoverBucket {
+    pub x: f32,
+    pub label: String,
+    pub series_values: Vec<Option<(f32, f64)>>,
+    pub volume: i64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct HoverModel {
+    /// Vertical extent for the crosshair line.
+    pub plot_top: f32,
+    pub plot_bottom: f32,
+    /// Sorted by x ascending.
+    pub buckets: Vec<HoverBucket>,
+}
+
+impl HoverModel {
+    /// Index of the bucket whose center is closest to pixel `x`.
+    pub fn nearest_index(&self, x: f32) -> Option<usize> {
+        if self.buckets.is_empty() {
+            return None;
+        }
+        let i = self.buckets.partition_point(|b| b.x < x);
+        if i == 0 {
+            return Some(0);
+        }
+        if i >= self.buckets.len() {
+            return Some(self.buckets.len() - 1);
+        }
+        if (x - self.buckets[i - 1].x) <= (self.buckets[i].x - x) {
+            Some(i - 1)
+        } else {
+            Some(i)
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PriceChartModel {
+    pub scene: Scene,
+    pub hover: HoverModel,
+    pub series: Vec<SeriesInfo>,
+    pub stats: Option<ChartStats>,
+    /// The level actually used (resolves `group_level: None`).
+    pub group_level: GroupLevel,
+}
+
+pub fn build_price_history_chart(
     world_helper: &WorldHelper,
     sales: &[SaleHistory],
     options: &PriceChartOptions,
-) -> Scene {
+) -> PriceChartModel {
     let theme = &options.theme;
     let mut scene = Scene {
         width: options.width,
@@ -100,12 +184,29 @@ pub fn build_price_history_scene(
     } else {
         Cow::Borrowed(sales)
     };
-    let series = group_sales_by_scope(world_helper, &sales);
-    let all_points = || series.iter().flat_map(|s| s.points.iter());
+    let level = options
+        .group_level
+        .unwrap_or_else(|| auto_group_level(world_helper, &sales));
+    let series = group_sales_by_level(world_helper, &sales, level);
+    let is_hidden = |name: &str| options.hidden_series.iter().any(|h| h == name);
+    let series_info: Vec<SeriesInfo> = series
+        .iter()
+        .enumerate()
+        .map(|(index, group)| SeriesInfo {
+            name: group.name.clone(),
+            color: theme.palette[index % theme.palette.len()],
+            hidden: is_hidden(&group.name),
+        })
+        .collect();
+    let all_points = || {
+        series
+            .iter()
+            .filter(|s| !is_hidden(&s.name))
+            .flat_map(|s| s.points.iter())
+    };
+    let visible_count = series.iter().filter(|s| !is_hidden(&s.name)).count();
 
     let Some((first_ts, last_ts)) = all_points().map(|p| p.ts).minmax().into_option() else {
-        // Deliberate "no data" card instead of an error — the Discord bot
-        // and the card endpoint still get a presentable image.
         scene.nodes.push(Node::Text {
             x: options.width / 2.0,
             y: options.height / 2.0,
@@ -115,13 +216,35 @@ pub fn build_price_history_scene(
             anchor: TextAnchor::Middle,
             bold: false,
         });
-        return scene;
+        return PriceChartModel {
+            scene,
+            hover: HoverModel {
+                plot_top: 0.0,
+                plot_bottom: 0.0,
+                buckets: Vec::new(),
+            },
+            series: series_info,
+            stats: None,
+            group_level: level,
+        };
     };
     let (min_price, max_price) = all_points()
         .map(|p| p.price)
         .minmax()
         .into_option()
         .expect("non-empty by the timestamp check above");
+
+    let stats = {
+        let prices: Vec<i32> = all_points().map(|p| p.price).collect();
+        let pairs: Vec<(i32, i32)> = all_points().map(|p| (p.price, p.quantity)).collect();
+        Some(ChartStats {
+            n: prices.len(),
+            market_average: vwap(&pairs),
+            median: median(&prices),
+            min: min_price,
+            max: max_price,
+        })
+    };
 
     // ── Geometry ────────────────────────────────────────────────────────
     let title_height = if options.title.is_some() { 56.0 } else { 12.0 };
@@ -179,7 +302,8 @@ pub fn build_price_history_scene(
             bold: false,
         });
     }
-    for tick in time.ticks(6) {
+    let x_tick_target = ((options.width / 150.0) as usize).clamp(3, 8);
+    for tick in time.ticks(x_tick_target, options.utc_offset_minutes) {
         let x = time.scale(tick.ts);
         scene.nodes.push(Node::Text {
             x,
@@ -195,8 +319,8 @@ pub fn build_price_history_scene(
     // ── Volume lane ─────────────────────────────────────────────────────
     let span_days = (last_ts - first_ts).num_days();
     let bucket_secs = bucket_seconds(options.days_range, span_days);
+    let volumes = volume_buckets_from_points(all_points(), bucket_secs);
     if options.show_volume {
-        let volumes = volume_buckets(&sales, bucket_secs);
         if let Some(max_volume) = volumes.iter().map(|v| v.quantity).max() {
             let volume = LinearScale::new((0.0, max_volume as f64), (plot_bottom, volume_top));
             let bucket_px =
@@ -226,6 +350,9 @@ pub fn build_price_history_scene(
     // ── Raw sale dots (under the lines) ─────────────────────────────────
     let series_color = |index: usize| theme.palette[index % theme.palette.len()];
     for (index, group) in series.iter().enumerate() {
+        if series_info[index].hidden {
+            continue;
+        }
         let color = series_color(index);
         for point in &group.points {
             scene.nodes.push(Node::Circle {
@@ -238,14 +365,25 @@ pub fn build_price_history_scene(
     }
 
     // ── VWAP lines (the primary visual) ─────────────────────────────────
+    let mut hover_map: BTreeMap<i64, Vec<Option<(f32, f64)>>> = BTreeMap::new();
     for (index, group) in series.iter().enumerate() {
+        if series_info[index].hidden {
+            continue;
+        }
         let color = series_color(index);
-        let line: Vec<(f32, f32)> = vwap_buckets(&group.points, bucket_secs)
+        let buckets = vwap_buckets(&group.points, bucket_secs);
+        for point in &buckets {
+            // key by bucket START so it aligns with the volume buckets
+            let key = point.ts.and_utc().timestamp() - bucket_secs / 2;
+            hover_map.entry(key).or_insert_with(|| vec![None; series.len()])[index] =
+                Some((price.scale(point.vwap), point.vwap));
+        }
+        let line: Vec<(f32, f32)> = buckets
             .into_iter()
             .map(|p| (time.scale(p.ts), price.scale(p.vwap)))
             .collect();
         if line.len() > 1 {
-            if series.len() == 1 {
+            if visible_count == 1 {
                 scene.nodes.push(Node::Area {
                     points: line.clone(),
                     baseline_y: price_bottom,
@@ -357,7 +495,48 @@ pub fn build_price_history_scene(
         }
     }
 
-    scene
+    let mut volume_by_bucket: BTreeMap<i64, i64> = volumes
+        .iter()
+        .map(|v| (v.ts.and_utc().timestamp(), v.quantity))
+        .collect();
+    let label_format = if bucket_secs < 86_400 {
+        "%m-%d %H:%M"
+    } else {
+        "%Y-%m-%d"
+    };
+    let hover_buckets: Vec<HoverBucket> = hover_map
+        .into_iter()
+        .filter_map(|(start, series_values)| {
+            let center = chrono::DateTime::from_timestamp(start + bucket_secs / 2, 0)?.naive_utc();
+            let display = center + TimeDelta::minutes(options.utc_offset_minutes as i64);
+            Some(HoverBucket {
+                x: time.scale(center),
+                label: display.format(label_format).to_string(),
+                series_values,
+                volume: volume_by_bucket.remove(&start).unwrap_or(0),
+            })
+        })
+        .collect();
+
+    PriceChartModel {
+        scene,
+        hover: HoverModel {
+            plot_top,
+            plot_bottom,
+            buckets: hover_buckets,
+        },
+        series: series_info,
+        stats,
+        group_level: level,
+    }
+}
+
+pub fn build_price_history_scene(
+    world_helper: &WorldHelper,
+    sales: &[SaleHistory],
+    options: &PriceChartOptions,
+) -> Scene {
+    build_price_history_chart(world_helper, sales, options).scene
 }
 
 #[cfg(test)]
@@ -514,5 +693,135 @@ mod tests {
                 "trendline endpoint y={y} escaped"
             );
         }
+    }
+
+    #[test]
+    fn model_exposes_hover_buckets_series_and_stats() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
+        assert_eq!(model.series.len(), 2);
+        assert!(!model.hover.buckets.is_empty());
+        for bucket in &model.hover.buckets {
+            assert_eq!(bucket.series_values.len(), 2);
+            assert!(!bucket.label.is_empty());
+        }
+        // sorted by x
+        assert!(
+            model
+                .hover
+                .buckets
+                .windows(2)
+                .all(|w| w[0].x <= w[1].x)
+        );
+        let stats = model.stats.expect("stats for non-empty sales");
+        assert_eq!(stats.n, 20);
+        assert!(stats.min <= stats.max);
+        assert!(stats.market_average.is_some());
+    }
+
+    #[test]
+    fn nearest_index_snaps_to_the_closest_bucket() {
+        let hover = HoverModel {
+            plot_top: 0.0,
+            plot_bottom: 100.0,
+            buckets: [10.0_f32, 20.0, 30.0]
+                .iter()
+                .map(|x| HoverBucket {
+                    x: *x,
+                    label: String::new(),
+                    series_values: Vec::new(),
+                    volume: 0,
+                })
+                .collect(),
+        };
+        assert_eq!(hover.nearest_index(-5.0), Some(0));
+        assert_eq!(hover.nearest_index(14.0), Some(0));
+        assert_eq!(hover.nearest_index(16.0), Some(1));
+        assert_eq!(hover.nearest_index(99.0), Some(2));
+        let empty = HoverModel {
+            plot_top: 0.0,
+            plot_bottom: 0.0,
+            buckets: Vec::new(),
+        };
+        assert_eq!(empty.nearest_index(10.0), None);
+    }
+
+    #[test]
+    fn scene_function_delegates_to_the_model() {
+        let scene =
+            build_price_history_scene(&world_helper(), &two_world_sales(), &PriceChartOptions::default());
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
+        assert_eq!(scene, model.scene);
+    }
+
+    #[test]
+    fn hidden_series_are_excluded_from_drawing_but_kept_in_metadata() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions {
+                hidden_series: vec!["Gilgamesh".to_string()],
+                ..Default::default()
+            },
+        );
+        // Both series stay in metadata (the legend needs the hidden one to
+        // offer un-hiding), flagged appropriately.
+        assert_eq!(model.series.len(), 2);
+        assert!(model.series.iter().any(|s| s.hidden));
+        assert!(model.series.iter().any(|s| !s.hidden));
+        // Only the visible series draws — and a single visible series gets
+        // the area fill.
+        let polylines = model
+            .scene
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Polyline { .. }))
+            .count();
+        assert_eq!(polylines, 1);
+        let areas = model
+            .scene
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, Node::Area { .. }))
+            .count();
+        assert_eq!(areas, 1);
+        // Hover keeps full-length series_values with None at the hidden slot
+        // (series sort by name: Adamantoise=0, Gilgamesh=1).
+        for bucket in &model.hover.buckets {
+            assert_eq!(bucket.series_values.len(), 2);
+            assert!(bucket.series_values[1].is_none());
+        }
+    }
+
+    #[test]
+    fn hiding_every_series_yields_the_no_data_card_but_keeps_metadata() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions {
+                hidden_series: vec!["Gilgamesh".to_string(), "Adamantoise".to_string()],
+                ..Default::default()
+            },
+        );
+        assert!(model.hover.buckets.is_empty());
+        assert_eq!(model.series.len(), 2, "legend must still offer un-hiding");
+    }
+
+    #[test]
+    fn empty_sales_yield_empty_model_with_no_data_scene() {
+        let model =
+            build_price_history_chart(&world_helper(), &[], &PriceChartOptions::default());
+        assert!(model.hover.buckets.is_empty());
+        assert!(model.stats.is_none());
+        assert!(model.scene.nodes.iter().any(
+            |n| matches!(n, Node::Text { content, .. } if content == "No recent sales")
+        ));
     }
 }

--- a/ultros-frontend/ultros-charts/src/charts/price_history.rs
+++ b/ultros-frontend/ultros-charts/src/charts/price_history.rs
@@ -815,6 +815,27 @@ mod tests {
     }
 
     #[test]
+    fn hover_volume_corresponds_to_bucket_sales() {
+        let model = build_price_history_chart(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
+        // Every hover bucket was created from at least one VWAP point, and the
+        // volume lane keys by the same bucket start — so each bucket with any
+        // series value must carry that bucket's quantity sum.
+        let total: i64 = model.hover.buckets.iter().map(|b| b.volume).sum();
+        assert_eq!(total, 40, "20 sales x quantity 2 all land in hover buckets");
+        for bucket in &model.hover.buckets {
+            assert!(
+                bucket.series_values.iter().any(|v| v.is_some()),
+                "no orphan hover buckets"
+            );
+            assert!(bucket.volume > 0, "aligned volume for every populated bucket");
+        }
+    }
+
+    #[test]
     fn empty_sales_yield_empty_model_with_no_data_scene() {
         let model =
             build_price_history_chart(&world_helper(), &[], &PriceChartOptions::default());

--- a/ultros-frontend/ultros-charts/src/charts/price_history.rs
+++ b/ultros-frontend/ultros-charts/src/charts/price_history.rs
@@ -375,7 +375,9 @@ pub fn build_price_history_chart(
         for point in &buckets {
             // key by bucket START so it aligns with the volume buckets
             let key = point.ts.and_utc().timestamp() - bucket_secs / 2;
-            hover_map.entry(key).or_insert_with(|| vec![None; series.len()])[index] =
+            hover_map
+                .entry(key)
+                .or_insert_with(|| vec![None; series.len()])[index] =
                 Some((price.scale(point.vwap), point.vwap));
         }
         let line: Vec<(f32, f32)> = buckets
@@ -709,13 +711,7 @@ mod tests {
             assert!(!bucket.label.is_empty());
         }
         // sorted by x
-        assert!(
-            model
-                .hover
-                .buckets
-                .windows(2)
-                .all(|w| w[0].x <= w[1].x)
-        );
+        assert!(model.hover.buckets.windows(2).all(|w| w[0].x <= w[1].x));
         let stats = model.stats.expect("stats for non-empty sales");
         assert_eq!(stats.n, 20);
         assert!(stats.min <= stats.max);
@@ -751,8 +747,11 @@ mod tests {
 
     #[test]
     fn scene_function_delegates_to_the_model() {
-        let scene =
-            build_price_history_scene(&world_helper(), &two_world_sales(), &PriceChartOptions::default());
+        let scene = build_price_history_scene(
+            &world_helper(),
+            &two_world_sales(),
+            &PriceChartOptions::default(),
+        );
         let model = build_price_history_chart(
             &world_helper(),
             &two_world_sales(),
@@ -831,18 +830,24 @@ mod tests {
                 bucket.series_values.iter().any(|v| v.is_some()),
                 "no orphan hover buckets"
             );
-            assert!(bucket.volume > 0, "aligned volume for every populated bucket");
+            assert!(
+                bucket.volume > 0,
+                "aligned volume for every populated bucket"
+            );
         }
     }
 
     #[test]
     fn empty_sales_yield_empty_model_with_no_data_scene() {
-        let model =
-            build_price_history_chart(&world_helper(), &[], &PriceChartOptions::default());
+        let model = build_price_history_chart(&world_helper(), &[], &PriceChartOptions::default());
         assert!(model.hover.buckets.is_empty());
         assert!(model.stats.is_none());
-        assert!(model.scene.nodes.iter().any(
-            |n| matches!(n, Node::Text { content, .. } if content == "No recent sales")
-        ));
+        assert!(
+            model
+                .scene
+                .nodes
+                .iter()
+                .any(|n| matches!(n, Node::Text { content, .. } if content == "No recent sales"))
+        );
     }
 }

--- a/ultros-frontend/ultros-charts/src/charts/price_history.rs
+++ b/ultros-frontend/ultros-charts/src/charts/price_history.rs
@@ -320,30 +320,30 @@ pub fn build_price_history_chart(
     let span_days = (last_ts - first_ts).num_days();
     let bucket_secs = bucket_seconds(options.days_range, span_days);
     let volumes = volume_buckets_from_points(all_points(), bucket_secs);
-    if options.show_volume {
-        if let Some(max_volume) = volumes.iter().map(|v| v.quantity).max() {
-            let volume = LinearScale::new((0.0, max_volume as f64), (plot_bottom, volume_top));
-            let bucket_px =
-                time.scale(first_ts + TimeDelta::seconds(bucket_secs)) - time.scale(first_ts);
-            let bar_width = (bucket_px * 0.8).max(1.0);
-            for bucket in &volumes {
-                let center = bucket.ts + TimeDelta::seconds(bucket_secs / 2);
-                let x = time.scale(center);
-                let left = (x - bar_width / 2.0).max(plot_left);
-                let right = (x + bar_width / 2.0).min(plot_right);
-                if right <= left {
-                    continue;
-                }
-                let top = volume.scale(bucket.quantity as f64);
-                scene.nodes.push(Node::Rect {
-                    x: left,
-                    y: top,
-                    width: right - left,
-                    height: (plot_bottom - top).max(1.0),
-                    rx: 1.0,
-                    fill: theme.volume.with_alpha(0.7),
-                });
+    if options.show_volume
+        && let Some(max_volume) = volumes.iter().map(|v| v.quantity).max()
+    {
+        let volume = LinearScale::new((0.0, max_volume as f64), (plot_bottom, volume_top));
+        let bucket_px =
+            time.scale(first_ts + TimeDelta::seconds(bucket_secs)) - time.scale(first_ts);
+        let bar_width = (bucket_px * 0.8).max(1.0);
+        for bucket in &volumes {
+            let center = bucket.ts + TimeDelta::seconds(bucket_secs / 2);
+            let x = time.scale(center);
+            let left = (x - bar_width / 2.0).max(plot_left);
+            let right = (x + bar_width / 2.0).min(plot_right);
+            if right <= left {
+                continue;
             }
+            let top = volume.scale(bucket.quantity as f64);
+            scene.nodes.push(Node::Rect {
+                x: left,
+                y: top,
+                width: right - left,
+                height: (plot_bottom - top).max(1.0),
+                rx: 1.0,
+                fill: theme.volume.with_alpha(0.7),
+            });
         }
     }
 

--- a/ultros-frontend/ultros-charts/src/charts/sparkline.rs
+++ b/ultros-frontend/ultros-charts/src/charts/sparkline.rs
@@ -108,9 +108,18 @@ mod tests {
     #[test]
     fn trend_color_follows_pct_change() {
         use crate::scene::Color;
-        assert_eq!(build_sparkline(&[1, 2], 5.0, 80.0, 24.0).color, Color::hex("#34d399"));
-        assert_eq!(build_sparkline(&[1, 2], -5.0, 80.0, 24.0).color, Color::hex("#f87171"));
-        assert_eq!(build_sparkline(&[1, 2], 0.0, 80.0, 24.0).color, Color::hex("#94a3b8"));
+        assert_eq!(
+            build_sparkline(&[1, 2], 5.0, 80.0, 24.0).color,
+            Color::hex("#34d399")
+        );
+        assert_eq!(
+            build_sparkline(&[1, 2], -5.0, 80.0, 24.0).color,
+            Color::hex("#f87171")
+        );
+        assert_eq!(
+            build_sparkline(&[1, 2], 0.0, 80.0, 24.0).color,
+            Color::hex("#94a3b8")
+        );
     }
 
     #[test]
@@ -120,6 +129,9 @@ mod tests {
         assert_eq!(m.nearest_index(15.0), Some(0));
         assert_eq!(m.nearest_index(25.0), Some(1));
         assert_eq!(m.nearest_index(999.0), Some(2));
-        assert_eq!(build_sparkline(&[], 0.0, 80.0, 24.0).nearest_index(10.0), None);
+        assert_eq!(
+            build_sparkline(&[], 0.0, 80.0, 24.0).nearest_index(10.0),
+            None
+        );
     }
 }

--- a/ultros-frontend/ultros-charts/src/charts/sparkline.rs
+++ b/ultros-frontend/ultros-charts/src/charts/sparkline.rs
@@ -1,0 +1,125 @@
+//! Geometry for the tiny inline sparklines (Market Movers, Continue
+//! Tracking, Trends, Analyzer). Same visual rules as the old hand-rolled
+//! component: 2px vertical inset, min→bottom / max→top scaling, gap
+//! interpolation across quiet hours, single trend color.
+
+use crate::data::interpolate::interpolate_gaps;
+use crate::scene::Color;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SparklineModel {
+    pub width: f32,
+    pub height: f32,
+    /// Scaled polyline vertices; empty for an empty/all-zero series.
+    pub points: Vec<(f32, f32)>,
+    /// Interpolated values aligned with `points` (tooltip content).
+    pub values: Vec<f32>,
+    /// Trend color: emerald up, red down, slate flat.
+    pub color: Color,
+}
+
+impl SparklineModel {
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+
+    /// Nearest sample index for pixel `x` (viewBox units).
+    pub fn nearest_index(&self, x: f32) -> Option<usize> {
+        if self.points.is_empty() {
+            return None;
+        }
+        if self.points.len() == 1 {
+            return Some(0);
+        }
+        let step = self.width / (self.points.len() as f32 - 1.0);
+        let index = (x / step).round() as i64;
+        Some(index.clamp(0, self.points.len() as i64 - 1) as usize)
+    }
+}
+
+fn trend_color(pct_change: f32) -> Color {
+    if pct_change > 0.0 {
+        Color::hex("#34d399")
+    } else if pct_change < 0.0 {
+        Color::hex("#f87171")
+    } else {
+        Color::hex("#94a3b8")
+    }
+}
+
+pub fn build_sparkline(raw: &[u32], pct_change: f32, width: f32, height: f32) -> SparklineModel {
+    let filled = interpolate_gaps(raw);
+    let color = trend_color(pct_change);
+    if filled.iter().all(|&v| v == 0.0) {
+        return SparklineModel {
+            width,
+            height,
+            points: Vec::new(),
+            values: Vec::new(),
+            color,
+        };
+    }
+    let (min, max) = filled
+        .iter()
+        .copied()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    let span = (max - min).max(1.0);
+    let inset = 2.0;
+    let usable_h = height - inset * 2.0;
+    let n = filled.len();
+    let step = if n > 1 { width / (n as f32 - 1.0) } else { 0.0 };
+    let points = filled
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (i as f32 * step, inset + (1.0 - (v - min) / span) * usable_h))
+        .collect();
+    SparklineModel {
+        width,
+        height,
+        points,
+        values: filled,
+        color,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scales_min_to_bottom_and_max_to_top_inset() {
+        let m = build_sparkline(&[100, 200], 1.0, 80.0, 24.0);
+        assert_eq!(m.points.len(), 2);
+        assert_eq!(m.points[0], (0.0, 22.0)); // min → height - inset
+        assert_eq!(m.points[1], (80.0, 2.0)); // max → inset
+        assert_eq!(m.values, vec![100.0, 200.0]);
+    }
+
+    #[test]
+    fn all_zero_series_is_empty() {
+        let m = build_sparkline(&[0, 0, 0], 0.0, 80.0, 24.0);
+        assert!(m.is_empty());
+        let m = build_sparkline(&[], 0.0, 80.0, 24.0);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn trend_color_follows_pct_change() {
+        use crate::scene::Color;
+        assert_eq!(build_sparkline(&[1, 2], 5.0, 80.0, 24.0).color, Color::hex("#34d399"));
+        assert_eq!(build_sparkline(&[1, 2], -5.0, 80.0, 24.0).color, Color::hex("#f87171"));
+        assert_eq!(build_sparkline(&[1, 2], 0.0, 80.0, 24.0).color, Color::hex("#94a3b8"));
+    }
+
+    #[test]
+    fn nearest_index_snaps_and_clamps() {
+        let m = build_sparkline(&[10, 20, 30], 0.0, 80.0, 24.0); // step = 40
+        assert_eq!(m.nearest_index(-10.0), Some(0));
+        assert_eq!(m.nearest_index(15.0), Some(0));
+        assert_eq!(m.nearest_index(25.0), Some(1));
+        assert_eq!(m.nearest_index(999.0), Some(2));
+        assert_eq!(build_sparkline(&[], 0.0, 80.0, 24.0).nearest_index(10.0), None);
+    }
+}

--- a/ultros-frontend/ultros-charts/src/components.rs
+++ b/ultros-frontend/ultros-charts/src/components.rs
@@ -77,6 +77,7 @@ fn node_view(node: &Node) -> AnyView {
                 stroke=color_attr(&stroke.color)
                 stroke-width=px(stroke.width)
                 stroke-linecap="round"
+                stroke-linejoin="round"
                 stroke-dasharray=dash_attr(stroke)
             />
         }

--- a/ultros-frontend/ultros-charts/src/components.rs
+++ b/ultros-frontend/ultros-charts/src/components.rs
@@ -1,0 +1,201 @@
+//! Leptos renderer over [`Scene`] — the browser counterpart of [`crate::svg`].
+//!
+//! [`scene_view`] maps display-list nodes to SVG view nodes. It renders a
+//! snapshot of the scene; reactivity comes from the caller rebuilding the
+//! scene inside a memo/closure. Hover layers are drawn by the app on top.
+
+use leptos::prelude::*;
+
+use crate::scene::{Color, Node, Scene, Stroke, TextAnchor};
+use crate::svg::{area_path_d, points_attr};
+
+/// CSS color string. Browsers accept `rgba()`, so unlike the resvg-bound
+/// serializer this needs no separate `*-opacity` attributes.
+pub fn color_attr(c: &Color) -> String {
+    if c.a >= 1.0 {
+        format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)
+    } else {
+        format!("rgba({},{},{},{:.3})", c.r, c.g, c.b, c.a)
+    }
+}
+
+fn px(v: f32) -> String {
+    format!("{v:.1}")
+}
+
+fn dash_attr(stroke: &Stroke) -> Option<String> {
+    stroke.dash.map(|(dash, gap)| format!("{dash:.1} {gap:.1}"))
+}
+
+/// Render the scene's nodes (plus its background) as SVG children. Embed
+/// inside an `<svg viewBox="0 0 {scene.width} {scene.height}">`.
+pub fn scene_view(scene: &Scene) -> impl IntoView {
+    let background = scene.background.as_ref().map(|bg| {
+        view! {
+            <rect x="0" y="0" width=px(scene.width) height=px(scene.height) fill=color_attr(bg) />
+        }
+    });
+    let nodes = scene.nodes.iter().map(node_view).collect_view();
+    view! {
+        {background}
+        <g font-family=scene.font_family.clone()>{nodes}</g>
+    }
+}
+
+fn node_view(node: &Node) -> AnyView {
+    match node {
+        Node::Rect {
+            x,
+            y,
+            width,
+            height,
+            rx,
+            fill,
+        } => view! {
+            <rect
+                x=px(*x)
+                y=px(*y)
+                width=px(*width)
+                height=px(*height)
+                rx=(*rx > 0.0).then(|| px(*rx))
+                fill=color_attr(fill)
+            />
+        }
+        .into_any(),
+        Node::Line {
+            x1,
+            y1,
+            x2,
+            y2,
+            stroke,
+        } => view! {
+            <line
+                x1=px(*x1)
+                y1=px(*y1)
+                x2=px(*x2)
+                y2=px(*y2)
+                stroke=color_attr(&stroke.color)
+                stroke-width=px(stroke.width)
+                stroke-linecap="round"
+                stroke-dasharray=dash_attr(stroke)
+            />
+        }
+        .into_any(),
+        Node::Polyline { points, stroke } => view! {
+            <polyline
+                points=points_attr(points)
+                fill="none"
+                stroke=color_attr(&stroke.color)
+                stroke-width=px(stroke.width)
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-dasharray=dash_attr(stroke)
+            />
+        }
+        .into_any(),
+        Node::Area {
+            points,
+            baseline_y,
+            fill,
+        } => match area_path_d(points, *baseline_y) {
+            Some(d) => view! { <path d=d fill=color_attr(fill) /> }.into_any(),
+            None => ().into_any(),
+        },
+        Node::Circle { cx, cy, r, fill } => view! {
+            <circle cx=px(*cx) cy=px(*cy) r=px(*r) fill=color_attr(fill) />
+        }
+        .into_any(),
+        Node::Text {
+            x,
+            y,
+            content,
+            size,
+            color,
+            anchor,
+            bold,
+        } => {
+            let anchor = match anchor {
+                TextAnchor::Start => "start",
+                TextAnchor::Middle => "middle",
+                TextAnchor::End => "end",
+            };
+            view! {
+                <text
+                    x=px(*x)
+                    y=px(*y)
+                    font-size=px(*size)
+                    text-anchor=anchor
+                    font-weight=bold.then_some("bold")
+                    fill=color_attr(color)
+                >
+                    {content.clone()}
+                </text>
+            }
+            .into_any()
+        }
+        Node::Image {
+            x,
+            y,
+            width,
+            height,
+            href,
+        } => view! {
+            <image x=px(*x) y=px(*y) width=px(*width) height=px(*height) href=href.clone() />
+        }
+        .into_any(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scene::{Color, Node, Scene, Stroke, TextAnchor};
+
+    #[test]
+    fn renders_scene_nodes_as_svg_markup() {
+        let scene = Scene {
+            width: 100.0,
+            height: 50.0,
+            background: Some(Color::hex("#202124")),
+            font_family: "sans-serif".to_string(),
+            nodes: vec![
+                Node::Circle {
+                    cx: 5.0,
+                    cy: 5.0,
+                    r: 2.0,
+                    fill: Color::rgb(9, 9, 9).with_alpha(0.5),
+                },
+                Node::Polyline {
+                    points: vec![(0.0, 0.0), (5.0, 5.0)],
+                    stroke: Stroke {
+                        color: Color::rgb(0, 0, 255),
+                        width: 2.0,
+                        dash: Some((2.0, 4.0)),
+                    },
+                },
+                Node::Area {
+                    points: vec![(0.0, 10.0), (5.0, 5.0)],
+                    baseline_y: 20.0,
+                    fill: Color::rgb(1, 2, 3),
+                },
+                Node::Text {
+                    x: 1.0,
+                    y: 1.0,
+                    content: "hi".to_string(),
+                    size: 13.0,
+                    color: Color::rgb(0, 0, 0),
+                    anchor: TextAnchor::Middle,
+                    bold: true,
+                },
+            ],
+        };
+        let html = scene_view(&scene).to_html();
+        assert!(html.contains("<rect"), "background rect: {html}");
+        assert!(html.contains("rgba(9,9,9,0.500)"));
+        assert!(html.contains("<polyline"));
+        assert!(html.contains("stroke-dasharray=\"2.0 4.0\""));
+        assert!(html.contains("<path"));
+        assert!(html.contains("text-anchor=\"middle\""));
+        assert!(html.contains(">hi</text>"));
+    }
+}

--- a/ultros-frontend/ultros-charts/src/data/buckets.rs
+++ b/ultros-frontend/ultros-charts/src/data/buckets.rs
@@ -127,9 +127,21 @@ mod tests {
     #[test]
     fn volume_buckets_sum_quantities() {
         let points = [
-            SalePoint { ts: ts(0), price: 100, quantity: 2 },
-            SalePoint { ts: ts(60), price: 100, quantity: 3 },
-            SalePoint { ts: ts(86_400), price: 100, quantity: 5 },
+            SalePoint {
+                ts: ts(0),
+                price: 100,
+                quantity: 2,
+            },
+            SalePoint {
+                ts: ts(60),
+                price: 100,
+                quantity: 3,
+            },
+            SalePoint {
+                ts: ts(86_400),
+                price: 100,
+                quantity: 5,
+            },
         ];
         let buckets = volume_buckets_from_points(points.iter(), 86_400);
         assert_eq!(buckets.len(), 2);

--- a/ultros-frontend/ultros-charts/src/data/buckets.rs
+++ b/ultros-frontend/ultros-charts/src/data/buckets.rs
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn volume_buckets_sum_quantities() {
-        let points = vec![
+        let points = [
             SalePoint { ts: ts(0), price: 100, quantity: 2 },
             SalePoint { ts: ts(60), price: 100, quantity: 3 },
             SalePoint { ts: ts(86_400), price: 100, quantity: 5 },

--- a/ultros-frontend/ultros-charts/src/data/buckets.rs
+++ b/ultros-frontend/ultros-charts/src/data/buckets.rs
@@ -5,7 +5,6 @@
 use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;
-use ultros_api_types::SaleHistory;
 
 use crate::data::grouping::SalePoint;
 
@@ -65,15 +64,19 @@ pub struct VolumeBucket {
     pub quantity: i64,
 }
 
-/// Total quantity sold per bucket across all series.
-pub fn volume_buckets(sales: &[SaleHistory], bucket_secs: i64) -> Vec<VolumeBucket> {
-    if bucket_secs <= 0 || sales.is_empty() {
+/// Total quantity per bucket over grouped sale points (the chart feeds the
+/// visible series' points here so hidden series don't count).
+pub fn volume_buckets_from_points<'a>(
+    points: impl Iterator<Item = &'a SalePoint>,
+    bucket_secs: i64,
+) -> Vec<VolumeBucket> {
+    if bucket_secs <= 0 {
         return Vec::new();
     }
     let mut sums: BTreeMap<i64, i64> = BTreeMap::new();
-    for sale in sales {
-        let bucket = sale.sold_date.and_utc().timestamp().div_euclid(bucket_secs) * bucket_secs;
-        *sums.entry(bucket).or_default() += sale.quantity as i64;
+    for point in points {
+        let bucket = point.ts.and_utc().timestamp().div_euclid(bucket_secs) * bucket_secs;
+        *sums.entry(bucket).or_default() += point.quantity as i64;
     }
     sums.into_iter()
         .filter_map(|(bucket, quantity)| {
@@ -89,7 +92,7 @@ pub fn volume_buckets(sales: &[SaleHistory], bucket_secs: i64) -> Vec<VolumeBuck
 mod tests {
     use super::*;
     use crate::data::grouping::SalePoint;
-    use crate::test_util::{sale, ts};
+    use crate::test_util::ts;
 
     #[test]
     fn bucket_seconds_scales_with_window() {
@@ -123,12 +126,12 @@ mod tests {
 
     #[test]
     fn volume_buckets_sum_quantities() {
-        let sales = vec![
-            sale(100, 2, 1, ts(0)),
-            sale(100, 3, 1, ts(60)),
-            sale(100, 5, 1, ts(86_400)),
+        let points = vec![
+            SalePoint { ts: ts(0), price: 100, quantity: 2 },
+            SalePoint { ts: ts(60), price: 100, quantity: 3 },
+            SalePoint { ts: ts(86_400), price: 100, quantity: 5 },
         ];
-        let buckets = volume_buckets(&sales, 86_400);
+        let buckets = volume_buckets_from_points(points.iter(), 86_400);
         assert_eq!(buckets.len(), 2);
         assert_eq!(buckets[0].quantity, 5);
         assert_eq!(buckets[1].quantity, 5);

--- a/ultros-frontend/ultros-charts/src/data/grouping.rs
+++ b/ultros-frontend/ultros-charts/src/data/grouping.rs
@@ -4,7 +4,7 @@
 //! server's local timezone, which is UTC in prod anyway; keeping UTC makes
 //! output deterministic across environments).
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use chrono::NaiveDateTime;
 use itertools::Itertools;
@@ -26,9 +26,83 @@ pub struct Series {
     pub points: Vec<SalePoint>,
 }
 
-/// All sales on one datacenter → one series per world; one region → per
-/// datacenter; otherwise per region. Series sort by name for stable colors.
-pub fn group_sales_by_scope(world_helper: &WorldHelper, sales: &[SaleHistory]) -> Vec<Series> {
+/// Which level of the world hierarchy to roll sales up to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GroupLevel {
+    Region,
+    Datacenter,
+    World,
+}
+
+impl GroupLevel {
+    /// Stable identifier (list keys / debugging); user-facing names come
+    /// from the app's i18n layer.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Region => "Region",
+            Self::Datacenter => "Datacenter",
+            Self::World => "World",
+        }
+    }
+}
+
+/// Group sales at an explicit hierarchy level. Sales whose world id isn't in
+/// the helper are dropped. Series sort by name; points by timestamp.
+pub fn group_sales_by_level(
+    world_helper: &WorldHelper,
+    sales: &[SaleHistory],
+    level: GroupLevel,
+) -> Vec<Series> {
+    let mut groups = BTreeMap::<AnySelector, Series>::new();
+    for sale in sales {
+        let Some(world) = world_helper
+            .lookup_selector(AnySelector::World(sale.world_id))
+            .and_then(|r| r.as_world())
+        else {
+            continue;
+        };
+        let selector = match level {
+            GroupLevel::World => AnySelector::World(world.id),
+            GroupLevel::Datacenter => AnySelector::Datacenter(world.datacenter_id),
+            GroupLevel::Region => {
+                let Some(datacenter) = world_helper
+                    .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                    .and_then(|r| r.as_datacenter())
+                else {
+                    continue;
+                };
+                AnySelector::Region(datacenter.region_id)
+            }
+        };
+        let Some(result) = world_helper.lookup_selector(selector) else {
+            continue;
+        };
+        groups
+            .entry(selector)
+            .or_insert_with(|| Series {
+                name: result.get_name().to_string(),
+                points: Vec::new(),
+            })
+            .points
+            .push(SalePoint {
+                ts: sale.sold_date,
+                price: sale.price_per_item,
+                quantity: sale.quantity,
+            });
+    }
+    let mut series: Vec<Series> = groups
+        .into_values()
+        .sorted_by_cached_key(|series| series.name.clone())
+        .collect();
+    for series in &mut series {
+        series.points.sort_by_key(|p| p.ts);
+    }
+    series
+}
+
+/// The narrowest level that still yields multiple groups — the old
+/// `group_sales_by_scope` cascade.
+pub fn auto_group_level(world_helper: &WorldHelper, sales: &[SaleHistory]) -> GroupLevel {
     let world_ids: HashSet<_> = sales
         .iter()
         .map(|s| AnySelector::World(s.world_id))
@@ -51,45 +125,36 @@ pub fn group_sales_by_scope(world_helper: &WorldHelper, sales: &[SaleHistory]) -
                 .map(|dc| AnySelector::Region(dc.region_id))
         })
         .collect();
-    let selectors = if datacenters.len() == 1 {
-        world_ids
-    } else if regions.len() == 1 {
-        datacenters
+    if datacenters.len() <= 1 {
+        GroupLevel::World
+    } else if regions.len() <= 1 {
+        GroupLevel::Datacenter
     } else {
-        regions
-    };
-    selectors
-        .into_iter()
-        .flat_map(|selector| series_for(world_helper, selector, sales))
-        .sorted_by_cached_key(|series| series.name.clone())
-        .collect()
+        GroupLevel::Region
+    }
 }
 
-fn series_for(
-    world_helper: &WorldHelper,
-    selector: AnySelector,
-    sales: &[SaleHistory],
-) -> Option<Series> {
-    let result = world_helper.lookup_selector(selector)?;
-    let mut points: Vec<SalePoint> = sales
-        .iter()
-        .filter(|sale| {
-            world_helper
-                .lookup_selector(AnySelector::World(sale.world_id))
-                .map(|world| world.is_in(&result))
-                .unwrap_or_default()
-        })
-        .map(|sale| SalePoint {
-            ts: sale.sold_date,
-            price: sale.price_per_item,
-            quantity: sale.quantity,
-        })
-        .collect();
-    points.sort_by_key(|p| p.ts);
-    Some(Series {
-        name: result.get_name().to_string(),
-        points,
-    })
+/// Which grouping levels make sense for the scope page being viewed —
+/// ported from the web UI (a world page only offers World; a DC page offers
+/// DC + World; a region page or unknown scope offers everything).
+pub fn available_group_levels(world_helper: &WorldHelper, scope_name: &str) -> Vec<GroupLevel> {
+    match world_helper.lookup_world_by_name(scope_name) {
+        Some(result) if result.as_world().is_some() => vec![GroupLevel::World],
+        Some(result) if result.as_datacenter().is_some() => {
+            vec![GroupLevel::Datacenter, GroupLevel::World]
+        }
+        _ => vec![
+            GroupLevel::Region,
+            GroupLevel::Datacenter,
+            GroupLevel::World,
+        ],
+    }
+}
+
+/// Auto-picked grouping (the PNG path): the narrowest level that still
+/// yields multiple groups.
+pub fn group_sales_by_scope(world_helper: &WorldHelper, sales: &[SaleHistory]) -> Vec<Series> {
+    group_sales_by_level(world_helper, sales, auto_group_level(world_helper, sales))
 }
 
 #[cfg(test)]
@@ -141,5 +206,54 @@ mod tests {
         let series = group_sales_by_scope(&world_helper(), &sales);
         assert_eq!(names(&series), vec!["Gilgamesh"]);
         assert_eq!(series[0].points.len(), 1);
+    }
+
+    #[test]
+    fn explicit_level_overrides_auto() {
+        // Sales on one DC would auto-group by world; force datacenter level.
+        let sales = vec![sale(100, 1, 1, ts(0)), sale(200, 1, 2, ts(10))];
+        let series = group_sales_by_level(&world_helper(), &sales, GroupLevel::Datacenter);
+        assert_eq!(names(&series), vec!["Aether"]);
+        assert_eq!(series[0].points.len(), 2);
+        let series = group_sales_by_level(&world_helper(), &sales, GroupLevel::Region);
+        assert_eq!(names(&series), vec!["North-America"]);
+    }
+
+    #[test]
+    fn auto_level_matches_scope_cascade() {
+        let h = world_helper();
+        // one DC → world level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 2, ts(0))]),
+            GroupLevel::World
+        );
+        // two DCs, one region → datacenter level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 3, ts(0))]),
+            GroupLevel::Datacenter
+        );
+        // two regions → region level
+        assert_eq!(
+            auto_group_level(&h, &[sale(1, 1, 1, ts(0)), sale(1, 1, 4, ts(0))]),
+            GroupLevel::Region
+        );
+    }
+
+    #[test]
+    fn available_levels_follow_the_viewed_scope() {
+        let h = world_helper();
+        assert_eq!(available_group_levels(&h, "Gilgamesh"), vec![GroupLevel::World]);
+        assert_eq!(
+            available_group_levels(&h, "Aether"),
+            vec![GroupLevel::Datacenter, GroupLevel::World]
+        );
+        assert_eq!(
+            available_group_levels(&h, "North-America"),
+            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+        );
+        assert_eq!(
+            available_group_levels(&h, "Not A Scope"),
+            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+        );
     }
 }

--- a/ultros-frontend/ultros-charts/src/data/grouping.rs
+++ b/ultros-frontend/ultros-charts/src/data/grouping.rs
@@ -240,6 +240,21 @@ mod tests {
     }
 
     #[test]
+    fn scope_grouping_equals_explicit_level_at_the_auto_level() {
+        let h = world_helper();
+        let scenarios = [
+            vec![sale(100, 1, 1, ts(0)), sale(200, 1, 2, ts(10))], // one DC
+            vec![sale(100, 1, 1, ts(0)), sale(200, 1, 3, ts(10))], // one region
+            vec![sale(100, 1, 1, ts(0)), sale(200, 1, 4, ts(10))], // two regions
+        ];
+        for sales in scenarios {
+            let auto = group_sales_by_scope(&h, &sales);
+            let explicit = group_sales_by_level(&h, &sales, auto_group_level(&h, &sales));
+            assert_eq!(auto, explicit);
+        }
+    }
+
+    #[test]
     fn available_levels_follow_the_viewed_scope() {
         let h = world_helper();
         assert_eq!(available_group_levels(&h, "Gilgamesh"), vec![GroupLevel::World]);

--- a/ultros-frontend/ultros-charts/src/data/grouping.rs
+++ b/ultros-frontend/ultros-charts/src/data/grouping.rs
@@ -257,18 +257,29 @@ mod tests {
     #[test]
     fn available_levels_follow_the_viewed_scope() {
         let h = world_helper();
-        assert_eq!(available_group_levels(&h, "Gilgamesh"), vec![GroupLevel::World]);
+        assert_eq!(
+            available_group_levels(&h, "Gilgamesh"),
+            vec![GroupLevel::World]
+        );
         assert_eq!(
             available_group_levels(&h, "Aether"),
             vec![GroupLevel::Datacenter, GroupLevel::World]
         );
         assert_eq!(
             available_group_levels(&h, "North-America"),
-            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+            vec![
+                GroupLevel::Region,
+                GroupLevel::Datacenter,
+                GroupLevel::World
+            ]
         );
         assert_eq!(
             available_group_levels(&h, "Not A Scope"),
-            vec![GroupLevel::Region, GroupLevel::Datacenter, GroupLevel::World]
+            vec![
+                GroupLevel::Region,
+                GroupLevel::Datacenter,
+                GroupLevel::World
+            ]
         );
     }
 }

--- a/ultros-frontend/ultros-charts/src/data/interpolate.rs
+++ b/ultros-frontend/ultros-charts/src/data/interpolate.rs
@@ -1,0 +1,76 @@
+/// Replace each zero in the series with a linear interpolation between
+/// the surrounding non-zero values. Leading/trailing zeros are clamped to
+/// the nearest non-zero. If the whole series is zero, returns zeros.
+pub fn interpolate_gaps(raw: &[u32]) -> Vec<f32> {
+    let n = raw.len();
+    let mut out: Vec<f32> = raw.iter().map(|&v| v as f32).collect();
+
+    // Pass 1: anchor positions of non-zero values.
+    let positions: Vec<usize> = raw
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &v)| if v > 0 { Some(i) } else { None })
+        .collect();
+
+    if positions.is_empty() {
+        return out;
+    }
+
+    // Leading zeros: pin to first non-zero.
+    let first = positions[0];
+    for o in out.iter_mut().take(first) {
+        *o = raw[first] as f32;
+    }
+    // Trailing zeros: pin to last non-zero.
+    let last = *positions.last().unwrap();
+    for o in out.iter_mut().take(n).skip(last + 1) {
+        *o = raw[last] as f32;
+    }
+
+    // Internal gaps: linear interp between consecutive anchors.
+    for w in positions.windows(2) {
+        let (a, b) = (w[0], w[1]);
+        if b - a <= 1 {
+            continue;
+        }
+        let va = raw[a] as f32;
+        let vb = raw[b] as f32;
+        let gap = (b - a) as f32;
+        for k in 1..(b - a) {
+            let t = k as f32 / gap;
+            out[a + k] = va + (vb - va) * t;
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpolate_fills_leading_and_trailing_zeros() {
+        let out = interpolate_gaps(&[0, 0, 10, 20, 0, 0]);
+        assert_eq!(out, vec![10.0, 10.0, 10.0, 20.0, 20.0, 20.0]);
+    }
+
+    #[test]
+    fn interpolate_bridges_internal_gap_linearly() {
+        // 100 at idx 0, 200 at idx 4 → 125, 150, 175 between
+        let out = interpolate_gaps(&[100, 0, 0, 0, 200]);
+        assert_eq!(out, vec![100.0, 125.0, 150.0, 175.0, 200.0]);
+    }
+
+    #[test]
+    fn interpolate_all_zeros_stays_zero() {
+        let out = interpolate_gaps(&[0, 0, 0]);
+        assert_eq!(out, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn interpolate_passthrough_when_no_gaps() {
+        let out = interpolate_gaps(&[10, 20, 30]);
+        assert_eq!(out, vec![10.0, 20.0, 30.0]);
+    }
+}

--- a/ultros-frontend/ultros-charts/src/data/mod.rs
+++ b/ultros-frontend/ultros-charts/src/data/mod.rs
@@ -1,5 +1,6 @@
 pub mod buckets;
 pub mod grouping;
+pub mod interpolate;
 pub mod outliers;
 pub mod stats;
 pub mod trend;

--- a/ultros-frontend/ultros-charts/src/lib.rs
+++ b/ultros-frontend/ultros-charts/src/lib.rs
@@ -17,5 +17,8 @@ mod icon;
 #[cfg(feature = "image")]
 pub use icon::item_icon_data_uri;
 
+#[cfg(feature = "leptos")]
+pub mod components;
+
 #[cfg(test)]
 pub(crate) mod test_util;

--- a/ultros-frontend/ultros-charts/src/scale.rs
+++ b/ultros-frontend/ultros-charts/src/scale.rs
@@ -1,7 +1,7 @@
 //! Numeric and time axes: domain→pixel mapping, "nice" tick generation,
 //! and the K/mil number formatting shared with the web UI.
 
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, TimeDelta};
 
 /// Format an integer gil value as `1.50K` / `2.30mil`, matching the web UI.
 pub fn short_number(value: i32) -> String {
@@ -120,9 +120,10 @@ impl TimeScale {
         self.range.0 + t as f32 * (self.range.1 - self.range.0)
     }
 
-    /// At most `target` ticks aligned to step boundaries, labelled with a
-    /// format that matches the step size.
-    pub fn ticks(&self, target: usize) -> Vec<TimeTick> {
+    /// At most `target` ticks aligned to step boundaries. `label_offset_minutes`
+    /// shifts the LABEL text only (viewer-local display); tick positions stay
+    /// UTC-aligned so SSR and client geometry agree.
+    pub fn ticks(&self, target: usize, label_offset_minutes: i32) -> Vec<TimeTick> {
         let span = self.end - self.start;
         let step = TIME_STEPS
             .iter()
@@ -146,9 +147,10 @@ impl TimeScale {
         while tick <= self.end {
             if let Some(ts) = chrono::DateTime::from_timestamp(tick, 0) {
                 let ts = ts.naive_utc();
+                let display = ts + TimeDelta::minutes(label_offset_minutes as i64);
                 out.push(TimeTick {
                     ts,
-                    label: ts.format(format).to_string(),
+                    label: display.format(format).to_string(),
                 });
             }
             tick += step;
@@ -206,7 +208,7 @@ mod tests {
             ts(1_700_000_000 + 2 * 3600),
             (0.0, 100.0),
         );
-        let ticks = scale.ticks(6);
+        let ticks = scale.ticks(6, 0);
         assert!(!ticks.is_empty() && ticks.len() <= 6);
         // Sub-day spans label as %H:%M
         assert!(ticks[0].label.contains(':'));
@@ -229,9 +231,19 @@ mod tests {
     fn time_ticks_use_day_steps_for_month_spans() {
         let start = ts(1_700_000_000);
         let end = ts(1_700_000_000 + 30 * 86_400);
-        let ticks = TimeScale::new(start, end, (0.0, 100.0)).ticks(6);
+        let ticks = TimeScale::new(start, end, (0.0, 100.0)).ticks(6, 0);
         assert!(!ticks.is_empty() && ticks.len() <= 7);
         // Day-scale steps label as %m-%d: no time-of-day component
         assert!(ticks.iter().all(|t| !t.label.contains(':')));
+    }
+
+    #[test]
+    fn tick_labels_shift_with_offset_but_positions_do_not() {
+        let scale = TimeScale::new(ts(1_700_000_000), ts(1_700_000_000 + 2 * 3600), (0.0, 100.0));
+        let utc = scale.ticks(6, 0);
+        let shifted = scale.ticks(6, 60);
+        assert_eq!(utc.len(), shifted.len());
+        assert_eq!(utc[0].ts, shifted[0].ts);
+        assert_ne!(utc[0].label, shifted[0].label);
     }
 }

--- a/ultros-frontend/ultros-charts/src/scale.rs
+++ b/ultros-frontend/ultros-charts/src/scale.rs
@@ -239,7 +239,11 @@ mod tests {
 
     #[test]
     fn tick_labels_shift_with_offset_but_positions_do_not() {
-        let scale = TimeScale::new(ts(1_700_000_000), ts(1_700_000_000 + 2 * 3600), (0.0, 100.0));
+        let scale = TimeScale::new(
+            ts(1_700_000_000),
+            ts(1_700_000_000 + 2 * 3600),
+            (0.0, 100.0),
+        );
         let utc = scale.ticks(6, 0);
         let shifted = scale.ticks(6, 60);
         assert_eq!(utc.len(), shifted.len());

--- a/ultros-frontend/ultros-charts/src/svg.rs
+++ b/ultros-frontend/ultros-charts/src/svg.rs
@@ -61,7 +61,10 @@ pub(crate) fn area_path_d(points: &[(f32, f32)], baseline_y: f32) -> Option<Stri
     }
     let first_x = points[0].0;
     let last_x = points[points.len() - 1].0;
-    let _ = write!(d, "L{last_x:.1} {baseline_y:.1}L{first_x:.1} {baseline_y:.1}Z");
+    let _ = write!(
+        d,
+        "L{last_x:.1} {baseline_y:.1}L{first_x:.1} {baseline_y:.1}Z"
+    );
     Some(d)
 }
 

--- a/ultros-frontend/ultros-charts/src/svg.rs
+++ b/ultros-frontend/ultros-charts/src/svg.rs
@@ -38,7 +38,7 @@ fn push_stroke(out: &mut String, s: &Stroke) {
     }
 }
 
-fn points_attr(points: &[(f32, f32)]) -> String {
+pub(crate) fn points_attr(points: &[(f32, f32)]) -> String {
     let mut out = String::with_capacity(points.len() * 12);
     for (i, (x, y)) in points.iter().enumerate() {
         if i > 0 {
@@ -47,6 +47,22 @@ fn points_attr(points: &[(f32, f32)]) -> String {
         let _ = write!(out, "{x:.1},{y:.1}");
     }
     out
+}
+
+/// Path data for a filled area: the polyline plus a closing run along the
+/// baseline. `None` for fewer than 2 points.
+pub(crate) fn area_path_d(points: &[(f32, f32)], baseline_y: f32) -> Option<String> {
+    if points.len() < 2 {
+        return None;
+    }
+    let mut d = String::new();
+    for (i, (x, y)) in points.iter().enumerate() {
+        let _ = write!(d, "{}{x:.1} {y:.1}", if i == 0 { "M" } else { "L" });
+    }
+    let first_x = points[0].0;
+    let last_x = points[points.len() - 1].0;
+    let _ = write!(d, "L{last_x:.1} {baseline_y:.1}L{first_x:.1} {baseline_y:.1}Z");
+    Some(d)
 }
 
 fn escape_text(text: &str) -> String {
@@ -121,19 +137,9 @@ pub fn scene_to_svg(scene: &Scene) -> String {
                 baseline_y,
                 fill,
             } => {
-                if points.len() < 2 {
+                let Some(d) = area_path_d(points, *baseline_y) else {
                     continue;
-                }
-                let mut d = String::new();
-                for (i, (x, y)) in points.iter().enumerate() {
-                    let _ = write!(d, "{}{x:.1} {y:.1}", if i == 0 { "M" } else { "L" });
-                }
-                let first_x = points[0].0;
-                let last_x = points[points.len() - 1].0;
-                let _ = write!(
-                    d,
-                    "L{last_x:.1} {baseline_y:.1}L{first_x:.1} {baseline_y:.1}Z"
-                );
+                };
                 let _ = write!(out, r#"<path d="{d}""#);
                 push_fill(&mut out, fill);
                 out.push_str("/>");


### PR DESCRIPTION
PRs 2 + 3 of the ultros_charts rewrite, combined per request (spec: docs/superpowers/specs/2026-06-09-ultros-charts-design.md; plans: 2026-06-09-ultros-charts-pr2-web-chart.md, -pr3-sparklines.md).

## Price chart (item page)

- **ultros-charts core:** `build_price_history_chart` returns a `PriceChartModel` — the Scene plus hover buckets (per-series y/VWAP per time bucket + volume), stats (n/market avg/median/min/max), and series metadata with hidden flags. Explicit `GroupLevel` grouping (Region/DC/World) with the scope-based availability rule moved out of the app; auto-grouping equivalence is test-pinned. Time ticks gained a label-only viewer-timezone offset (geometry stays UTC). New `leptos` feature renders any Scene as SVG view nodes (`components::scene_view`).
- **ultros-app:** `price_history_chart.rs` rewritten from ~1050 lines of chartistry plumbing to ~430 lines of wiring — crosshair + per-series dots + HTML tooltip (flips at the midpoint), clickable legend chips that hide/show series (axes rescale), all existing toggles/stats/color-by preserved with the same i18n keys, responsive scene rebuild at the measured width (16px-quantized; `use_element_size`, no scroll listener — hover x comes from `getBoundingClientRect` per pointermove).
- **leptos-chartistry removed** from the workspace (dep + `._chartistry*` CSS + the nth-of-type marker-color hack).
- **Hydration safety:** timezone offset and width start at deterministic defaults (UTC / 960px) for SSR + first client render and shift via post-hydration effects — same pattern as the existing hydrated gates. Verified live: no tachys panics in console.

## Sparklines (Market Movers / Continue Tracking / Trends / Analyzer)

- Gap interpolation moved to `ultros-charts/data/interpolate.rs` (tests moved with it); `charts/sparkline.rs` builds a `SparklineModel` (scaled vertices, values, trend color, hover snap math).
- `<Sparkline>` is now interactive: hover shows a dot on the trace plus a micro-tooltip ("24.25K · 9h ago"), nothing rendered until hover. Call sites unchanged (prop-compatible).
- Two new i18n keys (`sparkline_now`, `sparkline_hours_ago`) added to all 7 locales with real translations.

## Untouched

- The server PNG path (Discord bot / item card): `item_card.rs` is not in this diff; `build_price_history_scene` delegates to the model builder and a test pins scene equality.

## Verification

- 55 unit + 2 PNG-integration tests in ultros-charts; full-workspace `cargo clippy --all-targets -- -D warnings` and fmt-check green; ssr + wasm32 hydrate targets compile.
- Live-browser pass on Windows (postgres + ClickHouse local): single-world and DC-scope charts, hover/crosshair/tooltip, all toggles, legend hide/show round-trip, 7d/30d window switching, 420px-wide responsive rebuild (448×300 viewBox — natural-size text), sparkline hover/leave on the home page. Screenshots in the session; the analyzer warm-up `—` and stale-ClickHouse empty movers are the documented local false alarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)