### PR TITLE
fix(error-reporting): stop dev-box errors flooding production GlitchTip

### DIFF
--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -192,6 +192,20 @@ async fn init_db(
     Ok(())
 }
 
+/// Whether Glitchtip/Sentry error reporting should be suppressed for this
+/// process based on the configured environment.
+///
+/// We deliberately *never* ship events from a `development` environment to the
+/// shared production Glitchtip: a local dev box that has `GLITCHTIP_DSN` set
+/// would otherwise pollute prod with cold-start noise (see the init site in
+/// `main`). This is an allow-list-shaped check — only the exact `development`
+/// value is suppressed, so production (`production`) and any unset/other value
+/// still report, which fails safe if `GLITCHTIP_ENVIRONMENT` is ever
+/// misconfigured on the real deployment.
+fn error_reporting_disabled(environment: Option<&str>) -> bool {
+    environment == Some("development")
+}
+
 // Bolt: Switched to multi-threaded runtime for better performance on multi-core systems
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -211,26 +225,40 @@ async fn main() -> Result<()> {
     // local dev runs without it. The guard must be held for the duration of
     // main() so the background transport can flush on shutdown.
     //
+    // We also skip init entirely when GLITCHTIP_ENVIRONMENT=development, even if
+    // GLITCHTIP_DSN is set. A local dev box that has the DSN configured (e.g.
+    // copied from the prod .env) would otherwise flood the *shared production*
+    // Glitchtip with cold-start noise: sqlx "Connection pool timed out" errors
+    // surfaced through the sentry-tracing layer below, which showed up in prod
+    // as GlitchTip #2214/#2215/#2216/#2217 (hundreds of events from `Bahamut`).
+    // The comment above already documents the intent — "local dev runs without
+    // it" — so enforce it by environment, not just by whether a DSN happens to
+    // be present.
+    //
     // GLITCHTIP_TRACES_SAMPLE_RATE controls performance/transaction sampling:
     // 0.0 disables (default — matches prior behavior), 1.0 sends every request.
     // Glitchtip 4.x and Sentry both accept transaction envelopes.
-    let _sentry_guard = std::env::var("GLITCHTIP_DSN").ok().map(|dsn| {
-        let traces_sample_rate = std::env::var("GLITCHTIP_TRACES_SAMPLE_RATE")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0.0);
-        sentry::init((
-            dsn,
-            sentry::ClientOptions {
-                release: sentry::release_name!(),
-                environment: std::env::var("GLITCHTIP_ENVIRONMENT").ok().map(Into::into),
-                traces_sample_rate,
-                attach_stacktrace: true,
-                send_default_pii: false,
-                ..Default::default()
-            },
-        ))
-    });
+    let environment = std::env::var("GLITCHTIP_ENVIRONMENT").ok();
+    let _sentry_guard = std::env::var("GLITCHTIP_DSN")
+        .ok()
+        .filter(|_| !error_reporting_disabled(environment.as_deref()))
+        .map(|dsn| {
+            let traces_sample_rate = std::env::var("GLITCHTIP_TRACES_SAMPLE_RATE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0.0);
+            sentry::init((
+                dsn,
+                sentry::ClientOptions {
+                    release: sentry::release_name!(),
+                    environment: environment.clone().map(Into::into),
+                    traces_sample_rate,
+                    attach_stacktrace: true,
+                    send_default_pii: false,
+                    ..Default::default()
+                },
+            ))
+        });
 
     // Create the db before we proceed
     let filter: EnvFilter =
@@ -413,4 +441,27 @@ async fn main() -> Result<()> {
     token.cancel();
     info!("Exiting");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::error_reporting_disabled;
+
+    #[test]
+    fn development_environment_suppresses_reporting() {
+        // A dev box (GLITCHTIP_ENVIRONMENT=development) must never reach the
+        // shared production Glitchtip, even with GLITCHTIP_DSN set. Regression
+        // guard for the #2214-#2217 cold-start pool-timeout flood.
+        assert!(error_reporting_disabled(Some("development")));
+    }
+
+    #[test]
+    fn production_and_other_environments_still_report() {
+        // Fail safe: anything that isn't exactly "development" reports, so a
+        // misconfigured / unset GLITCHTIP_ENVIRONMENT on the real deploy never
+        // silently drops production errors.
+        assert!(!error_reporting_disabled(Some("production")));
+        assert!(!error_reporting_disabled(Some("staging")));
+        assert!(!error_reporting_disabled(None));
+    }
 }


### PR DESCRIPTION
## Summary

Autonomous GlitchTip triage run (BugSquash #5). The largest *server-side*
bucket in the backlog — **GlitchTip #2214 / #2215 / #2216 / #2217**
(~800 events: "Error removing listings", "check_for_missed_items_on_world
failed", "Listing add failed", "Error inserting sale.") — is not a
production bug. Every event is tagged:

```
environment = development
server_name = Bahamut
release     = ultros@0.1.0
error       = Failed to acquire connection from pool: Connection pool timed out
location    = ultros/src/main.rs:160
```

i.e. a **local dev box** whose `.env` has `GLITCHTIP_DSN` set is reporting
its cold-start sqlx pool-timeout errors (surfaced via the `sentry-tracing`
layer) into the **shared production** GlitchTip, where they pile up and
bury real issues.

The init site already documents the intent — *"No-op when GLITCHTIP_DSN is
unset, so local dev runs without it"* — but a dev box that has the DSN set
(copied from prod, etc.) defeats that. This PR enforces the intent by
**environment** instead of by DSN presence.

## Change

`ultros/src/main.rs`: skip `sentry::init` entirely when
`GLITCHTIP_ENVIRONMENT=development`, even if a DSN is present.

- Allow-list shaped via a small, unit-tested predicate
  `error_reporting_disabled(env)`: only the *exact* `"development"` value
  is suppressed. `production`, unset, and any other value still report, so
  a misconfigured/empty `GLITCHTIP_ENVIRONMENT` on the real deployment
  **fails safe** (never silently drops prod errors).
- `sentry-tracing::layer()` stays wired; with no client bound it's a
  no-op, so dev still logs locally — it just doesn't ship to prod.

This stops *future* accumulation. The existing #2214–#2217 events were
ignored in the UI (see triage log below).

## Verification

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p ultros --all-targets -- -D warnings` — clean (compiled
  with the change; this is the CI gate).
- Added `#[cfg(test)] mod tests` covering the predicate (dev → suppressed;
  production / staging / unset → still report). The test **compiles**
  (verified via `clippy --all-targets`) but the bin **test binary** can't
  be linked on this Windows/MSVC box due to the pre-existing `ultros_app`
  leptos-link wall (unrelated to this change) — it links/runs on Linux CI.

## Backlog triage applied this run

Auto-mode GlitchTip writes were **not** blocked this run, so the noise was
sorted directly (43 issues → ignored):

**Dev-box noise fixed by this PR — ignored** (will stay quiet post-deploy):
#2214, #2215, #2216, #2217 (pool-timeout cluster) and #4881
("...recent_sale_history... subtree pointer out of bounds" — same dev box,
rkyv check on a stale *local* analyzer cache blob).

**External hydration-crawler flood — ignored** (confirmed external: modern-
Chrome crawler from Tencent-Cloud IPs, `Asia/Shanghai`; clean Chrome
hydrates these URLs fine; already handled at the source by the deployed
`error_filter.js` beforeSend suppressor through #770):
- `/items/jobset/<JOB>` cluster: #439, #176, #375, #4901, #4905, #4908,
  #4974, #4975, #5055.
- per-item `/item/<world>/<id>` cluster: #6632–#6663 (RefCell / unreachable).
- #6570 (×55, on the now-superseded `e59476b` build — dead, can't recur).

**Browser-compat / old-engine bots — ignored:** #4165, #6662
("CompileError: ... invalid value type 'externref'"). The rust-toolchain
(`nightly-2026-01-06`, Rust ≥1.82) enables `reference-types`/`multivalue`
by default, so the wasm carries `externref`. A site-wide max-compat fix
exists — add `-Ctarget-feature=-reference-types` to the wasm build in
`.cargo/config.toml` — but the failing clients look like old-V8 bots (the
error is V8-phrased on a spoofed-iPhone UA), and disabling it deopts
JS↔wasm interop for everyone, so I left it as an **owner decision**, not
shipped here. Ultros is SSR-first, so these clients still get content.

**Left unresolved (deliberate):**
- **#4** (×1150, "RuntimeError: unreachable" global-onerror catch-all) —
  fed by the unsuppressable modern-Chrome (>124) residual. Too broad to
  ignore autonomously (would swallow a future genuine `unreachable`); your
  call whether to resolve-and-accept-reopens or ignore.
- **#2218** ("Error deserializing text") — *not* the same cause memory had
  on file. Latest event shows `/api/v1/endpoints` returning **HTTP 200**
  with body `{"ApiError":"NotAuthenticated"}`, so the #754 status-based fix
  doesn't catch it and `api.rs:793` error-logs it. Dev-tagged now (so #783
  mutes the dev box), but the 200-with-error-body is environment-
  independent and likely fires in prod too. Spawned as a separate
  follow-up task rather than muting a possible real bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
