### PR TITLE
Update game data and fix cron workflow

### DIFF
--- a/.github/workflows/update_game_data.yml
+++ b/.github/workflows/update_game_data.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for updates
@@ -32,7 +32,12 @@ jobs:
       - name: Update Submodule
         if: steps.check.outputs.has_updates == 'true'
         run: |
-          git submodule update --remote --merge xiv-gen/ffxiv-datamining
+          git submodule update --init --recursive --remote xiv-gen/ffxiv-datamining
+
+      - name: Verify Build
+        if: steps.check.outputs.has_updates == 'true'
+        run: |
+          cargo check -p xiv-gen-db
 
       - name: Create Pull Request
         if: steps.check.outputs.has_updates == 'true'


### PR DESCRIPTION
The game data update cron job was failing because it didn't handle recursive submodules properly (needed for CN, KO, and TC data) and was using a merge strategy that could fail with unrelated histories.

This change:
1. Manually updates the `xiv-gen/ffxiv-datamining` submodule to the latest commit.
2. Fixes the GitHub Actions workflow to:
   - Use recursive submodule checkout.
   - Use `git submodule update --init --recursive --remote` for robust updates.
   - Verify the build with `cargo check -p xiv-gen-db` before creating a Pull Request.

Fixes #143

---
*PR created automatically by Jules for task [15821929095233404066](https://jules.google.com/task/15821929095233404066) started by @akarras*