### PR TITLE
List view: add session datacenter-exclusion controls

### DIFF
--- a/ultros-api-types/src/listings.rs
+++ b/ultros-api-types/src/listings.rs
@@ -19,4 +19,25 @@ impl ActiveListing {
     pub fn is_excluded(&self, excluded_worlds: &[i32]) -> bool {
         excluded_worlds.contains(&self.world_id)
     }
+
+    pub fn is_datacenter_excluded(
+        &self,
+        excluded_datacenters: &std::collections::HashSet<String>,
+        world_helper: &crate::world_helper::WorldHelper,
+    ) -> bool {
+        if excluded_datacenters.is_empty() {
+            return false;
+        }
+        world_helper
+            .lookup_selector(crate::world_helper::AnySelector::World(self.world_id))
+            .and_then(|r| r.as_world())
+            .and_then(|w| {
+                world_helper.lookup_selector(crate::world_helper::AnySelector::Datacenter(
+                    w.datacenter_id,
+                ))
+            })
+            .and_then(|r| r.as_datacenter())
+            .map(|dc| excluded_datacenters.contains(&dc.name))
+            .unwrap_or(false)
+    }
 }

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -590,6 +590,7 @@
     "list_view_delete": "删除",
     "list_view_select_all": "全选",
     "list_view_deselect_all": "取消全选",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "物品",
     "list_view_quantity": "数量",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -590,6 +590,7 @@
     "list_view_delete": "LÖSCHEN",
     "list_view_select_all": "ALLE AUSWÄHLEN",
     "list_view_deselect_all": "AUSWAHL AUFHEBEN",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "Gegenstand",
     "list_view_quantity": "Menge",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -590,6 +590,7 @@
     "list_view_delete": "DELETE",
     "list_view_select_all": "SELECT ALL",
     "list_view_deselect_all": "DESLECT ALL",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "Item",
     "list_view_quantity": "Quantity",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -590,6 +590,7 @@
     "list_view_delete": "SUPPRIMER",
     "list_view_select_all": "TOUT SÉLECTIONNER",
     "list_view_deselect_all": "TOUT DÉSÉLECTIONNER",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "Objet",
     "list_view_quantity": "Quantité",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -590,6 +590,7 @@
     "list_view_delete": "削除",
     "list_view_select_all": "すべて選択",
     "list_view_deselect_all": "選択を解除",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "アイテム",
     "list_view_quantity": "数量",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -590,6 +590,7 @@
     "list_view_delete": "삭제",
     "list_view_select_all": "전체 선택",
     "list_view_deselect_all": "선택 해제",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "아이템",
     "list_view_quantity": "수량",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -590,6 +590,7 @@
     "list_view_delete": "刪除",
     "list_view_select_all": "全選",
     "list_view_deselect_all": "取消全選",
+    "list_view_exclude_datacenters": "Exclude Datacenters",
     "list_view_hq": "HQ",
     "list_view_item": "物品",
     "list_view_quantity": "數量",

--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -7,7 +7,7 @@ use crate::i18n::{t, t_string, use_i18n};
 use icondata as i;
 use leptos::either::Either;
 use leptos::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use ultros_api_types::{
     ActiveListing,
     list::ListItem,
@@ -30,6 +30,9 @@ struct GroupedListing {
 pub fn BuyingView(
     items: Vec<(ListItem, Vec<ActiveListing>)>,
     edit_item: Action<ListItem, Result<(), crate::error::AppError>>,
+    #[prop(into, default = Signal::derive(HashSet::new))] excluded_datacenters: Signal<
+        HashSet<String>,
+    >,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let world_data = use_context::<LocalWorldData>()
@@ -40,53 +43,66 @@ pub fn BuyingView(
     let game_items = &data.items;
     let unknown_item_label = t_string!(i18n, unknown_item).to_string();
 
-    let mut selected_listings: Vec<(i32, GroupedListing)> = Vec::new();
+    let world_data_1 = world_data.clone();
+    let selected_listings = Memo::new(move |_| {
+        let mut selected_listings: Vec<(i32, GroupedListing)> = Vec::new();
 
-    for (list_item, mut listings) in items {
-        let quantity = list_item.quantity.unwrap_or(1);
-        let acquired = list_item.acquired.unwrap_or(0);
-        let needed = quantity.saturating_sub(acquired);
-        if needed <= 0 {
-            continue;
-        }
+        excluded_datacenters.with(|excluded| {
+            for (list_item, mut listings) in items.clone() {
+                let quantity = list_item.quantity.unwrap_or(1);
+                let acquired = list_item.acquired.unwrap_or(0);
+                let needed = quantity.saturating_sub(acquired);
+                if needed <= 0 {
+                    continue;
+                }
 
-        listings.sort_by_key(|l| l.price_per_unit);
-        let mut remaining = needed;
-        for listing in listings {
-            if remaining <= 0 {
-                break;
+                listings.sort_by_key(|l| l.price_per_unit);
+                let mut remaining = needed;
+                for listing in listings {
+                    if remaining <= 0 {
+                        break;
+                    }
+                    if matches!(list_item.hq, Some(hq) if listing.hq != hq) {
+                        continue;
+                    }
+
+                    if listing.is_datacenter_excluded(excluded, &world_data_1) {
+                        continue;
+                    }
+
+                    let buy_quantity = remaining.min(listing.quantity);
+                    let item_name = game_items
+                        .get(&ItemId(list_item.item_id))
+                        .map(|i| i.name.to_string())
+                        .unwrap_or_else(|| unknown_item_label.clone());
+
+                    selected_listings.push((
+                        listing.world_id,
+                        GroupedListing {
+                            item_id: list_item.item_id,
+                            item_name,
+                            price: listing.price_per_unit,
+                            quantity: buy_quantity,
+                            list_item: list_item.clone(),
+                            hq: listing.hq,
+                            listing_id: listing.id,
+                        },
+                    ));
+                    remaining -= buy_quantity;
+                }
             }
-            if matches!(list_item.hq, Some(hq) if listing.hq != hq) {
-                continue;
-            }
-            let buy_quantity = remaining.min(listing.quantity);
-            let item_name = game_items
-                .get(&ItemId(list_item.item_id))
-                .map(|i| i.name.to_string())
-                .unwrap_or_else(|| unknown_item_label.clone());
-
-            selected_listings.push((
-                listing.world_id,
-                GroupedListing {
-                    item_id: list_item.item_id,
-                    item_name,
-                    price: listing.price_per_unit,
-                    quantity: buy_quantity,
-                    list_item: list_item.clone(),
-                    hq: listing.hq,
-                    listing_id: listing.id,
-                },
-            ));
-            remaining -= buy_quantity;
-        }
-    }
+        });
+        selected_listings
+    });
 
     // Group by Datacenter -> World -> Listing
     type WorldMap = HashMap<i32, (String, Vec<GroupedListing>)>;
-    let mut dc_groups: HashMap<i32, (String, WorldMap)> = HashMap::new();
+    let world_data_2 = world_data.clone();
+    let dc_groups = Memo::new(move |_| {
+        let mut dc_groups: HashMap<i32, (String, WorldMap)> = HashMap::new();
 
-    for (world_id, listing) in selected_listings {
-        let world_res = world_data.lookup_selector(AnySelector::World(world_id));
+        for (world_id, listing) in selected_listings.get() {
+        let world_res = world_data_2.lookup_selector(AnySelector::World(world_id));
         if let Some(AnyResult::World(world)) = world_res {
             let dc_res = world_data.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
             if let Some(AnyResult::Datacenter(dc)) = dc_res {
@@ -101,25 +117,33 @@ pub fn BuyingView(
             }
         }
     }
+        dc_groups
+    });
 
     // Convert to sorted vectors for display
     type WorldList = Vec<(i32, String, Vec<GroupedListing>)>;
-    let mut sorted_dcs: Vec<(i32, String, WorldList)> = dc_groups
-        .into_iter()
-        .map(|(dc_id, (dc_name, worlds))| {
-            let mut sorted_worlds: WorldList = worlds
-                .into_iter()
-                .map(|(world_id, (world_name, listings))| (world_id, world_name, listings))
-                .collect();
-            sorted_worlds.sort_by(|a, b| a.1.cmp(&b.1));
-            (dc_id, dc_name, sorted_worlds)
-        })
-        .collect();
-    sorted_dcs.sort_by(|a, b| a.1.cmp(&b.1));
+    let sorted_dcs = Memo::new(move |_| {
+        let mut sorted_dcs: Vec<(i32, String, WorldList)> = dc_groups
+            .get()
+            .into_iter()
+            .map(|(dc_id, (dc_name, worlds))| {
+                let mut sorted_worlds: WorldList = worlds
+                    .into_iter()
+                    .map(|(world_id, (world_name, listings))| (world_id, world_name, listings))
+                    .collect();
+                sorted_worlds.sort_by(|a, b| a.1.cmp(&b.1));
+                (dc_id, dc_name, sorted_worlds)
+            })
+            .collect();
+        sorted_dcs.sort_by(|a, b| a.1.cmp(&b.1));
+        sorted_dcs
+    });
 
     view! {
         <div class="flex flex-col gap-4">
-            {if sorted_dcs.is_empty() {
+            {move || {
+                let sorted = sorted_dcs.get();
+                if sorted.is_empty() {
                 Either::Left(
                     view! {
                         <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] p-8 text-center text-[color:var(--color-text-muted)]">
@@ -131,7 +155,7 @@ pub fn BuyingView(
                 Either::Right(
                     view! {
                         <For
-                            each=move || sorted_dcs.clone()
+                            each=move || sorted.clone()
                             key=|(dc_id, _, _)| *dc_id
                             children=move |(_dc_id, dc_name, worlds)| {
                                 view! {
@@ -219,6 +243,7 @@ pub fn BuyingView(
                     },
                 )
             }}
+        }
         </div>
     }
 }

--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -102,21 +102,22 @@ pub fn BuyingView(
         let mut dc_groups: HashMap<i32, (String, WorldMap)> = HashMap::new();
 
         for (world_id, listing) in selected_listings.get() {
-        let world_res = world_data_2.lookup_selector(AnySelector::World(world_id));
-        if let Some(AnyResult::World(world)) = world_res {
-            let dc_res = world_data.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
-            if let Some(AnyResult::Datacenter(dc)) = dc_res {
-                let dc_entry = dc_groups
-                    .entry(dc.id)
-                    .or_insert_with(|| (dc.name.clone(), HashMap::new()));
-                let world_entry = dc_entry
-                    .1
-                    .entry(world.id)
-                    .or_insert_with(|| (world.name.clone(), Vec::new()));
-                world_entry.1.push(listing);
+            let world_res = world_data_2.lookup_selector(AnySelector::World(world_id));
+            if let Some(AnyResult::World(world)) = world_res {
+                let dc_res =
+                    world_data.lookup_selector(AnySelector::Datacenter(world.datacenter_id));
+                if let Some(AnyResult::Datacenter(dc)) = dc_res {
+                    let dc_entry = dc_groups
+                        .entry(dc.id)
+                        .or_insert_with(|| (dc.name.clone(), HashMap::new()));
+                    let world_entry = dc_entry
+                        .1
+                        .entry(world.id)
+                        .or_insert_with(|| (world.name.clone(), Vec::new()));
+                    world_entry.1.push(listing);
+                }
             }
         }
-    }
         dc_groups
     });
 

--- a/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_item_row.rs
@@ -18,7 +18,9 @@ pub fn ListItemRow(
     edit_list_mode: Signal<bool>,
     #[prop(into)] selected_items: RwSignal<HashSet<i32>>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
-    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
+    #[prop(into, default = Signal::derive(HashSet::new))] excluded_datacenters: Signal<
+        HashSet<String>,
+    >,
     // The return type of delete_list_item is impl Future<Output = Result<(), AppError>> so in Action it becomes () for the output if we don't care about the result, but wait. Action<I, O>. The original code used Action::new. Let's check original.
     // original: let delete_item = Action::new(move |list_item: &i32| delete_list_item(*list_item));
     // delete_list_item returns Result<(), AppError>.

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -203,23 +203,23 @@ pub fn ListSummary(
         let mut datacenter_totals: HashMap<i32, (String, i32, usize)> = HashMap::new();
 
         for (_, world_price) in world_prices {
-        datacenter_groups
-            .entry(world_price.datacenter_id)
-            .or_default()
-            .push(world_price.clone());
+            datacenter_groups
+                .entry(world_price.datacenter_id)
+                .or_default()
+                .push(world_price.clone());
 
-        datacenter_totals
-            .entry(world_price.datacenter_id)
-            .and_modify(|(_, price, count)| {
-                *price += world_price.total_price;
-                *count += world_price.item_count;
-            })
-            .or_insert((
-                world_price.datacenter_name.clone(),
-                world_price.total_price,
-                world_price.item_count,
-            ));
-    }
+            datacenter_totals
+                .entry(world_price.datacenter_id)
+                .and_modify(|(_, price, count)| {
+                    *price += world_price.total_price;
+                    *count += world_price.item_count;
+                })
+                .or_insert((
+                    world_price.datacenter_name.clone(),
+                    world_price.total_price,
+                    world_price.item_count,
+                ));
+        }
 
         // Sort datacenters by total item count (descending)
         let mut sorted_datacenters: Vec<_> = datacenter_totals.into_iter().collect();
@@ -245,7 +245,8 @@ pub fn ListSummary(
         let has_multiple = sorted_datacenters.len() > 1;
         if prev.is_none() || prev != Some(has_multiple) {
             if !has_multiple {
-                set_expanded_datacenters.set(sorted_datacenters.iter().map(|(id, _)| *id).collect());
+                set_expanded_datacenters
+                    .set(sorted_datacenters.iter().map(|(id, _)| *id).collect());
             } else {
                 set_expanded_datacenters.set(HashSet::new());
             }

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::components::icon::Icon;
 use crate::global_state::xiv_data::tracked_data;
@@ -13,7 +13,7 @@ use crate::global_state::LocalWorldData;
 use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
 
 /// Represents the total price for items from a specific world
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 struct WorldPrice {
     world_name: String,
     datacenter_id: i32,
@@ -28,7 +28,7 @@ fn get_cheapest_listing(
     quantity: i32,
     hq: Option<bool>,
     excluded_worlds: &[i32],
-    excluded_datacenters: &[&str],
+    excluded_datacenters: &HashSet<String>,
     world_helper: Option<&WorldHelper>,
 ) -> Vec<ActiveListing> {
     listings.sort_by_key(|listing| listing.price_per_unit);
@@ -40,13 +40,8 @@ fn get_cheapest_listing(
             if listing.is_excluded(excluded_worlds) {
                 return false;
             }
-            if !excluded_datacenters.is_empty()
-                && let Some(world_helper) = world_helper
-                && let Some(AnyResult::World(world)) =
-                    world_helper.lookup_selector(AnySelector::World(listing.world_id))
-                && let Some(AnyResult::Datacenter(dc)) =
-                    world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
-                && excluded_datacenters.iter().any(|&name| name == dc.name)
+            if let Some(world_helper) = world_helper
+                && listing.is_datacenter_excluded(excluded_datacenters, world_helper)
             {
                 return false;
             }
@@ -70,7 +65,7 @@ fn calculate_list_totals(
     world_data: &WorldHelper,
     unknown_label: &str,
     excluded_worlds: &[i32],
-    excluded_datacenters: &[&str],
+    excluded_datacenters: &HashSet<String>,
 ) -> (i32, HashMap<i32, WorldPrice>) {
     let mut grand_total = 0;
     let mut world_prices: HashMap<i32, WorldPrice> = HashMap::new();
@@ -138,7 +133,9 @@ fn calculate_list_totals(
 pub fn ListSummary(
     items: Vec<(ListItem, Vec<ActiveListing>)>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
-    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
+    #[prop(into, default = Signal::derive(HashSet::new))] excluded_datacenters: Signal<
+        HashSet<String>,
+    >,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let data = tracked_data();
@@ -173,15 +170,22 @@ pub fn ListSummary(
         .into_any();
     }
 
-    let (grand_total, world_prices) = calculate_list_totals(
-        marketable_items,
-        &world_data,
-        &unknown_label,
-        excluded_worlds,
-        excluded_datacenters,
-    );
+    let list_totals = Memo::new(move |_| {
+        excluded_datacenters.with(|excluded_datacenters| {
+            calculate_list_totals(
+                marketable_items.clone(),
+                &world_data,
+                &unknown_label,
+                excluded_worlds,
+                excluded_datacenters,
+            )
+        })
+    });
 
-    if grand_total == 0 && world_prices.is_empty() {
+    if (move || {
+        let (grand_total, world_prices) = list_totals.get();
+        grand_total == 0 && world_prices.is_empty()
+    })() {
         return view! {
             <div class="rounded-lg border border-[color:var(--brand-ring)]/40 bg-[color:var(--color-background-panel)] p-4">
                 <div class="text-center text-lg font-bold text-[color:var(--brand-fg)]">
@@ -193,10 +197,12 @@ pub fn ListSummary(
     }
 
     // Group by datacenter and calculate datacenter totals
-    let mut datacenter_groups: HashMap<i32, Vec<WorldPrice>> = HashMap::new();
-    let mut datacenter_totals: HashMap<i32, (String, i32, usize)> = HashMap::new();
+    let summary_data = Memo::new(move |_| {
+        let (_grand_total, world_prices) = list_totals.get();
+        let mut datacenter_groups: HashMap<i32, Vec<WorldPrice>> = HashMap::new();
+        let mut datacenter_totals: HashMap<i32, (String, i32, usize)> = HashMap::new();
 
-    for (_, world_price) in world_prices {
+        for (_, world_price) in world_prices {
         datacenter_groups
             .entry(world_price.datacenter_id)
             .or_default()
@@ -215,29 +221,36 @@ pub fn ListSummary(
             ));
     }
 
-    // Sort datacenters by total item count (descending)
-    let mut sorted_datacenters: Vec<_> = datacenter_totals.into_iter().collect();
-    sorted_datacenters.sort_by(|(_, (_, _, a_item_count)), (_, (_, _, b_item_count))| {
-        b_item_count.cmp(a_item_count)
-    });
-
-    // Sort worlds within each datacenter: by item count (descending), then alphabetically
-    for worlds in datacenter_groups.values_mut() {
-        worlds.sort_by(|a, b| match b.item_count.cmp(&a.item_count) {
-            std::cmp::Ordering::Equal => a.world_name.cmp(&b.world_name),
-            other => other,
+        // Sort datacenters by total item count (descending)
+        let mut sorted_datacenters: Vec<_> = datacenter_totals.into_iter().collect();
+        sorted_datacenters.sort_by(|(_, (_, _, a_item_count)), (_, (_, _, b_item_count))| {
+            b_item_count.cmp(a_item_count)
         });
-    }
 
-    // Track if we have multiple datacenters (enables collapsible behavior)
-    let has_multiple_datacenters = sorted_datacenters.len() > 1;
+        // Sort worlds within each datacenter: by item count (descending), then alphabetically
+        for worlds in datacenter_groups.values_mut() {
+            worlds.sort_by(|a, b| match b.item_count.cmp(&a.item_count) {
+                std::cmp::Ordering::Equal => a.world_name.cmp(&b.world_name),
+                other => other,
+            });
+        }
+        (sorted_datacenters, datacenter_groups)
+    });
 
     // Create a signal to track which datacenters are expanded
     // Initially expand all if single datacenter, or collapse all if multiple
-    let (expanded_datacenters, set_expanded_datacenters) = signal(if has_multiple_datacenters {
-        std::collections::HashSet::<i32>::new()
-    } else {
-        sorted_datacenters.iter().map(|(dc_id, _)| *dc_id).collect()
+    let (expanded_datacenters, set_expanded_datacenters) = signal(HashSet::<i32>::new());
+    Effect::new(move |prev: Option<bool>| {
+        let (sorted_datacenters, _) = summary_data.get();
+        let has_multiple = sorted_datacenters.len() > 1;
+        if prev.is_none() || prev != Some(has_multiple) {
+            if !has_multiple {
+                set_expanded_datacenters.set(sorted_datacenters.iter().map(|(id, _)| *id).collect());
+            } else {
+                set_expanded_datacenters.set(HashSet::new());
+            }
+        }
+        has_multiple
     });
 
     view! {
@@ -247,12 +260,15 @@ pub fn ListSummary(
                     {t!(i18n, list_summary_estimated_remaining_cost)}
                 </span>
                 <div class="text-lg font-bold text-[color:var(--brand-fg)]">
-                    <Gil amount=Signal::derive(move || grand_total) />
+                    <Gil amount=Signal::derive(move || list_totals.get().0) />
                 </div>
             </div>
 
             <div class="flex flex-col gap-2 p-3 text-sm">
-                {sorted_datacenters
+                {move || {
+                    let (sorted_datacenters, datacenter_groups) = summary_data.get();
+                    let has_multiple_datacenters = sorted_datacenters.len() > 1;
+                    sorted_datacenters
                     .into_iter()
                     .map(|(dc_id, (dc_name, dc_total, dc_count))| {
                         let worlds = datacenter_groups.get(&dc_id).cloned().unwrap_or_default();
@@ -333,7 +349,8 @@ pub fn ListSummary(
                             </div>
                         }
                     })
-                    .collect::<Vec<_>>()}
+                    .collect::<Vec<_>>()
+                }}
             </div>
         </div>
     }
@@ -368,7 +385,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -382,7 +399,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 12, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -449,7 +466,7 @@ mod tests {
             &world_data,
             "Unknown",
             &[],
-            &[],
+            &HashSet::new(),
         );
 
         // Grand total:
@@ -490,16 +507,23 @@ mod tests {
         let listings = vec![l1, l2, l3];
 
         // Case 1: Exclude the cheapest world (10)
-        let result = get_cheapest_listing(listings.clone(), 5, None, &[10], &[], None);
+        let result = get_cheapest_listing(listings.clone(), 5, None, &[10], &HashSet::new(), None);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 2); // Should pick the next cheapest
 
         // Case 2: Exclude all current listings
-        let result = get_cheapest_listing(listings.clone(), 5, None, &[10, 20, 30], &[], None);
+        let result = get_cheapest_listing(
+            listings.clone(),
+            5,
+            None,
+            &[10, 20, 30],
+            &HashSet::new(),
+            None,
+        );
         assert!(result.is_empty());
 
         // Case 3: Exclude none
-        let result = get_cheapest_listing(listings, 5, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 5, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 1);
     }
@@ -555,7 +579,7 @@ mod tests {
             &world_data,
             "Unknown",
             &[100],
-            &[],
+            &HashSet::new(),
         );
 
         // Total should be 10 * 200 = 2000 (from world 101)

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -182,10 +182,11 @@ pub fn ListSummary(
         })
     });
 
-    if {
+    let all_acquired = move || {
         let (grand_total, world_prices) = list_totals.get();
         grand_total == 0 && world_prices.is_empty()
-    } {
+    };
+    if all_acquired() {
         return view! {
             <div class="rounded-lg border border-[color:var(--brand-ring)]/40 bg-[color:var(--color-background-panel)] p-4">
                 <div class="text-center text-lg font-bold text-[color:var(--brand-fg)]">

--- a/ultros-frontend/ultros-app/src/components/list/list_summary.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_summary.rs
@@ -182,10 +182,10 @@ pub fn ListSummary(
         })
     });
 
-    if (move || {
+    if {
         let (grand_total, world_prices) = list_totals.get();
         grand_total == 0 && world_prices.is_empty()
-    })() {
+    } {
         return view! {
             <div class="rounded-lg border border-[color:var(--brand-ring)]/40 bg-[color:var(--color-background-panel)] p-4">
                 <div class="text-center text-lg font-bold text-[color:var(--brand-fg)]">

--- a/ultros-frontend/ultros-app/src/components/price_viewer.rs
+++ b/ultros-frontend/ultros-app/src/components/price_viewer.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use leptos::either::Either;
 use leptos::prelude::*;
 
@@ -5,14 +7,14 @@ use super::{datacenter_name::*, gil::*, world_name::*};
 use crate::global_state::LocalWorldData;
 use crate::i18n::*;
 use ultros_api_types::ActiveListing;
-use ultros_api_types::world_helper::{AnyResult, AnySelector, WorldHelper};
+use ultros_api_types::world_helper::{AnySelector, WorldHelper};
 
 fn get_cheapest_listing(
     mut listings: Vec<ActiveListing>,
     quantity: i32,
     hq: Option<bool>,
     excluded_worlds: &[i32],
-    excluded_datacenters: &[&str],
+    excluded_datacenters: &HashSet<String>,
     world_helper: Option<&WorldHelper>,
 ) -> Vec<ActiveListing> {
     // Optimization: Filter out unwanted listings *before* sorting.
@@ -21,13 +23,8 @@ fn get_cheapest_listing(
         if listing.is_excluded(excluded_worlds) {
             return false;
         }
-        if !excluded_datacenters.is_empty()
-            && let Some(world_helper) = world_helper
-            && let Some(AnyResult::World(world)) =
-                world_helper.lookup_selector(AnySelector::World(listing.world_id))
-            && let Some(AnyResult::Datacenter(dc)) =
-                world_helper.lookup_selector(AnySelector::Datacenter(world.datacenter_id))
-            && excluded_datacenters.iter().any(|&name| name == dc.name)
+        if let Some(world_helper) = world_helper
+            && listing.is_datacenter_excluded(excluded_datacenters, world_helper)
         {
             return false;
         }
@@ -57,23 +54,31 @@ pub fn PriceViewer(
     hq: Option<bool>,
     listings: Vec<ActiveListing>,
     #[prop(default = &[])] excluded_worlds: &'static [i32],
-    #[prop(default = &[])] excluded_datacenters: &'static [&'static str],
+    #[prop(into, default = Signal::derive(HashSet::new))] excluded_datacenters: Signal<
+        HashSet<String>,
+    >,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let world_data = use_context::<LocalWorldData>();
-    let world_helper = world_data.as_ref().and_then(|d| d.0.as_ref().ok());
 
-    let cheapest_listings = get_cheapest_listing(
-        listings,
-        quantity,
-        hq,
-        excluded_worlds,
-        excluded_datacenters,
-        world_helper.map(|h| h.as_ref()),
-    );
+    let cheapest_listings = Memo::new(move |_| {
+        let world_helper = world_data.as_ref().and_then(|d| d.0.as_ref().ok());
+        excluded_datacenters.with(|excluded_datacenters| {
+            get_cheapest_listing(
+                listings.clone(),
+                quantity,
+                hq,
+                excluded_worlds,
+                excluded_datacenters,
+                world_helper.map(|h| h.as_ref()),
+            )
+        })
+    });
     view! {
         <div class="flex flex-col gap-1">
-            {if cheapest_listings.is_empty() {
+            {move || {
+                let cheapest = cheapest_listings.get();
+                if cheapest.is_empty() {
                 Either::Left(
                     view! {
                         <span class="text-[color:var(--color-text-muted)]">{t!(i18n, price_viewer_no_listing_data)}</span>
@@ -81,7 +86,7 @@ pub fn PriceViewer(
                 )
             } else {
                 Either::Right(
-                    cheapest_listings
+                    cheapest
                         .iter()
                         .map(|listing| {
                             view! {
@@ -98,6 +103,7 @@ pub fn PriceViewer(
                         .collect::<Vec<_>>(),
                 )
             }}
+        }
         </div>
     }
     .into_any()
@@ -128,7 +134,7 @@ mod tests {
             mock_listing(2, 200, 5, false),
             mock_listing(3, 300, 5, false),
         ];
-        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -142,7 +148,7 @@ mod tests {
             mock_listing(3, 300, 5, false),
         ];
         // We need 12. We take the 5 from id=1, and we need 7 more, so we take the 10 from id=2.
-        let result = get_cheapest_listing(listings, 12, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 12, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -156,7 +162,7 @@ mod tests {
             mock_listing(3, 300, 5, true),  // HQ, taken
             mock_listing(4, 400, 5, false), // NQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(true), &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, Some(true), &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -170,7 +176,7 @@ mod tests {
             mock_listing(3, 300, 5, false), // NQ, taken
             mock_listing(4, 400, 5, true),  // HQ, skipped
         ];
-        let result = get_cheapest_listing(listings, 10, Some(false), &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, Some(false), &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 3);
@@ -185,7 +191,7 @@ mod tests {
             mock_listing(4, 400, 5, true),  // HQ
         ];
         // Should pick id=2 then id=1
-        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 2);
         assert_eq!(result[1].id, 1);
@@ -194,7 +200,7 @@ mod tests {
     #[test]
     fn test_get_cheapest_listing_empty() {
         let listings = vec![];
-        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, None, &[], &HashSet::new(), None);
         assert!(result.is_empty());
     }
 
@@ -205,7 +211,7 @@ mod tests {
             mock_listing(2, 200, 2, false),
         ];
         // We ask for 10, but only 7 are available. It should return all of them.
-        let result = get_cheapest_listing(listings, 10, None, &[], &[], None);
+        let result = get_cheapest_listing(listings, 10, None, &[], &HashSet::new(), None);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id, 1);
         assert_eq!(result[1].id, 2);
@@ -253,7 +259,9 @@ mod tests {
         let listings = vec![l1, l2];
 
         // Exclude Aether
-        let result = get_cheapest_listing(listings, 10, None, &[], &["Aether"], Some(&world_data));
+        let mut excluded = HashSet::new();
+        excluded.insert("Aether".to_string());
+        let result = get_cheapest_listing(listings, 10, None, &[], &excluded, Some(&world_data));
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].id, 2);

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -198,6 +198,7 @@ pub fn ListView() -> impl IntoView {
 
     let edit_list_mode = RwSignal::new(false);
     let selected_items = RwSignal::new(HashSet::new());
+    let excluded_datacenters = RwSignal::new(HashSet::<String>::new());
 
     type RowSnapshot = std::collections::HashMap<i32, (Option<i32>, Option<i32>)>;
     let recently_changed: RwSignal<HashSet<i32>> = RwSignal::new(HashSet::new());
@@ -379,6 +380,65 @@ pub fn ListView() -> impl IntoView {
                                 <span>{t!(i18n, list_view_settings)}</span>
                             </button>
                         </Tooltip>
+                    </div>
+                </div>
+            </div>
+
+            <div class="panel rounded-lg p-3">
+                <div class="flex flex-wrap items-center gap-3">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-[color:var(--color-text-muted)]">
+                        {t!(i18n, list_view_exclude_datacenters)}
+                    </span>
+                    <div class="flex flex-wrap gap-2">
+                        {move || {
+                            let world_data = use_context::<crate::global_state::LocalWorldData>();
+                            let helper = world_data.as_ref().and_then(|d| d.0.as_ref().ok());
+                            let list_data = list_view.get();
+                            match (helper, list_data) {
+                                (Some(helper), Some(Ok((list, _)))) => {
+                                    let filter = list.list.wdr_filter;
+                                    let datacenters = helper
+                                        .lookup_selector(filter)
+                                        .map(|r| helper.get_datacenters(&r))
+                                        .unwrap_or_default();
+                                    datacenters
+                                        .into_iter()
+                                        .map(|dc| {
+                                            let name = dc.name.clone();
+                                            let is_excluded = Signal::derive(move || {
+                                                excluded_datacenters.with(|set| set.contains(&name))
+                                            });
+                                            let toggle = {
+                                                let name = dc.name.clone();
+                                                move |_| {
+                                                    excluded_datacenters
+                                                        .update(|set| {
+                                                            if set.contains(&name) {
+                                                                set.remove(&name);
+                                                            } else {
+                                                                set.insert(name.clone());
+                                                            }
+                                                        })
+                                                }
+                                            };
+                                            view! {
+                                                <button
+                                                    class="btn-secondary px-3 py-1 text-xs"
+                                                    class:bg-red-950=is_excluded
+                                                    class:text-red-200=is_excluded
+                                                    class:border-red-400=is_excluded
+                                                    on:click=toggle
+                                                >
+                                                    {dc.name.clone()}
+                                                </button>
+                                            }
+                                        })
+                                        .collect_view()
+                                        .into_any()
+                                }
+                                _ => view! {}.into_any(),
+                            }
+                        }}
                     </div>
                 </div>
             </div>
@@ -616,7 +676,11 @@ pub fn ListView() -> impl IntoView {
                                                         </div>
                                                     </div>
                                                     <div class="p-4 sm:p-5">
-                                                        <BuyingView items=items.get_value() edit_item=edit_item />
+                                                        <BuyingView
+                                                            items=items.get_value()
+                                                            edit_item=edit_item
+                                                            excluded_datacenters=excluded_datacenters
+                                                        />
                                                     </div>
                                                 </section>
                                             },
@@ -876,7 +940,7 @@ pub fn ListView() -> impl IntoView {
                                                                                 recently_changed=recently_changed
                                                                                 can_write=Signal::derive(move || view_caps.with(|c| c.can_write))
                                                                                 excluded_worlds=&[]
-                                                                                excluded_datacenters=&[]
+                                                                                excluded_datacenters=excluded_datacenters
                                                                             />
                                                                         }
                                                                     }
@@ -886,7 +950,11 @@ pub fn ListView() -> impl IntoView {
                                                         </table>
                                                     </div>
                                                     <div class="p-4 sm:p-5">
-                                                        <ListSummary items=items.get_value() excluded_worlds=&[] excluded_datacenters=&[] />
+                                                        <ListSummary
+                                                            items=items.get_value()
+                                                            excluded_worlds=&[]
+                                                            excluded_datacenters=excluded_datacenters
+                                                        />
                                                     </div>
                                                     <div class="border-t border-[color:var(--color-outline)] p-4 sm:p-5">
                                                         <ActivityFeed activity=activity_view />

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -436,7 +436,7 @@ pub fn ListView() -> impl IntoView {
                                         .collect_view()
                                         .into_any()
                                 }
-                                _ => view! {}.into_any(),
+                                _ => ().into_any(),
                             }
                         }}
                     </div>


### PR DESCRIPTION
Add session-scoped datacenter exclusion controls to the shopping list view. This allows users to filter out specific datacenters and see immediate updates to cheapest prices and list totals.

Fixes #872

---
*PR created automatically by Jules for task [13251690793164465581](https://jules.google.com/task/13251690793164465581) started by @akarras*