### PR TITLE
[codex] Test list realtime stale matching

### DIFF
--- a/ultros-api-types/src/websocket.rs
+++ b/ultros-api-types/src/websocket.rs
@@ -153,6 +153,27 @@ pub fn is_analyzer_event_relevant(
     false
 }
 
+/// Decides whether a websocket market update should refresh a list view.
+///
+/// Listing updates carry an item id and are relevant only when that item is
+/// present in the current list view. `Stale` messages are already routed to a
+/// specific subscription and do not carry an item id, so they are relevant as
+/// long as the current list view has subscribed market items.
+pub fn is_list_market_update_relevant(message: &ServerClient, list_item_ids: &[i32]) -> bool {
+    match message {
+        ServerClient::Listings(event) => {
+            let data = match event {
+                EventType::Added(data) | EventType::Removed(data) | EventType::Updated(data) => {
+                    data
+                }
+            };
+            list_item_ids.contains(&data.item_id)
+        }
+        ServerClient::Stale { .. } => !list_item_ids.is_empty(),
+        _ => false,
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum EventType<T> {
     Added(T),
@@ -515,5 +536,53 @@ mod tests {
         // Verify "no item viewed" state handling (should return false)
         assert!(!is_analyzer_event_relevant(42, 100, 0, 100, None, &h));
         assert!(!is_analyzer_event_relevant(42, 100, 42, 0, None, &h));
+    }
+
+    fn list_market_message(item_id: i32) -> ServerClient {
+        ServerClient::Listings(EventType::Updated(ListingEventData {
+            item_id,
+            world_id: 100,
+            listings: vec![],
+        }))
+    }
+
+    #[test]
+    fn list_market_update_matches_item_id_in_current_list() {
+        let message = list_market_message(42);
+
+        assert!(is_list_market_update_relevant(&message, &[42]));
+    }
+
+    #[test]
+    fn list_market_update_ignores_unrelated_item_id() {
+        let message = list_market_message(42);
+
+        assert!(!is_list_market_update_relevant(&message, &[7]));
+    }
+
+    #[test]
+    fn list_market_update_ignores_empty_list() {
+        let message = list_market_message(42);
+
+        assert!(!is_list_market_update_relevant(&message, &[]));
+        assert!(!is_list_market_update_relevant(
+            &ServerClient::Stale { subscription_id: 1 },
+            &[]
+        ));
+    }
+
+    #[test]
+    fn list_market_update_matches_mixed_item_list() {
+        let message = list_market_message(42);
+
+        assert!(is_list_market_update_relevant(&message, &[7, 42, 99]));
+        assert!(!is_list_market_update_relevant(&message, &[7, 99]));
+    }
+
+    #[test]
+    fn list_market_stale_event_is_relevant_to_non_empty_subscription() {
+        let message = ServerClient::Stale { subscription_id: 1 };
+
+        assert!(is_list_market_update_relevant(&message, &[42]));
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -30,7 +30,9 @@ use crate::components::{
 };
 use crate::i18n::*;
 use crate::ws::realtime::{RealtimeSubscription, use_realtime};
-use ultros_api_types::websocket::{FilterPredicate, ServerClient, SocketMessageType};
+use ultros_api_types::websocket::{
+    FilterPredicate, ServerClient, SocketMessageType, is_list_market_update_relevant,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum MenuState {
@@ -161,13 +163,10 @@ pub fn ListView() -> impl IntoView {
         let Some(realtime) = realtime_for_market.clone() else {
             return;
         };
-        let filter =
-            FilterPredicate::World(list.list.wdr_filter).and(FilterPredicate::Items(item_ids));
+        let filter = FilterPredicate::World(list.list.wdr_filter)
+            .and(FilterPredicate::Items(item_ids.clone()));
         let sub = realtime.subscribe_market(filter, SocketMessageType::Listings, move |message| {
-            if matches!(
-                message,
-                ServerClient::Listings(_) | ServerClient::Stale { .. }
-            ) {
+            if is_list_market_update_relevant(&message, &item_ids) {
                 set_last_update_at.set(Some(chrono::Utc::now()));
                 list_view.refetch();
             }


### PR DESCRIPTION
## Summary
- Add a pure `is_list_market_update_relevant` helper for list-view realtime market refresh decisions.
- Cover matching item IDs, unrelated item IDs, empty lists, mixed-item lists, and subscription-scoped stale events without any websocket or browser session.
- Wire the list-view market subscription callback through the helper while leaving the existing subscription filter shape intact.

## Validation
- `cargo test -p ultros-api-types list_market`
- `./check_ci.sh`

Fixes #848.

Supersedes #855 without closing #855.
