### PR TITLE
⚡ Bolt: Optimize live_sale_ticker updates in-place without reallocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-10-27 - Remove Reactive closures for static props
 **Learning:** Leptos creates a reactive Effect for `move ||` closures even if the dependencies are static. For lists (like VirtualScroller), computing static styling outside the loop and passing it prevents unnecessary effect allocation per row.
 **Action:** Hoist static class/style generation out of the `children={ move |(idx, item)|` closure to avoid per-row closures/format calls.
+## 2024-07-16 - Replacing Vec clone/re-collect with retain in-place in Leptos
+**Learning:** In a hot path like WebSocket event parsing (which occurs frequently), converting slices to new iterators using `.cloned().collect()` creates garbage memory. Replacing it with `retain` where possible combined with short circuit conditions like `seen.len() < MAX` directly truncates the collection naturally while filtering. Furthermore, replacing `Memo::new()` with `Signal::derive` in leptos is a deoptimization for operations that clone/allocate on the heap because `Signal::derive` re-executes on every read, thus discarding caching benefits.
+**Action:** When seeing `Vec` reallocations with Iterators, look for in-place modifications using `make_contiguous`, `retain`, `drain`, or `truncate`. Also, do not blindly change `Memo` to `Signal::derive` if the inner function executes heap allocations.

--- a/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
+++ b/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
@@ -87,7 +87,9 @@ pub fn LiveSaleTicker() -> impl IntoView {
                             // ⚡ Bolt Optimization: Filter duplicates and truncate in-place
                             // to avoid allocating a new VecDeque and cloning items on every websocket event.
                             let mut seen = std::collections::HashSet::new();
-                            sales.retain(|sale| seen.len() < 8 && seen.insert((sale.item_id, sale.hq)));
+                            sales.retain(|sale| {
+                                seen.len() < 8 && seen.insert((sale.item_id, sale.hq))
+                            });
                         });
                     }
                     ServerClient::Stale { .. } => retrigger.set(true),

--- a/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
+++ b/ultros-frontend/ultros-app/src/components/live_sale_ticker.rs
@@ -80,16 +80,14 @@ pub fn LiveSaleTicker() -> impl IntoView {
                                     hq: sale.hq,
                                 });
                             }
-                            use itertools::Itertools;
                             sales
                                 .make_contiguous()
                                 .sort_by_key(|sale| std::cmp::Reverse(sale.sold_date));
-                            *sales = sales
-                                .iter()
-                                .unique_by(|sale| (sale.item_id, sale.hq))
-                                .take(8)
-                                .cloned()
-                                .collect();
+
+                            // ⚡ Bolt Optimization: Filter duplicates and truncate in-place
+                            // to avoid allocating a new VecDeque and cloning items on every websocket event.
+                            let mut seen = std::collections::HashSet::new();
+                            sales.retain(|sale| seen.len() < 8 && seen.insert((sale.item_id, sale.hq)));
                         });
                     }
                     ServerClient::Stale { .. } => retrigger.set(true),


### PR DESCRIPTION
💡 What: Updated `live_sale_ticker.rs` to filter duplicate entries and enforce its limit using an in-place `retain` call with a length limit check instead of `unique_by().cloned().collect()`.

🎯 Why: To reduce unnecessary memory reallocation and garbage generation on the hot path (when a new `AddSales` websocket message arrives), avoiding the reallocation of a new `VecDeque` and cloning `SaleView` structs repeatedly.

📊 Impact: Complete elimination of `VecDeque` initialization and `.cloned()` allocation over overhead for new list renders on the live sales websocket event.

🔬 Measurement: Observe memory footprint and garbage collector spikes during periods of high live sales websocket traffic.

---
*PR created automatically by Jules for task [6990520227043252565](https://jules.google.com/task/6990520227043252565) started by @akarras*