### PR TITLE
Fix empty exchange sources on item pages

### DIFF
--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -553,27 +553,57 @@ pub(crate) fn get_vendor_price(item_id: i32) -> Option<u32> {
 }
 
 pub(crate) fn special_shop_has_item(shop: &SpecialShop, item_id: i32) -> bool {
-    // The new SpecialShop struct has a flat `item` Vec<u16> with 60 elements.
-    // Check if any item in the shop matches the given item_id.
-    shop.item.iter().any(|&i| i as i32 == item_id)
+    // Check both possible receive slots for each of the 60 entries
+    shop.item_receive_0.iter().any(|&i| i as i32 == item_id)
+        || shop.item_receive_1.iter().any(|&i| i as i32 == item_id)
 }
 
 type Cost = (ItemId, u32);
 type TradeCosts = Vec<Cost>;
 
 fn get_trade_costs(shop: &SpecialShop, item_id: i32) -> Vec<TradeCosts> {
-    // The new SpecialShop struct has a flat `item` Vec<u16> without the old
-    // semantic separation of receive/cost/count fields. We can only report
-    // that the item exists in this shop; detailed cost information is no longer
-    // available from the data model.
-    let has_item = shop.item.iter().any(|&i| i as i32 == item_id);
-    if has_item {
-        // Return a single empty trade cost entry to indicate the shop has this item
-        // but we cannot determine the specific costs.
-        vec![vec![]]
-    } else {
-        vec![]
+    let mut results = Vec::new();
+    // SpecialShop has 60 entries, each with up to 2 receive items and 3 cost items
+    for i in 0..60 {
+        let is_receive_0 = shop
+            .item_receive_0
+            .get(i)
+            .map(|&id| id as i32 == item_id)
+            .unwrap_or(false);
+        let is_receive_1 = shop
+            .item_receive_1
+            .get(i)
+            .map(|&id| id as i32 == item_id)
+            .unwrap_or(false);
+
+        if is_receive_0 || is_receive_1 {
+            let mut costs = Vec::new();
+            // Check all three possible cost slots
+            if let Some(&cost_item) = shop.item_cost_0.get(i) {
+                if cost_item > 0 {
+                    let count = shop.count_cost_0.get(i).cloned().unwrap_or(0);
+                    costs.push((ItemId(cost_item as i32), count));
+                }
+            }
+            if let Some(&cost_item) = shop.item_cost_1.get(i) {
+                if cost_item > 0 {
+                    let count = shop.count_cost_1.get(i).cloned().unwrap_or(0);
+                    costs.push((ItemId(cost_item as i32), count));
+                }
+            }
+            if let Some(&cost_item) = shop.item_cost_2.get(i) {
+                if cost_item > 0 {
+                    let count = shop.count_cost_2.get(i).cloned().unwrap_or(0);
+                    costs.push((ItemId(cost_item as i32), count));
+                }
+            }
+
+            if !costs.is_empty() {
+                results.push(costs);
+            }
+        }
     }
+    results
 }
 
 #[component]
@@ -642,23 +672,59 @@ fn ExchangeSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use xiv_gen::SpecialShop;
 
     #[test]
     fn test_special_shop_has_item() {
-        // The new SpecialShop struct has 302 fields (item + 300 item_N_unknow_M + others).
-        // We cannot easily construct one manually without Default. Test the logic
-        // via special_shop_has_item and get_trade_costs using a minimal approach.
-
-        // Since SpecialShop doesn't derive Default and has 300+ fields, we test
-        // the logic indirectly. The functions are simple enough to verify by inspection.
-        // If Default is added to SpecialShop in the future, these tests can be expanded.
+        let shop = SpecialShop {
+            key_id: xiv_gen::SpecialShopId(1),
+            name: "Test Shop".to_string(),
+            item: vec![],
+            item_receive_0: vec![123, 456],
+            count_receive_0: vec![1, 1],
+            item_receive_1: vec![0, 789],
+            count_receive_1: vec![0, 1],
+            item_cost_0: vec![10, 20],
+            count_cost_0: vec![100, 200],
+            item_cost_1: vec![0, 0],
+            count_cost_1: vec![0, 0],
+            item_cost_2: vec![0, 0],
+            count_cost_2: vec![0, 0],
+        };
+        assert!(special_shop_has_item(&shop, 123));
+        assert!(special_shop_has_item(&shop, 789));
+        assert!(!special_shop_has_item(&shop, 999));
     }
 
     #[test]
-    fn test_get_trade_costs_empty() {
-        // Verify that get_trade_costs returns empty when item is not present.
-        // This test is a placeholder until SpecialShop derives Default or
-        // a constructor is available.
+    fn test_get_trade_costs() {
+        let shop = SpecialShop {
+            key_id: xiv_gen::SpecialShopId(1),
+            name: "Test Shop".to_string(),
+            item: vec![],
+            item_receive_0: vec![123, 456],
+            count_receive_0: vec![1, 1],
+            item_receive_1: vec![0, 789],
+            count_receive_1: vec![0, 1],
+            item_cost_0: vec![10, 20],
+            count_cost_0: vec![100, 200],
+            item_cost_1: vec![11, 0],
+            count_cost_1: vec![50, 0],
+            item_cost_2: vec![0, 0],
+            count_cost_2: vec![0, 0],
+        };
+
+        let costs_123 = get_trade_costs(&shop, 123);
+        assert_eq!(costs_123.len(), 1);
+        assert_eq!(costs_123[0].len(), 2);
+        assert_eq!(costs_123[0][0], (ItemId(10), 100));
+        assert_eq!(costs_123[0][1], (ItemId(11), 50));
+
+        let costs_789 = get_trade_costs(&shop, 789);
+        assert_eq!(costs_789.len(), 1);
+        assert_eq!(costs_789[0].len(), 1);
+        assert_eq!(costs_789[0][0], (ItemId(20), 200));
     }
 }
 

--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -579,23 +579,23 @@ fn get_trade_costs(shop: &SpecialShop, item_id: i32) -> Vec<TradeCosts> {
         if is_receive_0 || is_receive_1 {
             let mut costs = Vec::new();
             // Check all three possible cost slots
-            if let Some(&cost_item) = shop.item_cost_0.get(i) {
-                if cost_item > 0 {
-                    let count = shop.count_cost_0.get(i).cloned().unwrap_or(0);
-                    costs.push((ItemId(cost_item as i32), count));
-                }
+            if let Some(&cost_item) = shop.item_cost_0.get(i)
+                && cost_item > 0
+            {
+                let count = shop.count_cost_0.get(i).cloned().unwrap_or(0);
+                costs.push((ItemId(cost_item as i32), count));
             }
-            if let Some(&cost_item) = shop.item_cost_1.get(i) {
-                if cost_item > 0 {
-                    let count = shop.count_cost_1.get(i).cloned().unwrap_or(0);
-                    costs.push((ItemId(cost_item as i32), count));
-                }
+            if let Some(&cost_item) = shop.item_cost_1.get(i)
+                && cost_item > 0
+            {
+                let count = shop.count_cost_1.get(i).cloned().unwrap_or(0);
+                costs.push((ItemId(cost_item as i32), count));
             }
-            if let Some(&cost_item) = shop.item_cost_2.get(i) {
-                if cost_item > 0 {
-                    let count = shop.count_cost_2.get(i).cloned().unwrap_or(0);
-                    costs.push((ItemId(cost_item as i32), count));
-                }
+            if let Some(&cost_item) = shop.item_cost_2.get(i)
+                && cost_item > 0
+            {
+                let count = shop.count_cost_2.get(i).cloned().unwrap_or(0);
+                costs.push((ItemId(cost_item as i32), count));
             }
 
             if !costs.is_empty() {


### PR DESCRIPTION
Fixed the issue where empty exchange sources were visible on item pages by correctly implementing the SpecialShop cost extraction logic. Updated `special_shop_has_item` and `get_trade_costs` in `ultros-frontend/ultros-app/src/components/related_items.rs` to match the current data model in `xiv-gen`. Added unit tests to verify the fix.

Fixes #868

---
*PR created automatically by Jules for task [1847660499009903672](https://jules.google.com/task/1847660499009903672) started by @akarras*