### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Service (DoS) vulnerability in Webhooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security)
 **Learning:** The Axum server didn't have global security headers applied, opening the door to clickjacking, MIME-sniffing and MITM attacks via plain HTTP.
 **Prevention:** Always add global security headers via middleware (e.g. `SetResponseHeaderLayer` from `tower_http`) when configuring a web server.
+
+## 2024-05-24 - [Add Timeouts to Webhook Client]
+**Vulnerability:** Denial of Service (DoS) via Server Tarpitting / SSRF
+**Learning:** `reqwest::Client::new()` in Rust does not have a default timeout. If a user sets a malicious webhook URL that holds the connection open, it could exhaust server resources and block other alerts from being sent.
+**Prevention:** Always configure an explicit `.timeout()` when instantiating `reqwest::Client` for outbound HTTP requests to user-controlled URLs.

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -284,7 +284,9 @@ async fn send_webpush(
     let req = reqwest::Request::try_from(http_req)
         .map_err(|e| anyhow!("push request convert failed: {e}"))?;
 
-    let resp = reqwest::Client::new()
+    let resp = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?
         .execute(req)
         .await
         .map_err(|e| anyhow!("push send failed: {e}"))?;
@@ -339,7 +341,9 @@ async fn send_webhook(url: &str, title: &str, body: &str) -> Result<()> {
         }],
         "allowed_mentions": { "parse": [] },
     });
-    let resp = reqwest::Client::new()
+    let resp = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?
         .post(url)
         .json(&payload)
         .send()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `reqwest::Client` had no timeout, allowing malicious webhook URLs to tarpit the server.
🎯 Impact: Denial of Service (DoS) via resource exhaustion.
🔧 Fix: Add `timeout(std::time::Duration::from_secs(10))` to the `reqwest` clients.
✅ Verification: `cargo check` and CI script verify the changes compile correctly and tests pass.

---
*PR created automatically by Jules for task [13189097354722108255](https://jules.google.com/task/13189097354722108255) started by @akarras*