### PR TITLE
Item view: use freshness trust verdict in listing freshness chip

### DIFF
--- a/ultros-frontend/ultros-app/src/components/freshness_badge.rs
+++ b/ultros-frontend/ultros-app/src/components/freshness_badge.rs
@@ -1,0 +1,35 @@
+use crate::freshness::{FreshnessTone, get_freshness_verdict_display};
+use crate::i18n::*;
+use chrono::Duration;
+use leptos::prelude::*;
+use ultros_api_types::freshness::FreshnessVerdict;
+
+#[component]
+pub fn FreshnessBadge(verdict: FreshnessVerdict, age: Option<Duration>) -> impl IntoView {
+    let i18n = use_i18n();
+    let display = get_freshness_verdict_display(verdict, age);
+    let classes = match display.tone {
+        FreshnessTone::Success => {
+            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
+             border text-emerald-300 border-emerald-400/40 \
+             bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]"
+        }
+        FreshnessTone::Warning => {
+            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
+             border text-amber-300 border-amber-400/40 \
+             bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]"
+        }
+        FreshnessTone::Error => {
+            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
+             border text-red-300 border-red-400/40 \
+             bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]"
+        }
+        FreshnessTone::Neutral => {
+            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
+             border text-[color:var(--color-text)] border-[color:var(--color-outline)] \
+             bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]"
+        }
+    };
+
+    view! { <span class=classes>{display.format_label(i18n)}</span> }
+}

--- a/ultros-frontend/ultros-app/src/components/mod.rs
+++ b/ultros-frontend/ultros-app/src/components/mod.rs
@@ -17,6 +17,7 @@ pub mod datacenter_name;
 pub mod endpoints_panel;
 pub mod filter_card;
 pub mod fonts;
+pub mod freshness_badge;
 pub mod gil;
 pub mod history_panel;
 pub mod icon;

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1,5 +1,6 @@
 use crate::api::{get_extended_sale_history, get_item_stats, get_listings};
 use crate::components::confidence_badge::ConfidenceBadge;
+use crate::components::freshness_badge::FreshnessBadge;
 use crate::components::gil::Gil;
 use crate::components::icon::Icon;
 use crate::components::price_history_chart::PriceHistoryChart;
@@ -329,11 +330,38 @@ fn MarketStatsPanel(
                                 .get(&ItemId(item_id()))
                                 .map(|item| item.price_mid as i32)
                                 .filter(|p| *p > 0);
-                            let _latest_timestamp = data
+
+                            let sales_per_day = if recent_sales.len() > 1 {
+                                let newest = recent_sales.first().unwrap().sold_date;
+                                let oldest = recent_sales.last().unwrap().sold_date;
+                                let seconds = (newest - oldest).num_seconds().abs();
+                                let count = recent_sales.len() - 1;
+                                if seconds > 0 {
+                                    Some((count as f32) / (seconds as f32 / 86400.0))
+                                } else {
+                                    Some(100.0) // high velocity
+                                }
+                            } else if recent_sales.is_empty() {
+                                Some(0.0)
+                            } else {
+                                None
+                            };
+
+                            let latest_timestamp = data
                                 .listings
                                 .iter()
                                 .map(|(listing, _)| listing.timestamp)
                                 .max();
+
+                            let age = latest_timestamp.map(|t| {
+                                chrono::Utc::now().naive_utc() - t
+                            });
+
+                            let freshness_verdict = ultros_api_types::freshness::calculate_freshness_verdict(
+                                age,
+                                sales_per_day,
+                            );
+
                             let real = crate::analysis::real_price(
                                 &recent_sales
                                     .iter()
@@ -543,6 +571,7 @@ fn MarketStatsPanel(
                                                     status=realtime_status
                                                     last_update=last_update_at
                                                 />
+                                                    <FreshnessBadge verdict=freshness_verdict age=age />
                                             </div>
                                             <p class="text-sm text-[color:var(--color-text-muted)]">
                                                 {move || t!(i18n, based_on_sales, count = recent_sales.len())}


### PR DESCRIPTION
Updated the item-view freshness chip to use the merged freshness verdict/display helper. The page now shows a trust verdict badge (Fresh, Caution, etc.) instead of a raw timestamp. Reuses existing logic from ultros-api-types and ultros-app's freshness helper.

Fixes #883

---
*PR created automatically by Jules for task [2246431904521121392](https://jules.google.com/task/2246431904521121392) started by @akarras*