### PR TITLE
🎨 Palette: Add scope attribute to table headers

### DIFF
--- a/ultros-frontend/ultros-app/src/components/alert_rules_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/alert_rules_panel.rs
@@ -142,13 +142,13 @@ pub fn AlertRulesPanel() -> impl IntoView {
                                     <table class="w-full text-sm">
                                         <thead>
                                             <tr>
-                                                <th class="text-left p-1">{t!(i18n, item)}</th>
-                                                <th class="text-left p-1">{t!(i18n, alert_rules_col_threshold)}</th>
-                                                <th class="text-left p-1">{t!(i18n, world)}</th>
-                                                <th class="text-left p-1">{t!(i18n, hq)}</th>
-                                                <th class="text-left p-1">{t!(i18n, endpoints_heading)}</th>
-                                                <th class="text-left p-1">{t!(i18n, status_label)}</th>
-                                                <th class="text-left p-1">{t!(i18n, actions)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, item)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, alert_rules_col_threshold)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, world)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, hq)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, endpoints_heading)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, status_label)}</th>
+                                                <th scope="col" class="text-left p-1">{t!(i18n, actions)}</th>
                                             </tr>
                                         </thead>
                                         <tbody>

--- a/ultros-frontend/ultros-app/src/components/history_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/history_panel.rs
@@ -50,11 +50,11 @@ pub fn HistoryPanel() -> impl IntoView {
                         <table class="w-full text-sm">
                             <thead>
                                 <tr>
-                                    <th class="text-left p-1">{t!(i18n, col_time)}</th>
-                                    <th class="text-left p-1">{t!(i18n, item)}</th>
-                                    <th class="text-left p-1">{t!(i18n, history_col_matched_price)}</th>
-                                    <th class="text-left p-1">{t!(i18n, history_col_delivered)}</th>
-                                    <th class="text-left p-1">{t!(i18n, actions)}</th>
+                                    <th scope="col" class="text-left p-1">{t!(i18n, col_time)}</th>
+                                    <th scope="col" class="text-left p-1">{t!(i18n, item)}</th>
+                                    <th scope="col" class="text-left p-1">{t!(i18n, history_col_matched_price)}</th>
+                                    <th scope="col" class="text-left p-1">{t!(i18n, history_col_delivered)}</th>
+                                    <th scope="col" class="text-left p-1">{t!(i18n, actions)}</th>
                                 </tr>
                             </thead>
                             <tbody>


### PR DESCRIPTION
💡 What: Added `scope="col"` to all `<th>` tags in `alert_rules_panel.rs` and `history_panel.rs`.

🎯 Why: Improves screen reader accessibility for data tables.

♿ Accessibility: Explicitly associating header cells with their columns ensures screen readers announce the correct headers when navigating data cells.

---
*PR created automatically by Jules for task [1239437864056579686](https://jules.google.com/task/1239437864056579686) started by @akarras*