### PR TITLE
Centralize and test shared-list UI capabilities

### DIFF
--- a/ultros-api-types/src/list.rs
+++ b/ultros-api-types/src/list.rs
@@ -48,6 +48,23 @@ pub struct ListWithPermission {
     pub owner_name: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ListCapabilities {
+    pub can_write: bool,
+    pub can_admin: bool,
+    pub can_leave: bool,
+}
+
+impl From<ListPermission> for ListCapabilities {
+    fn from(permission: ListPermission) -> Self {
+        Self {
+            can_write: permission >= ListPermission::Write,
+            can_admin: permission >= ListPermission::Owner,
+            can_leave: permission == ListPermission::Write || permission == ListPermission::Read,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ListItem {
     pub id: i32,
@@ -269,6 +286,29 @@ mod tests {
         let s = serde_json::to_string(&item).unwrap();
         let back: ListItem = serde_json::from_str(&s).unwrap();
         assert_eq!(item, back);
+    }
+
+    #[test]
+    fn list_capabilities_from_permission() {
+        let none = ListCapabilities::from(ListPermission::None);
+        assert!(!none.can_write);
+        assert!(!none.can_admin);
+        assert!(!none.can_leave);
+
+        let read = ListCapabilities::from(ListPermission::Read);
+        assert!(!read.can_write);
+        assert!(!read.can_admin);
+        assert!(read.can_leave);
+
+        let write = ListCapabilities::from(ListPermission::Write);
+        assert!(write.can_write);
+        assert!(!write.can_admin);
+        assert!(write.can_leave);
+
+        let owner = ListCapabilities::from(ListPermission::Owner);
+        assert!(owner.can_write);
+        assert!(owner.can_admin);
+        assert!(!owner.can_leave);
     }
 
     #[test]

--- a/ultros-frontend/ultros-app/src/components/add_to_list.rs
+++ b/ultros-frontend/ultros-app/src/components/add_to_list.rs
@@ -9,7 +9,7 @@ use leptos::prelude::*;
 use leptos::reactive::wrappers::write::SignalSetter;
 use leptos::task::spawn_local;
 use ultros_api_types::icon_size::IconSize;
-use ultros_api_types::list::{ListItem, ListPermission};
+use ultros_api_types::list::{ListCapabilities, ListItem, ListPermission};
 use xiv_gen::ItemId;
 
 use crate::api::add_item_to_list;
@@ -118,7 +118,8 @@ fn AddToListModal(
                                     .map(|lwp| {
                                         let permission = lwp.permission;
                                         let list = lwp.list;
-                                        let can_write = permission >= ListPermission::Write;
+                                        let caps = ListCapabilities::from(permission);
+                                        let can_write = caps.can_write;
                                         let (saved, set_saved) = signal(false);
                                         let (running, set_running) = signal(false);
                                         let (error, set_error) = signal(Option::<String>::None);

--- a/ultros-frontend/ultros-app/src/components/list/auto_mark_purchases.rs
+++ b/ultros-frontend/ultros-app/src/components/list/auto_mark_purchases.rs
@@ -5,7 +5,7 @@ use crate::ws::realtime::{RealtimeSubscription, use_realtime};
 use icondata as i;
 use leptos::prelude::*;
 use ultros_api_types::ActiveListing;
-use ultros_api_types::list::{ListItem, ListPermission, ListWithPermission};
+use ultros_api_types::list::{ListCapabilities, ListItem, ListPermission, ListWithPermission};
 use ultros_api_types::websocket::{EventType, FilterPredicate, ServerClient, SocketMessageType};
 
 type ListViewResult =
@@ -77,7 +77,7 @@ pub fn AutoMarkPurchases(list_view: Resource<ListViewResult>) -> impl IntoView {
                             list_view
                                 .get()
                                 .and_then(Result::ok)
-                                .map(|(list, _)| list.permission < ListPermission::Write)
+                                .map(|(list, _)| !ListCapabilities::from(list.permission).can_write)
                                 .unwrap_or(true)
                         }
                         on:click=move |_| set_is_watching.update(|w| *w = !*w)
@@ -95,7 +95,7 @@ fn apply_purchase_to_list(
     items: &mut [(ListItem, Vec<ActiveListing>)],
     item_id: i32,
 ) -> Vec<ListItem> {
-    if permission < ListPermission::Write {
+    if !ListCapabilities::from(permission).can_write {
         return vec![];
     }
     let mut updated_items = Vec::new();

--- a/ultros-frontend/ultros-app/src/components/list/list_settings_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/list/list_settings_drawer.rs
@@ -8,7 +8,7 @@ use icondata as i;
 use leptos::either::EitherOf3;
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
-use ultros_api_types::list::{List, ListPermission};
+use ultros_api_types::list::{List, ListCapabilities, ListPermission};
 
 #[component]
 pub fn ListSettingsDrawer(
@@ -20,8 +20,9 @@ pub fn ListSettingsDrawer(
     set_visible: WriteSignal<bool>,
 ) -> impl IntoView {
     let i18n = use_i18n();
-    let can_admin = permission >= ListPermission::Owner;
-    let can_leave = permission == ListPermission::Read || permission == ListPermission::Write;
+    let caps = ListCapabilities::from(permission);
+    let can_admin = caps.can_admin;
+    let can_leave = caps.can_leave;
     let navigate = use_navigate();
 
     let list_id = list.id;

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -8,7 +8,7 @@ use icondata as i;
 use leptos::either::Either;
 use leptos::prelude::*;
 use leptos_router::hooks::use_params_map;
-use ultros_api_types::list::{ListActivity, ListItem, ListPermission};
+use ultros_api_types::list::{ListActivity, ListCapabilities, ListItem};
 
 use crate::api::{
     add_item_to_list, delete_list_item, delete_list_items, edit_list, edit_list_item,
@@ -241,25 +241,11 @@ pub fn ListView() -> impl IntoView {
         }
     });
 
-    #[derive(Clone, Copy, Default, PartialEq, Eq)]
-    struct ViewCaps {
-        can_write: bool,
-        can_admin: bool,
-        can_leave: bool,
-    }
-
-    let view_caps = RwSignal::new(ViewCaps::default());
+    let view_caps = RwSignal::new(ListCapabilities::default());
     Effect::new(move |_| {
         let next = match list_view.get() {
-            Some(Ok((list_with_perm, _))) => {
-                let p = list_with_perm.permission;
-                ViewCaps {
-                    can_write: p >= ListPermission::Write,
-                    can_admin: p >= ListPermission::Owner,
-                    can_leave: p == ListPermission::Write || p == ListPermission::Read,
-                }
-            }
-            _ => ViewCaps::default(),
+            Some(Ok((list_with_perm, _))) => ListCapabilities::from(list_with_perm.permission),
+            _ => ListCapabilities::default(),
         };
         view_caps.set(next);
     });

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -17,7 +17,9 @@ use crate::components::list::share_list_modal::ShareListModal;
 use crate::components::meta::{MetaDescription, MetaRobotsNoIndex, MetaTitle};
 use crate::components::{loading::*, tooltip::*, world_name::*, world_picker::*};
 use crate::global_state::home_world::get_price_zone;
-use ultros_api_types::list::{CreateList, List, ListPermission, ListWithPermission};
+use ultros_api_types::list::{
+    CreateList, List, ListCapabilities, ListPermission, ListWithPermission,
+};
 
 #[component]
 pub fn ListInviteAccept() -> impl IntoView {
@@ -141,6 +143,7 @@ fn ListCard(
     user_id: Signal<Option<u64>>,
 ) -> impl IntoView {
     let permission = list.permission;
+    let caps = ListCapabilities::from(permission);
     let list_owner = list.list.owner;
     let owner_name = StoredValue::new(list.owner_name.clone());
     let list = list.list;
@@ -166,7 +169,7 @@ fn ListCard(
                 let list = list_for_render.clone();
                 if is_edit() {
                     let list_id = list.id;
-                    if permission >= ListPermission::Owner {
+                    if caps.can_admin {
                         let list_for_save = list.clone();
                         let list_for_delete = list.clone();
                         view! {
@@ -260,7 +263,7 @@ fn ListCard(
                                         <WorldName id=list.wdr_filter />
                                         <PermissionPill permission />
                                     </div>
-                                    <Show when=move || permission < ListPermission::Owner>
+                                    <Show when=move || !caps.can_admin>
                                         <div class="text-xs text-gray-500">
                                             {move || {
                                                 let name = owner_name.with_value(|n| n.clone()).unwrap_or_else(|| list_owner.to_string());
@@ -270,7 +273,7 @@ fn ListCard(
                                     </Show>
                                 </div>
                                 <div class="flex items-center gap-1">
-                                    <Show when=move || { permission >= ListPermission::Owner }>
+                                    <Show when=move || { caps.can_admin }>
                                         <Tooltip tooltip_text=Signal::derive(move || "Share list".to_string())>
                                             <button class="btn-ghost btn-sm text-gray-400 hover:text-white" on:click=move |_| set_share_open(true) aria_label="Share list">
                                                 <Icon icon=i::BiShareAltRegular />
@@ -467,7 +470,7 @@ pub fn EditLists() -> impl IntoView {
                                 Ok(lists) => {
                                     let (owned, shared): (Vec<_>, Vec<_>) = lists
                                         .into_iter()
-                                        .partition(|lwp| lwp.permission >= ListPermission::Owner);
+                                        .partition(|lwp| ListCapabilities::from(lwp.permission).can_admin);
                                     let shared_count = shared.len();
 
                                     if owned.is_empty() && shared.is_empty() {

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -167,7 +167,7 @@ fn ListCard(
         <div class="panel p-4 rounded-xl flex flex-col gap-2 h-full justify-between transition-shadow hover:shadow-lg dark:hover:shadow-gray-700/30 relative">
             {move || {
                 let list = list_for_render.clone();
-                if is_edit() {
+                if is_edit() && (caps.can_admin || caps.can_leave) {
                     let list_id = list.id;
                     if caps.can_admin {
                         let list_for_save = list.clone();
@@ -280,16 +280,18 @@ fn ListCard(
                                             </button>
                                         </Tooltip>
                                     </Show>
-                                    <Tooltip tooltip_text=Signal::derive(move || t_string!(i18n, edit_list).to_string())>
-                                        <button
-                                            type="button"
-                                            class="btn-ghost btn-sm text-gray-400 hover:text-white"
-                                            aria-label=move || t_string!(i18n, edit_list).to_string()
-                                            on:click=move |_| set_is_edit(true)
-                                        >
-                                            <Icon icon=i::BsPencilFill />
-                                        </button>
-                                    </Tooltip>
+                                    <Show when=move || { caps.can_admin || caps.can_leave }>
+                                        <Tooltip tooltip_text=Signal::derive(move || t_string!(i18n, edit_list).to_string())>
+                                            <button
+                                                type="button"
+                                                class="btn-ghost btn-sm text-gray-400 hover:text-white"
+                                                aria-label=move || t_string!(i18n, edit_list).to_string()
+                                                on:click=move |_| set_is_edit(true)
+                                            >
+                                                <Icon icon=i::BsPencilFill />
+                                            </button>
+                                        </Tooltip>
+                                    </Show>
                                 </div>
                             </div>
                             <div class="mt-4 flex justify-end">


### PR DESCRIPTION
This change centralizes the logic for mapping list permissions to UI capabilities into a new `ListCapabilities` struct in the `ultros-api-types` crate. It includes comprehensive unit tests to ensure that the mapping is correct for all permission levels (None, Read, Write, and Owner) and that UI affordances like editing, admin tasks, and leaving a list are correctly gated.

The frontend has been refactored to use this new helper, removing duplicate logic and ensuring a consistent user experience across different views and components.

Fixes #886

---
*PR created automatically by Jules for task [15467591574431217127](https://jules.google.com/task/15467591574431217127) started by @akarras*