### PR TITLE
⚡ Bolt: Remove unnecessary reactive closures for roi_badge_class

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -520,7 +520,6 @@ fn FCCraftingAnalyzerTable(
                     each=computed_data.into()
                     key=move |(index, data): &(usize, Arc<FCCraftProfitData>)| (*index, data.sequence.key_id)
                     view=move |(index, data): (usize, Arc<FCCraftProfitData>)| {
-                        let data_clone = data.clone();
                         let item_id = ItemId(data.sequence.result_item);
                         let item = items.get(&item_id).map(|i| i.name.as_str().to_string()).unwrap_or_else(|| t_string!(i18n, unknown).to_string());
                         let classes = if (index % 2) == 0 {
@@ -584,10 +583,7 @@ fn FCCraftingAnalyzerTable(
                                     <Gil amount=data.profit />
                                 </div>
                                 <div role="cell" class="px-4 py-2 w-30 shrink-0 text-right">
-                                    <span class={
-                                        let data = data_clone.clone();
-                                        move || roi_badge_class(data.return_on_investment)
-                                    }>
+                                    <span class={roi_badge_class(data.return_on_investment)}>
                                         {format!("{}%", data.return_on_investment)}
                                     </span>
                                 </div>

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -585,8 +585,6 @@ fn RecipeAnalyzerTable(
                     each=computed_data.into()
                     key=move |(index, data): &(usize, Arc<RecipeProfitData>)| (*index, data.recipe.key_id)
                     view=move |(index, data): (usize, Arc<RecipeProfitData>)| {
-                        // Clone data for use in closures to avoid moving the Arc
-                        let data_clone = data.clone();
                         let item_id = ItemId(data.recipe.item_result);
                         let item = items.get(&item_id).map(|i| i.name.as_str()).unwrap_or("Unknown");
                         let item_level = items.get(&item_id).map(|i| i.level_item).unwrap_or(0);
@@ -636,10 +634,7 @@ fn RecipeAnalyzerTable(
                                     <Gil amount=data.profit />
                                 </div>
                                 <div role="cell" class="px-4 py-2 w-32 shrink-0 text-right">
-                                     <span class={
-                                        let data = data_clone.clone();
-                                        move || roi_badge_class(data.return_on_investment)
-                                    }>
+                                     <span class={roi_badge_class(data.return_on_investment)}>
                                         {format!("{}%", data.return_on_investment)}
                                     </span>
                                 </div>

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -621,7 +621,6 @@ fn VendorResaleTable(
                             } else {
                                 "flex flex-row items-center flex-nowrap h-10 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] hover:ring-1 hover:ring-[color:color-mix(in_srgb,var(--brand-ring)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--color-text)_8%,transparent)] transition-colors"
                             };
-                            let data_clone = data.clone();
                             view! {
                                 <div class=classes role="row-group">
                                     <div role="cell" class="px-2 py-2 w-[40px] flex items-center justify-center">
@@ -644,9 +643,7 @@ fn VendorResaleTable(
                                         <Gil amount=data.profit />
                                     </div>
                                     <div role="cell" class="px-4 py-2 w-30 text-right flex items-center justify-end">
-                                        <span class={
-                                            move || roi_badge_class(data_clone.return_on_investment)
-                                        }>
+                                        <span class={roi_badge_class(data.return_on_investment)}>
                                             {format!("{}%", data.return_on_investment)}
                                         </span>
                                     </div>


### PR DESCRIPTION
💡 **What**: Removed reactive closures (`move || roi_badge_class(...)`) in virtual scrollers and replaced them with static calls to `roi_badge_class(...)` in `recipe_analyzer.rs`, `vendor_resale.rs`, and `fc_crafting_analyzer.rs`.
🎯 **Why**: Leptos creates a reactive Effect for `move ||` closures, even when dependencies are completely static. In a virtual scroller rendering many rows, computing the static class styling per row creates unnecessary overhead and allocations.
📊 **Impact**: Reduces unnecessary effect allocations for each virtual scroller row, which directly translates to lower memory overhead and faster rendering for the frontend analyzer tables.
🔬 **Measurement**: Inspect the DOM or trace memory allocations when rapidly scrolling down the analyzer views, which should now show fewer allocations per render.

---
*PR created automatically by Jules for task [4503615126314569491](https://jules.google.com/task/4503615126314569491) started by @akarras*