### PR TITLE
Add E2E coverage for deleting shared-list invite links

### DIFF
--- a/integration/shared-list.cjs
+++ b/integration/shared-list.cjs
@@ -168,6 +168,56 @@ async function main() {
     });
     failIf(!errorText.includes("Could not accept invite:"), failures, `over-limit user expected error message, got: "${errorText}"`);
 
+    // Invite deletion path
+    console.log("[step] owner creates a second invite for deletion");
+    const deleteInvite = await api(ownerPage, "POST", `/api/v1/list/${listId}/invite/create`, {
+      permission: "Write",
+      max_uses: 5,
+    });
+    failIf(deleteInvite.status !== 200, failures, `create second invite expected 200, got ${deleteInvite.status}`);
+    const deleteInviteId = deleteInvite.body.id;
+
+    console.log("[step] owner deletes invite via UI");
+    await ownerPage.goto(`${BASE_URL}/list/${listId}`, { waitUntil: "networkidle0" });
+    await ownerPage.click('[data-testid="list-settings-btn"]');
+    await ownerPage.waitForSelector('[data-testid="list-settings-drawer"]', { timeout: 10000 });
+
+    // Find the row containing our new invite ID (first 10 chars)
+    const shortId = deleteInviteId.substring(0, 10);
+    const deleted = await ownerPage.evaluate((id) => {
+      const rows = Array.from(document.querySelectorAll("div.flex.items-center.gap-3.py-2"));
+      const targetRow = rows.find((row) => row.innerText.includes(`Link: ${id}`));
+      if (targetRow) {
+        const btn = targetRow.querySelector('button[aria-label="Remove access"]');
+        if (btn) {
+          btn.click();
+          return true;
+        }
+      }
+      return false;
+    }, shortId);
+    failIf(!deleted, failures, "could not find or click delete button for invite");
+
+    // Verify it disappears without reload
+    const disappeared = await ownerPage
+      .waitForFunction((id) => !document.body.innerText.includes(`Link: ${id}`), { timeout: 10000 }, shortId)
+      .then(() => true)
+      .catch(() => false);
+    failIf(!disappeared, failures, "invite link did not disappear from UI after deletion");
+
+    console.log("[step] over-limit user attempts to redeem deleted invite via UI");
+    await overLimitPage.goto(`${BASE_URL}/list/invite/${deleteInviteId}`, { waitUntil: "networkidle0" });
+    await overLimitPage.waitForSelector(".alert-error", { timeout: 10000 }).catch(() => {});
+    const deletedInviteError = await overLimitPage.evaluate(() => {
+      const el = document.querySelector(".alert-error");
+      return el ? el.innerText : "";
+    });
+    failIf(
+      !deletedInviteError.includes("Could not accept invite:"),
+      failures,
+      `over-limit user expected error for deleted invite, got: "${deletedInviteError}"`,
+    );
+
     for (const page of [ownerPage, readerPage, invitedPage, overLimitPage]) {
       await page.close();
     }


### PR DESCRIPTION
Added browser-level E2E coverage for deleting a shared-list invite from the share/manage access UI.
The test:
1. Creates a second invite via API.
2. Navigates the owner to the list settings.
3. Deletes the invite via the UI.
4. Verifies the UI updates reactively.
5. Verifies the deleted invite is no longer redeemable by another test user.

Fixes #853

---
*PR created automatically by Jules for task [12687743391024020993](https://jules.google.com/task/12687743391024020993) started by @akarras*