### PR TITLE
Filter excluded worlds before cheapest listing selection in shopping lists

### DIFF
--- a/ultros-api-types/src/listings.rs
+++ b/ultros-api-types/src/listings.rs
@@ -13,3 +13,10 @@ pub struct ActiveListing {
     pub hq: bool,
     pub timestamp: NaiveDateTime,
 }
+
+impl ActiveListing {
+    /// Returns true if this listing belongs to a world that is in the excluded list
+    pub fn is_excluded(&self, excluded_worlds: &[i32]) -> bool {
+        excluded_worlds.contains(&self.world_id)
+    }
+}

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -17,6 +17,7 @@ pub fn ListItemRow(
     listings: Vec<ActiveListing>,
     edit_list_mode: Signal<bool>,
     #[prop(into)] selected_items: RwSignal<HashSet<i32>>,
+    #[prop(default = &[])] excluded_worlds: &'static [i32],
     // The return type of delete_list_item is impl Future<Output = Result<(), AppError>> so in Action it becomes () for the output if we don't care about the result, but wait. Action<I, O>. The original code used Action::new. Let's check original.
     // original: let delete_item = Action::new(move |list_item: &i32| delete_list_item(*list_item));
     // delete_list_item returns Result<(), AppError>.
@@ -200,6 +201,7 @@ pub fn ListItemRow(
                                             quantity=remaining
                                             hq=item.with(|i| i.hq)
                                             listings=listings()
+                                            excluded_worlds=excluded_worlds
                                         />
                                     }
                                 }}
@@ -404,6 +406,7 @@ pub fn ListItemRow(
                                             quantity=remaining
                                             hq=item.hq
                                             listings=listings()
+                                            excluded_worlds=excluded_worlds
                                         />
                                     }
                                 }}

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -27,6 +27,7 @@ fn get_cheapest_listing(
     mut listings: Vec<ActiveListing>,
     quantity: i32,
     hq: Option<bool>,
+    excluded_worlds: &[i32],
 ) -> Vec<ActiveListing> {
     listings.sort_by_key(|listing| listing.price_per_unit);
     let quantity_needed = quantity;
@@ -34,6 +35,9 @@ fn get_cheapest_listing(
     listings
         .into_iter()
         .filter(|listing| {
+            if listing.is_excluded(excluded_worlds) {
+                return false;
+            }
             if let Some(hq) = hq {
                 listing.hq == hq
             } else {
@@ -53,6 +57,7 @@ fn calculate_list_totals(
     items: Vec<(ListItem, Vec<ActiveListing>)>,
     world_data: &ultros_api_types::world_helper::WorldHelper,
     unknown_label: &str,
+    excluded_worlds: &[i32],
 ) -> (i32, HashMap<i32, WorldPrice>) {
     let mut grand_total = 0;
     let mut world_prices: HashMap<i32, WorldPrice> = HashMap::new();
@@ -66,7 +71,7 @@ fn calculate_list_totals(
         }
         let hq = list_item.hq;
 
-        let cheapest_listings = get_cheapest_listing(listings, quantity, hq);
+        let cheapest_listings = get_cheapest_listing(listings, quantity, hq, excluded_worlds);
 
         for listing in cheapest_listings {
             let price = listing.price_per_unit * listing.quantity;
@@ -110,7 +115,10 @@ fn calculate_list_totals(
 }
 
 #[component]
-pub fn ListSummary(items: Vec<(ListItem, Vec<ActiveListing>)>) -> impl IntoView {
+pub fn ListSummary(
+    items: Vec<(ListItem, Vec<ActiveListing>)>,
+    #[prop(default = &[])] excluded_worlds: &'static [i32],
+) -> impl IntoView {
     let i18n = use_i18n();
     let data = tracked_data();
     let game_items = &data.items;
@@ -144,8 +152,12 @@ pub fn ListSummary(items: Vec<(ListItem, Vec<ActiveListing>)>) -> impl IntoView 
         .into_any();
     }
 
-    let (grand_total, world_prices) =
-        calculate_list_totals(marketable_items, &world_data, &unknown_label);
+    let (grand_total, world_prices) = calculate_list_totals(
+        marketable_items,
+        &world_data,
+        &unknown_label,
+        excluded_worlds,
+    );
 
     if grand_total == 0 && world_prices.is_empty() {
         return view! {
@@ -334,7 +346,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None);
+        let result = get_cheapest_listing(listings, 10, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -348,7 +360,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None);
+        let result = get_cheapest_listing(listings, 12, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -414,6 +426,7 @@ mod tests {
             vec![(item1, listings1), (item2, vec![listing2_a, listing2_b])],
             &world_data,
             "Unknown",
+            &[],
         );
 
         // Grand total:
@@ -440,5 +453,87 @@ mod tests {
         assert_eq!(world_prices.get(&101).unwrap().datacenter_name, "Aether");
         assert_eq!(world_prices.get(&101).unwrap().world_name, "Cactuar");
         assert_eq!(world_prices.get(&101).unwrap().datacenter_id, 10);
+    }
+
+    #[test]
+    fn test_get_cheapest_listing_with_excluded_world() {
+        let mut l1 = mock_listing(1, 100, 5, false);
+        l1.world_id = 10;
+        let mut l2 = mock_listing(2, 150, 5, false);
+        l2.world_id = 20;
+        let mut l3 = mock_listing(3, 200, 5, false);
+        l3.world_id = 30;
+
+        let listings = vec![l1, l2, l3];
+
+        // Case 1: Exclude the cheapest world (10)
+        let result = get_cheapest_listing(listings.clone(), 5, None, &[10]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, 2); // Should pick the next cheapest
+
+        // Case 2: Exclude all current listings
+        let result = get_cheapest_listing(listings.clone(), 5, None, &[10, 20, 30]);
+        assert!(result.is_empty());
+
+        // Case 3: Exclude none
+        let result = get_cheapest_listing(listings, 5, None, &[]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, 1);
+    }
+
+    #[test]
+    fn test_calculate_list_totals_with_excluded_worlds() {
+        use ultros_api_types::world::{Datacenter, Region, World, WorldData};
+        use ultros_api_types::world_helper::WorldHelper;
+
+        let world_data: WorldHelper = WorldData {
+            regions: vec![Region {
+                id: 1,
+                name: "North-America".into(),
+                datacenters: vec![Datacenter {
+                    id: 10,
+                    name: "Aether".into(),
+                    region_id: 1,
+                    worlds: vec![
+                        World {
+                            id: 100,
+                            name: "Adamantoise".into(),
+                            datacenter_id: 10,
+                        },
+                        World {
+                            id: 101,
+                            name: "Cactuar".into(),
+                            datacenter_id: 10,
+                        },
+                    ],
+                }],
+            }],
+        }
+        .into();
+
+        let item = ListItem {
+            id: 1,
+            list_id: 1,
+            item_id: 1,
+            quantity: Some(10),
+            acquired: Some(0),
+            hq: None,
+            target_price: None,
+        };
+
+        let mut l1 = mock_listing(1, 100, 10, false);
+        l1.world_id = 100; // Cheapest but we will exclude it
+        let mut l2 = mock_listing(2, 200, 10, false);
+        l2.world_id = 101; // Next cheapest
+
+        // Exclude world 100
+        let (total, world_prices) =
+            calculate_list_totals(vec![(item, vec![l1, l2])], &world_data, "Unknown", &[100]);
+
+        // Total should be 10 * 200 = 2000 (from world 101)
+        assert_eq!(total, 2000);
+        assert_eq!(world_prices.len(), 1);
+        assert!(world_prices.contains_key(&101));
+        assert!(!world_prices.contains_key(&100));
     }
 }

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -9,12 +9,20 @@ fn get_cheapest_listing(
     mut listings: Vec<ActiveListing>,
     quantity: i32,
     hq: Option<bool>,
+    excluded_worlds: &[i32],
 ) -> Vec<ActiveListing> {
-    // Optimization: Filter out unwanted quality types *before* sorting.
-    // This significantly reduces the N in O(N log N) sorting time when filtering by HQ/NQ.
-    if let Some(hq) = hq {
-        listings.retain(|listing| listing.hq == hq);
-    }
+    // Optimization: Filter out unwanted listings *before* sorting.
+    // This significantly reduces the N in O(N log N) sorting time.
+    listings.retain(|listing| {
+        if listing.is_excluded(excluded_worlds) {
+            return false;
+        }
+        if let Some(hq) = hq {
+            listing.hq == hq
+        } else {
+            true
+        }
+    });
     listings.sort_by_key(|listing| listing.price_per_unit);
 
     let quantity_needed = quantity;
@@ -30,9 +38,14 @@ fn get_cheapest_listing(
 }
 
 #[component]
-pub fn PriceViewer(quantity: i32, hq: Option<bool>, listings: Vec<ActiveListing>) -> impl IntoView {
+pub fn PriceViewer(
+    quantity: i32,
+    hq: Option<bool>,
+    listings: Vec<ActiveListing>,
+    #[prop(default = &[])] excluded_worlds: &'static [i32],
+) -> impl IntoView {
     let i18n = use_i18n();
-    let cheapest_listings = get_cheapest_listing(listings, quantity, hq);
+    let cheapest_listings = get_cheapest_listing(listings, quantity, hq, excluded_worlds);
     view! {
         <div class="flex flex-col gap-1">
             {if cheapest_listings.is_empty() {
@@ -90,7 +103,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None);
+        let result = get_cheapest_listing(listings, 10, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -104,7 +117,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None);
+        let result = get_cheapest_listing(listings, 12, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -118,7 +131,7 @@ mod tests {
             mock_listing(3, 300, 5, true),  // HQ, taken
             mock_listing(4, 400, 5, false), // NQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(true));
+        let result = get_cheapest_listing(listings, 10, Some(true), &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -132,7 +145,7 @@ mod tests {
             mock_listing(3, 300, 5, false), // NQ, taken
             mock_listing(4, 400, 5, true),  // HQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(false));
+        let result = get_cheapest_listing(listings, 10, Some(false), &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -147,7 +160,7 @@ mod tests {
             mock_listing(4, 400, 5, true),  // HQ
         ];
         // Should pick id=2 then id=1
-        let result = get_cheapest_listing(listings, 10, None);
+        let result = get_cheapest_listing(listings, 10, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 1);
@@ -156,7 +169,7 @@ mod tests {
     #[test]
     fn test_get_cheapest_listing_empty() {
         let listings = vec![];
-        let result = get_cheapest_listing(listings, 10, None);
+        let result = get_cheapest_listing(listings, 10, None, &[]);
         assert!(result.is_empty());
     }
 
@@ -167,7 +180,7 @@ mod tests {
             mock_listing(2, 200, 2, false),
         ];
         // We ask for 10, but only 7 are available. It should return all of them.
-        let result = get_cheapest_listing(listings, 10, None);
+        let result = get_cheapest_listing(listings, 10, None, &[]);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -922,6 +922,7 @@ pub fn ListView() -> impl IntoView {
                                                                                 edit_item=edit_item
                                                                                 recently_changed=recently_changed
                                                                                 can_write=Signal::derive(move || view_caps.with(|c| c.can_write))
+                                                                                excluded_worlds=&[]
                                                                             />
                                                                         }
                                                                     }
@@ -931,7 +932,7 @@ pub fn ListView() -> impl IntoView {
                                                         </table>
                                                     </div>
                                                     <div class="p-4 sm:p-5">
-                                                        <ListSummary items=items.get_value() />
+                                                        <ListSummary items=items.get_value() excluded_worlds=&[] />
                                                     </div>
                                                     <div class="border-t border-[color:var(--color-outline)] p-4 sm:p-5">
                                                         <ActivityFeed activity=activity_view />


### PR DESCRIPTION
Implemented world exclusion filtering in the list pricing calculation layer.

Key changes:
1.  **ultros-api-types/src/listings.rs**: Added `ActiveListing::is_excluded` helper.
2.  **ultros-frontend/ultros-app/src/components/list/list_summary.rs**:
    - Updated `get_cheapest_listing` and `calculate_list_totals` to filter out excluded worlds.
    - Added comprehensive unit tests for these changes.
    - Updated `ListSummary` component signature.
3.  **ultros-frontend/ultros-app/src/components/price_viewer.rs**: Updated `get_cheapest_listing` and `PriceViewer` component to support filtering.
4.  **ultros-frontend/ultros-app/src/components/list/list_item_row.rs**: Updated to pass `excluded_worlds` through to `PriceViewer`.
5.  **ultros-frontend/ultros-app/src/routes/list_view.rs**: Updated call sites to pass empty exclusion list (current default).

This ensures that cheapest listing selection and total gil estimates respect world exclusions.

Fixes #822

---
*PR created automatically by Jules for task [2836797332096606893](https://jules.google.com/task/2836797332096606893) started by @akarras*