### PR TITLE
fix(hydrate): keep SSR content instead of panicking when XIV game data fails to load

### DIFF
--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -331,9 +331,10 @@ pub fn hydrate() {
         // Use the SSR-injected bootstrap when available; only fall back to
         // network requests if it's missing (e.g. stale cached HTML).
         let bootstrap = read_bootstrap();
-        let (worlds, region, current_user) = if let Some(b) = bootstrap {
-            let _ = populate_xiv_gen_data().await;
+        let (xiv_data, worlds, region, current_user) = if let Some(b) = bootstrap {
+            let xiv_data = populate_xiv_gen_data().await;
             (
+                xiv_data,
                 Ok(Arc::new(WorldHelper::from(b.world_data))),
                 b.region,
                 Some(b.current_user),
@@ -347,7 +348,7 @@ pub fn hydrate() {
             // the SSR DOM (rendered with the server's view of auth state)
             // and the client view tree (auth state still loading) diverge
             // and tachys hydration panics at hydration.rs:163.
-            let (_, ((worlds, region), current_user)) = join(
+            let (xiv_data, ((worlds, region), current_user)) = join(
                 populate_xiv_gen_data(),
                 join(
                     join(get_world_data(), get_region()),
@@ -355,8 +356,33 @@ pub fn hydrate() {
                 ),
             )
             .await;
-            (worlds, region, Some(current_user))
+            (xiv_data, worlds, region, Some(current_user))
         };
+
+        // The entire client view tree reads game data through
+        // `xiv_gen_db::data()` (via `tracked_data()`, used across ~37 route and
+        // component files). If the `.rkyv` data archive failed to populate —
+        // an ad blocker or corporate proxy dropping the binary fetch, a flaky
+        // network, or a crawler like Baiduspider that won't fetch it — then
+        // `data()` panics with "XIV data not initialized" the instant we
+        // hydrate (xiv-gen-db/src/lib.rs), taking down the page and firing a
+        // WASM panic to GlitchTip (issue #6765). The SSR HTML was rendered
+        // server-side with the embedded data, so it already shows the correct
+        // page; hydrating with no client data could only panic — or, worse,
+        // silently diverge into a hydration mismatch. Leave the static SSR
+        // content in place instead. Navigation still works as full page loads,
+        // each re-rendered server-side with real data.
+        if let Err(e) = xiv_data {
+            error!(
+                "XIV game data failed to load; leaving server-rendered content un-hydrated: {e}"
+            );
+            // Resolve the boot-progress indicator, which waits on this event
+            // and would otherwise show a "taking longer than expected" error
+            // once its watchdog fires — the SSR page is the final state here.
+            dispatch_boot_event("ultros:hydrated");
+            return;
+        }
+
         info!("hydrating body");
         let world_data = match worlds {
             Ok(worlds) => LocalWorldData(Ok(worlds)),


### PR DESCRIPTION
## Summary

Fixes GlitchTip [#6765](https://glitchtip.ultros.app/ultros/issues/6765) — `RustWasmPanic: XIV data not initialized` (`xiv-gen-db/src/lib.rs:37`).

When the client fetches the game-data archive `/static/data/<version>/<lang>.rkyv` and that fetch **fails**, the app hydrated anyway and then hard-panicked the moment any component read game data. The panic took down the page and fired a WASM panic to GlitchTip.

### Root cause (straight from the production breadcrumb trace)

The event for #6765 shows the exact sequence:

1. `hydrate mode - hydrating` → `fetching..`
2. **`fetch …/en.rkyv` → 4× `level: error`** (the `retry(_, 3)` loop + the fallback `init_data()`, all failing immediately — status 0, a network/abort-level failure)
3. `hydrating body` → `app run!`
4. **`panicked at xiv-gen-db/src/lib.rs:37:30: XIV data not initialized`**

`hydrate()` called `populate_xiv_gen_data().await` but **discarded the `Result`** (`let _ =` / `_` in the `join`). When the `.rkyv` fetch fails, `try_init` never runs, so `XIV_DATA` stays `None`. The client view tree reads game data through `xiv_gen_db::data()` (via `tracked_data()` — used across **~37 route/component files**, including shared chrome like `related_items`, `item_icon`, `recently_viewed`, `market_movers`), so the first read calls `.expect("XIV data not initialized")` and panics.

This is **guaranteed** whenever the data fetch fails. The triggering client in the latest event is `Baiduspider-render` (a crawler that won't fetch our binary data file), but the same gap hits any real user behind an ad blocker / corporate proxy or on a flaky network.

### Fix

Capture the `populate_xiv_gen_data()` result. If it failed, **skip hydration and leave the server-rendered HTML in place** rather than hydrating into a guaranteed panic.

Why skip rather than fall back to empty data: the SSR HTML was rendered server-side with the fully-**embedded** data, so it already shows the correct page. Hydrating with *no* client data could only panic — and hydrating with *empty/default* data would silently diverge from the SSR DOM and trip a tachys **hydration mismatch** instead. Leaving the static SSR content is the only correct degradation; navigation still works as full page loads, each re-rendered server-side with real data.

We also dispatch `ultros:hydrated` in the skip path so the boot-progress indicator resolves cleanly instead of tripping its 30s "taking longer than expected" watchdog (the SSR page is the final rendered state for these clients).

`Ok(())` from `populate_xiv_gen_data()` strictly implies `XIV_DATA` is initialized — every `Ok` path (IndexedDB cache hit, network `init_data`, and the retry/fallback) calls `try_init` before returning — so the guard fires **only** in the genuine "no data" case and never changes the success path's behavior.

## Verification

- `cargo fmt --all -- --check` — passes
- `cargo check -p ultros-client --target wasm32-unknown-unknown` — passes
- `cargo clippy -p ultros-client --target wasm32-unknown-unknown` — the changed lines produce **zero** warnings (the only lints reported, `collapsible_if` in `get_i18n_lang` and `type_complexity` in `ws/realtime.rs`, are pre-existing client-only code untouched here and outside CI's host/`ssr` clippy gate)

A full in-browser reproduction (block `*.rkyv`, load an item page, observe the panic disappear) was not run because the SSR server build hits the Windows jemalloc/MSVC wall in this environment — but the root cause and fix are unambiguous from the production breadcrumb trace above and the change compiles + lints clean for the wasm target.

## GlitchTip backlog triage (same run)

Alongside this fix, swept the backlog and **ignored 45 unactionable issues** (in ≤10 batches):
- **3** transient `TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok` + their session's one-off `RuntimeError: unreachable` (#6768–#6771) — client wasm-fetch returned non-2xx; covered going forward by the in-flight #790 filter work.
- **41** stale external-translation hydration panics on old releases (lastSeen 2026-06-11): the `/items/jobset/*` set (#601/#3005/#4911/#4863/#402/#291/#226/#104/#322/#5058/#5009/#4948 + #6406) and the per-URL `/item/<world>/<id>` count=1 fragments (#6448–#6476). Spot-checked #601: `tachys-0.2.15/hydration.rs:227` mismatch on frozen Chrome 109 / Tencent-Cloud IP with a successful `.rkyv` fetch — the known translation-injection class, now collapsed by #787's fingerprinting and handled going-forward by the `error_filter.js` ≤124-Chrome prong.

Left **unresolved by design** (active canaries for the server-side-translation flood, which has no safe `beforeSend` fingerprint): #6758, #6757, #6772, #6759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)