### PR TITLE
Show owner attribution on shared list cards

### DIFF
--- a/ultros-api-types/src/list.rs
+++ b/ultros-api-types/src/list.rs
@@ -44,6 +44,8 @@ pub struct List {
 pub struct ListWithPermission {
     pub list: List,
     pub permission: ListPermission,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
@@ -232,11 +234,13 @@ mod tests {
                 wdr_filter: AnySelector::World(3),
             },
             permission: ListPermission::Write,
+            owner_name: Some("OwnerName".to_string()),
         };
         let s = serde_json::to_string(&list).unwrap();
         let back: ListWithPermission = serde_json::from_str(&s).unwrap();
         assert_eq!(back.list.id, 1);
         assert_eq!(back.permission, ListPermission::Write);
+        assert_eq!(back.owner_name, Some("OwnerName".to_string()));
     }
 
     #[test]

--- a/ultros-db/src/entity/list.rs
+++ b/ultros-db/src/entity/list.rs
@@ -51,6 +51,14 @@ pub enum Relation {
         on_delete = "NoAction"
     )]
     World,
+    #[sea_orm(
+        belongs_to = "super::discord_user::Entity",
+        from = "Column::Owner",
+        to = "super::discord_user::Column::Id",
+        on_update = "NoAction",
+        on_delete = "NoAction"
+    )]
+    DiscordUser,
 }
 
 impl Related<super::alert_price::Entity> for Entity {
@@ -98,6 +106,12 @@ impl Related<super::region::Entity> for Entity {
 impl Related<super::world::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::World.def()
+    }
+}
+
+impl Related<super::discord_user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::DiscordUser.def()
     }
 }
 

--- a/ultros-db/src/lists.rs
+++ b/ultros-db/src/lists.rs
@@ -223,9 +223,13 @@ impl UltrosDb {
         Ok(())
     }
 
-    pub async fn get_lists_for_user(&self, discord_user: i64) -> Result<Vec<list::Model>> {
+    pub async fn get_lists_for_user(
+        &self,
+        discord_user: i64,
+    ) -> Result<Vec<(list::Model, Option<String>)>> {
         // This should probably also include lists shared with the user
         let owned_lists = list::Entity::find()
+            .find_also_related(discord_user::Entity)
             .filter(list::Column::Owner.eq(discord_user))
             .all(&self.db)
             .await?;
@@ -233,6 +237,7 @@ impl UltrosDb {
         let shared_lists = list::Entity::find()
             .inner_join(list_shared_user::Entity)
             .filter(list_shared_user::Column::UserId.eq(discord_user))
+            .find_also_related(discord_user::Entity)
             .all(&self.db)
             .await?;
 
@@ -247,16 +252,20 @@ impl UltrosDb {
                 user_group::Relation::UserGroupMember.def(),
             )
             .filter(user_group_member::Column::UserId.eq(discord_user))
+            .find_also_related(discord_user::Entity)
             .all(&self.db)
             .await?;
 
         let mut all_lists = owned_lists;
         all_lists.extend(shared_lists);
         all_lists.extend(group_lists);
-        all_lists.sort_by_key(|l| l.id);
-        all_lists.dedup_by_key(|l| l.id);
+        all_lists.sort_by_key(|(l, _)| l.id);
+        all_lists.dedup_by_key(|(l, _)| l.id);
 
-        Ok(all_lists)
+        Ok(all_lists
+            .into_iter()
+            .map(|(l, u)| (l, u.map(|u| u.username)))
+            .collect())
     }
 
     pub async fn get_list_by_name_for_user(
@@ -301,16 +310,20 @@ impl UltrosDb {
         Ok(group_list)
     }
 
-    pub async fn get_list(&self, list_id: i32, discord_user: i64) -> Result<list::Model> {
+    pub async fn get_list(&self, list_id: i32, discord_user: i64) -> Result<(list::Model, String)> {
         let permission = self.get_permission(list_id, discord_user).await?;
         if permission < ListPermission::Read {
             return Err(ListError::Forbidden("Insufficient permissions to read list").into());
         }
-        let list = list::Entity::find_by_id(list_id)
+        let (list, owner) = list::Entity::find_by_id(list_id)
+            .find_also_related(discord_user::Entity)
             .one(&self.db)
             .await?
             .ok_or(ListError::NotFound)?;
-        Ok(list)
+        let owner_name = owner
+            .map(|u| u.username)
+            .unwrap_or_else(|| list.owner.to_string());
+        Ok((list, owner_name))
     }
 
     pub async fn get_list_items(

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "清单",
     "list_shared_editor_badge": "共享 · 编辑者",
     "list_shared_viewer_badge": "共享 · 查看者",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "与我共享",
     "no_owned_lists_but_shared": "你还没有自己的清单 — 但其他人已与你分享了 {{count}} 个。",
     "leave_list": "退出清单",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "Listen",
     "list_shared_editor_badge": "Geteilt · Editor",
     "list_shared_viewer_badge": "Geteilt · Betrachter",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "Mit mir geteilt",
     "no_owned_lists_but_shared": "Du besitzt noch keine Listen — aber andere haben {{count}} mit dir geteilt.",
     "leave_list": "Liste verlassen",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -1012,6 +1012,7 @@
     "list_shared_viewer_badge": "Shared · Viewer",
     "shared_with_me": "Shared With Me",
     "no_owned_lists_but_shared": "You don't own any lists yet — but others have shared {{count}} with you.",
+    "list_shared_by": "Shared by {{name}}",
     "leave_list": "Leave list",
     "leave_list_confirm": "Stop following this shared list?",
     "leave_list_tooltip": "Remove yourself from this shared list",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "Listes",
     "list_shared_editor_badge": "Partagé · Éditeur",
     "list_shared_viewer_badge": "Partagé · Lecteur",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "Partagé avec moi",
     "no_owned_lists_but_shared": "Vous ne possédez aucune liste — mais d'autres en ont partagé {{count}} avec vous.",
     "leave_list": "Quitter la liste",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "リスト",
     "list_shared_editor_badge": "共有 · 編集者",
     "list_shared_viewer_badge": "共有 · 閲覧者",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "共有されたもの",
     "no_owned_lists_but_shared": "まだリストを所有していません — でも他のユーザーから {{count}} 件共有されています。",
     "leave_list": "リストから離脱",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "리스트",
     "list_shared_editor_badge": "공유 · 편집자",
     "list_shared_viewer_badge": "공유 · 보기 전용",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "나와 공유됨",
     "no_owned_lists_but_shared": "아직 소유한 리스트는 없지만 다른 사람이 {{count}}개를 공유했습니다.",
     "leave_list": "리스트 나가기",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -1026,6 +1026,7 @@
     "lists_page_title": "清單",
     "list_shared_editor_badge": "共享 · 編輯者",
     "list_shared_viewer_badge": "共享 · 檢視者",
+    "list_shared_by": "Shared by {{name}}",
     "shared_with_me": "與我共享",
     "no_owned_lists_but_shared": "你還沒有自己的清單 — 但其他人已與你分享了 {{count}} 個。",
     "leave_list": "退出清單",

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -141,6 +141,8 @@ fn ListCard(
     user_id: Signal<Option<u64>>,
 ) -> impl IntoView {
     let permission = list.permission;
+    let list_owner = list.list.owner;
+    let owner_name = StoredValue::new(list.owner_name.clone());
     let list = list.list;
     let (is_edit, set_is_edit) = signal(false);
     let (share_open, set_share_open) = signal(false);
@@ -258,6 +260,14 @@ fn ListCard(
                                         <WorldName id=list.wdr_filter />
                                         <PermissionPill permission />
                                     </div>
+                                    <Show when=move || permission < ListPermission::Owner>
+                                        <div class="text-xs text-gray-500">
+                                            {move || {
+                                                let name = owner_name.with_value(|n| n.clone()).unwrap_or_else(|| list_owner.to_string());
+                                                t!(i18n, list_shared_by, name = name)
+                                            }}
+                                        </div>
+                                    </Show>
                                 </div>
                                 <div class="flex items-center gap-1">
                                     <Show when=move || { permission >= ListPermission::Owner }>

--- a/ultros/src/discord/ffxiv/lists.rs
+++ b/ultros/src/discord/ffxiv/lists.rs
@@ -68,7 +68,7 @@ pub(crate) async fn show_lists(ctx: Context<'_>) -> Result<(), Error> {
         .await?;
     let lists = ctx.data().db.get_lists_for_user(user.id).await?;
     let mut names = Vec::with_capacity(lists.len());
-    for list in lists {
+    for (list, _) in lists {
         let permission = ctx.data().db.get_permission(list.id, user.id).await?;
         names.push(format!("{} ({})", list.name, permission_name(permission)));
     }
@@ -95,6 +95,7 @@ async fn autocomplete_list_name(
         .await
         .unwrap_or_default()
         .into_iter()
+        .map(|(l, _)| l)
         .filter(move |l| l.name.to_ascii_lowercase().contains(&partial))
         .map(|l| poise::serenity_prelude::AutocompleteChoice::new(l.name.clone(), l.name))
 }

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -509,7 +509,7 @@ pub(crate) async fn get_lists(
         db.get_lists_for_user(user.id as i64)
             .await?
             .into_iter()
-            .map(|list| {
+            .map(|(list, owner_name)| {
                 let db = db.clone();
                 let user_id = user.id as i64;
                 async move {
@@ -517,6 +517,7 @@ pub(crate) async fn get_lists(
                     Ok::<_, ApiError>(ListWithPermission {
                         list: List::try_from(list)?,
                         permission,
+                        owner_name,
                     })
                 }
             }),
@@ -529,7 +530,7 @@ pub(crate) async fn get_list(
     State(db): State<UltrosDb>,
     perm: crate::web::list_permission::RequireListPermission<{ crate::web::list_permission::READ }>,
 ) -> Result<Json<(ListWithPermission, Vec<ListItem>)>, ApiError> {
-    let (list, list_items) = futures::future::try_join(
+    let ((list, owner_name), list_items) = futures::future::try_join(
         db.get_list(perm.list_id, perm.user_id),
         db.get_list_items(perm.list_id, perm.user_id),
     )
@@ -541,6 +542,7 @@ pub(crate) async fn get_list(
     let list = ListWithPermission {
         list: List::try_from(list)?,
         permission: perm.permission,
+        owner_name: Some(owner_name),
     };
     Ok(Json((list, list_items)))
 }
@@ -551,7 +553,7 @@ pub(crate) async fn get_list_with_listings(
     Path(id): Path<i32>,
     user: AuthDiscordUser,
 ) -> Result<Json<(ListWithPermission, Vec<(ListItem, Vec<ActiveListing>)>)>, ApiError> {
-    let (list, list_items) = futures::future::try_join(
+    let ((list, owner_name), list_items) = futures::future::try_join(
         db.get_list(id, user.id as i64),
         db.get_list_items(id, user.id as i64),
     )
@@ -587,6 +589,7 @@ pub(crate) async fn get_list_with_listings(
         ListWithPermission {
             list: List::try_from(list)?,
             permission,
+            owner_name: Some(owner_name),
         },
         list_items,
     )))
@@ -617,7 +620,7 @@ pub(crate) async fn delete_list(
         { crate::web::list_permission::OWNER },
     >,
 ) -> Result<Json<()>, ApiError> {
-    let list = db.get_list(perm.list_id, perm.user_id).await?;
+    let (list, _) = db.get_list(perm.list_id, perm.user_id).await?;
     db.delete_list(perm.list_id, perm.user_id).await?;
     send_list_event(
         &senders,
@@ -705,7 +708,7 @@ pub(crate) async fn post_item_to_list(
     >,
     Json(item): Json<ListItem>,
 ) -> Result<Json<()>, ApiError> {
-    let list = db.get_list(perm.list_id, perm.user_id).await?;
+    let (list, _) = db.get_list(perm.list_id, perm.user_id).await?;
     let ListItem {
         item_id,
         hq,
@@ -748,7 +751,7 @@ pub(crate) async fn post_items_to_list(
     user: AuthDiscordUser,
     Json(items): Json<Vec<ListItem>>,
 ) -> Result<Json<()>, ApiError> {
-    let list = db.get_list(id, user.id as i64).await?;
+    let (list, _) = db.get_list(id, user.id as i64).await?;
 
     let _list = db
         .add_items_to_list(&list, user.id as i64, items.into_iter().map(|i| i.into()))
@@ -1114,7 +1117,7 @@ async fn broadcast_list_update(
     list_id: i32,
     user: i64,
 ) -> Result<(), ApiError> {
-    let list = db.get_list(list_id, user).await?;
+    let (list, _) = db.get_list(list_id, user).await?;
     send_list_event(
         senders,
         EventType::updated(ListEventData::List(List::try_from(list)?)),


### PR DESCRIPTION
This PR adds owner attribution to shared list cards. 

Key changes:
- `ultros-api-types`: Added `owner_name` to `ListWithPermission`.
- `ultros-db`: Updated `get_lists_for_user` and `get_list` to return the owner's username. Added a `DiscordUser` relation to the `List` entity to support the join.
- `ultros`: Updated web handlers and the Discord bot's list commands to handle the updated database return types.
- `ultros-frontend`: Added the `list_shared_by` i18n key and updated the `ListCard` component to render the attribution below the world/permission line for shared lists. Fixed a closure capture issue in the frontend using `StoredValue`.

Verified with `cargo check` and unit tests in `ultros-api-types` and `ultros-db`.

Fixes #805

---
*PR created automatically by Jules for task [9557709832894710942](https://jules.google.com/task/9557709832894710942) started by @akarras*