### PR TITLE
⚡ Bolt: Eliminate reactive string allocations and unnecessary closures

### DIFF
--- a/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_recipe_to_list.rs
@@ -135,9 +135,9 @@ fn AddRecipeToListModal(
                 </div>
 
                 <div class="flex flex-wrap items-center gap-3">
-                    <label class="text-sm text-[color:var(--color-text-muted)]" for=move || format!("craft-qty-{}", recipe.key_id.0)>{t!(i18n, add_recipe_number_of_crafts)}</label>
+                    <label class="text-sm text-[color:var(--color-text-muted)]" for=format!("craft-qty-{}", recipe.key_id.0)>{t!(i18n, add_recipe_number_of_crafts)}</label>
                     <input
-                        id=move || format!("craft-qty-{}", recipe.key_id.0)
+                        id=format!("craft-qty-{}", recipe.key_id.0)
                         type="number"
                         min="1"
                         class="input w-24"
@@ -169,11 +169,11 @@ fn AddRecipeToListModal(
                         children=move |ingredient| {
                             view! {
                                 <div class="flex items-center gap-2">
-                                    <label for=move || format!("ingredient-qty-{}", ingredient.item_id.0) class="flex-1">
+                                    <label for=format!("ingredient-qty-{}", ingredient.item_id.0) class="flex-1">
                                         <SmallItemDisplay item=ingredient.item />
                                     </label>
                                     <input
-                                        id=move || format!("ingredient-qty-{}", ingredient.item_id.0)
+                                        id=format!("ingredient-qty-{}", ingredient.item_id.0)
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"

--- a/ultros-frontend/ultros-app/src/components/add_set_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_set_to_list.rs
@@ -164,13 +164,13 @@ fn AddSetToListModal(
                             view! {
                                 <div class="flex items-center gap-2">
                                     <label
-                                        for=move || format!("set-entry-qty-{}", entry.item_id.0)
+                                        for=format!("set-entry-qty-{}", entry.item_id.0)
                                         class="flex-1 min-w-0"
                                     >
                                         <SmallItemDisplay item=entry.item />
                                     </label>
                                     <input
-                                        id=move || format!("set-entry-qty-{}", entry.item_id.0)
+                                        id=format!("set-entry-qty-{}", entry.item_id.0)
                                         type="number"
                                         min="0"
                                         class="input w-24 ml-auto"

--- a/ultros-frontend/ultros-app/src/components/market_movers.rs
+++ b/ultros-frontend/ultros-app/src/components/market_movers.rs
@@ -200,14 +200,13 @@ pub fn MarketMovers(world: Signal<Option<String>>) -> impl IntoView {
         let active = move || tab.get() == this;
         // ⚡ Bolt: Removed string allocation on reactive renders by avoiding `format!` with multiple class strings.
         // Returning `&'static str` based on conditional checks saves string allocations, making UI updates faster.
-        let base_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors";
-        let active_class = "bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
-        let inactive_class = "bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
+        let active_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
+        let inactive_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
         view! {
             <button
                 type="button"
                 title=tooltip
-                class=move || format!("{} {}", base_class, if active() { active_class } else { inactive_class })
+                class=move || if active() { active_combined_class } else { inactive_combined_class }
                 on:click=move |_| set_tab.set(this)
             >
                 {label}

--- a/ultros-frontend/ultros-app/src/components/market_movers.rs
+++ b/ultros-frontend/ultros-app/src/components/market_movers.rs
@@ -198,8 +198,6 @@ pub fn MarketMovers(world: Signal<Option<String>>) -> impl IntoView {
 
     let tab_btn = move |this: MoverTab, label: AnyView, tooltip: String| {
         let active = move || tab.get() == this;
-        // ⚡ Bolt: Removed string allocation on reactive renders by avoiding `format!` with multiple class strings.
-        // Returning `&'static str` based on conditional checks saves string allocations, making UI updates faster.
         let active_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
         let inactive_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
         view! {

--- a/ultros-frontend/ultros-app/src/routes/trends.rs
+++ b/ultros-frontend/ultros-app/src/routes/trends.rs
@@ -362,9 +362,8 @@ pub fn Trends() -> impl IntoView {
 
     // ⚡ Bolt: Removed `format!` macro that dynamically generated class strings. We now just conditionally return the `&'static str`
     // representing the classes, eliminating string allocations during reactive renders.
-    let pill_active_class = "bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
-    let pill_inactive_class = "bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
-    let pill_base_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors";
+    let pill_active_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
+    let pill_inactive_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
 
     view! {
         <MetaTitle title=t_string!(i18n, trends_meta_title).to_string() />
@@ -388,21 +387,21 @@ pub fn Trends() -> impl IntoView {
                         <ToolbarPills>
                             <button
                                 aria-pressed=move || (window_days() == 7).to_string()
-                                class=move || format!("{} {}", pill_base_class, if window_days() == 7 { pill_active_class } else { pill_inactive_class })
+                                class=move || if window_days() == 7 { pill_active_combined_class } else { pill_inactive_combined_class }
                                 on:click=move |_| set_window_param.set(Some(7))
                             >
                                 {t!(i18n, trends_window_7d)}
                             </button>
                             <button
                                 aria-pressed=move || (window_days() == 30).to_string()
-                                class=move || format!("{} {}", pill_base_class, if window_days() == 30 { pill_active_class } else { pill_inactive_class })
+                                class=move || if window_days() == 30 { pill_active_combined_class } else { pill_inactive_combined_class }
                                 on:click=move |_| set_window_param.set(Some(30))
                             >
                                 {t!(i18n, trends_window_30d)}
                             </button>
                             <button
                                 aria-pressed=move || (window_days() == 90).to_string()
-                                class=move || format!("{} {}", pill_base_class, if window_days() == 90 { pill_active_class } else { pill_inactive_class })
+                                class=move || if window_days() == 90 { pill_active_combined_class } else { pill_inactive_combined_class }
                                 on:click=move |_| set_window_param.set(Some(90))
                             >
                                 {t!(i18n, trends_window_90d)}
@@ -477,7 +476,7 @@ pub fn Trends() -> impl IntoView {
                             type="button"
                             title=t_string!(i18n, trends_show_suspicious_help).to_string()
                             aria-pressed=move || show_suspicious().to_string()
-                            class=move || format!("{} {}", pill_base_class, if show_suspicious() { pill_active_class } else { pill_inactive_class })
+                            class=move || if show_suspicious() { pill_active_combined_class } else { pill_inactive_combined_class }
                             on:click=move |_| set_suspicious.set(Some(!show_suspicious()))
                         >
                             {move || if show_suspicious() { "On" } else { "Off" }}

--- a/ultros-frontend/ultros-app/src/routes/trends.rs
+++ b/ultros-frontend/ultros-app/src/routes/trends.rs
@@ -360,8 +360,6 @@ pub fn Trends() -> impl IntoView {
         items
     });
 
-    // ⚡ Bolt: Removed `format!` macro that dynamically generated class strings. We now just conditionally return the `&'static str`
-    // representing the classes, eliminating string allocations during reactive renders.
     let pill_active_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] text-[color:var(--color-text)] border-[color:color-mix(in_srgb,var(--brand-ring)_40%,var(--color-outline))]";
     let pill_inactive_combined_class = "px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors bg-transparent text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] border-transparent";
 


### PR DESCRIPTION
💡 **What:** 
- Replaced dynamic `format!` calls inside reactive class closures with conditional returns of pre-combined `&'static str` literals.
- Removed unnecessary `move ||` closures on attributes (`id`, `for`) that rely entirely on static item IDs.

🎯 **Why:** 
- In Leptos, using `format!` inside a reactive `move ||` closure allocates a new `String` on the heap *every single time* the signal updates. Returning a `&'static str` eliminates this overhead completely, making toggling tabs/filters noticeably snappier and reducing garbage collection pressure.
- Leptos creates a reactive Effect for any `move ||` closure passed to an attribute, even if its dependencies are static. Removing the closure saves memory and reduces initial render time by bypassing the reactivity system where it isn't needed.

📊 **Impact:** 
- Eliminates string allocations on state changes for these components.
- Reduces number of reactive effects created per row in the add-to-list modals.

🔬 **Measurement:** 
- Verify the change by observing identical behavior when switching tabs in Market Movers, changing windows in Trends, and opening the "Add Recipe/Set to List" modals. Profiling the heap in browser dev tools will show fewer string allocations during these interactions.

---
*PR created automatically by Jules for task [12014447694986541715](https://jules.google.com/task/12014447694986541715) started by @akarras*