### PR TITLE
fix(error-reporting): suppress modern-Chrome translation-injected hydration panic flood

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -26,9 +26,13 @@ const FILTER_PATH = path.join(
 );
 const SRC = fs.readFileSync(FILTER_PATH, "utf8");
 
-// Load the filter with a given UA and return its `shouldDrop` predicate.
-function loadFilter(userAgent) {
+// Load the filter with a given UA (and optional fake document) and return
+// its `shouldDrop` predicate. The font-injection fingerprint reads
+// `window.document.getElementsByTagName("font")`, so cases that exercise it
+// pass a fake document; omitting it mirrors a browser with no <font> nodes.
+function loadFilter(userAgent, documentObj) {
   const win = {};
+  if (documentObj !== undefined) win.document = documentObj;
   // eslint-disable-next-line no-new-func
   const factory = new Function("window", "navigator", SRC);
   factory(win, { userAgent: userAgent || "" });
@@ -38,6 +42,16 @@ function loadFilter(userAgent) {
     "error_filter.js must define window.__ultrosShouldDropEvent",
   );
   return win.__ultrosShouldDropEvent;
+}
+
+// A minimal document stand-in whose getElementsByTagName("font") reports
+// `fontCount` injected <font> nodes (any other tag reports zero).
+function fakeDocument(fontCount) {
+  return {
+    getElementsByTagName(tag) {
+      return { length: tag === "font" ? fontCount : 0 };
+    },
+  };
 }
 
 // Real Chrome/112 WebView UA from GlitchTip issue #707's request payload.
@@ -52,6 +66,20 @@ const CURRENT_CHROME =
 const HYDRATION_LOC =
   "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/" +
   "tachys-0.2.15/src/hydration.rs:227:9";
+
+// Where the secondary `RefCell already borrowed` cascade panics — the
+// wasm-bindgen-futures executor, NOT a tachys path. Such events are only
+// recognized as the hydration flood via the tachys hydration breadcrumb.
+const JS_SYS_SINGLETHREAD_LOC =
+  "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/" +
+  "js-sys-0.3.99/src/futures/task/singlethread.rs:142:37";
+
+// The console breadcrumb every shape of the flood carries: the original
+// hydration panic that kicked off the cascade.
+const TACHYS_PANIC_BREADCRUMB = {
+  category: "console",
+  message: "panicked at " + HYDRATION_LOC + ":\ninternal error: entered unreachable code",
+};
 
 function rustPanic(location, extra) {
   return Object.assign(
@@ -95,11 +123,88 @@ const cases = [
     expectDrop: true,
   },
   {
-    name: "hydration panic on a CURRENT browser is preserved (real bugs still reach GlitchTip)",
+    name: "hydration panic on a CURRENT browser with NO injected <font> is preserved (real bugs still reach GlitchTip)",
     ua: CURRENT_CHROME,
+    document: fakeDocument(0),
     event: rustPanic(HYDRATION_LOC, {
       breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
     }),
+    expectDrop: false,
+  },
+  // The modern-Chrome CN-translation population that ignores the notranslate
+  // trifecta: a current browser, but the live DOM has translation-injected
+  // <font> wrappers. This is the #3005/#4911/#6406 flood PR #760 still missed.
+  {
+    name: "tachys hydration panic on a current browser WITH injected <font> (translation overlay) is dropped",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(7),
+    event: rustPanic(HYDRATION_LOC, {
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    }),
+    expectDrop: true,
+  },
+  // The secondary cascade: `RefCell already borrowed` panics in the js-sys
+  // executor (not a tachys path), so it is recognized only via the tachys
+  // hydration breadcrumb. With injected <font> present it is the flood.
+  {
+    name: "RefCell-already-borrowed cascade (js-sys location) with tachys breadcrumb + injected <font> is dropped",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(4),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: {
+        values: [
+          { category: "console", message: "app run!" },
+          TACHYS_PANIC_BREADCRUMB,
+          {
+            category: "console",
+            message: "panicked at " + JS_SYS_SINGLETHREAD_LOC + ":\nRefCell already borrowed",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  // Same cascade shape but on a CLEAN (untranslated) page — a genuine
+  // hydration mismatch. No injected <font>, so it must still report.
+  {
+    name: "RefCell-already-borrowed cascade from a genuine (untranslated) hydration mismatch is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(0),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }, TACHYS_PANIC_BREADCRUMB] },
+    },
+    expectDrop: false,
+  },
+  // The unhandled wasm trap that reaches window.onerror: type RuntimeError,
+  // no rust_panic context at all — recognized via the tachys breadcrumb.
+  {
+    name: "unhandled RuntimeError unreachable (window.onerror, no rust_panic) with tachys breadcrumb + injected <font> is dropped",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(1),
+    event: {
+      exception: { values: [{ type: "RuntimeError", value: "unreachable" }] },
+      breadcrumbs: { values: [TACHYS_PANIC_BREADCRUMB] },
+    },
+    expectDrop: true,
+  },
+  // A non-hydration RuntimeError with injected <font> present must NOT be
+  // swept up: the font fingerprint only suppresses tachys hydration panics.
+  {
+    name: "a non-hydration RuntimeError is preserved even when <font> is present",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(5),
+    event: {
+      exception: { values: [{ type: "RuntimeError", value: "table index is out of bounds" }] },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
     expectDrop: false,
   },
 
@@ -294,7 +399,7 @@ const cases = [
 
 for (const c of cases) {
   test(c.name, () => {
-    const shouldDrop = loadFilter(c.ua);
+    const shouldDrop = loadFilter(c.ua, c.document);
     const dropped = shouldDrop(c.event) === true;
     assert.strictEqual(
       dropped,

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -28,13 +28,23 @@
 //      Browser / UC / WeChat in-app WebViews on frozen Chrome 112).
 //      GlitchTip issues #1, #7, #313, #770, #1047, #2776–#2812.
 //   3. tachys hydration `unreachable!()` panics at
-//      /tachys-*/src/hydration.rs:* triggered by the same population
-//      when an injected auto-translation overlay wraps text nodes in
-//      <font> elements before Leptos hydrates. Matched on the exact
-//      crates.io path AND a fingerprint of the injecting browser so
-//      legit hydration mismatches on current browsers still reach
-//      GlitchTip. Issues #678, #707, #770, #1307, #2277, #2775, #4951,
-//      #4905.
+//      /tachys-*/src/hydration.rs:* triggered when an injected
+//      auto-translation overlay wraps text nodes in <font> elements
+//      before Leptos hydrates (see shell() in lib.rs for the full
+//      chain). Three event shapes share this one root: the handled
+//      `internal error: entered unreachable code` panic (tachys path in
+//      contexts.rust_panic), its `RefCell already borrowed` cascade in
+//      the wasm-bindgen-futures executor (a js-sys path — matched via a
+//      tachys hydration breadcrumb instead), and the unhandled
+//      `RuntimeError: unreachable` that reaches window.onerror with no
+//      rust_panic context at all. Suppressed only when an injecting
+//      fingerprint is present: a <font> element in the live DOM (which
+//      Ultros never emits, so it is necessarily translation-injected —
+//      this catches the modern-Chrome CN population that ignores the
+//      notranslate trifecta), the page-stability breadcrumb, or the
+//      frozen Chrome 112 WebView UA. Genuine hydration mismatches on a
+//      clean page have no <font> and still reach GlitchTip. Issues #678,
+//      #707, #770, #1307, #2277, #2775, #3005, #4905, #4911, #6406.
 //   4. "Non-Error promise rejection captured with value: undefined"
 //      (and the null variant) — Sentry's synthetic wrapper for a promise
 //      rejected with no reason. Zero diagnostic value (no message, no
@@ -128,23 +138,74 @@
     return false;
   }
 
+  function breadcrumbList(event) {
+    // The Sentry SDK passes in-flight breadcrumbs as a bare array; the
+    // server/envelope shape nests them under `.values`. Handle both.
+    return (
+      (event && event.breadcrumbs && event.breadcrumbs.values) ||
+      (event && event.breadcrumbs) ||
+      []
+    );
+  }
+
+  // Is this event the tachys hydration panic, in any of its three shapes?
+  function isTachysHydrationPanicEvent(event) {
+    // (a) The handled root panic carries the tachys path in rust_panic.
+    var ctx = event && event.contexts && event.contexts.rust_panic;
+    var loc = ctx && ctx.location;
+    if (
+      typeof loc === "string" &&
+      loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") === 0 &&
+      ULTROS_TACHYS_HYDRATION_RE.test(loc)
+    ) {
+      return true;
+    }
+    // (b) The `RefCell already borrowed` cascade reports with a js-sys
+    //     executor location, and the unhandled `RuntimeError: unreachable`
+    //     (window.onerror) has no rust_panic context at all — but both still
+    //     carry the original `panicked at .../tachys-*/src/hydration.rs:`
+    //     console breadcrumb that kicked off the cascade.
+    var crumbs = breadcrumbList(event);
+    if (Array.isArray(crumbs)) {
+      for (var i = 0; i < crumbs.length; i++) {
+        var msg = crumbs[i] && crumbs[i].message;
+        if (typeof msg === "string" && ULTROS_TACHYS_HYDRATION_RE.test(msg)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Ultros never emits <font>: no `view!` produces it and item text is
+  // escaped to text nodes, not elements. So any <font> in the live document
+  // was injected by a translation overlay rewriting text nodes — the exact
+  // mutation that shifts tachys' hydration cursor (see shell() in lib.rs).
+  // This catches the modern, self-updating Chrome population (CN data-center
+  // users reading the English UI) that ignores the notranslate trifecta and
+  // so is missed by the frozen-Chrome-112 UA check. Ads and the
+  // funding-choices consent dialog render in iframes, which
+  // getElementsByTagName does not traverse, so they cannot match.
+  function hasInjectedTranslationFont() {
+    try {
+      var doc = typeof window !== "undefined" && window.document;
+      if (!doc || typeof doc.getElementsByTagName !== "function") return false;
+      var fonts = doc.getElementsByTagName("font");
+      return !!fonts && fonts.length > 0;
+    } catch (_) {
+      return false;
+    }
+  }
+
   function isInjectedTachysHydrationPanic(event) {
     try {
-      var ctx = event && event.contexts && event.contexts.rust_panic;
-      var loc = ctx && ctx.location;
-      if (typeof loc !== "string") return false;
-      if (loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") !== 0)
-        return false;
-      if (!ULTROS_TACHYS_HYDRATION_RE.test(loc)) return false;
+      if (!isTachysHydrationPanicEvent(event)) return false;
 
-      // Second prong: only suppress when the third-party DOM mutation
-      // fingerprint is present. Either a breadcrumb from the page-stability
-      // detector, or the frozen Chrome 112 UA shared by the affected
-      // WebView population.
-      var crumbs =
-        (event.breadcrumbs && event.breadcrumbs.values) ||
-        event.breadcrumbs ||
-        [];
+      // Only suppress when an injecting-population fingerprint is present, so
+      // a genuine hydration mismatch on a clean page still reaches GlitchTip.
+
+      // Page-stability detector breadcrumb (the injected overlay's own log).
+      var crumbs = breadcrumbList(event);
       if (Array.isArray(crumbs)) {
         for (var i = 0; i < crumbs.length; i++) {
           var msg = crumbs[i] && crumbs[i].message;
@@ -156,16 +217,17 @@
           }
         }
       }
-      // Server-derived tag, kept for any ingestion path that pre-populates
-      // it — but it is normally ABSENT during client-side beforeSend...
+
+      // Injected <font> in the live DOM — the precise translation mutation,
+      // independent of which tool or browser injected it.
+      if (hasInjectedTranslationFont()) return true;
+
+      // Frozen Chrome 112 in-app WebView population. The server-derived
+      // `browser` tag is normally ABSENT during client-side beforeSend, so
+      // the live navigator UA is the signal that actually fires here.
       var tags = event.tags || {};
-      if (tags.browser === "Chrome 112.0.0") {
-        return true;
-      }
-      // ...so the live navigator UA is the signal that actually fires here.
-      if (ULTROS_FROZEN_CHROME_RE.test(userAgent())) {
-        return true;
-      }
+      if (tags.browser === "Chrome 112.0.0") return true;
+      if (ULTROS_FROZEN_CHROME_RE.test(userAgent())) return true;
     } catch (_) {
       /* never let the filter throw */
     }

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -577,6 +577,11 @@ mod error_filter_wiring {
         assert!(FILTER_JS.contains("ULTROS_FROZEN_CHROME_RE"));
         assert!(FILTER_JS.contains("navigator.userAgent"));
         assert!(FILTER_JS.contains("hydration.rs"));
+        // Category 3 (modern-Chrome translation population): the injected
+        // <font> DOM fingerprint that catches the flood the frozen-112 UA
+        // misses. Removing it silently re-opens the #3005/#4911/#6406 flood.
+        assert!(FILTER_JS.contains("hasInjectedTranslationFont"));
+        assert!(FILTER_JS.contains("getElementsByTagName"));
         // Category 4: empty promise rejections.
         assert!(FILTER_JS.contains("Non-Error promise rejection captured with value: undefined"));
     }


### PR DESCRIPTION
## What

The GlitchTip backlog is almost entirely **one panic class** on item routes
(`/items/jobset/*` and `/item/<world>/<id>`). A single page-view produces a
three-panic cascade, which GlitchTip splits into three issue families:

| Reported title | rust_panic location | Role |
|---|---|---|
| `RustWasmPanic: internal error: entered unreachable code` | `tachys-0.2.15/src/hydration.rs:227` | **root** (handled) |
| `RustWasmPanic: RefCell already borrowed` | `js-sys-.../futures/task/singlethread.rs:142` | cascade in the futures executor |
| `RuntimeError: unreachable` | *(none — reaches `window.onerror`)* | unhandled wasm trap |

I confirmed via `glitchtip_latest_event` that all three share one `trace_id`
and identical breadcrumbs (e.g. #4911 + #3005 on `/items/jobset/GNB`, #6406 on
`/item/梦羽宝境/51248`). This is exactly the chain `lib.rs` `shell()` already
documents in a comment: **a translation overlay rewrites text nodes into
`<font>` wrappers before Leptos hydrates, shifting tachys' hydration cursor.**

The affected population is consistent across events: modern, self-updating
Chrome (133, 117…), `Asia/Shanghai` timezone, `en-US` locale, Chinese
FFXIV data-center worlds (梦羽宝境, 晨曦王座, 拉诺西亚 …) — i.e. CN users reading
the English UI through translation tooling. Because it spans many routes and
items but only this population, it is **not** a deterministic code bug (a real
SSR/CSR mismatch would reproduce for everyone on a route).

## Why it still floods despite PR #760

PR #760's `beforeSend` suppressor only fingerprints the **frozen Chrome 112**
in-app WebView population (`Chrome/112.` UA + the `检测页面稳定` breadcrumb). This
live flood is current Chrome whose translation tooling ignores the
`notranslate` trifecta, so it slips straight through. The release in the
events (`d60906b`, PR #762) already contains #760.

## The fix

Add an **injected-`<font>` DOM fingerprint** to the category-3 suppressor.
Ultros never emits `<font>` (no `view!` produces it; item text is escaped to
text nodes, not elements — verified by grep), so any `<font>` in the live
document is necessarily translation-injected — the precise mutation that
breaks hydration. It is tool/browser-agnostic and, crucially, **narrow**:

- Suppression still requires the event to *be* a tachys hydration panic, now
  recognized across all three shapes (the cascade's js-sys location and the
  `onerror` `RuntimeError` with no `rust_panic` are matched via the tachys
  hydration **breadcrumb**).
- A genuine hydration mismatch on a **clean (untranslated) page has no
  `<font>`** and still reaches GlitchTip. Ads / funding-choices render in
  iframes, which `getElementsByTagName` does not traverse, so they can't match.

## Files

- `ultros-frontend/ultros-app/src/error_filter.js` — split recognizer into
  `isTachysHydrationPanicEvent` + `hasInjectedTranslationFont`; suppress on
  the font fingerprint.
- `integration/error-filter.test.cjs` — **+6 cases**: font drops the flood
  across all three event shapes; **no-font preserves real bugs**; the
  fingerprint stays scoped to hydration (a non-hydration `RuntimeError` with
  `<font>` present is preserved).
- `ultros-frontend/ultros-app/src/lib.rs` — guard the new load-bearing tokens
  in the Rust↔JS wiring test.

## Verification

- `node --test integration/error-filter.test.cjs` → **20/20 pass** (14 prior +
  6 new, no regressions).
- `cargo fmt --all -- --check` → clean.
- clippy **not** run: the only Rust change is test-module `assert!` lines, and
  a full clippy build hits the OpenSSL/submodule wall documented in CLAUDE.md.
  No production Rust changed.

## Backlog housekeeping (needs a human — auto-mode blocked the writes)

This run could not mark issues `ignored` (the GlitchTip MCP write is blocked by
the auto-mode classifier). Once this ships, these issues stop receiving events;
they can be bulk-**ignored** as confirmed-external (translation-injection) noise
— the same call works for the whole family:

- **Root (`internal error: entered unreachable code`)**: 291, 3005, 5918, 439,
  4920, 224, 697, 1306, 2775, 4889, 2205, 6293
- **Cascade (`RefCell already borrowed`)**: 5058, 5919, 4911, 4905, 4901, 4921,
  4906, 5392, 4910, 5391, 4989, 6294
- **Unhandled (`RuntimeError: unreachable`)**: 6406, 4
- Plus the count=1 `/item/<world>/<id>` pairs that are the same signature
  (6426–6449 range).

Any new issue matching `tachys-*/hydration.rs:227` + a `<font>` in the DOM is
this class and safe to ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
