### PR TITLE
Add reusable world exclusion helper

### DIFF
--- a/ultros-api-types/src/world_helper.rs
+++ b/ultros-api-types/src/world_helper.rs
@@ -189,6 +189,28 @@ impl<'a> From<&'a Region> for AnyResult<'a> {
     }
 }
 
+pub trait WorldMatcher {
+    fn matches(&self, world: &World) -> bool;
+}
+
+impl WorldMatcher for i32 {
+    fn matches(&self, world: &World) -> bool {
+        *self == world.id
+    }
+}
+
+impl WorldMatcher for &str {
+    fn matches(&self, world: &World) -> bool {
+        self.eq_ignore_ascii_case(&world.name)
+    }
+}
+
+impl WorldMatcher for String {
+    fn matches(&self, world: &World) -> bool {
+        self.as_str().eq_ignore_ascii_case(&world.name)
+    }
+}
+
 impl WorldHelper {
     pub fn new(world_data: WorldData) -> Self {
         Self { world_data }
@@ -332,6 +354,37 @@ impl<'a> WorldHelper {
         I: IntoIterator<Item = T>,
         S: AsRef<str> + std::hash::Hash + Eq,
     {
+        self.filter_by_world(listings, |world| {
+            let dc = self.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
+            let Some(AnyResult::Datacenter(dc)) = dc else {
+                return true;
+            };
+
+            !excluded_datacenters.iter().any(|s| s.as_ref() == dc.name)
+        })
+    }
+
+    pub fn filter_by_excluded_worlds<T, I, W>(
+        &self,
+        listings: I,
+        excluded_worlds: &std::collections::HashSet<W>,
+    ) -> Vec<T>
+    where
+        T: HasWorldId,
+        I: IntoIterator<Item = T>,
+        W: WorldMatcher + std::hash::Hash + Eq,
+    {
+        self.filter_by_world(listings, |world| {
+            !excluded_worlds.iter().any(|w| w.matches(world))
+        })
+    }
+
+    fn filter_by_world<T, I, F>(&self, listings: I, predicate: F) -> Vec<T>
+    where
+        T: HasWorldId,
+        I: IntoIterator<Item = T>,
+        F: Fn(&World) -> bool,
+    {
         listings
             .into_iter()
             .filter(|item| {
@@ -340,12 +393,8 @@ impl<'a> WorldHelper {
                 let Some(AnyResult::World(world)) = world else {
                     return true;
                 };
-                let dc = self.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
-                let Some(AnyResult::Datacenter(dc)) = dc else {
-                    return true;
-                };
 
-                !excluded_datacenters.iter().any(|s| s.as_ref() == dc.name)
+                predicate(world)
             })
             .collect()
     }
@@ -768,5 +817,164 @@ mod tests {
 
         let filtered = helper.filter_by_excluded_datacenters(listings, &excluded);
         assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_filter_excluded_world_by_id() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![
+            ActiveListing {
+                id: 1,
+                world_id: 100, // Adamantoise
+                item_id: 1,
+                retainer_id: 1,
+                price_per_unit: 100,
+                quantity: 1,
+                hq: false,
+                timestamp: chrono::Utc::now().naive_utc(),
+            },
+            ActiveListing {
+                id: 2,
+                world_id: 101, // Cactuar
+                item_id: 1,
+                retainer_id: 1,
+                price_per_unit: 200,
+                quantity: 1,
+                hq: false,
+                timestamp: chrono::Utc::now().naive_utc(),
+            },
+        ];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert(100);
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, 2);
+    }
+
+    #[test]
+    fn test_filter_excluded_world_by_name() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![
+            ActiveListing {
+                id: 1,
+                world_id: 100, // Adamantoise
+                item_id: 1,
+                retainer_id: 1,
+                price_per_unit: 100,
+                quantity: 1,
+                hq: false,
+                timestamp: chrono::Utc::now().naive_utc(),
+            },
+            ActiveListing {
+                id: 2,
+                world_id: 101, // Cactuar
+                item_id: 1,
+                retainer_id: 1,
+                price_per_unit: 200,
+                quantity: 1,
+                hq: false,
+                timestamp: chrono::Utc::now().naive_utc(),
+            },
+        ];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert("Adamantoise");
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, 2);
+    }
+
+    #[test]
+    fn test_filter_excluded_world_by_name_case_insensitive() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![ActiveListing {
+            id: 1,
+            world_id: 100, // Adamantoise
+            item_id: 1,
+            retainer_id: 1,
+            price_per_unit: 100,
+            quantity: 1,
+            hq: false,
+            timestamp: chrono::Utc::now().naive_utc(),
+        }];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert("ADAMANTOISE");
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_filter_worlds_unknown_world_fail_open() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![ActiveListing {
+            id: 1,
+            world_id: 999, // Unknown
+            item_id: 1,
+            retainer_id: 1,
+            price_per_unit: 100,
+            quantity: 1,
+            hq: false,
+            timestamp: chrono::Utc::now().naive_utc(),
+        }];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert(100);
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert_eq!(filtered.len(), 1);
+    }
+
+    #[test]
+    fn test_filter_worlds_tuple_input() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![(
+            ActiveListing {
+                id: 1,
+                world_id: 100,
+                item_id: 1,
+                retainer_id: 1,
+                price_per_unit: 100,
+                quantity: 1,
+                hq: false,
+                timestamp: chrono::Utc::now().naive_utc(),
+            },
+            "some extra data",
+        )];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert(100);
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_filter_worlds_empty_listings() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings: Vec<ActiveListing> = vec![];
+        let mut excluded = std::collections::HashSet::new();
+        excluded.insert(100);
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_filter_worlds_empty_excluded() {
+        let helper: WorldHelper = sample_world_data().into();
+        let listings = vec![ActiveListing {
+            id: 1,
+            world_id: 100,
+            item_id: 1,
+            retainer_id: 1,
+            price_per_unit: 100,
+            quantity: 1,
+            hq: false,
+            timestamp: chrono::Utc::now().naive_utc(),
+        }];
+        let excluded = std::collections::HashSet::<i32>::new();
+
+        let filtered = helper.filter_by_excluded_worlds(listings, &excluded);
+        assert_eq!(filtered.len(), 1);
     }
 }


### PR DESCRIPTION
Added a focused helper to `WorldHelper` for filtering items by excluded worlds, as requested. The solution uses a trait-based approach to support both world names and IDs efficiently. It also refactors the existing datacenter filtering logic to reduce duplication and improve maintainability. All required test cases are covered.

Fixes #836

---
*PR created automatically by Jules for task [6785613849559839272](https://jules.google.com/task/6785613849559839272) started by @akarras*