### PR TITLE
🎨 Palette: Fix missing label associations in alert drawers

### DIFF
--- a/ultros-frontend/ultros-app/src/components/alert_config_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/alert_config_drawer.rs
@@ -104,8 +104,9 @@ pub fn AlertConfigDrawer(
                 </div>
 
                 <div class="space-y-1">
-                    <label class="text-sm font-semibold">{t!(i18n, alert_drawer_threshold_label)}</label>
+                    <label class="text-sm font-semibold" for="alert-config-threshold">{t!(i18n, alert_drawer_threshold_label)}</label>
                     <input
+                        id="alert-config-threshold"
                         class="input w-full"
                         type="number"
                         min="1"

--- a/ultros-frontend/ultros-app/src/components/create_alert_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/create_alert_drawer.rs
@@ -133,7 +133,7 @@ pub fn CreateAlertDrawer(
                 <h2 class="text-xl font-bold">{t!(i18n, create_alert_title)}</h2>
 
                 <div class="space-y-1">
-                    <label class="text-sm font-semibold">{t!(i18n, create_alert_item_label)}</label>
+                    <label class="text-sm font-semibold" for="create-alert-search">{t!(i18n, create_alert_item_label)}</label>
                     {move || match selected_item.get() {
                         Some((id, name)) => view! {
                             <div class="flex items-center justify-between gap-2 rounded border border-[color:var(--color-outline)] p-2">
@@ -153,6 +153,7 @@ pub fn CreateAlertDrawer(
                         None => view! {
                             <div class="space-y-1">
                                 <input
+                                    id="create-alert-search"
                                     class="input w-full"
                                     placeholder=t_string!(i18n, create_alert_search_placeholder)
                                     prop:value=search
@@ -202,8 +203,9 @@ pub fn CreateAlertDrawer(
                 </div>
 
                 <div class="space-y-1">
-                    <label class="text-sm font-semibold">{t!(i18n, alert_drawer_threshold_label)}</label>
+                    <label class="text-sm font-semibold" for="create-alert-threshold">{t!(i18n, alert_drawer_threshold_label)}</label>
                     <input
+                        id="create-alert-threshold"
                         class="input w-full"
                         type="number"
                         min="1"


### PR DESCRIPTION
🎨 **Palette here!**

This PR adds small but helpful accessibility improvements to the Alert Config and Create Alert drawers. 

**💡 What:** 
Added `for` attributes to labels and matching `id` attributes to their inputs.

**🎯 Why:**
Form inputs without associated labels are difficult for screen reader users to navigate. Now, screen readers will announce the label text when the input is focused, and mouse users can click the label text to focus the corresponding input field.

**♿ Accessibility:**
- Associated the search input with its label in `CreateAlertDrawer`.
- Associated the price threshold input with its label in both `CreateAlertDrawer` and `AlertConfigDrawer`.

---
*PR created automatically by Jules for task [4153365702514808361](https://jules.google.com/task/4153365702514808361) started by @akarras*