### PR TITLE
Shared lists: manual invite-code redemption E2E coverage

### DIFF
--- a/integration/shared-list.cjs
+++ b/integration/shared-list.cjs
@@ -10,7 +10,8 @@ const USERS = {
   owner: { id: 880000000001, username: "SharedListOwner" },
   reader: { id: 880000000002, username: "SharedListReader" },
   invited: { id: 880000000003, username: "SharedListInvited" },
-  overLimit: { id: 880000000004, username: "SharedListOverLimit" },
+  manual: { id: 880000000004, username: "SharedListManual" },
+  overLimit: { id: 880000000005, username: "SharedListOverLimit" },
 };
 
 async function login(page, baseUrl, user) {
@@ -67,20 +68,23 @@ async function main() {
     const ownerCtx = await browser.createBrowserContext();
     const readerCtx = await browser.createBrowserContext();
     const invitedCtx = await browser.createBrowserContext();
+    const manualCtx = await browser.createBrowserContext();
     const overLimitCtx = await browser.createBrowserContext();
 
     const ownerPage = await ownerCtx.newPage();
     const readerPage = await readerCtx.newPage();
     const invitedPage = await invitedCtx.newPage();
+    const manualPage = await manualCtx.newPage();
     const overLimitPage = await overLimitCtx.newPage();
 
-    for (const page of [ownerPage, readerPage, invitedPage, overLimitPage]) {
+    for (const page of [ownerPage, readerPage, invitedPage, manualPage, overLimitPage]) {
       page.setDefaultTimeout(TIMEOUT_MS);
     }
 
     await login(ownerPage, BASE_URL, USERS.owner);
     await login(readerPage, BASE_URL, USERS.reader);
     await login(invitedPage, BASE_URL, USERS.invited);
+    await login(manualPage, BASE_URL, USERS.manual);
     await login(overLimitPage, BASE_URL, USERS.overLimit);
 
     const worldData = await api(ownerPage, "GET", "/api/v1/world_data");
@@ -140,14 +144,28 @@ async function main() {
 
     const invite = await api(ownerPage, "POST", `/api/v1/list/${listId}/invite/create`, {
       permission: "Read",
-      max_uses: 1,
+      max_uses: 2,
     });
     failIf(invite.status !== 200, failures, `create invite expected 200, got ${invite.status}`);
     const inviteId = invite.body.id;
     failIf(!inviteId || inviteId.length < 32, failures, "invite id was missing or too short");
 
-    // UI-level invite redemption
-    console.log(`[step] invited user redeems invite via UI: /list/invite/${inviteId}`);
+    // Manual invite redemption via UI
+    console.log(`[step] manual user redeems invite via code input: ${inviteId}`);
+    await manualPage.goto(`${BASE_URL}/list`, { waitUntil: "networkidle0" });
+    await manualPage.type('input[placeholder="Invite code"]', inviteId);
+    await manualPage.click('button.btn-secondary ::-p-text(Redeem)');
+    await manualPage.waitForFunction(
+      (expected) => window.location.pathname === expected,
+      { timeout: 10000 },
+      `/list/${listId}`,
+    ).catch(() => {});
+
+    const manualUrl = manualPage.url();
+    failIf(!manualUrl.endsWith(`/list/${listId}`), failures, `manual user expected redirect to /list/${listId}, got ${manualUrl}`);
+
+    // UI-level invite redemption (direct link)
+    console.log(`[step] invited user redeems invite via direct link UI: /list/invite/${inviteId}`);
     await invitedPage.goto(`${BASE_URL}/list/invite/${inviteId}`, { waitUntil: "networkidle0" });
     await invitedPage.waitForFunction(
       (expected) => window.location.pathname === expected,
@@ -238,7 +256,7 @@ async function main() {
     const ownerListAfterLeave = ownerListsAfterLeave.body.find((entry) => entry.list.id === listId);
     failIf(!ownerListAfterLeave, failures, "list disappeared for owner after reader left");
 
-    for (const page of [ownerPage, readerPage, invitedPage, overLimitPage]) {
+    for (const page of [ownerPage, readerPage, invitedPage, overLimitPage, manualPage]) {
       await page.close();
     }
   } finally {


### PR DESCRIPTION
This PR adds E2E coverage for the manual invite-code redemption flow in `integration/shared-list.cjs`. 

Key changes:
- Created a fresh branch from main.
- Updated `integration/shared-list.cjs` to include a new test step where a user redeems an invite code manually via the input on the `/list` page.
- Added a 5th user context (`manualPage`) to ensure clean state for the manual redemption test.
- Increased the `max_uses` of the first created invite to 2 so it can be used for both the manual redemption test and the existing direct link redemption test.
- All existing tests (invite deletion, leaving lists) are preserved and adjusted for the new user count.

I attempted to run the full CI suite and E2E tests, but was hampered by the absence of `cargo-leptos` in the environment and the long duration of background compilation tasks. The changes are strictly confined to the E2E test file as requested.

Fixes #891

---
*PR created automatically by Jules for task [7207591156009922421](https://jules.google.com/task/7207591156009922421) started by @akarras*