### PR TITLE
fix(clipboard): consume blocked clipboard-write rejections (GlitchTip #5767)

### DIFF
--- a/integration/clipboard-rejection.test.cjs
+++ b/integration/clipboard-rejection.test.cjs
@@ -1,0 +1,106 @@
+// Regression test for GlitchTip issue #5767:
+//   "NotAllowedError: Clipboard write was blocked due to lack of user activation."
+//
+// Root cause: the `<Clipboard>` component (and `copy_invite_url`) called
+//   `let _ = clipboard.write_text(&text);`
+// which DROPS the Promise returned by `navigator.clipboard.writeText()`.
+// That Promise rejects whenever the browser blocks the write (Firefox revokes
+// transient user activation when an ad iframe steals focus, the document is not
+// focused, permissions, etc.). A dropped rejecting Promise becomes an
+// *unhandled rejection*, which Sentry/GlitchTip captures via its
+// `onunhandledrejection` global handler (mechanism
+// `auto.browser.global_handlers.onunhandledrejection`, handled: false) and
+// reports as an error.
+//
+// The fix awaits the Promise on a spawned task and swallows the error, so a
+// blocked best-effort copy no longer surfaces as an unhandled rejection.
+//
+// This test models the two code patterns at the Promise level (the semantics
+// are identical in the browser and in Node) and asserts the dropped pattern
+// produces an unhandled rejection while the awaited/handled pattern does not.
+//
+// Run with: node --test integration/clipboard-rejection.test.cjs
+
+const test = require("node:test");
+const assert = require("node:assert");
+
+// A stub of `navigator.clipboard.writeText()` that rejects asynchronously,
+// exactly like a real browser blocking the write (the rejection settles after
+// an async round-trip, NOT synchronously).
+function writeTextThatRejects() {
+  return new Promise((_resolve, reject) => {
+    setTimeout(
+      () =>
+        reject(
+          new Error(
+            "Clipboard write was blocked due to lack of user activation.",
+          ),
+        ),
+      0,
+    );
+  });
+}
+
+// Capture unhandled rejections that occur while running `fn`. Returns the list
+// of rejection reasons seen after the micro/macrotask queues have drained.
+//
+// During the measurement window we detach any other `unhandledRejection`
+// listeners (notably the `node --test` runner's own handler, which would
+// otherwise fail the BUG test on the *intentional* leak) so only our collector
+// observes the rejection, then restore them.
+async function collectUnhandledRejections(fn) {
+  const seen = [];
+  const onUnhandled = (reason) => seen.push(reason);
+  const prev = process.listeners("unhandledRejection");
+  process.removeAllListeners("unhandledRejection");
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    fn();
+    // Let the rejection settle and Node's unhandled-rejection detection run.
+    await new Promise((r) => setTimeout(r, 10));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+    for (const l of prev) process.on("unhandledRejection", l);
+  }
+  return seen;
+}
+
+test("BUG (pre-fix pattern): dropping the writeText Promise leaks an unhandled rejection", async () => {
+  // Mirrors `let _ = clipboard.write_text(&text);` — the Promise is discarded.
+  const seen = await collectUnhandledRejections(() => {
+    const _promise = writeTextThatRejects();
+    void _promise; // dropped, no handler attached
+  });
+  assert.strictEqual(
+    seen.length,
+    1,
+    "the discarded rejecting clipboard Promise should surface as an unhandled rejection (what GlitchTip reports)",
+  );
+  assert.match(seen[0].message, /lack of user activation/);
+});
+
+test("FIX (spawn_local + JsFuture::from(promise).await): the rejection is consumed", async () => {
+  // Mirrors the fix:
+  //   let promise = clipboard.write_text(&text);
+  //   spawn_local(async move {
+  //       if JsFuture::from(promise).await.is_err() { /* best-effort, log */ }
+  //   });
+  // The handler is attached on a spawned task (a later microtask), but the
+  // clipboard rejection settles truly-async, so the handler is in place first.
+  const seen = await collectUnhandledRejections(() => {
+    const promise = writeTextThatRejects();
+    // The spawned task awaits the promise and swallows the error.
+    (async () => {
+      try {
+        await promise;
+      } catch (_e) {
+        // best-effort copy; nothing to recover. (Rust logs a dev-console warn.)
+      }
+    })();
+  });
+  assert.strictEqual(
+    seen.length,
+    0,
+    "awaiting and swallowing the rejection must not produce an unhandled rejection",
+  );
+});

--- a/ultros-frontend/ultros-app/src/components/clipboard.rs
+++ b/ultros-frontend/ultros-app/src/components/clipboard.rs
@@ -50,11 +50,27 @@ pub fn Clipboard(#[prop(into)] clipboard_text: Signal<String>) -> impl IntoView 
                 e.prevent_default();
                 #[cfg(all(feature = "hydrate"))]
                 {
+                    use leptos::task::spawn_local;
+                    use wasm_bindgen_futures::JsFuture;
                     if let Some(window) = web_sys::window() {
                         let navigator = window.navigator();
                         let clipboard = navigator.clipboard();
                         let text = clipboard_text.get_untracked();
-                        let _ = clipboard.write_text(&text);
+                        // `write_text` returns a Promise that REJECTS when the browser
+                        // blocks the write (e.g. Firefox revokes transient user
+                        // activation when an ad iframe holds focus, or the document is
+                        // not focused). Dropping that Promise leaks the rejection as an
+                        // unhandled promise rejection, which our error reporter flags as
+                        // an error (GlitchTip #5767). Await it so the rejection is
+                        // consumed — a blocked copy is best-effort and unrecoverable.
+                        let promise = clipboard.write_text(&text);
+                        spawn_local(async move {
+                            if JsFuture::from(promise).await.is_err() {
+                                leptos::logging::warn!(
+                                    "clipboard write_text was blocked by the browser"
+                                );
+                            }
+                        });
                         last_copied_text.0.set(Some(text));
                         if let Some(toasts) = toasts {
                             toasts.success("Copied to clipboard!");

--- a/ultros-frontend/ultros-app/src/components/list/share_list_modal.rs
+++ b/ultros-frontend/ultros-app/src/components/list/share_list_modal.rs
@@ -51,8 +51,19 @@ pub(crate) fn copy_invite_url(
     let url = invite_url(invite_id);
     #[cfg(feature = "hydrate")]
     if let Some(window) = web_sys::window() {
+        use leptos::task::spawn_local;
+        use wasm_bindgen_futures::JsFuture;
         let clipboard = window.navigator().clipboard();
-        let _ = clipboard.write_text(&url);
+        // `write_text` returns a Promise that rejects when the browser blocks the
+        // write. Dropping it leaks an unhandled promise rejection that our error
+        // reporter flags as an error (see GlitchTip #5767). Await it so a blocked
+        // best-effort copy is consumed instead of reported.
+        let promise = clipboard.write_text(&url);
+        spawn_local(async move {
+            if JsFuture::from(promise).await.is_err() {
+                leptos::logging::warn!("clipboard write_text was blocked by the browser");
+            }
+        });
     }
     if let Some(last_copied) = last_copied {
         last_copied.0.set(Some(url));


### PR DESCRIPTION
## What

Re-lands the clipboard-rejection fix originally proposed in #801, on a **clean base off current `main`**.

Fixes GlitchTip #5767 — `NotAllowedError: Clipboard write was blocked due to lack of user activation.`

## Root cause

`navigator.clipboard.writeText()` returns a Promise that **rejects** when the browser blocks the write (Firefox revokes transient user activation when an ad iframe holds focus; document not focused; permissions). Both call sites dropped it:

```rust
let _ = clipboard.write_text(&text);
```

A dropped rejecting Promise becomes an **unhandled promise rejection**, which the error reporter captures via `onunhandledrejection` (`handled: false`) and reports as an error.

## Fix

Await the Promise on a spawned task and swallow the error (log a warn). Applied to `clipboard.rs` (`<Clipboard>`) and `share_list_modal.rs` (`copy_invite_url`). The optimistic toast + copied-checkmark state are unchanged (still set synchronously).

## Why not #801

#801's branch was cut from a **stale local-`main` lineage** and was never rebased. Its diff vs current `main` is 66 files / +2358 −3991 and would **revert** the ultros_charts web-chart migration, sparklines, the `error_filter.js` beforeSend noise work, and i18n locale keys — and it committed an agent-local `.mcp.json` containing a **secret GlitchTip token**. This PR carries only the 3 files that matter.

## Verification

The changed code is `#[cfg(feature = "hydrate")]`, so CI's `cargo clippy` (ssr features) doesn't compile it. Verified locally:
- `node --test integration/clipboard-rejection.test.cjs` → 2/2 pass (models both patterns at the Promise level; pre-fix leaks 1 unhandled rejection, fix leaks 0)
- `cargo check -p ultros-client --target wasm32-unknown-unknown` → Finished (hydrate build, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)