### PR TITLE
feat(fc-crafting): variable-height rows with ResizeObserver re-measure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target/
 .env
+# Agent-local MCP config — may contain tokens / machine-specific paths
+.mcp.json
 .DS_Store
 executables/
 integration/node_modules/

--- a/integration/fc-crafting-breakdown.cjs
+++ b/integration/fc-crafting-breakdown.cjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Focused Puppeteer E2E for the FC Crafting Analyzer material breakdown.
+ *
+ * Regression covered:
+ *   - clicking "Material breakdown" must not follow the item link
+ *   - the native details element must open
+ *   - the virtual-scroller row must grow instead of clipping the expanded body
+ *
+ * Env:
+ *   BASE_URL   default http://127.0.0.1:8080
+ *   WORLD      default Goblin
+ *   HEADLESS   "new" | "true" | "false" (default "new")
+ *   TIMEOUT_MS default 90000
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const puppeteer = require("puppeteer");
+
+function parseHeadless(value) {
+  if (value === undefined || value === null || value === "") return "new";
+  const v = String(value).toLowerCase();
+  if (v === "new") return "new";
+  if (v === "true" || v === "1") return true;
+  if (v === "false" || v === "0") return false;
+  return "new";
+}
+
+const DEFAULT_CONSOLE_ALLOW = [
+  "favicon",
+  "ERR_BLOCKED_BY_CLIENT",
+  "net::ERR_ABORTED",
+];
+
+async function navigateWithFallback(page, url, timeout) {
+  try {
+    return await page.goto(url, { waitUntil: "networkidle0", timeout });
+  } catch (_e) {
+    console.warn(`[warn] networkidle0 timed out, retrying domcontentloaded: ${url}`);
+    return await page.goto(url, { waitUntil: "domcontentloaded", timeout });
+  }
+}
+
+async function materialSummaryHandle(page) {
+  const handle = await page.evaluateHandle(() => {
+    return (
+      Array.from(document.querySelectorAll("summary")).find((el) =>
+        (el.textContent || "").includes("Material breakdown"),
+      ) || null
+    );
+  });
+  const element = handle.asElement();
+  if (!element) await handle.dispose();
+  return element;
+}
+
+async function breakdownState(page) {
+  return page.evaluate(() => {
+    const summary = Array.from(document.querySelectorAll("summary")).find((el) =>
+      (el.textContent || "").includes("Material breakdown"),
+    );
+    if (!summary) return { found: false };
+
+    const details = summary.closest("details");
+    const body = details && details.querySelector(".mt-2");
+    const rowWrapper = details && details.closest(".content-auto, .content-visible");
+    const detailsRect = details
+      ? details.getBoundingClientRect()
+      : { height: 0, bottom: 0 };
+    const bodyRect = body ? body.getBoundingClientRect() : { height: 0 };
+    const rowRect = rowWrapper
+      ? rowWrapper.getBoundingClientRect()
+      : { height: 0, bottom: 0 };
+
+    return {
+      found: true,
+      open: Boolean(details && details.open),
+      detailsHeight: detailsRect.height,
+      bodyHeight: bodyRect.height,
+      rowHeight: rowRect.height,
+      clipped:
+        Boolean(rowWrapper) && detailsRect.bottom > rowRect.bottom + 1,
+      rowClass: rowWrapper ? rowWrapper.className : "",
+      rowStyle: rowWrapper ? rowWrapper.getAttribute("style") || "" : "",
+      text: body ? body.textContent || "" : "",
+    };
+  });
+}
+
+async function main() {
+  const BASE_URL = process.env.BASE_URL || "http://127.0.0.1:8080";
+  const WORLD = process.env.WORLD || "Goblin";
+  const TIMEOUT_MS = Number(process.env.TIMEOUT_MS || 90000);
+  const headless = parseHeadless(process.env.HEADLESS);
+  const consoleAllow = [
+    ...DEFAULT_CONSOLE_ALLOW,
+    ...(process.env.CONSOLE_ALLOW || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  ];
+  const outdir = path.resolve(__dirname, "artifacts", "fc-crafting");
+  fs.mkdirSync(outdir, { recursive: true });
+
+  const route = `/fc-crafting-analyzer/${encodeURIComponent(WORLD)}`;
+  const url = new URL(route, BASE_URL).toString();
+  const base = new URL(BASE_URL);
+
+  console.log(`[info] BASE_URL=${BASE_URL}`);
+  console.log(`[info] WORLD=${WORLD}`);
+  console.log(`[info] OUTPUT_DIR=${outdir}`);
+
+  const consoleErrors = [];
+  const pageErrors = [];
+  const isAllowed = (message) => consoleAllow.some((s) => message.includes(s));
+
+  let browser;
+  try {
+    browser = await puppeteer.launch({
+      headless,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+    });
+
+    const page = await browser.newPage();
+    page.setDefaultTimeout(TIMEOUT_MS);
+    await page.setViewport({ width: 1280, height: 800, deviceScaleFactor: 1 });
+    await page.setCookie({
+      name: "HOME_WORLD",
+      value: WORLD,
+      domain: base.hostname,
+      path: "/",
+    });
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        const text = msg.text();
+        if (!isAllowed(text)) consoleErrors.push(text);
+      }
+    });
+    page.on("pageerror", (err) => {
+      const text = (err && err.stack) || String(err);
+      if (!isAllowed(text)) pageErrors.push(text);
+    });
+
+    console.log(`[step] visiting ${url}`);
+    const resp = await navigateWithFallback(page, url, TIMEOUT_MS);
+    const status = resp ? resp.status() : -1;
+    if (!resp || status >= 400) {
+      throw new Error(`bad status ${status} for ${url}`);
+    }
+
+    await page.waitForFunction(
+      () =>
+        Array.from(document.querySelectorAll("summary")).some((el) =>
+          (el.textContent || "").includes("Material breakdown"),
+        ),
+      { timeout: TIMEOUT_MS },
+    );
+    await new Promise((r) => setTimeout(r, 500));
+    await page.screenshot({
+      path: path.join(outdir, "before-breakdown.png"),
+      fullPage: true,
+    });
+
+    const beforeUrl = page.url();
+    const before = await breakdownState(page);
+    if (!before.found) throw new Error("material breakdown summary not found");
+    if (before.open) throw new Error("material breakdown unexpectedly starts open");
+
+    const summary = await materialSummaryHandle(page);
+    if (!summary) throw new Error("material breakdown summary handle not found");
+    await summary.evaluate((el) =>
+      el.scrollIntoView({ block: "center", inline: "nearest" }),
+    );
+    await summary.click();
+    await summary.dispose();
+
+    await Promise.race([
+      page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 1500 }).catch(() => null),
+      new Promise((r) => setTimeout(r, 800)),
+    ]);
+
+    const afterUrl = page.url();
+    if (afterUrl !== beforeUrl) {
+      throw new Error(
+        `clicking material breakdown navigated away: before=${beforeUrl} after=${afterUrl}`,
+      );
+    }
+    if (new URL(afterUrl).pathname.startsWith("/item/")) {
+      throw new Error(`clicking material breakdown opened an item page: ${afterUrl}`);
+    }
+
+    await page.waitForFunction(
+      () => {
+        const summary = Array.from(document.querySelectorAll("summary")).find((el) =>
+          (el.textContent || "").includes("Material breakdown"),
+        );
+        const details = summary && summary.closest("details");
+        const body = details && details.querySelector(".mt-2");
+        const rowWrapper =
+          details && details.closest(".content-auto, .content-visible");
+        if (!details || !body || !rowWrapper || !details.open) return false;
+        const bodyRect = body.getBoundingClientRect();
+        const detailsRect = details.getBoundingClientRect();
+        const rowRect = rowWrapper.getBoundingClientRect();
+        return (
+          bodyRect.height > 0 &&
+          rowRect.height > 60 &&
+          detailsRect.bottom <= rowRect.bottom + 1
+        );
+      },
+      { timeout: 10000 },
+    );
+
+    const after = await breakdownState(page);
+    await page.screenshot({
+      path: path.join(outdir, "after-breakdown-open.png"),
+      fullPage: true,
+    });
+
+    if (!after.open) throw new Error("material breakdown did not open");
+    if (after.bodyHeight <= 0) {
+      throw new Error(`material breakdown body has no visible height: ${JSON.stringify(after)}`);
+    }
+    if (after.rowHeight <= 60) {
+      throw new Error(`virtual row did not grow after opening: ${JSON.stringify(after)}`);
+    }
+    if (after.clipped) {
+      throw new Error(`material breakdown is clipped by the virtual row: ${JSON.stringify(after)}`);
+    }
+    if (!/\d+\s*x\s+/.test(after.text)) {
+      throw new Error(`material rows did not render expected quantity text: ${JSON.stringify(after)}`);
+    }
+
+    if (consoleErrors.length || pageErrors.length) {
+      const lines = [
+        ...consoleErrors.map((e) => `console.error: ${e}`),
+        ...pageErrors.map((e) => `pageerror: ${e}`),
+      ];
+      throw new Error(lines.join("\n"));
+    }
+
+    console.log("[done] FC crafting material breakdown opens in-place and is not clipped");
+    await browser.close();
+    browser = null;
+  } catch (err) {
+    console.error("[error]", err && err.stack ? err.stack : err);
+    if (browser) {
+      try {
+        await browser.close();
+      } catch (_) {}
+    }
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/integration/package.json
+++ b/integration/package.json
@@ -17,6 +17,7 @@
     "test:list-card-edit": "node ./list-card-edit.cjs",
     "test:list-view-rename": "node ./list-view-rename.cjs",
     "test:list-bulk-edit": "node ./list-bulk-edit.cjs",
+    "test:fc-crafting-breakdown": "node ./fc-crafting-breakdown.cjs",
     "test:dashboard": "node ./dashboard.cjs",
     "test:error-filter": "node --test ./error-filter.test.cjs"
   },

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -18,7 +18,8 @@
 #   ANALYZER_READY_TIMEOUT  default 180       (seconds to wait for analyzer)
 #   DEVICE         desktop | mobile | both (default both)
 #   SKIP_BUILD     1 to skip `cargo leptos build` before serve
-#   LEPTOS_FEATURES extra leptos-bin-features (space-separated)
+#   LEPTOS_FEATURES extra leptos-bin-features (space-separated). Set to an
+#                  explicit empty string to override metadata bin-features.
 #
 # Exit code is the npm test exit code (0 on success).
 
@@ -33,6 +34,10 @@ READY_TIMEOUT="${READY_TIMEOUT:-300}"
 ANALYZER_READY_PATH="${ANALYZER_READY_PATH-/api/v1/cheapest/North-America}"
 ANALYZER_READY_TIMEOUT="${ANALYZER_READY_TIMEOUT:-180}"
 DEVICE="${DEVICE:-both}"
+bin_feature_args=()
+if [ "${LEPTOS_FEATURES+x}" = "x" ]; then
+    bin_feature_args=(--bin-features "$LEPTOS_FEATURES")
+fi
 
 log() { printf '[e2e] %s\n' "$*" >&2; }
 
@@ -95,11 +100,7 @@ else
 
     if [ "${SKIP_BUILD:-0}" != "1" ]; then
         log "cargo leptos build (set SKIP_BUILD=1 to skip)"
-        if [ -n "${LEPTOS_FEATURES:-}" ]; then
-            cargo leptos build --bin-features "$LEPTOS_FEATURES"
-        else
-            cargo leptos build
-        fi
+        cargo leptos build "${bin_feature_args[@]}"
     fi
 
     set -m
@@ -107,7 +108,7 @@ else
         HOSTNAME="$BASE_URL" \
         LEPTOS_SITE_ADDR="127.0.0.1:$port" \
         cargo leptos serve \
-        ${LEPTOS_FEATURES:+--bin-features "$LEPTOS_FEATURES"} \
+        "${bin_feature_args[@]}" \
         >/tmp/ultros-e2e-server.log 2>&1 &
     server_pid=$!
     set +m
@@ -155,6 +156,15 @@ else
     log "running npm run $test_script in integration/ against $BASE_URL"
     # `|| test_exit=$?` captures the npm exit code without triggering set -e.
     ( cd integration && BASE_URL="$BASE_URL" npm run "$test_script" ) || test_exit=$?
+fi
+
+if [ "${RUN_FC_CRAFTING_BREAKDOWN:-1}" != "0" ]; then
+    log "running FC crafting material-breakdown E2E"
+    fc_crafting_exit=0
+    ( cd integration && BASE_URL="$BASE_URL" npm run test:fc-crafting-breakdown ) || fc_crafting_exit=$?
+    if [ "$fc_crafting_exit" -ne 0 ] && [ "$test_exit" -eq 0 ]; then
+        test_exit="$fc_crafting_exit"
+    fi
 fi
 
 # If we built with test-auth, also exercise the login flow even when the

--- a/ultros-frontend/ultros-app/Cargo.toml
+++ b/ultros-frontend/ultros-app/Cargo.toml
@@ -32,6 +32,7 @@ web-sys = { version = "0.3", optional = true, features = [
     "DomRect",
     "Element",
     "PointerEvent",
+    "ResizeObserver",
     "WebSocket",
     "MessageEvent",
     "CloseEvent",

--- a/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+++ b/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::{cell::RefCell, rc::Rc};
 use web_sys::wasm_bindgen::JsCast;
 use web_sys::wasm_bindgen::closure::Closure;
-use web_sys::{HtmlDivElement, window};
+use web_sys::{HtmlDivElement, ResizeObserver, window};
 
 struct Fenwick {
     n: usize,
@@ -331,20 +331,52 @@ where
                                 let height_deltas = height_deltas;
                                 let fenwick = fenwick;
                                 if variable_height {
+                                    let resize_observer = StoredValue::new_local(
+                                        None::<(ResizeObserver, Closure<dyn FnMut()>)>,
+                                    );
+                                    on_cleanup(move || {
+                                        resize_observer.update_value(|handle| {
+                                            if let Some((observer, _callback)) = handle.take() {
+                                                observer.disconnect();
+                                            }
+                                        });
+                                    });
+
                                     Effect::new(move |_| {
                                         if let Some(el) = row.get() {
-                                            let measured = el.offset_height() as f64;
-                                            let delta = measured - row_height;
-                                            height_deltas.update_value(|v| {
-                                                if idx < v.len() {
-                                                    let old = v[idx];
-                                                    if (old - delta).abs() > 0.5 {
-                                                        v[idx] = delta;
-                                                        // O(log n) update instead of rebuilding prefix sums
-                                                        fenwick.update(|f| f.add(idx, delta - old));
+                                            let measure_height = move |measured: f64| {
+                                                let delta = measured - row_height;
+                                                height_deltas.update_value(|v| {
+                                                    if idx < v.len() {
+                                                        let old = v[idx];
+                                                        if (old - delta).abs() > 0.5 {
+                                                            v[idx] = delta;
+                                                            // O(log n) update instead of rebuilding prefix sums
+                                                            fenwick.update(|f| f.add(idx, delta - old));
+                                                        }
                                                     }
+                                                });
+                                            };
+
+                                            measure_height(el.offset_height() as f64);
+
+                                            if resize_observer
+                                                .with_value(|observer| observer.is_none())
+                                            {
+                                                let observed_el = el.clone();
+                                                let callback = Closure::wrap(Box::new(move || {
+                                                    measure_height(observed_el.offset_height() as f64);
+                                                })
+                                                    as Box<dyn FnMut()>);
+
+                                                if let Ok(observer) = ResizeObserver::new(
+                                                    callback.as_ref().unchecked_ref(),
+                                                ) {
+                                                    observer.observe(&el);
+                                                    resize_observer
+                                                        .set_value(Some((observer, callback)));
                                                 }
-                                            });
+                                            }
                                         }
                                     });
                                 }

--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -463,7 +463,7 @@ fn FCCraftingAnalyzerTable(
                     row_height=60.0
                     overscan=8
                     header_height=64.0
-                    variable_height=false
+                    variable_height=true
                      header=view! {
                         <div class="flex flex-row align-top h-16 bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]" role="rowgroup">
                              <div role="columnheader" class="w-84 shrink-0 p-4">{t!(i18n, fc_crafting_analyzer_col_project_result)}</div>
@@ -507,10 +507,10 @@ fn FCCraftingAnalyzerTable(
                         let data_clone = data.clone();
                         let item_id = ItemId(data.sequence.result_item);
                         let item = items.get(&item_id).map(|i| i.name.as_str().to_string()).unwrap_or_else(|| t_string!(i18n, unknown).to_string());
-                         let classes = if (index % 2) == 0 {
-                            "flex flex-row items-center flex-nowrap h-15 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] hover:ring-1 hover:ring-[color:color-mix(in_srgb,var(--brand-ring)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--color-text)_6%,transparent)] transition-colors"
+                        let classes = if (index % 2) == 0 {
+                            "flex flex-row items-start flex-nowrap min-h-[60px] hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] hover:ring-1 hover:ring-[color:color-mix(in_srgb,var(--brand-ring)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--color-text)_6%,transparent)] transition-colors"
                         } else {
-                            "flex flex-row items-center flex-nowrap h-15 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] hover:ring-1 hover:ring-[color:color-mix(in_srgb,var(--brand-ring)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--color-text)_8%,transparent)] transition-colors"
+                            "flex flex-row items-start flex-nowrap min-h-[60px] hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] hover:ring-1 hover:ring-[color:color-mix(in_srgb,var(--brand-ring)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--color-text)_8%,transparent)] transition-colors"
                         };
                          let sales_tooltip = format!(
                             "Based on {} sales over {:.1} days",
@@ -537,15 +537,20 @@ fn FCCraftingAnalyzerTable(
                         view! {
                             <div class=classes role="row-group">
                                 <div role="cell" class="px-4 py-2 flex flex-row w-84 shrink-0 items-center gap-2">
-                                     <a
-                                        class="flex flex-row items-center gap-2 hover:text-brand-300 transition-colors truncate overflow-x-clip w-full"
-                                        href=format!("/item/{}/{}", world(), item_id.0)
-                                    >
-                                        <div class="shrink-0">
+                                    <div class="flex flex-row items-center gap-2 min-w-0 w-full">
+                                        <a
+                                            class="shrink-0 hover:text-brand-300 transition-colors"
+                                            href=format!("/item/{}/{}", world(), item_id.0)
+                                        >
                                             <ItemIcon item_id=item_id.0 icon_size=IconSize::Small />
-                                        </div>
-                                        <div class="flex flex-col truncate">
-                                            <span>{item}</span>
+                                        </a>
+                                        <div class="flex flex-col min-w-0">
+                                            <a
+                                                class="truncate hover:text-brand-300 transition-colors"
+                                                href=format!("/item/{}/{}", world(), item_id.0)
+                                            >
+                                                {item}
+                                            </a>
                                             <ResultBreakdownDisclosure title=t_string!(i18n, fc_crafting_disclosure_material_breakdown).to_string()>
                                                 <div class="flex flex-col gap-1">
                                                     {material_rows.into_iter().map(|(name, qty, unit_cost)| view! {
@@ -557,7 +562,7 @@ fn FCCraftingAnalyzerTable(
                                                 </div>
                                             </ResultBreakdownDisclosure>
                                         </div>
-                                    </a>
+                                    </div>
                                 </div>
                                 <div role="cell" class="px-4 py-2 w-30 shrink-0 text-right">
                                     <Gil amount=data.profit />


### PR DESCRIPTION
## What

Adds the **FC crafting material-breakdown** feature plus the **virtual-scroll dynamic re-measure** it needs.

### FC crafting analyzer (`fc_crafting_analyzer.rs`)
- Results table switched to `variable_height=true` so the material-breakdown disclosure can expand inline (rows are now `items-start min-h-[60px]`).
- Item link restructured: previously the whole row (icon + name + the breakdown **disclosure**) was wrapped in a single `<a>`, which nests an interactive disclosure button inside an anchor (invalid HTML). Icon and name are now sibling anchors; the disclosure is a separate sibling.

### VirtualScroller (`virtual_scroller.rs`)
- Variable-height rows now re-measure via a `ResizeObserver` (with `on_cleanup` disconnect) so rows that grow/shrink **after** first paint update their Fenwick offsets — not just the one-shot mount measurement.
- Layered on top of `main`'s hoisted row `class`/`style` and the existing Fenwick unit tests (both preserved).
- Adds the web-sys `ResizeObserver` feature in `Cargo.toml`.

### Tooling
- New E2E `integration/fc-crafting-breakdown.cjs`, wired into `scripts/run_e2e.sh` via `RUN_FC_CRAFTING_BREAKDOWN` (default on), plus `LEPTOS_FEATURES=""` override support.
- `.gitignore` now ignores `.mcp.json` (agent-local MCP config — should never be committed).

## Provenance

These changes were committed directly to a local `main` that had drifted 28 commits behind `origin/main`. This branch **re-bases the work cleanly onto current `main`**:
- The `virtual_scroller.rs` change was hand-merged against `main`'s concurrent rework (kept `main`'s class/style hoisting + Fenwick tests, added the ResizeObserver).
- Dropped a stale `docs/.../ultros-charts-pr2-web-chart.md` commit (byte-identical to the copy already merged via #762).
- Excluded an accidentally-committed agent-local `.mcp.json` (now gitignored).

`cargo fmt --all -- --check` passes locally.