### PR TITLE
HQ only option for lists

### DIFF
--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -598,10 +598,9 @@ impl UltrosDb {
         for list_id in list_ids {
             let permission = self.get_permission(list_id, discord_user).await?;
             if permission < ListPermission::Write {
-                return Err(ListError::Forbidden(
-                    "Insufficient permissions to update list items",
-                )
-                .into());
+                return Err(
+                    ListError::Forbidden("Insufficient permissions to update list items").into(),
+                );
             }
         }
 

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -16,7 +16,10 @@ use sea_orm::{
     ModelTrait, QueryFilter, QueryOrder, QuerySelect, RelationTrait, TransactionTrait,
     sea_query::Expr,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use thiserror::Error;
 use tracing::instrument;
 use ultros_api_types::list::{ListActivityKind, ListPermission};
@@ -577,6 +580,37 @@ impl UltrosDb {
         .exec_without_returning(&self.db)
         .await?;
         Ok(many)
+    }
+
+    #[instrument(skip(self))]
+    pub async fn set_list_items_hq(
+        &self,
+        discord_user: i64,
+        list_item_ids: &[i32],
+        hq: Option<bool>,
+    ) -> Result<Vec<i32>> {
+        let items = list_item::Entity::find()
+            .filter(list_item::Column::Id.is_in(list_item_ids.to_vec()))
+            .all(&self.db)
+            .await?;
+        let list_ids: HashSet<i32> = items.iter().map(|i| i.list_id).collect();
+        let list_ids_vec: Vec<i32> = list_ids.iter().copied().collect();
+        for list_id in list_ids {
+            let permission = self.get_permission(list_id, discord_user).await?;
+            if permission < ListPermission::Write {
+                return Err(ListError::Forbidden(
+                    "Insufficient permissions to update list items",
+                )
+                .into());
+            }
+        }
+
+        list_item::Entity::update_many()
+            .col_expr(list_item::Column::Hq, Expr::value(hq))
+            .filter(list_item::Column::Id.is_in(list_item_ids.to_vec()))
+            .exec(&self.db)
+            .await?;
+        Ok(list_ids_vec)
     }
 
     #[instrument(skip(self))]

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -585,6 +585,8 @@
     "list_view_adding": "添加中…",
     "list_view_add": "添加",
     "list_view_bulk_edit": "批量编辑",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "删除",
     "list_view_select_all": "全选",
     "list_view_deselect_all": "取消全选",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -585,6 +585,8 @@
     "list_view_adding": "wird hinzugefügt…",
     "list_view_add": "hinzufügen",
     "list_view_bulk_edit": "stapelbearbeitung",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "LÖSCHEN",
     "list_view_select_all": "ALLE AUSWÄHLEN",
     "list_view_deselect_all": "AUSWAHL AUFHEBEN",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -585,6 +585,8 @@
     "list_view_adding": "adding...",
     "list_view_add": "add",
     "list_view_bulk_edit": "bulk edit",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "DELETE",
     "list_view_select_all": "SELECT ALL",
     "list_view_deselect_all": "DESLECT ALL",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -585,6 +585,8 @@
     "list_view_adding": "ajout…",
     "list_view_add": "ajouter",
     "list_view_bulk_edit": "édition groupée",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "SUPPRIMER",
     "list_view_select_all": "TOUT SÉLECTIONNER",
     "list_view_deselect_all": "TOUT DÉSÉLECTIONNER",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -585,6 +585,8 @@
     "list_view_adding": "追加中…",
     "list_view_add": "追加",
     "list_view_bulk_edit": "一括編集",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "削除",
     "list_view_select_all": "すべて選択",
     "list_view_deselect_all": "選択を解除",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -585,6 +585,8 @@
     "list_view_adding": "추가 중…",
     "list_view_add": "추가",
     "list_view_bulk_edit": "일괄 편집",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "삭제",
     "list_view_select_all": "전체 선택",
     "list_view_deselect_all": "선택 해제",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -585,6 +585,8 @@
     "list_view_adding": "新增中…",
     "list_view_add": "新增",
     "list_view_bulk_edit": "批次編輯",
+    "list_view_bulk_set_hq": "FORCE HQ",
+    "list_view_bulk_any_quality": "ANY QUALITY",
     "list_view_delete": "刪除",
     "list_view_select_all": "全選",
     "list_view_deselect_all": "取消全選",

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -443,6 +443,16 @@ pub(crate) async fn delete_list_items(list_items: Vec<i32>) -> AppResult<()> {
     post_api("/api/v1/list/item/delete", list_items).await
 }
 
+#[derive(Serialize)]
+pub(crate) struct BulkHqUpdate {
+    pub(crate) ids: Vec<i32>,
+    pub(crate) hq: Option<bool>,
+}
+
+pub(crate) async fn edit_list_items_hq(ids: Vec<i32>, hq: Option<bool>) -> AppResult<()> {
+    post_api("/api/v1/list/item/hq", BulkHqUpdate { ids, hq }).await
+}
+
 pub(crate) async fn get_groups() -> AppResult<Vec<UserGroup>> {
     fetch_api("/api/v1/group").await
 }

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -91,13 +91,37 @@ pub fn ListItemRow(
                                     let complete = a >= q;
                                     view! {
                                         <div class="flex flex-col items-start gap-1">
-                                            {item_now.hq.and_then(|hq| {
-                                                hq.then_some(view! {
-                                                    <span class="inline-flex rounded-md border border-[color:var(--brand-ring)]/40 px-2 py-0.5 text-xs font-bold text-[color:var(--brand-fg)]">
-                                                        "HQ"
-                                                    </span>
-                                                })
-                                            })}
+                                            {move || {
+                                                if can_write.get() {
+                                                    Either::Left(view! {
+                                                        <Tooltip tooltip_text=Signal::derive(move || if item.with(|i| i.hq == Some(true)) { t_string!(i18n, list_view_bulk_any_quality).to_string() } else { t_string!(i18n, list_view_bulk_set_hq).to_string() })>
+                                                            <button
+                                                                class="inline-flex rounded-md border px-2 py-0.5 text-xs font-bold transition-colors"
+                                                                class=("border-[color:var(--brand-ring)]/40", move || item.with(|i| i.hq == Some(true)))
+                                                                class=("text-[color:var(--brand-fg)]", move || item.with(|i| i.hq == Some(true)))
+                                                                class=("border-[color:var(--color-outline)]", move || item.with(|i| i.hq != Some(true)))
+                                                                class=("text-[color:var(--color-text-muted)]", move || item.with(|i| i.hq != Some(true)))
+                                                                on:click=move |_| {
+                                                                    item.update(|i| {
+                                                                        i.hq = if i.hq == Some(true) { None } else { Some(true) };
+                                                                    });
+                                                                    let _ = edit_item.dispatch(item.get());
+                                                                }
+                                                            >
+                                                                "HQ"
+                                                            </button>
+                                                        </Tooltip>
+                                                    })
+                                                } else {
+                                                    Either::Right(item_now.hq.and_then(|hq| {
+                                                        hq.then_some(view! {
+                                                            <span class="inline-flex rounded-md border border-[color:var(--brand-ring)]/40 px-2 py-0.5 text-xs font-bold text-[color:var(--brand-fg)]">
+                                                                "HQ"
+                                                            </span>
+                                                        })
+                                                    }))
+                                                }
+                                            }}
                                             {complete.then(|| view! {
                                                 <span
                                                     class="inline-flex items-center gap-1 rounded-md border border-green-400/40 px-1.5 py-0.5 text-xs text-green-200"

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -12,7 +12,7 @@ use ultros_api_types::list::{ListActivity, ListItem, ListPermission};
 
 use crate::api::{
     add_item_to_list, delete_list_item, delete_list_items, edit_list, edit_list_item,
-    get_list_activity, get_list_items_with_listings,
+    edit_list_items_hq, get_list_activity, get_list_items_with_listings,
 };
 use crate::components::{
     add_recipe_to_current_list::AddRecipeToCurrentListModal,
@@ -60,6 +60,10 @@ pub fn ListView() -> impl IntoView {
 
     let edit_item = Action::new(move |item: &ListItem| edit_list_item(item.clone()));
     let delete_items = Action::new(move |items: &Vec<i32>| delete_list_items(items.clone()));
+    let edit_items_hq =
+        Action::new(move |(items, hq): &(Vec<i32>, Option<bool>)| {
+            edit_list_items_hq(items.clone(), *hq)
+        });
     let edit_list_action =
         Action::new(move |list: &ultros_api_types::list::List| edit_list(list.clone()));
 
@@ -84,6 +88,7 @@ pub fn ListView() -> impl IntoView {
                     external_update_version.get(),
                     edit_item.version().get(),
                     delete_items.version().get(),
+                        edit_items_hq.version().get(),
                     edit_list_action.version().get(),
                 ),
             )
@@ -823,6 +828,30 @@ pub fn ListView() -> impl IntoView {
                                                                     >
                                                                         <Icon icon=i::BiTrashSolid />
                                                                         <span>{t!(i18n, list_view_delete)}</span>
+                                                                    </button>
+                                                                    <button
+                                                                        class="btn-secondary"
+                                                                        on:click=move |_| {
+                                                                            let items = selected_items
+                                                                                .with_untracked(|s| {
+                                                                                    s.iter().copied().collect::<Vec<_>>()
+                                                                                });
+                                                                            edit_items_hq.dispatch((items, Some(true)));
+                                                                        }
+                                                                    >
+                                                                        <span>{t!(i18n, list_view_bulk_set_hq)}</span>
+                                                                    </button>
+                                                                    <button
+                                                                        class="btn-secondary"
+                                                                        on:click=move |_| {
+                                                                            let items = selected_items
+                                                                                .with_untracked(|s| {
+                                                                                    s.iter().copied().collect::<Vec<_>>()
+                                                                                });
+                                                                            edit_items_hq.dispatch((items, None));
+                                                                        }
+                                                                    >
+                                                                        <span>{t!(i18n, list_view_bulk_any_quality)}</span>
                                                                     </button>
                                                                 </div>
                                                             </div>

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -60,10 +60,9 @@ pub fn ListView() -> impl IntoView {
 
     let edit_item = Action::new(move |item: &ListItem| edit_list_item(item.clone()));
     let delete_items = Action::new(move |items: &Vec<i32>| delete_list_items(items.clone()));
-    let edit_items_hq =
-        Action::new(move |(items, hq): &(Vec<i32>, Option<bool>)| {
-            edit_list_items_hq(items.clone(), *hq)
-        });
+    let edit_items_hq = Action::new(move |(items, hq): &(Vec<i32>, Option<bool>)| {
+        edit_list_items_hq(items.clone(), *hq)
+    });
     let edit_list_action =
         Action::new(move |list: &ultros_api_types::list::List| edit_list(list.clone()));
 
@@ -88,7 +87,7 @@ pub fn ListView() -> impl IntoView {
                     external_update_version.get(),
                     edit_item.version().get(),
                     delete_items.version().get(),
-                        edit_items_hq.version().get(),
+                    edit_items_hq.version().get(),
                     edit_list_action.version().get(),
                 ),
             )

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -850,6 +850,46 @@ pub(crate) async fn delete_list_item(
     Ok(Json(()))
 }
 
+#[derive(Deserialize)]
+pub(crate) struct BulkHqUpdate {
+    pub(crate) ids: Vec<i32>,
+    pub(crate) hq: Option<bool>,
+}
+
+pub(crate) async fn bulk_edit_list_items_hq(
+    State(db): State<UltrosDb>,
+    State(senders): State<EventSenders>,
+    user: AuthDiscordUser,
+    Json(data): Json<BulkHqUpdate>,
+) -> Result<Json<()>, ApiError> {
+    let list_ids = db
+        .set_list_items_hq(user.id as i64, &data.ids, data.hq)
+        .await?;
+
+    for list_id in list_ids {
+        if let Ok(list) = db.get_list(list_id, user.id as i64).await {
+            send_list_event(
+                &senders,
+                EventType::updated(ListEventData::List(List::try_from(list)?)),
+            );
+            let _ = record_list_activity(
+                &db,
+                &senders,
+                list_id,
+                &user,
+                ListActivityKind::ItemUpdated,
+                None,
+                None,
+                serde_json::json!({ "bulk_hq": data.hq, "count": data.ids.len() }),
+                format!("{} bulk updated HQ for {} items", user.name, data.ids.len()),
+            )
+            .await;
+        }
+    }
+
+    Ok(Json(()))
+}
+
 pub(crate) async fn delete_multiple_list_items(
     State(db): State<UltrosDb>,
     State(senders): State<EventSenders>,
@@ -1461,6 +1501,7 @@ pub(crate) async fn start_web(state: WebState) {
         .route("/api/v1/list/{id}/delete", delete(delete_list))
         .route("/api/v1/list/item/{id}/delete", delete(delete_list_item))
         .route("/api/v1/list/item/delete", post(delete_multiple_list_items))
+        .route("/api/v1/list/item/hq", post(bulk_edit_list_items_hq))
         .route("/api/v1/group", get(get_groups))
         .route("/api/v1/group/create", post(create_group))
         .route("/api/v1/group/{id}", delete(delete_group))


### PR DESCRIPTION
This change adds the ability to force list items to show only High Quality (HQ) prices. 

Key features:
- **Individual Toggle**: Users with write permissions can now click the "HQ" badge on any list item row to toggle between "HQ only" and "Any Quality".
- **Bulk Edit**: New buttons added to the bulk edit mode allow setting multiple items to "FORCE HQ" or "ANY QUALITY" at once.
- **Backend Support**: Added a new API endpoint and database logic to handle bulk quality updates securely, including permission checks and activity logging.
- **Improved UX**: The quality requirement is now easily adjustable without entering the full item edit mode.

Display logic in `PriceViewer` and `ListSummary` already respected the `hq` field, so these changes immediately affect price calculations and list totals.

Fixes #53

---
*PR created automatically by Jules for task [5761354613706256816](https://jules.google.com/task/5761354613706256816) started by @akarras*