### PR TITLE
fix(error-reporting): catch the RefCell/unreachable hydration cascade beforeSend was missing

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -355,6 +355,84 @@ const cases = [
     expectDrop: false,
   },
 
+  // ── Category 3d: breadcrumb-INDEPENDENT recognition of the cascade ──
+  // The cascade shapes (`RefCell already borrowed` in the js-sys executor, and
+  // the unhandled `RuntimeError: unreachable` at window.onerror) were only ever
+  // recognized via the tachys hydration *breadcrumb*. But at real client-side
+  // beforeSend that breadcrumb is NOT in the array the SDK hands the filter —
+  // only the explicitly-set `contexts.rust_panic` survives. Proof from prod
+  // (release e59476b): on a single stale-Chrome (<=124) page-load the root
+  // `internal error` panic — recognized via its tachys rust_panic location —
+  // was dropped, yet the SAME load's `RefCell already borrowed` cascade leaked
+  // (GlitchTip #6661 Chrome 106, #4908 Chrome 104, with no paired internal-error
+  // issue). Same load => same UA => same fingerprint, so the only difference is
+  // recognition: the breadcrumb prong does not fire at beforeSend. These cases
+  // model that reality (no tachys breadcrumb present) and require recognition
+  // from event-level signals that ARE reliably present: the js-sys executor
+  // rust_panic location, and the exact RuntimeError "unreachable" value.
+  {
+    name: "stale Chrome RefCell cascade (js-sys loc, NO tachys breadcrumb) is dropped",
+    ua: staleChromeUA(106),
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "stale Chrome onerror RuntimeError unreachable (NO tachys breadcrumb) is dropped",
+    ua: staleChromeUA(106),
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: { values: [{ type: "RuntimeError", value: "unreachable" }] },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "RefCell cascade (js-sys loc) with injected <font>, NO tachys breadcrumb, is dropped",
+    ua: CURRENT_CHROME,
+    document: fakeDocument(3),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: true,
+  },
+  // Guard: the breadcrumb-independent recognition must NOT over-suppress a
+  // genuine cascade on a clean, current browser (no font, no translate class,
+  // no stale UA) — those are the real hydration bugs the filter must preserve.
+  {
+    name: "RefCell cascade (js-sys loc) on a current clean browser with no fingerprint is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "onerror RuntimeError unreachable on a current clean browser with no fingerprint is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: { values: [{ type: "RuntimeError", value: "unreachable" }] },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: false,
+  },
+
   // ── Category 1: WASM/bundle fetch aborts ──
   {
     name: 'TypeError "Failed to fetch dynamically imported module" of the pkg bundle is dropped',

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -58,6 +58,14 @@
 (function () {
   var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
   var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
+  // The wasm-bindgen-futures single-threaded executor. When the tachys
+  // hydration panic unwinds through a running future poll, re-entering the
+  // executor trips `RefCell already borrowed` HERE — the documented cascade of
+  // the hydration panic (see shell() in lib.rs). `__ultrosReportRustPanic` sets
+  // this exact path in contexts.rust_panic, so — unlike the tachys console
+  // breadcrumb — it is reliably present on the event at client-side beforeSend.
+  var ULTROS_JSSYS_EXECUTOR_RE =
+    /\/js-sys-[\d.]+\/src\/futures\/task\/singlethread\.rs:/;
   var ULTROS_INJECTOR_BREADCRUMB = "检测页面稳定";
   // The stale-Chrome population behind the hydration flood: stuck in-app
   // WebViews (Tencent QQ / UC / WeChat, frozen near Chrome 112) and
@@ -175,23 +183,52 @@
     );
   }
 
-  // Is this event the tachys hydration panic, in any of its three shapes?
+  // Is this event the tachys hydration panic, in any of its shapes? One
+  // page-load emits up to three Sentry events from this single root:
+  //   - the handled `internal error: entered unreachable code` panic, whose
+  //     contexts.rust_panic points at the tachys hydration path;
+  //   - its `RefCell already borrowed` cascade, whose contexts.rust_panic
+  //     points at the js-sys wasm-bindgen-futures executor;
+  //   - the unhandled `RuntimeError: unreachable` wasm trap that reaches
+  //     window.onerror with NO rust_panic context at all.
+  //
+  // Recognition must lean on signals reliably present at client-side
+  // beforeSend. The `panicked at .../tachys-*/hydration.rs:` console breadcrumb
+  // that the stored GlitchTip payload shows is NOT in the breadcrumb array the
+  // SDK passes to beforeSend, so the breadcrumb scan (prong b) misfires there.
+  // Proof from prod release e59476b: on a single stale-Chrome (<=124) load the
+  // root panic was dropped (recognized via its tachys rust_panic location) yet
+  // the SAME load's RefCell cascade leaked (GlitchTip #6661/#4908 with no paired
+  // internal-error issue) — same UA, same fingerprint, so only recognition
+  // differed. Prongs (a) and (c) below therefore key off event-level fields
+  // (rust_panic.location, exception type/value); prong (b) stays as a best-
+  // effort fallback for paths where the breadcrumb IS attached.
   function isTachysHydrationPanicEvent(event) {
-    // (a) The handled root panic carries the tachys path in rust_panic.
+    // (a) The root panic and its RefCell cascade both carry an explicit
+    //     contexts.rust_panic location (set by __ultrosReportRustPanic): the
+    //     tachys hydration path, or the js-sys futures executor it cascades to.
     var ctx = event && event.contexts && event.contexts.rust_panic;
     var loc = ctx && ctx.location;
     if (
       typeof loc === "string" &&
       loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") === 0 &&
-      ULTROS_TACHYS_HYDRATION_RE.test(loc)
+      (ULTROS_TACHYS_HYDRATION_RE.test(loc) ||
+        ULTROS_JSSYS_EXECUTOR_RE.test(loc))
     ) {
       return true;
     }
-    // (b) The `RefCell already borrowed` cascade reports with a js-sys
-    //     executor location, and the unhandled `RuntimeError: unreachable`
-    //     (window.onerror) has no rust_panic context at all — but both still
-    //     carry the original `panicked at .../tachys-*/src/hydration.rs:`
-    //     console breadcrumb that kicked off the cascade.
+    // (c) The unhandled wasm trap at window.onerror has no rust_panic context;
+    //     its only event-level signal is the exact RuntimeError "unreachable"
+    //     value. (A genuine wasm `unreachable` on a clean current browser still
+    //     reports — this is gated behind the injecting-population fingerprint in
+    //     isInjectedTachysHydrationPanic.) Matched exactly so other RuntimeError
+    //     values, e.g. "table index is out of bounds", are untouched.
+    var ex = firstException(event);
+    if (ex && ex.type === "RuntimeError" && ex.value === "unreachable") {
+      return true;
+    }
+    // (b) Best-effort fallback: the original tachys hydration panic console
+    //     breadcrumb, when the SDK path does attach it.
     var crumbs = breadcrumbList(event);
     if (Array.isArray(crumbs)) {
       for (var i = 0; i < crumbs.length; i++) {

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -571,14 +571,22 @@ mod error_filter_wiring {
         assert!(FILTER_JS.contains("WebAssembly compilation aborted"));
         // Category 2: injected-WebView document TypeError.
         assert!(FILTER_JS.contains("HTMLDocument.c"));
-        // Category 3: frozen-Chrome-112 translate-overlay hydration panic.
-        // Must read the live UA (the browser tag is server-derived and absent
-        // in beforeSend), so the navigator read is the load-bearing part.
-        assert!(FILTER_JS.contains("ULTROS_FROZEN_CHROME_RE"));
+        // Category 3: hydration-panic flood, gated behind an injecting-
+        // population fingerprint. The stale-Chrome check must read the live UA
+        // (the browser tag is server-derived and absent in beforeSend), so the
+        // navigator read is the load-bearing part.
+        assert!(FILTER_JS.contains("isStaleChromeMajor"));
         assert!(FILTER_JS.contains("navigator.userAgent"));
         assert!(FILTER_JS.contains("hydration.rs"));
+        // The cascade shapes are recognized WITHOUT the tachys breadcrumb (it
+        // is not in the array the SDK hands beforeSend): the `RefCell already
+        // borrowed` cascade via the js-sys futures-executor rust_panic location,
+        // and the unhandled wasm trap via the exact RuntimeError "unreachable"
+        // value. Deleting either silently re-opens the #6661/#4908/#6570 flood.
+        assert!(FILTER_JS.contains("ULTROS_JSSYS_EXECUTOR_RE"));
+        assert!(FILTER_JS.contains("\"unreachable\""));
         // Category 3 (modern-Chrome translation population): the injected
-        // <font> DOM fingerprint that catches the flood the frozen-112 UA
+        // <font> DOM fingerprint that catches the flood the stale-UA check
         // misses. Removing it silently re-opens the #3005/#4911/#6406 flood.
         assert!(FILTER_JS.contains("hasInjectedTranslationFont"));
         assert!(FILTER_JS.contains("getElementsByTagName"));


### PR DESCRIPTION
## What

Closes the remaining leak in the Sentry `beforeSend` noise filter for the **tachys hydration-mismatch flood** — the dominant source of the current GlitchTip backlog.

This is the same external flood prior PRs (#751/#760/#764/#766) addressed: stale-Chrome in-app WebViews and version-pinned crawler fleets (Tencent-Cloud IPs `43.172/173.x`, `Asia/Shanghai`) whose pre-hydration DOM mutation shifts tachys' hydration cursor and panics at `hydration.rs:227`. A clean current browser hydrates the exact failing URLs fine — it's external, not an app bug.

## Root cause (proven from prod, not guessed)

One crawler page-load emits **up to three** Sentry events from the single hydration panic:

| Shape | Title | `contexts.rust_panic` |
|---|---|---|
| root panic | `internal error: entered unreachable code` | tachys `hydration.rs` |
| cascade | `RefCell already borrowed` | **js-sys** `futures/task/singlethread.rs` |
| wasm trap (onerror) | `RuntimeError: unreachable` | **none** |

PR #766's filter recognized the **cascade** and **onerror** shapes *only* via the `panicked at .../tachys-*/hydration.rs:` **console breadcrumb**. That breadcrumb appears in the stored GlitchTip payload, but **is not in the breadcrumb array the Sentry SDK hands `beforeSend`** — so that prong never fires in prod.

**The proof is in the data (release `e59476b`, which already ships #766):** on a *single* stale-Chrome (≤124) page-load, the root panic was **dropped** (recognized via its tachys `rust_panic` location — no breadcrumb needed) while the **same load's** `RefCell` cascade **leaked**:

- #6661 (`/item/拂晓之间/52339`, **Chrome 106**) — RefCell leaked, **no** paired `internal error` issue for that URL ⇒ the root panic on that load *was* dropped.
- #4908 (`/items/jobset/DRK`, **Chrome 104**) — same pattern.

Same UA ⇒ same fingerprint ⇒ the *only* difference is recognition. The `internal error` leaks that do exist (#6634, #6644) are **Chrome 133** (>124) — the separate, intentional modern-crawler gap (no `<font>`/translate-class, so deliberately not suppressed to avoid hiding real bugs). This asymmetry is impossible unless the breadcrumb prong fails at `beforeSend`.

## The fix

Recognize the two cascade shapes from event-level fields that **are** reliably present at `beforeSend`, instead of the breadcrumb:

- **RefCell cascade** → `contexts.rust_panic.location` matching the js-sys wasm-bindgen-futures executor (`/js-sys-*/src/futures/task/singlethread.rs:`). `__ultrosReportRustPanic` sets this explicitly, exactly like the tachys location prong that already works.
- **onerror trap** → the exact `RuntimeError` value `"unreachable"`.

Both remain **gated behind the existing injecting-population fingerprint** (`<font>` / `html.translated-*` / stale Chrome ≤124 / page-stability breadcrumb), so a genuine hydration mismatch on a clean, current browser still reaches GlitchTip. The breadcrumb prong is kept as a best-effort fallback.

Also fixes a latent breakage: the `lib.rs` wiring guard still asserted `ULTROS_FROZEN_CHROME_RE`, a token #766 renamed — the guard only runs under `cargo test` (not in CI), so it had silently rotted. Updated to the current tokens and extended to guard the two new load-bearing signals.

### Scope note
This restores stale-Chrome (≤124) suppression for the cascade shapes to parity with the root panic. The **Chrome >124 modern-crawler** population (#6634/#6644/#2388) is *not* newly suppressed — that's the deliberate boundary from #766 (a current-Chrome hydration panic with no `<font>`/translate marker is indistinguishable from a real bug at `beforeSend`).

## Test plan

- `npm --prefix integration run test:error-filter` → **33/33** (5 new cases: stale-Chrome RefCell cascade w/ no breadcrumb, stale-Chrome onerror unreachable w/ no breadcrumb, `<font>` cascade; + two over-suppression guards that keep genuine clean-browser cascades reporting). The 3 drop-cases were confirmed RED on the pre-fix filter.
- `cargo fmt --all -- --check` → clean.
- clippy not run locally (workspace build needs the `xiv-gen` submodule); the only Rust change is string-literal `assert!`s in a `#[cfg(test)]` mod, and `error_filter.js` is `include_str!`'d as a JS string — neither can produce a clippy warning.

## GlitchTip triage follow-up (apply after this deploys)

Mass-ignoring now is premature — the crawler keeps hitting the unfixed prod build, so anything ignored/resolved pre-deploy just re-opens. **Once the new release ships:**

- **Resolve** (not ignore, so a future genuine trap re-opens): #4 (`RuntimeError: unreachable` ×1143, broad catch-all) and #6570 (×55).
- **Ignore / resolve** the now-suppressed cascade clusters: the per-URL `/item/<world>/<id>` count=1 flood (#6627–#6661 …) and the jobset RefCell/internal-error issues (#4908, #4901, #4905, #4974, #4975, #4989, #4962, #5055, #5919, #2388, #439, #176, #375, …).
- **Leave open / watch**: the Chrome >124 crawler subset (#6634, #6644, #2388 on Chrome 133) — out of scope by design; revisit only if volume warrants a non-UA signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
