### PR TITLE
[codex] Refetch analyzer data on realtime listing updates

### DIFF
--- a/ultros-api-types/src/websocket.rs
+++ b/ultros-api-types/src/websocket.rs
@@ -153,6 +153,46 @@ pub fn is_analyzer_event_relevant(
     false
 }
 
+/// Decides whether a websocket market update should refresh the analyzer.
+///
+/// Listing updates are relevant only when they match one of the currently
+/// analyzed item ids and the analyzer's sell/buy world state. `Stale` messages
+/// are scoped to the subscription that produced them, so any non-empty analyzer
+/// subscription should refetch when one arrives.
+pub fn is_analyzer_market_update_relevant(
+    message: &ServerClient,
+    viewed_item_ids: &[i32],
+    sell_world_id: i32,
+    buy_filter: Option<AnySelector>,
+    world_helper: &WorldHelper,
+) -> bool {
+    if viewed_item_ids.is_empty() || sell_world_id == 0 {
+        return false;
+    }
+
+    match message {
+        ServerClient::Listings(event) => {
+            let data = match event {
+                EventType::Added(data) | EventType::Removed(data) | EventType::Updated(data) => {
+                    data
+                }
+            };
+            viewed_item_ids.iter().any(|viewed_item_id| {
+                is_analyzer_event_relevant(
+                    data.item_id,
+                    data.world_id,
+                    *viewed_item_id,
+                    sell_world_id,
+                    buy_filter,
+                    world_helper,
+                )
+            })
+        }
+        ServerClient::Stale { .. } => true,
+        _ => false,
+    }
+}
+
 /// Decides whether a websocket market update should refresh a list view.
 ///
 /// Listing updates carry an item id and are relevant only when that item is
@@ -536,6 +576,98 @@ mod tests {
         // Verify "no item viewed" state handling (should return false)
         assert!(!is_analyzer_event_relevant(42, 100, 0, 100, None, &h));
         assert!(!is_analyzer_event_relevant(42, 100, 42, 0, None, &h));
+    }
+
+    fn analyzer_market_message(item_id: i32, world_id: i32) -> ServerClient {
+        ServerClient::Listings(EventType::Updated(ListingEventData {
+            item_id,
+            world_id,
+            listings: vec![],
+        }))
+    }
+
+    #[test]
+    fn analyzer_market_update_matches_current_item_on_sell_world() {
+        let h = helper();
+        let message = analyzer_market_message(42, 100);
+
+        assert!(is_analyzer_market_update_relevant(
+            &message,
+            &[42],
+            100,
+            None,
+            &h
+        ));
+    }
+
+    #[test]
+    fn analyzer_market_update_ignores_unrelated_item_id() {
+        let h = helper();
+        let message = analyzer_market_message(42, 100);
+
+        assert!(!is_analyzer_market_update_relevant(
+            &message,
+            &[7],
+            100,
+            None,
+            &h
+        ));
+    }
+
+    #[test]
+    fn analyzer_market_update_matches_buy_filter_world_or_datacenter() {
+        let h = helper();
+        let message = analyzer_market_message(42, 101);
+
+        assert!(is_analyzer_market_update_relevant(
+            &message,
+            &[42],
+            100,
+            Some(AnySelector::World(101)),
+            &h
+        ));
+        assert!(is_analyzer_market_update_relevant(
+            &message,
+            &[42],
+            100,
+            Some(AnySelector::Datacenter(10)),
+            &h
+        ));
+    }
+
+    #[test]
+    fn analyzer_market_update_ignores_unmatched_world_without_buy_filter() {
+        let h = helper();
+        let message = analyzer_market_message(42, 101);
+
+        assert!(!is_analyzer_market_update_relevant(
+            &message,
+            &[42],
+            100,
+            None,
+            &h
+        ));
+    }
+
+    #[test]
+    fn analyzer_market_stale_event_matches_non_empty_subscription_only() {
+        let h = helper();
+        let message = ServerClient::Stale { subscription_id: 1 };
+
+        assert!(is_analyzer_market_update_relevant(
+            &message,
+            &[42],
+            100,
+            None,
+            &h
+        ));
+        assert!(!is_analyzer_market_update_relevant(
+            &message,
+            &[],
+            100,
+            None,
+            &h
+        ));
     }
 
     fn list_market_message(item_id: i32) -> ServerClient {

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -92,6 +92,20 @@ pub(crate) async fn get_cheapest_listings(world_name: &str) -> AppResult<Cheapes
     fetch_api(&format!("/api/v1/cheapest/{}", world_name)).await
 }
 
+pub(crate) async fn get_cheapest_listings_live(
+    world_name: &str,
+    refresh_version: u64,
+) -> AppResult<CheapestListings> {
+    if refresh_version == 0 {
+        get_cheapest_listings(world_name).await
+    } else {
+        fetch_api(&format!(
+            "/api/v1/cheapest/{world_name}?rt={refresh_version}"
+        ))
+        .await
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct ResaleStatsDto {
     pub(crate) profit: i32,

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1,9 +1,11 @@
 use crate::analysis::{SaleSummary, get_sales_cadence, roi_badge_class};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
-use crate::ws::realtime::use_realtime;
+use crate::ws::realtime::{RealtimeSubscription, use_realtime};
 use crate::{
-    api::{get_cheapest_listings, get_recent_sales_for_world, get_resale_quality, post_sparklines},
+    api::{
+        get_cheapest_listings_live, get_recent_sales_for_world, get_resale_quality, post_sparklines,
+    },
     components::{
         add_to_list::AddToList,
         clipboard::*,
@@ -127,6 +129,7 @@ use std::{
 use ultros_api_types::{
     cheapest_listings::CheapestListings,
     recent_sales::{RecentSales, SaleData},
+    websocket::{FilterPredicate, SocketMessageType, is_analyzer_market_update_relevant},
     world_helper::{AnyResult, AnySelector, WorldHelper},
 };
 use xiv_gen::ItemId;
@@ -419,9 +422,11 @@ fn AnalyzerTable(
     worlds: Arc<WorldHelper>,
     world: Signal<String>,
     filter_outliers: bool,
+    on_market_update: Callback<()>,
 ) -> impl IntoView {
     let i18n = use_i18n();
     let realtime = use_realtime();
+    let realtime_for_market = realtime.clone();
     let rt_status = realtime.clone();
     let realtime_status = Signal::derive(move || {
         rt_status
@@ -429,7 +434,7 @@ fn AnalyzerTable(
             .map(|r| r.status.get())
             .unwrap_or_else(|| "offline".to_string())
     });
-    let rt_update = realtime;
+    let rt_update = realtime.clone();
     let last_update = Signal::derive(move || rt_update.as_ref().and_then(|r| r.last_update.get()));
     let profits = ProfitTable::new(
         sales,
@@ -467,6 +472,14 @@ fn AnalyzerTable(
             .map(|w| w.id)
             .collect::<Vec<_>>();
         Some(filter)
+    });
+
+    let world_clone = worlds.clone();
+    let buy_filter = Memo::new(move |_| {
+        let world = world_filter().or_else(datacenter_filter)?;
+        world_clone
+            .lookup_world_by_name(&world)
+            .map(|world| AnySelector::from(&world))
     });
 
     let world_clone = worlds.clone();
@@ -645,6 +658,63 @@ fn AnalyzerTable(
     // Generation counter for debounce-with-cancellation (RwSignal, mirroring
     // components/search_box.rs). `gen` is a reserved keyword in edition 2024.
     let fetch_id = RwSignal::new(0u64);
+    let analyzer_market_subscription = StoredValue::new(None::<RealtimeSubscription>);
+    let worlds_for_market = worlds.clone();
+
+    Effect::new(move |_| {
+        analyzer_market_subscription.update_value(|sub| *sub = None);
+
+        let Some(realtime) = realtime_for_market.clone() else {
+            return;
+        };
+        let Some(sell_world_id) = lookup_world().and_then(|world| world.as_world_id()) else {
+            return;
+        };
+        let buy_filter = buy_filter();
+        let range = visible_range.get();
+        let mut item_ids = sorted_data.with(|data| {
+            let (start, end) = range;
+            let lo = start.saturating_sub(PREFETCH_MARGIN);
+            let hi = (end + PREFETCH_MARGIN).min(data.len());
+            data.get(lo..hi)
+                .unwrap_or(&[])
+                .iter()
+                .map(|(_, data)| data.inner.sale_summary.item_id)
+                .collect::<Vec<_>>()
+        });
+        item_ids.sort_unstable();
+        item_ids.dedup();
+        if item_ids.is_empty() {
+            return;
+        }
+
+        let sell_selector = AnySelector::World(sell_world_id);
+        let mut world_filter = FilterPredicate::World(sell_selector);
+        if let Some(filter) = buy_filter
+            && filter != sell_selector
+        {
+            world_filter = world_filter.or(FilterPredicate::World(filter));
+        }
+        let filter = world_filter.and(FilterPredicate::Items(item_ids.clone()));
+        let worlds = worlds_for_market.clone();
+        let subscribed_item_ids = item_ids.clone();
+        let sub = realtime.subscribe_market(filter, SocketMessageType::Listings, move |message| {
+            if is_analyzer_market_update_relevant(
+                &message,
+                &subscribed_item_ids,
+                sell_world_id,
+                buy_filter,
+                &worlds,
+            ) {
+                on_market_update.run(());
+            }
+        });
+        analyzer_market_subscription.set_value(Some(sub));
+    });
+
+    on_cleanup(move || {
+        analyzer_market_subscription.update_value(|sub| *sub = None);
+    });
 
     // Reset accumulated enrichment when the world changes. Defense-in-depth: if
     // the component is updated in place rather than remounted, another world's
@@ -1542,6 +1612,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     let i18n = use_i18n();
     let params = use_params_map();
     let world = Signal::derive(move || params.with(|p| p.get("world").clone()).unwrap_or_default());
+    let (market_refresh_version, set_market_refresh_version) = signal(0_u64);
     let sales = ArcResource::new(
         move || params.with(|p| p.get("world").clone()),
         move |world| async move {
@@ -1550,10 +1621,15 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     );
 
     let world_cheapest_listings = ArcResource::new(
-        move || params.with(|p| p.get("world").clone()),
-        move |world| async move {
+        move || {
+            (
+                params.with(|p| p.get("world").clone()),
+                market_refresh_version.get(),
+            )
+        },
+        move |(world, refresh_version)| async move {
             let world = world.ok_or(AppError::ParamMissing)?;
-            get_cheapest_listings(&world).await
+            get_cheapest_listings_live(&world, refresh_version).await
         },
     );
 
@@ -1574,9 +1650,12 @@ pub fn AnalyzerWorldView() -> impl IntoView {
         Result::<_, AppError>::Ok(region)
     });
 
-    let global_cheapest_listings = ArcResource::new(region, move |region| async move {
-        get_cheapest_listings(region?.as_str()).await
-    });
+    let global_cheapest_listings = ArcResource::new(
+        move || (region(), market_refresh_version.get()),
+        move |(region, refresh_version)| async move {
+            get_cheapest_listings_live(region?.as_str(), refresh_version).await
+        },
+    );
 
     let (cross_region_enabled, set_cross_region_enabled) = query_signal::<bool>("cross");
     let (filter_outliers, set_filter_outliers) = query_signal::<bool>("filter-outliers");
@@ -1592,8 +1671,15 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     };
 
     let cross_region = ArcResource::new(
-        move || (cross_region_enabled(), region(), enabled_regions()),
-        move |(enabled, region, enabled_regions)| async move {
+        move || {
+            (
+                cross_region_enabled(),
+                region(),
+                enabled_regions(),
+                market_refresh_version.get(),
+            )
+        },
+        move |(enabled, region, enabled_regions, refresh_version)| async move {
             let region = region?;
             if enabled.unwrap_or_default() && connected_regions.contains(&region.as_str()) {
                 Ok(futures::future::join_all(
@@ -1601,7 +1687,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                         .iter()
                         .filter(|r| **r != region.as_str())
                         .filter(|r| enabled_regions.contains(r))
-                        .map(|region| get_cheapest_listings(region)),
+                        .map(|region| get_cheapest_listings_live(region, refresh_version)),
                 )
                 .await
                 .into_iter()
@@ -1612,6 +1698,12 @@ pub fn AnalyzerWorldView() -> impl IntoView {
             }
         },
     );
+
+    let refetch_market_data = Callback::new(move |_| {
+        set_market_refresh_version.update(|version| {
+            *version = version.wrapping_add(1);
+        });
+    });
 
     view! {
         <div class="main-content p-2 sm:p-6">
@@ -1767,6 +1859,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                                                     worlds
                                                     world=world
                                                     filter_outliers=filter_outliers().unwrap_or(false)
+                                                    on_market_update=refetch_market_data
                                                 />
                                             },
                                         )


### PR DESCRIPTION
## Summary
- Subscribe the Flip Finder analyzer table to the existing realtime listing stream for the active visible analyzer rows.
- Refetch analyzer cheapest-listing resources when matching listing or stale events affect the current analyzed item set, while ignoring unrelated item IDs.
- Add a message-level analyzer matcher with focused tests for listing, buy-filter, unrelated-item, and stale-event behavior.

## Notes
- Fixes #838.
- Supersedes the failed Jules attempt for this issue; this branch is based on current `main` and does not reuse a stale Jules branch.
- Realtime-triggered cheapest-listing refreshes include a refresh query parameter after the first load so browser cache does not hide websocket updates.

## Validation
- `cargo test -p ultros-api-types --lib websocket::tests`
- `PATH="/c/Strawberry/perl/bin:$PATH" ./check_ci.sh`

Environment note: the first CI attempt exposed local setup gaps (MSYS Perl missing `Locale::Maketext::Simple`, then uninitialized submodules). I reran with Strawberry Perl first on `PATH` and after `git submodule update --init --recursive`; the final `check_ci.sh` run passed.
