### PR TITLE
🛡️ Sentinel: [HIGH] Add timeout to reqwest Clients

### DIFF
--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -667,7 +667,8 @@ where
 
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     let client = CLIENT.get_or_init(|| {
-        reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
+        reqwest::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(60))
             .build()
             .unwrap()
@@ -752,7 +753,8 @@ where
 
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     let client = CLIENT.get_or_init(|| {
-        reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
+        reqwest::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(60))
             .build()
             .unwrap()

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -667,7 +667,7 @@ where
 
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     let client = CLIENT.get_or_init(|| {
-        reqwest::ClientBuilder::new()
+        reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(60))
             .build()
             .unwrap()
@@ -752,7 +752,7 @@ where
 
     static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     let client = CLIENT.get_or_init(|| {
-        reqwest::ClientBuilder::new()
+        reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
             .tcp_keepalive(std::time::Duration::from_secs(60))
             .build()
             .unwrap()

--- a/ultros/src/discord/mod.rs
+++ b/ultros/src/discord/mod.rs
@@ -121,7 +121,10 @@ pub(crate) async fn start_discord(
                 ));
                 Ok(Data {
                     db,
-                    lodestone_client: reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap(),
+                    lodestone_client: reqwest::Client::builder()
+                        .timeout(std::time::Duration::from_secs(10))
+                        .build()
+                        .unwrap(),
                     event_senders,
                     analyzer_service,
                     world_cache,

--- a/ultros/src/discord/mod.rs
+++ b/ultros/src/discord/mod.rs
@@ -121,7 +121,7 @@ pub(crate) async fn start_discord(
                 ));
                 Ok(Data {
                     db,
-                    lodestone_client: reqwest::Client::new(),
+                    lodestone_client: reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap(),
                     event_senders,
                     analyzer_service,
                     world_cache,

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -399,7 +399,10 @@ async fn main() -> Result<()> {
     ));
 
     let character_verification = CharacterVerifierService {
-        client: reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap(),
+        client: reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap(),
         db: db.clone(),
         world_cache: world_cache.clone(),
     };

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -399,7 +399,7 @@ async fn main() -> Result<()> {
     ));
 
     let character_verification = CharacterVerifierService {
-        client: reqwest::Client::new(),
+        client: reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap(),
         db: db.clone(),
         world_cache: world_cache.clone(),
     };

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -970,7 +970,7 @@ async fn character_search(
     //     let world_name = world.get_name();
     //     builder = builder.server(Server::from_str(world_name)?);
     // }
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap();
     let search_results = builder.send_async(&client).await?;
 
     let characters = search_results

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -970,7 +970,10 @@ async fn character_search(
     //     let world_name = world.get_name();
     //     builder = builder.server(Server::from_str(world_name)?);
     // }
-    let client = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10)).build().unwrap();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap();
     let search_results = builder.send_async(&client).await?;
 
     let characters = search_results

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -420,7 +420,8 @@ impl DiscordAuthConfig {
                 RevocationUrl::new("https://discord.com/api/oauth2/token/revoke".to_string())
                     .expect("Failed to parse revoke URL"),
             );
-        let http_client = oauth2::reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
+        let http_client = oauth2::reqwest::ClientBuilder::new()
+            .timeout(std::time::Duration::from_secs(10))
             .redirect(oauth2::reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build oauth2 reqwest client");

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -420,7 +420,7 @@ impl DiscordAuthConfig {
                 RevocationUrl::new("https://discord.com/api/oauth2/token/revoke".to_string())
                     .expect("Failed to parse revoke URL"),
             );
-        let http_client = oauth2::reqwest::ClientBuilder::new()
+        let http_client = oauth2::reqwest::ClientBuilder::new().timeout(std::time::Duration::from_secs(10))
             .redirect(oauth2::reqwest::redirect::Policy::none())
             .build()
             .expect("Failed to build oauth2 reqwest client");


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded HTTP Request Timeout (Denial of Service)
🎯 **Impact:** If an external API or remote webhook (e.g., Discord or Lodestone) hangs or deliberately tarpits the connection, `reqwest::Client` will block indefinitely. Over time, this could exhaust all available sockets or background threads, causing the application to stop processing other requests.
🔧 **Fix:** Added a `.timeout(std::time::Duration::from_secs(10))` to all `reqwest::Client` instances where timeouts were not previously configured.
✅ **Verification:** Verified that the project builds successfully and the modified packages compile without errors using `cargo check`. Code review confirmed correct Rust semantics for `ClientBuilder`.

---
*PR created automatically by Jules for task [17129230412375842290](https://jules.google.com/task/17129230412375842290) started by @akarras*