### PR TITLE
fix(error-reporting): fingerprint Rust WASM panics by panic site, not page URL

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -160,6 +160,17 @@ fn error_reporting_script() -> Option<String> {
             if (location) {{
                 scope.setContext("rust_panic", {{ location: location }});
             }}
+            // Group by the Rust panic site, not the JS stack. This reporter
+            // is defined in INLINE page script, so the stack frame Sentry
+            // captures for it has the PAGE URL as its filename (e.g.
+            // /item/Siren/12412). Default grouping keys off that frame, so a
+            // single recurring panic — most of our volume is the external
+            // translation-overlay hydration flood, see shell() — fragments
+            // into one count=1 issue PER URL (hundreds of them). A stable
+            // fingerprint keyed on the panic location collapses them into one
+            // issue per site, while genuinely distinct panics (different
+            // location) still split out and stay individually actionable.
+            scope.setFingerprint(["rust-wasm-panic", location || message || "unknown"]);
             Sentry.captureException(error);
         }});
     }};


### PR DESCRIPTION
## What

`window.__ultrosReportRustPanic` (the Rust panic hook's JS reporter) is defined in **inline page script**, so the stack frame Sentry captures for it has the **page URL** as its filename (e.g. `/item/Siren/12412`). GlitchTip's default grouping keys off that frame → **a single recurring panic fragments into one count=1 issue per URL.**

This collapses them: set a stable Sentry `fingerprint` keyed on the Rust panic *location* in `__ultrosReportRustPanic`.

## Why (triage context)

The GlitchTip backlog is currently dominated by hundreds of paired `RustWasmPanic: RefCell already borrowed` + `RustWasmPanic: internal error: entered unreachable code` issues, each on a distinct `/item/<world>/<id>` URL, each count=1, all from a CN-datacenter (Tencent Cloud) Chrome-131 population.

Root cause is the known **external translation-overlay hydration cascade**: an injected auto-translator wraps text nodes before Leptos hydrates → `failed_to_cast_text_node` panic at tachys `hydration.rs:227` → `RefCell already borrowed` cascade in the wasm-bindgen-futures executor (see `shell()` and the notranslate trifecta we already ship).

I verified the pages are **not** broken: loading `https://ultros.app/item/Siren/12412` (the exact URL from issue #6720) in a clean, current Chrome hydrates with zero console errors, `notranslate`/`translate="no"` intact, no `<font>` injection. So the panic is external DOM mutation, not an SSR/CSR regression — which is why the `beforeSend` filter deliberately **preserves** these (they *could* be real bugs on a current browser; there are explicit guard tests for that). This PR keeps that policy untouched and instead fixes the **fragmentation**.

## Effect

- All events from one panic site collapse into a **single** GlitchTip issue instead of one-per-URL.
- Genuinely distinct panics (different `location`) still split into their own groups and stay individually actionable.
- The primary hydration panic and its RefCell cascade have different locations, so they remain two clearly-labelled issues rather than hundreds.

## Safety / no behavior regression

`contexts.rust_panic.location` and `error.name` are unchanged, so the existing `error_filter.js` recognition keys still match. Change is purely additive (grouping only). Reconstructed the emitted inline JS and confirmed: syntax valid, same-location events share a fingerprint, distinct-location events don't, no-location falls back to the message, and the `rust_panic` context is still set.

## Verification

- `cargo fmt --all -- --check` → clean.
- `npm --prefix integration run test:error-filter` → 33/33 pass (filter untouched; baseline).
- Standalone Node check of the generated reporter JS (syntax + fingerprint grouping behavior).

> [!NOTE]
> `cargo clippy` was **not** run locally (workspace needs the `ffxiv-datamining` submodule + a ~10-min vendored-OpenSSL build). The change is confined to a JS string literal inside an existing `format!`, so it cannot affect Rust lints; CI clippy will confirm.

## Companion triage

The existing per-URL `/item/*` `RustWasmPanic` cluster (plus the `RuntimeError: unreachable` onerror issues #4 and #6664) are this same unresolvable external-translation noise and are being marked **ignored** in GlitchTip as part of this triage run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)