### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in Settings and Groups

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-06-17 - Toast Accessibility
 **Learning:** Found that toast close buttons were missing keyboard focus indicators making them hard to use with keyboard navigation.
 **Action:** Always add focus-visible ring styles (e.g., `focus-visible:ring-[var(--brand-ring)]`) to interactive elements like close buttons.
+## 2024-05-18 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** Found multiple instances where icon-only buttons (like search or remove member buttons) were missing `aria-label` attributes across different components (`settings.rs`, `groups.rs`). This is a common accessibility issue that prevents screen readers from announcing the button's purpose.
+**Action:** When creating or reviewing components with icon-only buttons, always ensure an `aria-label` is provided using `t_string!(i18n, ...)` to maintain accessibility and internationalization.

--- a/ultros-frontend/ultros-app/src/routes/groups.rs
+++ b/ultros-frontend/ultros-app/src/routes/groups.rs
@@ -250,6 +250,7 @@ fn GroupCard(
                                                             }>
                                                                 <button
                                                                     class="opacity-0 group-hover:opacity-100 btn-ghost btn-xs text-red-400 hover:text-red-300"
+                                                                    aria-label=move || t_string!(i18n, groups_remove_member).to_string()
                                                                     on:click=move |_| {
                                                                         remove_member_action
                                                                             .dispatch((group.id, member_id as u64));

--- a/ultros-frontend/ultros-app/src/routes/settings.rs
+++ b/ultros-frontend/ultros-app/src/routes/settings.rs
@@ -98,6 +98,7 @@ fn AddCharacterMenu(claim_character: Action<i32, AppResult<(i32, String)>>) -> i
                                     class="px-4 py-2 rounded-lg bg-brand-900/30 hover:bg-brand-800/40
                                     border border-white/10 hover:border-brand-300/30
                                     transition-all duration-300 text-gray-200 hover:text-brand-300"
+                                    aria-label=move || t_string!(i18n, search_character).to_string()
                                     on:click=move |_| {
                                         let _ = search_action.dispatch(character_search());
                                     }


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to icon-only buttons in the application.
🎯 **Why**: Icon-only buttons without accessible labels cannot be interpreted by screen readers. This ensures these buttons can be correctly announced to users navigating the site via assistive technology.
♿ **Accessibility**: Added ARIA labels mapped to the existing localization keys (`search_character` and `groups_remove_member`) for screen reader support.

---
*PR created automatically by Jules for task [12457502533125326286](https://jules.google.com/task/12457502533125326286) started by @akarras*