### PR TITLE
Item view pricing: apply datacenter exclusions to PriceViewer callers

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -18,6 +18,7 @@ pub fn ListItemRow(
     edit_list_mode: Signal<bool>,
     #[prop(into)] selected_items: RwSignal<HashSet<i32>>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
+    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
     // The return type of delete_list_item is impl Future<Output = Result<(), AppError>> so in Action it becomes () for the output if we don't care about the result, but wait. Action<I, O>. The original code used Action::new. Let's check original.
     // original: let delete_item = Action::new(move |list_item: &i32| delete_list_item(*list_item));
     // delete_list_item returns Result<(), AppError>.
@@ -202,6 +203,7 @@ pub fn ListItemRow(
                                             hq=item.with(|i| i.hq)
                                             listings=listings()
                                             excluded_worlds=excluded_worlds
+                                            excluded_datacenters=excluded_datacenters
                                         />
                                     }
                                 }}
@@ -407,6 +409,7 @@ pub fn ListItemRow(
                                             hq=item.hq
                                             listings=listings()
                                             excluded_worlds=excluded_worlds
+                                            excluded_datacenters=excluded_datacenters
                                         />
                                     }
                                 }}

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -10,7 +10,7 @@ use xiv_gen::ItemId;
 
 use crate::components::gil::*;
 use crate::global_state::LocalWorldData;
-use ultros_api_types::world_helper::{AnyResult, AnySelector};
+use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
 
 /// Represents the total price for items from a specific world
 #[derive(Clone, Debug)]
@@ -29,7 +29,7 @@ fn get_cheapest_listing(
     hq: Option<bool>,
     excluded_worlds: &[i32],
     excluded_datacenters: &[&str],
-    world_helper: Option<&ultros_api_types::world_helper::WorldHelper>,
+    world_helper: Option<&WorldHelper>,
 ) -> Vec<ActiveListing> {
     listings.sort_by_key(|listing| listing.price_per_unit);
     let quantity_needed = quantity;
@@ -40,20 +40,15 @@ fn get_cheapest_listing(
             if listing.is_excluded(excluded_worlds) {
                 return false;
             }
-            if !excluded_datacenters.is_empty() {
-                if let Some(world_helper) = world_helper {
-                    if let Some(AnyResult::World(world)) =
-                        world_helper.lookup_selector(AnySelector::World(listing.world_id))
-                    {
-                        if let Some(AnyResult::Datacenter(dc)) = world_helper
-                            .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
-                        {
-                            if excluded_datacenters.iter().any(|&name| name == dc.name) {
-                                return false;
-                            }
-                        }
-                    }
-                }
+            if !excluded_datacenters.is_empty()
+                && let Some(world_helper) = world_helper
+                && let Some(AnyResult::World(world)) =
+                    world_helper.lookup_selector(AnySelector::World(listing.world_id))
+                && let Some(AnyResult::Datacenter(dc)) = world_helper
+                    .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                && excluded_datacenters.iter().any(|&name| name == dc.name)
+            {
+                return false;
             }
             if let Some(hq) = hq {
                 listing.hq == hq
@@ -72,7 +67,7 @@ fn get_cheapest_listing(
 /// Calculate the total price and breakdown by world for all items in the list
 fn calculate_list_totals(
     items: Vec<(ListItem, Vec<ActiveListing>)>,
-    world_data: &ultros_api_types::world_helper::WorldHelper,
+    world_data: &WorldHelper,
     unknown_label: &str,
     excluded_worlds: &[i32],
     excluded_datacenters: &[&str],

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -28,6 +28,8 @@ fn get_cheapest_listing(
     quantity: i32,
     hq: Option<bool>,
     excluded_worlds: &[i32],
+    excluded_datacenters: &[&str],
+    world_helper: Option<&ultros_api_types::world_helper::WorldHelper>,
 ) -> Vec<ActiveListing> {
     listings.sort_by_key(|listing| listing.price_per_unit);
     let quantity_needed = quantity;
@@ -37,6 +39,21 @@ fn get_cheapest_listing(
         .filter(|listing| {
             if listing.is_excluded(excluded_worlds) {
                 return false;
+            }
+            if !excluded_datacenters.is_empty() {
+                if let Some(world_helper) = world_helper {
+                    if let Some(AnyResult::World(world)) =
+                        world_helper.lookup_selector(AnySelector::World(listing.world_id))
+                    {
+                        if let Some(AnyResult::Datacenter(dc)) = world_helper
+                            .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                        {
+                            if excluded_datacenters.iter().any(|&name| name == dc.name) {
+                                return false;
+                            }
+                        }
+                    }
+                }
             }
             if let Some(hq) = hq {
                 listing.hq == hq
@@ -58,6 +75,7 @@ fn calculate_list_totals(
     world_data: &ultros_api_types::world_helper::WorldHelper,
     unknown_label: &str,
     excluded_worlds: &[i32],
+    excluded_datacenters: &[&str],
 ) -> (i32, HashMap<i32, WorldPrice>) {
     let mut grand_total = 0;
     let mut world_prices: HashMap<i32, WorldPrice> = HashMap::new();
@@ -71,7 +89,14 @@ fn calculate_list_totals(
         }
         let hq = list_item.hq;
 
-        let cheapest_listings = get_cheapest_listing(listings, quantity, hq, excluded_worlds);
+        let cheapest_listings = get_cheapest_listing(
+            listings,
+            quantity,
+            hq,
+            excluded_worlds,
+            excluded_datacenters,
+            Some(world_data),
+        );
 
         for listing in cheapest_listings {
             let price = listing.price_per_unit * listing.quantity;
@@ -118,6 +143,7 @@ fn calculate_list_totals(
 pub fn ListSummary(
     items: Vec<(ListItem, Vec<ActiveListing>)>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
+    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
 ) -> impl IntoView {
     let i18n = use_i18n();
     let data = tracked_data();
@@ -157,6 +183,7 @@ pub fn ListSummary(
         &world_data,
         &unknown_label,
         excluded_worlds,
+        excluded_datacenters,
     );
 
     if grand_total == 0 && world_prices.is_empty() {
@@ -346,7 +373,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None, &[]);
+        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -360,7 +387,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None, &[]);
+        let result = get_cheapest_listing(listings, 12, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -427,6 +454,7 @@ mod tests {
             &world_data,
             "Unknown",
             &[],
+            &[],
         );
 
         // Grand total:
@@ -467,16 +495,16 @@ mod tests {
         let listings = vec![l1, l2, l3];
 
         // Case 1: Exclude the cheapest world (10)
-        let result = get_cheapest_listing(listings.clone(), 5, None, &[10]);
+        let result = get_cheapest_listing(listings.clone(), 5, None, &[10], &[], None);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 2); // Should pick the next cheapest
 
         // Case 2: Exclude all current listings
-        let result = get_cheapest_listing(listings.clone(), 5, None, &[10, 20, 30]);
+        let result = get_cheapest_listing(listings.clone(), 5, None, &[10, 20, 30], &[], None);
         assert!(result.is_empty());
 
         // Case 3: Exclude none
-        let result = get_cheapest_listing(listings, 5, None, &[]);
+        let result = get_cheapest_listing(listings, 5, None, &[], &[], None);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 1);
     }
@@ -527,8 +555,13 @@ mod tests {
         l2.world_id = 101; // Next cheapest
 
         // Exclude world 100
-        let (total, world_prices) =
-            calculate_list_totals(vec![(item, vec![l1, l2])], &world_data, "Unknown", &[100]);
+        let (total, world_prices) = calculate_list_totals(
+            vec![(item, vec![l1, l2])],
+            &world_data,
+            "Unknown",
+            &[100],
+            &[],
+        );
 
         // Total should be 10 * 200 = 2000 (from world 101)
         assert_eq!(total, 2000);

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -44,8 +44,8 @@ fn get_cheapest_listing(
                 && let Some(world_helper) = world_helper
                 && let Some(AnyResult::World(world)) =
                     world_helper.lookup_selector(AnySelector::World(listing.world_id))
-                && let Some(AnyResult::Datacenter(dc)) = world_helper
-                    .lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                && let Some(AnyResult::Datacenter(dc)) =
+                    world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
                 && excluded_datacenters.iter().any(|&name| name == dc.name)
             {
                 return false;

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -4,8 +4,8 @@ use leptos::prelude::*;
 use super::{datacenter_name::*, gil::*, world_name::*};
 use crate::global_state::LocalWorldData;
 use crate::i18n::*;
-use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
 use ultros_api_types::ActiveListing;
+use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
 
 fn get_cheapest_listing(
     mut listings: Vec<ActiveListing>,
@@ -258,14 +258,7 @@ mod tests {
         let listings = vec![l1, l2];
 
         // Exclude Aether
-        let result = get_cheapest_listing(
-            listings,
-            10,
-            None,
-            &[],
-            &["Aether"],
-            Some(&world_data),
-        );
+        let result = get_cheapest_listing(listings, 10, None, &[], &["Aether"], Some(&world_data));
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 2);

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -2,20 +2,39 @@ use leptos::either::Either;
 use leptos::prelude::*;
 
 use super::{datacenter_name::*, gil::*, world_name::*};
+use crate::global_state::LocalWorldData;
 use crate::i18n::*;
-use ultros_api_types::{ActiveListing, world_helper::AnySelector};
+use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
+use ultros_api_types::ActiveListing;
 
 fn get_cheapest_listing(
     mut listings: Vec<ActiveListing>,
     quantity: i32,
     hq: Option<bool>,
     excluded_worlds: &[i32],
+    excluded_datacenters: &[&str],
+    world_helper: Option<&WorldHelper>,
 ) -> Vec<ActiveListing> {
     // Optimization: Filter out unwanted listings *before* sorting.
     // This significantly reduces the N in O(N log N) sorting time.
     listings.retain(|listing| {
         if listing.is_excluded(excluded_worlds) {
             return false;
+        }
+        if !excluded_datacenters.is_empty() {
+            if let Some(world_helper) = world_helper {
+                if let Some(AnyResult::World(world)) =
+                    world_helper.lookup_selector(AnySelector::World(listing.world_id))
+                {
+                    if let Some(AnyResult::Datacenter(dc)) =
+                        world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+                    {
+                        if excluded_datacenters.iter().any(|&name| name == dc.name) {
+                            return false;
+                        }
+                    }
+                }
+            }
         }
         if let Some(hq) = hq {
             listing.hq == hq
@@ -43,9 +62,20 @@ pub fn PriceViewer(
     hq: Option<bool>,
     listings: Vec<ActiveListing>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
+    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
 ) -> impl IntoView {
     let i18n = use_i18n();
-    let cheapest_listings = get_cheapest_listing(listings, quantity, hq, excluded_worlds);
+    let world_data = use_context::<LocalWorldData>();
+    let world_helper = world_data.as_ref().and_then(|d| d.0.as_ref().ok());
+
+    let cheapest_listings = get_cheapest_listing(
+        listings,
+        quantity,
+        hq,
+        excluded_worlds,
+        excluded_datacenters,
+        world_helper.map(|h| h.as_ref()),
+    );
     view! {
         <div class="flex flex-col gap-1">
             {if cheapest_listings.is_empty() {
@@ -103,7 +133,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None, &[]);
+        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -117,7 +147,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None, &[]);
+        let result = get_cheapest_listing(listings, 12, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -131,7 +161,7 @@ mod tests {
             mock_listing(3, 300, 5, true),  // HQ, taken
             mock_listing(4, 400, 5, false), // NQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(true), &[]);
+        let result = get_cheapest_listing(listings, 10, Some(true), &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -145,7 +175,7 @@ mod tests {
             mock_listing(3, 300, 5, false), // NQ, taken
             mock_listing(4, 400, 5, true),  // HQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(false), &[]);
+        let result = get_cheapest_listing(listings, 10, Some(false), &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -160,7 +190,7 @@ mod tests {
             mock_listing(4, 400, 5, true),  // HQ
         ];
         // Should pick id=2 then id=1
-        let result = get_cheapest_listing(listings, 10, None, &[]);
+        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 1);
@@ -169,7 +199,7 @@ mod tests {
     #[test]
     fn test_get_cheapest_listing_empty() {
         let listings = vec![];
-        let result = get_cheapest_listing(listings, 10, None, &[]);
+        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
         assert!(result.is_empty());
     }
 
@@ -180,9 +210,65 @@ mod tests {
             mock_listing(2, 200, 2, false),
         ];
         // We ask for 10, but only 7 are available. It should return all of them.
-        let result = get_cheapest_listing(listings, 10, None, &[]);
+        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
+    }
+
+    #[test]
+    fn test_get_cheapest_listing_excluded_datacenter() {
+        use ultros_api_types::world::{Datacenter, Region, World, WorldData};
+
+        let world_data: WorldHelper = WorldData {
+            regions: vec![Region {
+                id: 1,
+                name: "North-America".into(),
+                datacenters: vec![
+                    Datacenter {
+                        id: 10,
+                        name: "Aether".into(),
+                        region_id: 1,
+                        worlds: vec![World {
+                            id: 100,
+                            name: "Adamantoise".into(),
+                            datacenter_id: 10,
+                        }],
+                    },
+                    Datacenter {
+                        id: 11,
+                        name: "Primal".into(),
+                        region_id: 1,
+                        worlds: vec![World {
+                            id: 110,
+                            name: "Behemoth".into(),
+                            datacenter_id: 11,
+                        }],
+                    },
+                ],
+            }],
+        }
+        .into();
+
+        let mut l1 = mock_listing(1, 100, 5, false);
+        l1.world_id = 100; // Aether
+        let mut l2 = mock_listing(2, 200, 5, false);
+        l2.world_id = 110; // Primal
+
+        let listings = vec![l1, l2];
+
+        // Exclude Aether
+        let result = get_cheapest_listing(
+            listings,
+            10,
+            None,
+            &[],
+            &["Aether"],
+            Some(&world_data),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, 2);
+        assert_eq!(result[0].world_id, 110);
     }
 }

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -21,20 +21,15 @@ fn get_cheapest_listing(
         if listing.is_excluded(excluded_worlds) {
             return false;
         }
-        if !excluded_datacenters.is_empty() {
-            if let Some(world_helper) = world_helper {
-                if let Some(AnyResult::World(world)) =
-                    world_helper.lookup_selector(AnySelector::World(listing.world_id))
-                {
-                    if let Some(AnyResult::Datacenter(dc)) =
-                        world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
-                    {
-                        if excluded_datacenters.iter().any(|&name| name == dc.name) {
-                            return false;
-                        }
-                    }
-                }
-            }
+        if !excluded_datacenters.is_empty()
+            && let Some(world_helper) = world_helper
+            && let Some(AnyResult::World(world)) =
+                world_helper.lookup_selector(AnySelector::World(listing.world_id))
+            && let Some(AnyResult::Datacenter(dc)) =
+                world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
+            && excluded_datacenters.iter().any(|&name| name == dc.name)
+        {
+            return false;
         }
         if let Some(hq) = hq {
             listing.hq == hq

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -923,6 +923,7 @@ pub fn ListView() -> impl IntoView {
                                                                                 recently_changed=recently_changed
                                                                                 can_write=Signal::derive(move || view_caps.with(|c| c.can_write))
                                                                                 excluded_worlds=&[]
+                                                                                excluded_datacenters=&[]
                                                                             />
                                                                         }
                                                                     }
@@ -932,7 +933,7 @@ pub fn ListView() -> impl IntoView {
                                                         </table>
                                                     </div>
                                                     <div class="p-4 sm:p-5">
-                                                        <ListSummary items=items.get_value() excluded_worlds=&[] />
+                                                        <ListSummary items=items.get_value() excluded_worlds=&[] excluded_datacenters=&[] />
                                                     </div>
                                                     <div class="border-t border-[color:var(--color-outline)] p-4 sm:p-5">
                                                         <ActivityFeed activity=activity_view />


### PR DESCRIPTION
This change wires datacenter exclusion filtering into the item-view price displays. It introduces a new `excluded_datacenters` prop to relevant components and updates the cheapest-listing selection logic to respect these exclusions when world data is available via context. 

Key changes:
- `PriceViewer` and `ListSummary` now accept `excluded_datacenters: &'static [&'static str]`.
- Internal `get_cheapest_listing` functions filter out listings from excluded datacenters.
- `ListItemRow` passes the exclusion list down to `PriceViewer`.
- `ListView` is updated to maintain existing behavior by passing empty exclusion lists.
- Added `test_get_cheapest_listing_excluded_datacenter` to verify the new filtering logic.

Fixes #845

---
*PR created automatically by Jules for task [16271451554011246730](https://jules.google.com/task/16271451554011246730) started by @akarras*