### PR TITLE
Analyzer rows: show sales-cadence velocity badge

### DIFF
--- a/ultros-frontend/ultros-app/src/components/sales_cadence_badge.rs
+++ b/ultros-frontend/ultros-app/src/components/sales_cadence_badge.rs
@@ -4,31 +4,33 @@ use crate::sales_cadence::{SalesCadenceTone, get_sales_cadence_display};
 use leptos::prelude::*;
 
 #[component]
-pub fn SalesCadenceBadge(cadence: SalesCadence, sales_per_day: f32) -> impl IntoView {
+pub fn SalesCadenceBadge(
+    cadence: SalesCadence,
+    sales_per_day: f32,
+    #[prop(optional)] compact: bool,
+) -> impl IntoView {
     let i18n = use_i18n();
     let display = get_sales_cadence_display(cadence, sales_per_day);
-    let classes = match display.tone {
-        SalesCadenceTone::Success => {
-            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
-             border text-emerald-300 border-emerald-400/40 \
-             bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]"
-        }
-        SalesCadenceTone::Warning => {
-            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
-             border text-amber-300 border-amber-400/40 \
-             bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]"
-        }
-        SalesCadenceTone::Error => {
-            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
-             border text-red-300 border-red-400/40 \
-             bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]"
-        }
-        SalesCadenceTone::Neutral => {
-            "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold \
-             border text-[color:var(--color-text)] border-[color:var(--color-outline)] \
-             bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]"
-        }
-    };
 
-    view! { <span class=classes>{display.format_label(i18n)}</span> }
+    view! {
+        <span
+            class="inline-flex items-center py-0.5 rounded-full text-xs font-semibold border"
+            class=("px-1.5", move || compact)
+            class=("px-2", move || !compact)
+            class=("text-emerald-300", move || display.tone == SalesCadenceTone::Success)
+            class=("border-emerald-400/40", move || display.tone == SalesCadenceTone::Success)
+            class=("bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]", move || display.tone == SalesCadenceTone::Success)
+            class=("text-amber-300", move || display.tone == SalesCadenceTone::Warning)
+            class=("border-amber-400/40", move || display.tone == SalesCadenceTone::Warning)
+            class=("bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]", move || display.tone == SalesCadenceTone::Warning)
+            class=("text-red-300", move || display.tone == SalesCadenceTone::Error)
+            class=("border-red-400/40", move || display.tone == SalesCadenceTone::Error)
+            class=("bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]", move || display.tone == SalesCadenceTone::Error)
+            class=("text-[color:var(--color-text)]", move || display.tone == SalesCadenceTone::Neutral)
+            class=("border-[color:var(--color-outline)]", move || display.tone == SalesCadenceTone::Neutral)
+            class=("bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]", move || display.tone == SalesCadenceTone::Neutral)
+        >
+            {display.format_label(i18n)}
+        </span>
+    }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1,4 +1,4 @@
-use crate::analysis::{SaleSummary, roi_badge_class};
+use crate::analysis::{SaleSummary, get_sales_cadence, roi_badge_class};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
 use crate::ws::realtime::use_realtime;
@@ -7,12 +7,14 @@ use crate::{
     components::{
         add_to_list::AddToList,
         clipboard::*,
+        confidence_badge::ConfidenceBadge,
         gil::*,
         icon::Icon,
         item_icon::*,
         meta::*,
         query_button::QueryButton,
         realtime_status::RealtimeStatus,
+        sales_cadence_badge::SalesCadenceBadge,
         skeleton::{BoxSkeleton, SingleLineSkeleton},
         sparkline::Sparkline,
         toggle::Toggle,
@@ -1284,7 +1286,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| view! {
-                                    <div role="columnheader" class="w-[88px] px-3 py-2 hidden md:flex flex-col items-end text-right leading-tight">
+                                    <div role="columnheader" class="w-[140px] px-3 py-2 hidden md:flex flex-col items-center text-center leading-tight">
                                         <span>{t!(i18n, analyzer_col_sales_per_day)}</span>
                                         <span class="text-[10px] font-normal normal-case text-[color:var(--color-text-muted)] truncate max-w-full">
                                             {move || world()}
@@ -1336,6 +1338,8 @@ fn AnalyzerTable(
                                 .to_string();
                             let world = Signal::derive(move || world.clone());
                             let item_id = data.inner.sale_summary.item_id;
+                            let hq = data.inner.sale_summary.hq;
+                            let row_key = (item_id, hq);
                             let item = items
                                 .get(&ItemId(item_id))
                                 .map(|item| item.name.as_str())
@@ -1364,6 +1368,17 @@ fn AnalyzerTable(
                                                 <ItemIcon item_id icon_size=IconSize::Small loading=icon_loading />
                                             </div>
                                             {item}
+                                            {move || {
+                                                let maps = enrichment.get();
+                                                maps.quality_for(&row_key).map(|q| {
+                                                    view! {
+                                                        <ConfidenceBadge
+                                                            band=q.confidence_band
+                                                            sample_size=q.sample_size as u32
+                                                        />
+                                                    }
+                                                })
+                                            }}
                                         </a>
                                         <AddToList item_id />
                                         <Clipboard clipboard_text=item.to_string() />
@@ -1453,13 +1468,28 @@ fn AnalyzerTable(
                                             })}
                                             {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| {
                                                 let maps = enrichment.get();
-                                                let inner = match (maps.quality_for(&row_key), maps.is_settled(&row_key)) {
-                                                    (Some(q), _) => view! { {format!("{:.1}", q.sales_per_day)} }.into_any(),
-                                                    (None, true) => view! { "—" }.into_any(),
-                                                    (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
+                                                let settled = maps.is_settled(&row_key);
+                                                let quality = maps.quality_for(&row_key);
+                                                let inner = if let Some(q) = quality {
+                                                    let cadence = get_sales_cadence(q.sales_per_day, q.sample_size as usize);
+                                                    view! { <SalesCadenceBadge cadence sales_per_day=q.sales_per_day compact=true /> }.into_any()
+                                                } else if settled {
+                                                    let summary = &data.inner.sale_summary;
+                                                    if summary.num_sold > 0 {
+                                                        let spd = summary.avg_sale_duration.map(|d| {
+                                                            let secs = d.num_seconds().abs().max(1) as f32;
+                                                            86400.0 / secs
+                                                        }).unwrap_or(0.0);
+                                                        let cadence = get_sales_cadence(spd, summary.num_sold as usize);
+                                                        view! { <SalesCadenceBadge cadence sales_per_day=spd compact=true /> }.into_any()
+                                                    } else {
+                                                        view! { "—" }.into_any()
+                                                    }
+                                                } else {
+                                                    view! { <SingleLineSkeleton /> }.into_any()
                                                 };
                                                 view! {
-                                                    <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                                    <div role="cell" class="px-3 py-2 w-[140px] hidden md:flex items-center justify-center">
                                                         {inner}
                                                     </div>
                                                 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1374,7 +1374,7 @@ fn AnalyzerTable(
                                                     view! {
                                                         <ConfidenceBadge
                                                             band=q.confidence_band
-                                                            sample_size=q.sample_size as u32
+                                                            sample_size=q.sample_size
                                                         />
                                                     }
                                                 })
@@ -1480,7 +1480,7 @@ fn AnalyzerTable(
                                                             let secs = d.num_seconds().abs().max(1) as f32;
                                                             86400.0 / secs
                                                         }).unwrap_or(0.0);
-                                                        let cadence = get_sales_cadence(spd, summary.num_sold as usize);
+                                                        let cadence = get_sales_cadence(spd, summary.num_sold);
                                                         view! { <SalesCadenceBadge cadence sales_per_day=spd compact=true /> }.into_any()
                                                     } else {
                                                         view! { "—" }.into_any()


### PR DESCRIPTION
This PR wires the existing sales-cadence velocity and confidence signals into the analyzer result rows. 

Key changes:
- `SalesCadenceBadge` now supports a `compact` boolean prop to fit better in dense tables.
- Analyzer rows now show the `ConfidenceBadge` next to item names.
- The `Sales/day` column now displays a color-coded velocity badge (Fast/Steady/Slow mover) instead of a raw number.
- Fallback logic ensures the badge is populated even when ClickHouse-backed data is missing by using the 6-sale history summary.
- Column widths and alignments were adjusted for a cleaner UI.

Manual verification: Verified via unit tests and successful `cargo check`. Full CI was triggered but timed out; however, targeted checks on the affected paths were successful.

Fixes #899

---
*PR created automatically by Jules for task [10554629293860764513](https://jules.google.com/task/10554629293860764513) started by @akarras*