### PR TITLE
Test auto-mark purchase quantity updates

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/auto_mark_purchases.rs
+++ b/ultros-frontend/ultros-app/src/components/list/auto_mark_purchases.rs
@@ -90,25 +90,107 @@ pub fn AutoMarkPurchases(list_view: Resource<ListViewResult>) -> impl IntoView {
     }
 }
 
+fn apply_purchase_to_list(
+    permission: ListPermission,
+    items: &mut [(ListItem, Vec<ActiveListing>)],
+    item_id: i32,
+) -> Vec<ListItem> {
+    if permission < ListPermission::Write {
+        return vec![];
+    }
+    let mut updated_items = Vec::new();
+    for (item, _) in items.iter_mut() {
+        if item.item_id == item_id {
+            let q = item.quantity.unwrap_or(1);
+            let current = item.acquired.unwrap_or(0);
+            if current < q {
+                item.acquired = Some(current + 1);
+                updated_items.push(item.clone());
+                break;
+            }
+        }
+    }
+    updated_items
+}
+
 fn mark_item_purchased(list_view: Resource<ListViewResult>, item_id: i32) {
     list_view.update(|data: &mut Option<ListViewResult>| {
         if let Some(Ok((list, items))) = data {
-            if list.permission < ListPermission::Write {
-                return;
-            }
-            for (item, _) in items.iter_mut() {
-                if item.item_id == item_id {
-                    let q = item.quantity.unwrap_or(1);
-                    let current = item.acquired.unwrap_or(0);
-                    if current < q {
-                        item.acquired = Some(current + 1);
-                        let item_clone = item.clone();
-                        leptos::task::spawn_local(async move {
-                            let _ = edit_list_item(item_clone).await;
-                        });
-                    }
-                }
+            let updated = apply_purchase_to_list(list.permission, items, item_id);
+            for item in updated {
+                leptos::task::spawn_local(async move {
+                    let _ = edit_list_item(item).await;
+                });
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_purchase_increment() {
+        let mut items = vec![(
+            ListItem {
+                item_id: 1,
+                quantity: Some(5),
+                acquired: Some(0),
+                ..Default::default()
+            },
+            vec![],
+        )];
+        let updated = apply_purchase_to_list(ListPermission::Write, &mut items, 1);
+        assert_eq!(updated.len(), 1);
+        assert_eq!(items[0].0.acquired, Some(1));
+    }
+
+    #[test]
+    fn test_apply_purchase_no_exceed() {
+        let mut items = vec![(
+            ListItem {
+                item_id: 1,
+                quantity: Some(1),
+                acquired: Some(1),
+                ..Default::default()
+            },
+            vec![],
+        )];
+        let updated = apply_purchase_to_list(ListPermission::Write, &mut items, 1);
+        assert_eq!(updated.len(), 0);
+        assert_eq!(items[0].0.acquired, Some(1));
+    }
+
+    #[test]
+    fn test_apply_purchase_ignore_mismatch() {
+        let mut items = vec![(
+            ListItem {
+                item_id: 1,
+                quantity: Some(5),
+                acquired: Some(0),
+                ..Default::default()
+            },
+            vec![],
+        )];
+        let updated = apply_purchase_to_list(ListPermission::Write, &mut items, 2);
+        assert_eq!(updated.len(), 0);
+        assert_eq!(items[0].0.acquired, Some(0));
+    }
+
+    #[test]
+    fn test_apply_purchase_respect_read_only() {
+        let mut items = vec![(
+            ListItem {
+                item_id: 1,
+                quantity: Some(5),
+                acquired: Some(0),
+                ..Default::default()
+            },
+            vec![],
+        )];
+        let updated = apply_purchase_to_list(ListPermission::Read, &mut items, 1);
+        assert_eq!(updated.len(), 0);
+        assert_eq!(items[0].0.acquired, Some(0));
+    }
 }

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -870,7 +870,7 @@ pub(crate) async fn bulk_edit_list_items_hq(
         .await?;
 
     for list_id in list_ids {
-        if let Ok(list) = db.get_list(list_id, user.id as i64).await {
+        if let Ok((list, _)) = db.get_list(list_id, user.id as i64).await {
             send_list_event(
                 &senders,
                 EventType::updated(ListEventData::List(List::try_from(list)?)),


### PR DESCRIPTION
This PR extracts the purchase-marking logic from the `AutoMarkPurchases` component into a pure, testable helper function `apply_purchase_to_list`. 

Changes:
- Refactored `mark_item_purchased` to use the new helper.
- Added a `break` in the loop to ensure only one unit is incremented per sale event, as per requirements.
- Included unit tests in `auto_mark_purchases.rs` covering:
    - Standard increment on matching item ID.
    - Not exceeding requested quantity.
    - Ignoring non-matching item IDs.
    - Respecting read-only permissions.

Verified by running unit tests and compilation checks.

Fixes #824

---
*PR created automatically by Jules for task [18439904408388752027](https://jules.google.com/task/18439904408388752027) started by @akarras*