### PR TITLE
Add item view savings banner

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "极高频率",
     "not_enough_data": "数据不足",
     "active_listings": "当前在售",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "Sehr hohe Frequenz",
     "not_enough_data": "Nicht genug Daten",
     "active_listings": "Aktive Angebote",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "Very high frequency",
     "not_enough_data": "Not enough data",
     "active_listings": "Active Listings",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "Très haute fréquence",
     "not_enough_data": "Pas assez de données",
     "active_listings": "Annonces actives",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "非常に高頻度",
     "not_enough_data": "データ不足",
     "active_listings": "現在の出品",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "매우 자주 판매",
     "not_enough_data": "데이터 부족",
     "active_listings": "현재 판매 중",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -73,6 +73,8 @@
     "very_high_frequency": "極高頻率",
     "not_enough_data": "資料不足",
     "active_listings": "目前在售",
+    "item_view_savings_cheapest_on": "Cheapest on",
+    "item_view_savings_save": "save",
     "item_view_exclude_datacenters": "Exclude Datacenters",
     "item_view_exclude_datacenter_aria": "Exclude {{datacenter}}",
     "item_view_include_datacenter_aria": "Include {{datacenter}}",

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -34,6 +34,40 @@ use xiv_gen::{ItemId, ItemSearchCategoryId, ItemUiCategoryId};
 
 type ListingRows = Vec<(ActiveListing, Arc<Retainer>)>;
 
+const MEANINGFUL_CROSS_WORLD_SAVINGS_GIL: i32 = 1_000;
+
+#[derive(Clone, Debug, PartialEq)]
+struct SavingsVerdict {
+    cheapest_listing: ActiveListing,
+    current_world_listing: ActiveListing,
+    savings: i32,
+    savings_percent: f64,
+}
+
+impl SavingsVerdict {
+    fn new(cheapest_listing: ActiveListing, current_world_listing: ActiveListing) -> Option<Self> {
+        if cheapest_listing.hq != current_world_listing.hq
+            || cheapest_listing.world_id == current_world_listing.world_id
+            || cheapest_listing.price_per_unit <= 0
+            || current_world_listing.price_per_unit <= 0
+        {
+            return None;
+        }
+
+        let savings = current_world_listing.price_per_unit - cheapest_listing.price_per_unit;
+        if savings < MEANINGFUL_CROSS_WORLD_SAVINGS_GIL {
+            return None;
+        }
+
+        Some(Self {
+            cheapest_listing,
+            current_world_listing: current_world_listing.clone(),
+            savings,
+            savings_percent: (savings as f64 / current_world_listing.price_per_unit as f64) * 100.0,
+        })
+    }
+}
+
 #[component]
 fn WorldButton(
     current_world: Memo<String>,
@@ -424,6 +458,48 @@ fn cheapest_listing_for_quality(
         .cloned()
 }
 
+fn savings_verdict_for_quality(
+    listings: &ListingRows,
+    current_world_id: i32,
+    hq: bool,
+) -> Option<SavingsVerdict> {
+    let (cheapest_listing, _) = cheapest_listing_for_quality(listings, hq)?;
+    let current_world_listing = listings
+        .iter()
+        .filter(|(listing, _)| listing.hq == hq && listing.world_id == current_world_id)
+        .min_by_key(|(listing, _)| listing.price_per_unit)
+        .map(|(listing, _)| listing.clone())?;
+
+    SavingsVerdict::new(cheapest_listing, current_world_listing)
+}
+
+fn cheapest_savings_verdict(
+    listings: &ListingRows,
+    current_world_id: i32,
+) -> Option<SavingsVerdict> {
+    [false, true]
+        .into_iter()
+        .filter_map(|hq| savings_verdict_for_quality(listings, current_world_id, hq))
+        .max_by(|left, right| {
+            left.savings
+                .cmp(&right.savings)
+                .then_with(|| {
+                    left.current_world_listing
+                        .price_per_unit
+                        .cmp(&right.current_world_listing.price_per_unit)
+                })
+                .then_with(|| left.cheapest_listing.hq.cmp(&right.cheapest_listing.hq))
+        })
+}
+
+fn format_savings_percent(percent: f64) -> String {
+    if percent >= 10.0 {
+        format!("{percent:.0}")
+    } else {
+        format!("{percent:.1}")
+    }
+}
+
 fn parse_excluded_world_ids(raw: Option<&str>) -> HashSet<i32> {
     raw.unwrap_or_default()
         .split(',')
@@ -436,11 +512,13 @@ fn MarketStatsPanel(
     listing_resource: Resource<Result<Arc<CurrentlyShownItem>, AppError>>,
     #[prop(into)] filtered_listings: Signal<ListingRows>,
     item_id: Memo<i32>,
+    world: Memo<String>,
     realtime_status: Signal<String>,
     last_update_at: Signal<Option<chrono::DateTime<chrono::Utc>>>,
 ) -> impl IntoView {
     let i18n = crate::i18n::use_i18n();
     let cheapest_prices = use_context::<CheapestPrices>();
+    let world_data = use_context::<LocalWorldData>().unwrap().0.unwrap();
 
     // Defer the `cheapest_prices.read_listings`-driven recipe-cost chip until
     // after hydration. The chip lives inside an inner `<Suspense>` in
@@ -483,6 +561,14 @@ fn MarketStatsPanel(
                             let cheapest_nq = cheapest_listing_for_quality(&listings, false);
                             let cheapest_hq = cheapest_listing_for_quality(&listings, true);
                             let listings_count = listings.len();
+                            let current_world_id = {
+                                let world_name = Url::unescape(&world());
+                                world_data
+                                    .lookup_world_by_name(&world_name)
+                                    .and_then(|result| result.as_world().map(|world| world.id))
+                            };
+                            let savings_verdict = current_world_id
+                                .and_then(|world_id| cheapest_savings_verdict(&listings, world_id));
                             let recent_sales = data.sales.clone();
                             let avg_price = if recent_sales.is_empty() {
                                 None
@@ -879,6 +965,44 @@ fn MarketStatsPanel(
                                     </div>
 
                                     <div class="mt-3 sm:mt-4 space-y-2">
+                                        {savings_verdict
+                                            .map(|verdict| {
+                                                let quality_label = if verdict.cheapest_listing.hq {
+                                                    t_string!(i18n, hq).to_string()
+                                                } else {
+                                                    t_string!(i18n, nq).to_string()
+                                                };
+                                                let percent = format_savings_percent(verdict.savings_percent);
+                                                view! {
+                                                    <a
+                                                        href="#listings"
+                                                        class="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-emerald-400/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100 transition-colors hover:border-emerald-300/70"
+                                                    >
+                                                        <Icon icon=icondata::FaGlobeSolid attr:class="text-sm shrink-0" />
+                                                        <span class="font-semibold">{t!(i18n, item_view_savings_cheapest_on)}</span>
+                                                        <span class="inline-flex items-center gap-1">
+                                                            <WorldName id=AnySelector::World(verdict.cheapest_listing.world_id) />
+                                                            <span class="rounded border border-emerald-300/40 px-1 text-[10px] font-bold leading-4 text-emerald-100">
+                                                                {quality_label}
+                                                            </span>
+                                                        </span>
+                                                        <span class="text-[color:var(--color-text-muted)]">":"</span>
+                                                        <div class="font-bold text-[color:var(--color-text)]">
+                                                            <Gil amount=verdict.cheapest_listing.price_per_unit />
+                                                        </div>
+                                                        <span class="text-[color:var(--color-text-muted)]">"-"</span>
+                                                        <span>{t!(i18n, item_view_savings_save)}</span>
+                                                        <div class="font-bold text-[color:var(--color-text)]">
+                                                            <Gil amount=verdict.savings />
+                                                        </div>
+                                                        <span class="text-[color:var(--color-text-muted)]">
+                                                            "("{percent}"%)"
+                                                        </span>
+                                                    </a>
+                                                }
+                                                .into_any()
+                                            })
+                                            .unwrap_or_else(|| ().into_any())}
                                         {source_callout}
                                         {if listings_count == 0 {
                                             view! {
@@ -1372,6 +1496,7 @@ fn ListingsContent(
                     listing_resource
                     filtered_listings
                     item_id
+                    world
                     realtime_status=realtime_status.into()
                     last_update_at=last_update_at.into()
                 />
@@ -1670,6 +1795,76 @@ mod tests {
 
         assert_eq!(result.0.id, 2);
         assert_eq!(result.0.world_id, 200);
+    }
+
+    #[test]
+    fn item_view_savings_verdict_no_listings() {
+        let listings = Vec::new();
+
+        let result = cheapest_savings_verdict(&listings, 100);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn item_view_savings_verdict_same_world_cheapest() {
+        let listings = vec![listing(1, 100, 5_000, false), listing(2, 200, 6_000, false)];
+
+        let result = cheapest_savings_verdict(&listings, 100);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn item_view_savings_verdict_cross_world_savings() {
+        let listings = vec![listing(1, 100, 5_000, false), listing(2, 200, 3_000, false)];
+
+        let result = cheapest_savings_verdict(&listings, 100).unwrap();
+
+        assert_eq!(result.cheapest_listing.id, 2);
+        assert_eq!(result.cheapest_listing.world_id, 200);
+        assert!(!result.cheapest_listing.hq);
+        assert_eq!(result.current_world_listing.id, 1);
+        assert_eq!(result.savings, 2_000);
+        assert_eq!(result.savings_percent, 40.0);
+    }
+
+    #[test]
+    fn item_view_savings_verdict_ignores_trivial_savings() {
+        let listings = vec![
+            listing(1, 100, 10_000, false),
+            listing(2, 200, 9_001, false),
+        ];
+
+        let result = cheapest_savings_verdict(&listings, 100);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn item_view_savings_verdict_matches_quality() {
+        let listings = vec![
+            listing(1, 100, 10_000, false),
+            listing(2, 200, 9_000, false),
+            listing(3, 100, 50_000, true),
+            listing(4, 200, 20_000, true),
+        ];
+
+        let result = cheapest_savings_verdict(&listings, 100).unwrap();
+
+        assert!(result.cheapest_listing.hq);
+        assert_eq!(result.cheapest_listing.id, 4);
+        assert_eq!(result.current_world_listing.id, 3);
+        assert_eq!(result.savings, 30_000);
+    }
+
+    #[test]
+    fn item_view_savings_verdict_requires_current_world_matching_quality() {
+        let listings = vec![listing(1, 100, 10_000, false), listing(2, 200, 2_000, true)];
+
+        let result = savings_verdict_for_quality(&listings, 100, true);
+
+        assert!(result.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a pure item-view savings verdict helper that compares the selected world's cheapest matching-quality listing against the cheapest listing in the current filtered scope.
- Render a compact "Cheapest on" savings banner only when the selected world is not already cheapest and savings clear the 1,000 gil threshold.
- Add helper coverage for no listings, same-world cheapest, cross-world savings, trivial savings, and HQ/NQ matching.

Closes #777.

## Verification
- `cargo test -p ultros-app item_view_savings_verdict -- --nocapture`
- `bash -lc 'PATH="/c/Strawberry/perl/bin:$PATH"; ./check_ci.sh'`

Note: the Strawberry Perl PATH prefix is needed in this Windows environment so vendored OpenSSL uses the Perl installation that has `Locale::Maketext::Simple`.
