### PR TITLE
🎨 Palette: Improve keyboard accessibility for Toast close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2026-05-21 - Prevent screen readers from reading decorative icons in buttons
 **Learning:** Found that when buttons have an icon next to visible text, sometimes the icon isn't hidden with `aria_hidden=true`. While this isn't an error, adding `aria_hidden=true` to the icon (since the button already has visible text) makes the screen reader experience smoother by preventing it from reading the decorative icon.
 **Action:** When inspecting buttons with both text and icons, consider adding `aria_hidden=true` to the icon component (if supported, e.g. the `Icon` component in this repo supports it) to avoid redundant or confusing announcements.
+## 2026-06-17 - Toast Accessibility
+**Learning:** Found that toast close buttons were missing keyboard focus indicators making them hard to use with keyboard navigation.
+**Action:** Always add focus-visible ring styles (e.g., `focus-visible:ring-[var(--brand-ring)]`) to interactive elements like close buttons.

--- a/ultros-frontend/ultros-app/src/components/toast.rs
+++ b/ultros-frontend/ultros-app/src/components/toast.rs
@@ -47,7 +47,7 @@ pub fn ToastItem(toast: Toast) -> impl IntoView {
             <Icon icon width="1.2em" height="1.2em" aria_hidden=true />
             <div class="flex-1">{message}</div>
             <button
-                class="opacity-70 hover:opacity-100 transition-opacity"
+                class="opacity-70 hover:opacity-100 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-ring)] rounded"
                 aria-label=t_string!(i18n, close)
                 on:click=move |_| {
                     set_is_exiting(true);


### PR DESCRIPTION
💡 **What:** Added keyboard focus styles (`focus-visible:ring-2`) to the Toast close button.
🎯 **Why:** The close button previously had no visual indication when focused via keyboard navigation, making it difficult for keyboard-only users to dismiss toasts.
♿ **Accessibility:** Improved keyboard navigability by ensuring focus states are visible and conform to existing focus-ring design patterns.

---
*PR created automatically by Jules for task [5338234209282952809](https://jules.google.com/task/5338234209282952809) started by @akarras*