### PR TITLE
⚡ Bolt: Replace Memo::new with Signal::derive for trivial O(1) ops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2025-05-30 - Avoid Memo::new for trivial map lookups and struct accesses in Leptos components
 **Learning:** Found multiple components (`RelatedItems`, `VirtualScroller`, `ItemExplorer`) where `Memo::new` was used for completely O(1) operations. In `RelatedItems` we wrapped a HashMap `.get()`. `Memo` creates a new reactive node, tracks dependencies, allocates memory for the value, and does equality checks on every update. For extremely cheap O(1) operations, the reactive system overhead is significantly higher than the operation itself.
 **Action:** Replace `Memo::new` with `Signal::derive` (or raw `move ||`) for cheap map lookups, struct field accesses, and trivial mathematical operations in Leptos. Save `Memo` for when the operation actually involves heavy allocations, sorting, iterating large collections, or expensive formatting.
+
+## 2025-06-10 - Replace Memo::new with Signal::derive for O(1) unwrap_or_default calls
+**Learning:** Found multiple instances where `Memo::new` was used for completely O(1) operations like `.unwrap_or_default()` and `.is_empty()` after `with()` on signals. Creating a `Memo` adds reactivity overhead including tracking dependencies, allocating memory, and checking equality. This is inefficient for trivial operations.
+**Action:** Always prefer `Signal::derive` (or simple closures) for trivial instantaneous operations such as unwrap, `is_empty`, and `.clone()` lookups. Only use `Memo::new` for more expensive operations such as iterating over lists or computing sorts.

--- a/ultros-frontend/ultros-app/src/components/on_hand_input.rs
+++ b/ultros-frontend/ultros-app/src/components/on_hand_input.rs
@@ -162,7 +162,7 @@ pub fn OnHandQuantity(
 ) -> impl IntoView {
     let i18n = use_i18n();
     let on_hand = use_context::<OnHandMap>().expect("OnHandMap not provided");
-    let value = Memo::new(move |_| on_hand.0.with(|m| m.get(&item_id()).copied().unwrap_or(0)));
+    let value = Signal::derive(move || on_hand.0.with(|m| m.get(&item_id()).copied().unwrap_or(0)));
     let aria = move || match &item_name {
         Some(name) => format!("On-hand quantity for {}", name.get()),
         None => "On-hand quantity".to_string(),
@@ -198,7 +198,7 @@ pub fn OnHandQuantity(
 pub fn OnHandPanel() -> impl IntoView {
     let i18n = use_i18n();
     let on_hand = use_context::<OnHandMap>().expect("OnHandMap not provided");
-    let is_empty = Memo::new(move |_| on_hand.0.with(|m| m.is_empty()));
+    let is_empty = Signal::derive(move || on_hand.0.with(|m| m.is_empty()));
 
     view! {
         <div class="panel p-4 rounded-lg border border-brand-700/30">

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -382,8 +382,8 @@ pub fn SalesInsights(sales: Signal<Vec<SaleHistory>>) -> impl IntoView {
             }
         }
     });
-    let day_sales = Memo::new(move |_| sales.with(|s| s.past_day.clone()).unwrap_or_default());
-    let month_sales = Memo::new(move |_| sales.with(|s| s.month.clone()).unwrap_or_default());
+    let day_sales = Signal::derive(move || sales.with(|s| s.past_day.clone()).unwrap_or_default());
+    let month_sales = Signal::derive(move || sales.with(|s| s.month.clone()).unwrap_or_default());
     view! {
         <div class="mb-4 flex flex-wrap items-end justify-between gap-2">
             <h3 class="text-xl font-bold text-[color:var(--brand-fg)]">{t!(i18n, sale_history_insights_title)}</h3>

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1721,7 +1721,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                                                     world_cheapest_listings=w
                                                     cross_region
                                                     worlds
-                                                    world=world.into()
+                                                    world=world
                                                     filter_outliers=filter_outliers().unwrap_or(false)
                                                 />
                                             },

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1497,7 +1497,7 @@ fn AnalyzerTable(
 pub fn AnalyzerWorldView() -> impl IntoView {
     let i18n = use_i18n();
     let params = use_params_map();
-    let world = Memo::new(move |_| params.with(|p| p.get("world").clone()).unwrap_or_default());
+    let world = Signal::derive(move || params.with(|p| p.get("world").clone()).unwrap_or_default());
     let sales = ArcResource::new(
         move || params.with(|p| p.get("world").clone()),
         move |world| async move {

--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -215,7 +215,7 @@ pub fn JobItems() -> impl IntoView {
     let params = use_params_map();
     let data = tracked_data();
     let (non_market, set_non_market) = query_signal::<bool>("show-non-market");
-    let market_only = Memo::new(move |_| !non_market().unwrap_or_default());
+    let market_only = Signal::derive(move || !non_market().unwrap_or_default());
     let set_market_only =
         SignalSetter::map(move |market: bool| set_non_market((!market).then_some(true)));
     let items = Memo::new(move |_| {

--- a/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
+++ b/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
@@ -440,7 +440,7 @@ pub fn JobSetDetail() -> impl IntoView {
     let cheapest_prices = use_context::<CheapestPrices>();
     let default_zone_listings = cheapest_prices.map(|p| p.read_listings);
 
-    let set_stem = Memo::new(move |_| group.get().map(|g| g.stem).unwrap_or_default());
+    let set_stem = Signal::derive(move || group.get().map(|g| g.stem).unwrap_or_default());
     let job_name = Memo::new(move |_| {
         canonical_abbr
             .get()

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -741,7 +741,7 @@ pub fn VendorWorldView() -> impl IntoView {
                                             <VendorResaleTable
                                                 sales=s
                                                 world_cheapest_listings=w
-                                                world=world.into()
+                                                world=world
                                             />
                                         },
                                     )

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -661,7 +661,7 @@ fn VendorResaleTable(
 pub fn VendorWorldView() -> impl IntoView {
     let i18n = use_i18n();
     let params = use_params_map();
-    let world = Memo::new(move |_| params.with(|p| p.get("world").clone()).unwrap_or_default());
+    let world = Signal::derive(move || params.with(|p| p.get("world").clone()).unwrap_or_default());
 
     // We fetch sales for better estimation, even though we are comparing to vendor prices
     let sales = ArcResource::new(


### PR DESCRIPTION
💡 **What:** Replaced multiple instances of `Memo::new` with `Signal::derive` when wrapping simple getter functions, `.unwrap_or_default()`, or `.is_empty()` calls.

🎯 **Why:** `Memo::new` is designed for expensive operations that we want to cache, such as complex filtering or sorting. Creating a memo involves creating a reactive node, tracking dependencies, allocating memory for the cached value, and checking equality on every update. For an extremely cheap O(1) instantaneous operation, this reactivity overhead is significantly more expensive than the operation itself. By switching to `Signal::derive` (or a regular closure), Leptos will simply evaluate the inner value without paying the memoization tax. 

📊 **Impact:** Reduces reactive overhead (fewer signal nodes, no equality checks, fewer allocations) across multiple high-traffic components including item explorer, job sets, on-hand input, and analyzer tools.

🔬 **Measurement:** Code review. Profile leptos reactive graph creation and update cycles - memory footprint and component instantiation times should be slightly lowered.

---
*PR created automatically by Jules for task [11875047969609337191](https://jules.google.com/task/11875047969609337191) started by @akarras*