### PR TITLE
Add regression coverage for freshness trust chip

### DIFF
--- a/integration/runner.cjs
+++ b/integration/runner.cjs
@@ -51,7 +51,10 @@ function sanitizeFileComponent(s) {
 const ROUTE_ASSERTS = {
   "/": { titleIncludes: "Ultros" },
   "/items": { titleIncludes: "Ultros" },
-  "/item/46010": { titleIncludes: "Ceremonial Shamshir" },
+  "/item/46010": {
+    titleIncludes: "Ceremonial Shamshir",
+    bodyIncludesAny: ["Fresh", "Caution", "Verify In-Game", "No Data"],
+  },
   "/items/category/Gunbreaker's Arms": { titleIncludes: "Gunbreaker" },
   "/flip-finder": { titleIncludes: "Ultros" },
   "/flip-finder/Gilgamesh": { titleIncludes: "Gilgamesh" },

--- a/ultros-api-types/src/freshness.rs
+++ b/ultros-api-types/src/freshness.rs
@@ -184,4 +184,38 @@ mod tests {
             FreshnessVerdict::VerifyInGame
         );
     }
+
+    #[test]
+    fn test_item_view_regression_focused_coverage() {
+        use FreshnessVerdict::*;
+
+        // 1. Reliable/current: Very recent data for a slow mover
+        assert_eq!(
+            calculate_freshness_verdict(Some(Duration::minutes(5)), Some(0.1)),
+            Fresh,
+            "5-minute old data for slow mover should be Fresh"
+        );
+
+        // 2. Stale/verify-in-game: Old data for a very fast mover
+        // 100 sales/day => Fresh threshold ~14m, Caution ~42m.
+        assert_eq!(
+            calculate_freshness_verdict(Some(Duration::hours(2)), Some(100.0)),
+            VerifyInGame,
+            "2-hour old data for ultra-fast mover should be VerifyInGame"
+        );
+
+        // 3. Missing/unknown timestamp
+        assert_eq!(
+            calculate_freshness_verdict(None, Some(1.0)),
+            NoData,
+            "Missing age should result in NoData"
+        );
+
+        // 4. Missing velocity (unknown state)
+        assert_eq!(
+            calculate_freshness_verdict(Some(Duration::hours(1)), None),
+            NoData,
+            "Missing velocity should result in NoData"
+        );
+    }
 }

--- a/ultros-frontend/ultros-app/src/freshness.rs
+++ b/ultros-frontend/ultros-app/src/freshness.rs
@@ -118,6 +118,36 @@ mod tests {
     }
 
     #[test]
+    fn test_verdict_to_display_mapping_exhaustive() {
+        use FreshnessVerdict::*;
+
+        let cases = vec![
+            (Fresh, FreshnessLabel::Fresh, FreshnessTone::Success),
+            (Caution, FreshnessLabel::Caution, FreshnessTone::Warning),
+            (
+                VerifyInGame,
+                FreshnessLabel::VerifyInGame,
+                FreshnessTone::Error,
+            ),
+            (NoData, FreshnessLabel::NoData, FreshnessTone::Neutral),
+        ];
+
+        for (verdict, expected_label, expected_tone) in cases {
+            let display = get_freshness_verdict_display(verdict, None);
+            assert_eq!(
+                display.label, expected_label,
+                "Verdict {:?} should map to label {:?}",
+                verdict, expected_label
+            );
+            assert_eq!(
+                display.tone, expected_tone,
+                "Verdict {:?} should map to tone {:?}",
+                verdict, expected_tone
+            );
+        }
+    }
+
+    #[test]
     fn test_age_formatting_boundaries() {
         // 59 seconds
         let display =


### PR DESCRIPTION
Added focused regression coverage for the freshness trust chip in item view. This includes unit tests for the verdict calculation logic in `ultros-api-types`, UI mapping tests in `ultros-app`, and integration test assertions in the Puppeteer runner to verify that the rendered copy includes trust verdict semantics (e.g., "Fresh", "Verify In-Game") rather than just raw timestamps.

Fixes #885

---
*PR created automatically by Jules for task [3797523719659560370](https://jules.google.com/task/3797523719659560370) started by @akarras*