### PR TITLE
fix(error-reporting): drop stripped-hydration-bootstrap + wasm-compile noise in beforeSend

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -603,6 +603,203 @@ const cases = [
     expectDrop: false,
   },
 
+  // ── Category 1 (cont.): streaming WASM compile failures of our bundle ──
+  // A non-OK HTTP response for the .wasm (a stale chunk 404 in the seconds
+  // after a deploy) surfaces as a compile TypeError; a truncated download
+  // surfaces as a CompileError. Both are network / deploy-race noise, never an
+  // actionable code bug. GlitchTip #6755, #6762, #6763, #6764, #6766, #6767.
+  {
+    name: "WASM compile TypeError 'HTTP status code is not ok' (stale chunk after deploy) is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "WASM CompileError 'extends past end of the module' (truncated download) is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "CompileError",
+            value:
+              'WebAssembly.instantiateStreaming(): section (code 10, "Code") ' +
+              "extends past end of the module (length 10426626, remaining bytes " +
+              "10359267) @+126488",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  // Guard: a CompileError that is NOT a truncation (e.g. a genuinely corrupt
+  // build we shipped) must still report — that is a real bug worth seeing.
+  {
+    name: "a non-truncation WASM CompileError is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "CompileError",
+            value:
+              "WebAssembly.compile(): function body must end with END opcode @+1234",
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+
+  // ── Category 5: stripped leptos streaming-hydration bootstrap ──
+  // The SSR shell ALWAYS emits window.__RESOLVED_RESOURCES / __INCOMPLETE_CHUNKS
+  // / __PENDING_RESOURCES / __SERIALIZED_ERRORS (verified in the served HTML of
+  // the failing /item/<world>/<id> URLs), and they are read only by leptos's
+  // generated wasm-bindgen static accessors, never by app code. So a
+  // "ReferenceError: <name> is not defined" can only mean a proxy stripped or
+  // truncated the streamed bootstrap before the wasm hydrated — the same
+  // translation-proxy population behind the tachys flood. GlitchTip #6620,
+  // #6667, #6760, #6761.
+  {
+    name: "ReferenceError __RESOLVED_RESOURCES not defined from the pkg accessor is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "__RESOLVED_RESOURCES is not defined",
+            stacktrace: {
+              frames: [
+                { filename: "/pkg/a2d6028/ultros.js", function: "c" },
+                {
+                  filename: "/pkg/a2d6028/ultros.js",
+                  function:
+                    "__wbg_static_accessor___RESOLVED_RESOURCES_64c55267f5301918",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "ReferenceError __INCOMPLETE_CHUNKS not defined from the pkg accessor is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "__INCOMPLETE_CHUNKS is not defined",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/pkg/a2d6028/ultros.js",
+                  function:
+                    "__wbg_static_accessor___INCOMPLETE_CHUNKS_69295e643f835e34",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "ReferenceError __PENDING_RESOURCES not defined (accessor fn, no pkg filename) is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "__PENDING_RESOURCES is not defined",
+            stacktrace: {
+              frames: [
+                { function: "__wbg_static_accessor___PENDING_RESOURCES_abc123" },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "ReferenceError __SERIALIZED_ERRORS not defined with NO frames falls back to value match and is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "__SERIALIZED_ERRORS is not defined",
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  // Guard: a same-named global thrown from a THIRD-PARTY (non-pkg) script must
+  // NOT be swept up — the bundle scoping keeps it narrow.
+  {
+    name: "ReferenceError __RESOLVED_RESOURCES from a third-party (non-pkg) frame is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "__RESOLVED_RESOURCES is not defined",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "https://cdn.example.com/widget.js",
+                  function: "init",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  // Guard: an ordinary application ReferenceError from our own bundle must
+  // always report — only the leptos hydration globals are matched.
+  {
+    name: "a genuine application ReferenceError from the pkg bundle is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "ReferenceError",
+            value: "someAppHelper is not defined",
+            stacktrace: {
+              frames: [{ filename: "/pkg/a2d6028/ultros.js", function: "c" }],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+
   // ── Genuine application errors must always survive ──
   {
     name: "a genuine application Error is preserved",

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -15,14 +15,18 @@
 //
 // We drop several independent categories of unactionable noise:
 //
-//   1. WASM bundle fetch aborts — users navigating away during the
-//      streaming compile, ad blockers, corporate proxies. Two shapes:
-//      a bare "TypeError: Failed to fetch" from the wasm-bindgen glue,
-//      and the ESM-entry "Failed to fetch dynamically imported module:
-//      <pkg-url>" thrown when the module preload/import() of our own
-//      bundle aborts. GlitchTip issues #21, #2374, #2404, and the
-//      count=1 flood of #62xx "Failed to fetch dynamically imported
-//      module: .../pkg/<hash>/ultros.js".
+//   1. WASM bundle fetch / compile failures — users navigating away during
+//      the streaming compile, ad blockers, corporate proxies, and stale
+//      chunks 404ing in the seconds after a deploy. Shapes: a bare
+//      "TypeError: Failed to fetch" from the wasm-bindgen glue; the
+//      ESM-entry "Failed to fetch dynamically imported module: <pkg-url>"
+//      thrown when the module preload/import() of our own bundle aborts;
+//      "WebAssembly compilation aborted"; "TypeError: Failed to execute
+//      'compile' on 'WebAssembly': HTTP status code is not ok" (the .wasm
+//      came back non-OK); and "CompileError: ... extends past end of the
+//      module" (a truncated download). GlitchTip issues #21, #2374, #2404,
+//      #6755, #6762–#6767, and the count=1 flood of #62xx "Failed to fetch
+//      dynamically imported module: .../pkg/<hash>/ultros.js".
 //   2. A "Cannot read properties of undefined (reading 'document')"
 //      TypeError thrown by an injected third-party script (Tencent QQ
 //      Browser / UC / WeChat in-app WebViews on frozen Chrome 112).
@@ -55,9 +59,28 @@
 //      rejected with no reason. Zero diagnostic value (no message, no
 //      stack), overwhelmingly third-party (gtag / funding-choices / ads)
 //      or aborted fetches. The count=1 flood of #62xx "UnhandledRejection".
+//   5. "ReferenceError: __RESOLVED_RESOURCES is not defined" (and the
+//      __INCOMPLETE_CHUNKS / __PENDING_RESOURCES / __SERIALIZED_ERRORS
+//      variants) — leptos's streaming-hydration bootstrap globals, which the
+//      SSR shell ALWAYS emits and only leptos's generated wasm-bindgen static
+//      accessors ever read. "not defined" means a proxy/crawler stripped or
+//      truncated the streamed bootstrap before the wasm hydrated — the same
+//      translation-proxy population behind category 3. GlitchTip issues
+//      #6620, #6667, #6760, #6761.
 (function () {
   var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
   var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
+  // Leptos's streaming-hydration bootstrap globals. The SSR shell ALWAYS emits
+  // `window.__RESOLVED_RESOURCES = []` plus `__INCOMPLETE_CHUNKS` /
+  // `__PENDING_RESOURCES` / `__SERIALIZED_ERRORS` (verified in the served HTML
+  // of the failing /item/<world>/<id> URLs — see shell() in lib.rs), and they
+  // are read ONLY by leptos's generated wasm-bindgen static accessors, never by
+  // app code. So a "ReferenceError: <name> is not defined" for one of them can
+  // only mean a proxy/crawler stripped or truncated the streamed bootstrap
+  // before the wasm hydrated — the same translation-proxy population behind the
+  // tachys flood. Anchored ^…$ so it matches the bare global name only.
+  var ULTROS_HYDRATION_BOOTSTRAP_REFERR_RE =
+    /^__(?:RESOLVED_RESOURCES|INCOMPLETE_CHUNKS|PENDING_RESOURCES|SERIALIZED_ERRORS) is not defined$/;
   // The wasm-bindgen-futures single-threaded executor. When the tachys
   // hydration panic unwinds through a running future poll, re-entering the
   // executor trips `RefCell already borrowed` HERE — the documented cascade of
@@ -153,6 +176,78 @@
       }
     } catch (_) {
       /* be defensive — never let the filter throw */
+    }
+    return false;
+  }
+
+  // Category 1 (cont.): the streaming COMPILE of our wasm bundle failing. Two
+  // shapes, both network / deploy-race noise rather than an actionable bug:
+  //   - a non-OK HTTP response for the .wasm — a stale chunk 404 in the seconds
+  //     after a deploy — surfaces as `TypeError: Failed to execute 'compile' on
+  //     'WebAssembly': HTTP status code is not ok`;
+  //   - a truncated / aborted download surfaces as `CompileError:
+  //     WebAssembly.instantiateStreaming(): section (...) extends past end of
+  //     the module (...)`.
+  // The CompileError match is scoped to the truncation signature so a genuinely
+  // corrupt build (e.g. a bad opcode) still reports — that would be an
+  // all-users flood worth seeing, not these count=1 blips. GlitchTip #6755,
+  // #6762, #6763, #6764, #6766, #6767.
+  function isUltrosWasmCompileFailure(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex || typeof ex.value !== "string") return false;
+      if (
+        ex.type === "TypeError" &&
+        ex.value.indexOf(
+          "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+        ) === 0
+      ) {
+        return true;
+      }
+      if (
+        ex.type === "CompileError" &&
+        ex.value.indexOf("extends past end of the module") !== -1
+      ) {
+        return true;
+      }
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
+  // Category 5: a hydration accessor reading a leptos bootstrap global that the
+  // page never defined (see ULTROS_HYDRATION_BOOTSTRAP_REFERR_RE). Scoped to our
+  // own bundle so a same-named global thrown by some third-party script could
+  // never be swept up: when stack frames are present, require one from the pkg
+  // bundle or a `__wbg_static_accessor` frame; absent any frames the value alone
+  // — a leptos-internal name no app code references — is already definitive.
+  function isStrippedHydrationBootstrap(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex || ex.type !== "ReferenceError" || typeof ex.value !== "string") {
+        return false;
+      }
+      if (!ULTROS_HYDRATION_BOOTSTRAP_REFERR_RE.test(ex.value)) return false;
+      var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+      if (frames.length === 0) return true;
+      for (var i = 0; i < frames.length; i++) {
+        var f = frames[i] || {};
+        if (
+          typeof f.filename === "string" &&
+          ULTROS_PKG_BUNDLE_RE.test(f.filename)
+        ) {
+          return true;
+        }
+        if (
+          typeof f.function === "string" &&
+          f.function.indexOf("__wbg_static_accessor") === 0
+        ) {
+          return true;
+        }
+      }
+    } catch (_) {
+      /* never let the filter throw */
     }
     return false;
   }
@@ -353,6 +448,8 @@
   window.__ultrosShouldDropEvent = function (event) {
     return (
       isUltrosWasmFetchAbort(event) ||
+      isUltrosWasmCompileFailure(event) ||
+      isStrippedHydrationBootstrap(event) ||
       isInjectedDocumentTypeError(event) ||
       isInjectedTachysHydrationPanic(event) ||
       isEmptyPromiseRejection(event)


### PR DESCRIPTION
## What

Extends the Sentry `beforeSend` noise filter (`ultros-frontend/ultros-app/src/error_filter.js`) to drop **two more unactionable noise classes** that are leaking past the #770 filter into GlitchTip. Both come from the **same translation-proxy population** (Tencent Cloud IPs, `Asia/Shanghai`, en-US locale) already behind the tachys hydration flood — the proxy mutates/truncates the HTML server-side before it reaches the browser.

### Category 5 (new) — stripped leptos hydration bootstrap
`ReferenceError: __RESOLVED_RESOURCES is not defined` and the `__INCOMPLETE_CHUNKS` / `__PENDING_RESOURCES` / `__SERIALIZED_ERRORS` variants.

These are **leptos's streaming-hydration bootstrap globals**. The SSR shell *always* emits them — I verified by fetching the served HTML of an actually-failing URL:

```
$ curl -s -A "Chrome/137" https://ultros.app/item/Chaos/12190 | grep -oE '__RESOLVED_RESOURCES|__INCOMPLETE_CHUNKS|__PENDING_RESOURCES|__SERIALIZED_ERRORS'
   4 __RESOLVED_RESOURCES
   1 __INCOMPLETE_CHUNKS
   1 __PENDING_RESOURCES
   1 __SERIALIZED_ERRORS
```

They are read **only** by leptos's generated wasm-bindgen static accessors (`__wbg_static_accessor___RESOLVED_RESOURCES_…`), never by app code. So a `… is not defined` can only mean a proxy stripped/truncated the streamed bootstrap before the wasm hydrated. Resolves the GlitchTip flood: **#6620, #6667, #6760, #6761**.

### Category 1 (extended) — WASM streaming-compile failures
- `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok` — the `.wasm` came back non-OK (a stale chunk 404 in the seconds after a deploy).
- `CompileError: WebAssembly.instantiateStreaming(): section … extends past end of the module …` — a truncated download.

Same network/deploy-race class as the already-filtered `Failed to fetch`. Resolves **#6755, #6762, #6763, #6764, #6766, #6767**.

## Scoping / safety

- The ReferenceError match requires the exact leptos global name **and** (when frames are present) a pkg-bundle or `__wbg_static_accessor` frame, so a same-named third-party global is preserved. An app `ReferenceError` from our own bundle is preserved.
- The `CompileError` match is scoped to the **truncation** signature, so a genuinely corrupt build (bad opcode) — which would be an all-users flood worth seeing — still reports.
- Every predicate stays wrapped in try/catch; the filter never throws.

## Deliberately NOT touched

The Chrome-133 tachys hydration flood (**#6758 / #6757 / #6759**, ~680 events) is the **server-side-translation** population: the mutation happens before the HTML reaches the browser, so there is *no* client-detectable fingerprint at `beforeSend` (no `<font>`, no `translated-ltr/rtl` class, UA is current Chrome 133 > the stale-major cutoff). #787 already collapses it to 3 issues. Blindly suppressing those panic sites would also hide genuine clean-browser hydration regressions, so I left it — documented as a known residual.

## Tests

`integration/error-filter.test.cjs` — **42/42 pass** (9 new cases, including preserve-guards for third-party globals, ordinary app `ReferenceError`s, and non-truncation `CompileError`s). Confirmed the 6 new drop-cases fail against the pre-change filter first.

```
node --test integration/error-filter.test.cjs   # tests 42, pass 42, fail 0
```

> [!NOTE]
> JS-only change (the file is `include_str!`'d into `lib.rs`; valid JS, so the Rust build is unaffected). The Rust submodule wasn't initialized in this environment, so `cargo clippy`/`fmt` were not run locally — but neither touches this `.js` and there is no clippy/fmt/prettier impact. The gate for this file is the Node test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)