### PR TITLE
[codex] Add retainer character assignment API

### DIFF
--- a/ultros-api-types/src/user/user_retainers.rs
+++ b/ultros-api-types/src/user/user_retainers.rs
@@ -11,6 +11,11 @@ pub struct OwnedRetainer {
     pub weight: Option<i32>,
 }
 
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
+pub struct AssignRetainerCharacter {
+    pub character_id: Option<i32>,
+}
+
 pub type UserRetainerList = Vec<(Option<FfxivCharacter>, Vec<(OwnedRetainer, Retainer)>)>;
 pub type UserRetainerListWithListings =
     Vec<(Option<FfxivCharacter>, Vec<(Retainer, Vec<ActiveListing>)>)>;

--- a/ultros-db/src/ffxiv_character.rs
+++ b/ultros-db/src/ffxiv_character.rs
@@ -94,6 +94,20 @@ impl UltrosDb {
     }
 
     #[instrument(skip(self))]
+    pub async fn user_owns_character(
+        &self,
+        discord_user_id: i64,
+        ffxiv_character_id: i32,
+    ) -> Result<bool> {
+        let owned = owned_ffxiv_character::Entity::find()
+            .filter(owned_ffxiv_character::Column::DiscordUserId.eq(discord_user_id))
+            .filter(owned_ffxiv_character::Column::FfxivCharacterId.eq(ffxiv_character_id))
+            .one(&self.db)
+            .await?;
+        Ok(owned.is_some())
+    }
+
+    #[instrument(skip(self))]
     pub async fn get_pending_character_challenges_for_discord_user(
         &self,
         discord_user_id: i64,

--- a/ultros-db/src/retainers.rs
+++ b/ultros-db/src/retainers.rs
@@ -11,6 +11,7 @@ use sea_orm::EntityTrait;
 use sea_orm::LoaderTrait;
 use sea_orm::QueryFilter;
 use sea_orm::Set;
+use thiserror::Error;
 use tracing::info;
 use tracing::instrument;
 use ultros_api_types::user::OwnedRetainer;
@@ -42,6 +43,14 @@ pub type DiscordUserUndercutListings = Vec<(
 pub struct ListingUndercutData {
     pub number_behind: usize,
     pub price_to_beat: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum RetainerError {
+    #[error("Retainer ownership record not found")]
+    NotFound,
+    #[error("{0}")]
+    Forbidden(&'static str),
 }
 
 impl UltrosDb {
@@ -270,9 +279,9 @@ impl UltrosDb {
         let model = owned_retainers::Entity::find_by_id(owned_retainer_id)
             .one(&self.db)
             .await?
-            .ok_or_else(|| anyhow::Error::msg("Retainer with id not found"))?;
+            .ok_or(RetainerError::NotFound)?;
         if model.discord_id != owner_id {
-            return Err(anyhow::Error::msg("Unauthorized to edit this character"));
+            return Err(RetainerError::Forbidden("Unauthorized to edit this retainer").into());
         }
         let model = model.into_active_model();
         let model = update(model);
@@ -372,5 +381,148 @@ impl UltrosDb {
             .for_each(|(_, i)| i.sort_by_key(|(o, _)| o.weight));
         value.sort_by_key(|(o, _)| o.as_ref().map(|o| o.id).unwrap_or_default());
         Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use sea_orm::{EntityTrait, Set};
+
+    use super::*;
+
+    async fn test_db() -> UltrosDb {
+        UltrosDb::connect().await.expect("connect to test DB")
+    }
+
+    fn unique_seed() -> i32 {
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_millis();
+        (millis % 1_000_000) as i32
+    }
+
+    async fn create_owned_retainer_fixture(
+        db: &UltrosDb,
+        seed: i32,
+        owner: u64,
+    ) -> (owned_retainers::Model, final_fantasy_character::Model) {
+        db.insert_default_retainer_cities()
+            .await
+            .expect("insert retainer cities");
+        let region = db.store_region(&format!("TestRegion{seed}")).await.unwrap();
+        let datacenter = db
+            .store_datacenter(&format!("TestDatacenter{seed}"), &region.name)
+            .await
+            .unwrap();
+        let world_id = seed + 10_000_000;
+        db.store_world(
+            WorldId(world_id),
+            &format!("TestWorld{seed}"),
+            &datacenter.name,
+        )
+        .await
+        .unwrap();
+        let character = db
+            .insert_character(seed + 20_000_000, "Test", &format!("Owner{seed}"), world_id)
+            .await
+            .unwrap();
+        db.get_or_create_discord_user(owner, format!("owner-{seed}"))
+            .await
+            .unwrap();
+        db.create_owned_character(owner as i64, character.id)
+            .await
+            .unwrap();
+        let retainer = db
+            .store_retainer(
+                &format!("retainer-{seed}"),
+                &format!("Retainer{seed}"),
+                WorldId(world_id),
+                1,
+            )
+            .await
+            .unwrap();
+        let owned = db
+            .register_retainer(retainer.id, owner, format!("owner-{seed}"))
+            .await
+            .unwrap();
+        (owned, character)
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live DB; no test_helpers scaffolding in this crate yet"]
+    async fn update_owned_retainer_sets_and_clears_character_assignment() {
+        let db = test_db().await;
+        let owner: u64 = 9_000_000_000_000_001;
+        let seed = unique_seed();
+        let (owned, character) = create_owned_retainer_fixture(&db, seed, owner).await;
+
+        db.update_owned_retainer(owner as i64, owned.id, |mut owned_retainer| {
+            owned_retainer.character_id = Set(Some(character.id));
+            owned_retainer
+        })
+        .await
+        .unwrap();
+        let updated = owned_retainers::Entity::find_by_id(owned.id)
+            .one(db.get_connection())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.character_id, Some(character.id));
+
+        db.update_owned_retainer(owner as i64, owned.id, |mut owned_retainer| {
+            owned_retainer.character_id = Set(None);
+            owned_retainer
+        })
+        .await
+        .unwrap();
+        let updated = owned_retainers::Entity::find_by_id(owned.id)
+            .one(db.get_connection())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated.character_id, None);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live DB; no test_helpers scaffolding in this crate yet"]
+    async fn update_owned_retainer_rejects_another_users_retainer() {
+        let db = test_db().await;
+        let owner: u64 = 9_000_000_000_000_002;
+        let other_user: u64 = 9_000_000_000_000_003;
+        let seed = unique_seed();
+        let (owned, character) = create_owned_retainer_fixture(&db, seed, owner).await;
+
+        let err = db
+            .update_owned_retainer(other_user as i64, owned.id, |mut owned_retainer| {
+                owned_retainer.character_id = Set(Some(character.id));
+                owned_retainer
+            })
+            .await
+            .unwrap_err();
+        assert!(err.downcast_ref::<RetainerError>().is_some());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires live DB; no test_helpers scaffolding in this crate yet"]
+    async fn user_owns_character_scopes_to_discord_user() {
+        let db = test_db().await;
+        let owner: u64 = 9_000_000_000_000_004;
+        let other_user: u64 = 9_000_000_000_000_005;
+        let seed = unique_seed();
+        let (_owned, character) = create_owned_retainer_fixture(&db, seed, owner).await;
+
+        assert!(
+            db.user_owns_character(owner as i64, character.id)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !db.user_owns_character(other_user as i64, character.id)
+                .await
+                .unwrap()
+        );
     }
 }

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -43,7 +43,9 @@ use ultros_api_types::list::{
 };
 use ultros_api_types::retainer::RetainerListings;
 use ultros_api_types::user::group::{CreateGroup, UserGroup, UserGroupMember};
-use ultros_api_types::user::{OwnedRetainer, UserData, UserRetainerListings, UserRetainers};
+use ultros_api_types::user::{
+    AssignRetainerCharacter, OwnedRetainer, UserData, UserRetainerListings, UserRetainers,
+};
 use ultros_api_types::websocket::{ListEventData, ListingEventData};
 use ultros_api_types::world::WorldData;
 use ultros_api_types::{
@@ -1365,6 +1367,30 @@ async fn reorder_retainer(
     Ok(Json(()))
 }
 
+async fn assign_retainer_character(
+    user: AuthDiscordUser,
+    State(db): State<UltrosDb>,
+    Path(owned_retainer_id): Path<i32>,
+    Json(data): Json<AssignRetainerCharacter>,
+) -> Result<Json<()>, ApiError> {
+    if let Some(character_id) = data.character_id {
+        let owns_character = db.user_owns_character(user.id as i64, character_id).await?;
+        if !owns_character {
+            return Err(ApiError::Forbidden(
+                "Cannot assign a character owned by another user",
+            ));
+        }
+    }
+
+    db.update_owned_retainer(user.id as i64, owned_retainer_id, |mut owned_retainer| {
+        owned_retainer.character_id = ActiveValue::Set(data.character_id);
+        owned_retainer
+    })
+    .await?;
+
+    Ok(Json(()))
+}
+
 async fn delete_user(
     user: AuthDiscordUser,
     State(cache): State<AuthUserCache>,
@@ -1536,6 +1562,10 @@ pub(crate) async fn start_web(state: WebState) {
         .route("/api/v1/current_user", get(current_user))
         .route("/api/v1/user/retainer", get(user_retainers))
         .route("/api/v1/retainer/reorder", post(reorder_retainer))
+        .route(
+            "/api/v1/retainer/{id}/character",
+            post(assign_retainer_character),
+        )
         .route(
             "/api/v1/user/retainer/listings",
             get(user_retainer_listings),

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -20,7 +20,7 @@ use tracing::{error, info};
 use ultros_api_types::result::JsonErrorWrapper;
 use ultros_db::{
     SeaDbErr, common_type_conversions::ApiConversionError, lists::ListError,
-    world_data::world_cache::WorldCacheError,
+    retainers::RetainerError, world_data::world_cache::WorldCacheError,
 };
 
 use crate::{analyzer_service::AnalyzerError, event};
@@ -99,12 +99,15 @@ define_error_enum!(ApiError {
     NoAuthCookie,
     #[error("Discord token was invalid")]
     DiscordTokenInvalid(PrivateCookieJar<Key>),
+    #[error("{0}")]
+    Forbidden(&'static str),
 });
 
 impl ApiError {
     fn as_status_code(&self) -> StatusCode {
         match self {
             ApiError::NoAuthCookie => StatusCode::OK, // In this case I don't want a real error.
+            ApiError::Forbidden(_) => StatusCode::FORBIDDEN,
             ApiError::AnyhowError(e) => match e.downcast_ref::<ListError>() {
                 Some(ListError::Forbidden(_)) => StatusCode::FORBIDDEN,
                 Some(ListError::NotFound | ListError::InviteNotFound) => StatusCode::NOT_FOUND,
@@ -112,7 +115,8 @@ impl ApiError {
                     StatusCode::BAD_REQUEST
                 }
                 None => StatusCode::INTERNAL_SERVER_ERROR,
-            },
+            }
+            .or_else_status(e.downcast_ref::<RetainerError>()),
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -120,6 +124,7 @@ impl ApiError {
     fn as_api_error(&self) -> ultros_api_types::result::ApiError {
         match self {
             ApiError::NoAuthCookie => ultros_api_types::result::ApiError::NotAuthenticated,
+            ApiError::Forbidden(_) => ultros_api_types::result::ApiError::Forbidden,
             ApiError::AnyhowError(e) => match e.downcast_ref::<ListError>() {
                 Some(ListError::Forbidden(_)) => ultros_api_types::result::ApiError::Forbidden,
                 Some(ListError::NotFound | ListError::InviteNotFound) => {
@@ -131,9 +136,15 @@ impl ApiError {
                 Some(ListError::InviteExhausted) => ultros_api_types::result::ApiError::BadRequest(
                     "Invite has reached max uses".into(),
                 ),
-                None => {
-                    ultros_api_types::result::ApiError::Message("Internal server error".to_string())
-                }
+                None => match e.downcast_ref::<RetainerError>() {
+                    Some(RetainerError::Forbidden(_)) => {
+                        ultros_api_types::result::ApiError::Forbidden
+                    }
+                    Some(RetainerError::NotFound) => ultros_api_types::result::ApiError::NotFound,
+                    None => ultros_api_types::result::ApiError::Message(
+                        "Internal server error".to_string(),
+                    ),
+                },
             },
             _ => {
                 if self.as_status_code().is_server_error() {
@@ -142,6 +153,23 @@ impl ApiError {
                     ultros_api_types::result::ApiError::Message(self.to_string())
                 }
             }
+        }
+    }
+}
+
+trait RetainerStatus {
+    fn or_else_status(self, retainer_error: Option<&RetainerError>) -> StatusCode;
+}
+
+impl RetainerStatus for StatusCode {
+    fn or_else_status(self, retainer_error: Option<&RetainerError>) -> StatusCode {
+        if self != StatusCode::INTERNAL_SERVER_ERROR {
+            return self;
+        }
+        match retainer_error {
+            Some(RetainerError::Forbidden(_)) => StatusCode::FORBIDDEN,
+            Some(RetainerError::NotFound) => StatusCode::NOT_FOUND,
+            None => self,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/retainer/{id}/character` to set or clear an owned retainer's `character_id`.
- Validates the owned retainer through `UltrosDb::update_owned_retainer`, which now returns retainer-specific 403/404 API errors.
- Validates non-null character assignments with a DB-backed `UltrosDb::user_owns_character` check against verified/owned character records.
- Adds focused ignored live-DB tests covering set, clear, another user's retainer, and another user's character ownership validation.

Fixes #807.

## Validation
- `cargo check -p ultros-db -p ultros-api-types -p ultros --tests`
- `bash ./check_ci.sh`

## Test Notes
The focused retainer DB tests are checked in as `#[ignore]` because this crate does not currently have disposable DB test-helper scaffolding; they require `DATABASE_URL` pointed at a live disposable database and can be run explicitly with `cargo test -p ultros-db retainers::tests -- --ignored --test-threads=1`.

## PR Lineage
This is a clean replacement for the conflicted/contaminated Jules PR #816 and supersedes it without closing #816.