### PR TITLE
🎨 Palette: Add loading state to history resend button

### DIFF
--- a/ultros-frontend/ultros-app/src/components/history_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/history_panel.rs
@@ -5,6 +5,7 @@ use xiv_gen::ItemId;
 
 use crate::api::{get_alert_events, resend_alert_event};
 use crate::components::icon::Icon;
+use crate::components::loading::Loading;
 use crate::global_state::toasts::use_toast;
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::{t, use_i18n};
@@ -15,29 +16,6 @@ pub fn HistoryPanel() -> impl IntoView {
     let version = RwSignal::new(0u64);
     let events = Resource::new(move || version.get(), move |_| get_alert_events());
     let toasts = use_toast();
-
-    let resend = move |event_id: i64| {
-        spawn_local(async move {
-            match resend_alert_event(event_id).await {
-                Ok(r) if r.delivered => {
-                    if let Some(t) = toasts {
-                        t.success("Resent");
-                    }
-                    version.update(|v| *v += 1);
-                }
-                Ok(r) => {
-                    if let Some(t) = toasts {
-                        t.error(r.error.unwrap_or_else(|| "Resend failed".into()));
-                    }
-                }
-                Err(e) => {
-                    if let Some(t) = toasts {
-                        t.error(format!("{e}"));
-                    }
-                }
-            }
-        });
-    };
 
     view! {
         <Suspense fallback=move || view! { <div>{t!(i18n, loading)}</div> }>
@@ -72,6 +50,7 @@ pub fn HistoryPanel() -> impl IntoView {
                                         };
                                         let event_id = e.id;
                                         let delivered = e.delivered;
+                                        let (is_resending, set_is_resending) = RwSignal::new(false).split();
                                         view! {
                                             <tr class="border-t">
                                                 <td class="p-1">{fired_str}</td>
@@ -80,9 +59,39 @@ pub fn HistoryPanel() -> impl IntoView {
                                                 <td class="p-1">{delivered_str}</td>
                                                 <td class="p-1">
                                                     <Show when=move || !delivered>
-                                                        <button class="btn-ghost" on:click=move |_| resend(event_id)>
-                                                            <Icon icon=i::BsArrowRepeat />
-                                                            <span class="ml-1">{t!(i18n, history_resend_button)}</span>
+                                                        <button
+                                                            class="btn-ghost"
+                                                            disabled=move || is_resending.get()
+                                                            on:click=move |_| {
+                                                                set_is_resending.set(true);
+                                                                spawn_local(async move {
+                                                                    match resend_alert_event(event_id).await {
+                                                                        Ok(r) if r.delivered => {
+                                                                            if let Some(t) = toasts {
+                                                                                t.success("Resent");
+                                                                            }
+                                                                            version.update(|v| *v += 1);
+                                                                        }
+                                                                        Ok(r) => {
+                                                                            if let Some(t) = toasts {
+                                                                                t.error(r.error.unwrap_or_else(|| "Resend failed".into()));
+                                                                            }
+                                                                            set_is_resending.set(false);
+                                                                        }
+                                                                        Err(e) => {
+                                                                            if let Some(t) = toasts {
+                                                                                t.error(format!("{e}"));
+                                                                            }
+                                                                            set_is_resending.set(false);
+                                                                        }
+                                                                    }
+                                                                });
+                                                            }
+                                                        >
+                                                            <Show when=move || !is_resending.get() fallback=|| view! { <Loading /> }>
+                                                                <Icon icon=i::BsArrowRepeat />
+                                                                <span class="ml-1">{t!(i18n, history_resend_button)}</span>
+                                                            </Show>
                                                         </button>
                                                     </Show>
                                                 </td>


### PR DESCRIPTION
💡 **What**: Added a local `is_resending` state to the `HistoryPanel` resend button to disable the button and show a `<Loading />` spinner while the resend request is in flight.
🎯 **Why**: When users clicked the "Resend" button, there was no immediate visual feedback, allowing them to accidentally double-click or feel unsure if the system registered their action. The loading state provides clear feedback and prevents duplicate submissions.
♿ **Accessibility**: This improvement ensures that screen readers and all users understand the system is processing their request.

---
*PR created automatically by Jules for task [4562178055879810694](https://jules.google.com/task/4562178055879810694) started by @akarras*