### PR TITLE
fix(error-reporting): dedup the redundant onerror `RuntimeError: unreachable` of every Rust panic

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -433,6 +433,114 @@ const cases = [
     expectDrop: false,
   },
 
+  // ── Category 6: redundant onerror wasm `unreachable` trap (dedup) ──
+  // The onerror "RuntimeError: unreachable" the browser captures after Rust's
+  // abort() runs the wasm `unreachable` instruction. When its stack carries one
+  // of our pkg-bundle frames it is provably OUR wasm trap — the guaranteed
+  // duplicate of the actionable RustWasmPanic the panic hook already reported —
+  // so it is dropped UNCONDITIONALLY (no font / translate / stale-Chrome
+  // fingerprint), which the gated category-3 prong above could not do. This is
+  // the #6781–#6828 per-deploy fragmenting fleet. The frameless variant above
+  // is left preserved: only an attributable-to-our-bundle trap is a known dup.
+  {
+    name: "onerror RuntimeError unreachable WITH our pkg frames is dropped on a current clean browser (real #6827)",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "unreachable",
+            mechanism: {
+              type: "auto.browser.global_handlers.onerror",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                { filename: "/pkg/2b494b1/ultros.js", function: "c" },
+                {
+                  filename:
+                    "/pkg/2b494b1/ultros.wasm:wasm-function[5501]:0x5e8bff",
+                  function: "?",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "Firefox phrasing 'unreachable executed' from our wasm frame is dropped",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "unreachable executed",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "/pkg/2b494b1/ultros.wasm:wasm-function[5501]:0x5e8bff",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  {
+    name: "RuntimeError unreachable from a THIRD-PARTY wasm module (no pkg frame) is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "unreachable",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://cdn.example.com/widget.wasm:wasm-function[12]:0x100",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "a genuine non-unreachable RuntimeError from our bundle is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "memory access out of bounds",
+            stacktrace: {
+              frames: [{ filename: "/pkg/2b494b1/ultros.js" }],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+
   // ── Category 1: WASM/bundle fetch aborts ──
   {
     name: 'TypeError "Failed to fetch dynamically imported module" of the pkg bundle is dropped',

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -67,8 +67,30 @@
 //      truncated the streamed bootstrap before the wasm hydrated — the same
 //      translation-proxy population behind category 3. GlitchTip issues
 //      #6620, #6667, #6760, #6761.
+//   6. The redundant "RuntimeError: unreachable" that every Rust panic
+//      emits a SECOND time. The panic hook first reports an actionable
+//      RustWasmPanic (kept — it carries contexts.rust_panic.location and a
+//      stable per-location fingerprint, so it collapses to one issue per
+//      panic site). Then Rust's abort() runs the wasm `unreachable`
+//      instruction, whose trap the browser's global onerror re-captures as
+//      a "RuntimeError: unreachable" with NO rust_panic context. That copy
+//      never gets the stable fingerprint, and its
+//      /pkg/<hash>/ultros.wasm:wasm-function[N] frame filename fragments it
+//      into a NEW issue every deploy — the per-build #67xx/#68xx rotation
+//      (#6781–#6828) that prior triage had to ignore by hand each release.
+//      When the trap's stack carries one of our own pkg-bundle frames it is
+//      provably our wasm, hence a guaranteed duplicate of the kept
+//      RustWasmPanic, so it is dropped unconditionally — no injecting-
+//      population fingerprint needed: a real hydration bug on a current
+//      browser still reaches GlitchTip via the untouched RustWasmPanic. A
+//      frameless or third-party-framed RuntimeError is left untouched.
 (function () {
   var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
+  // Like ULTROS_PKG_BUNDLE_RE but tolerant of the trailing
+  // `:wasm-function[N]:0xADDR` the browser appends to a wasm trap's stack
+  // frame, so `/pkg/<hash>/ultros.wasm:wasm-function[5501]` still counts as
+  // originating in our bundle.
+  var ULTROS_PKG_FRAME_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)\b/;
   var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
   // Leptos's streaming-hydration bootstrap globals. The SSR shell ALWAYS emits
   // `window.__RESOLVED_RESOURCES = []` plus `__INCOMPLETE_CHUNKS` /
@@ -424,6 +446,39 @@
     return false;
   }
 
+  // Category 6: the redundant onerror copy of a Rust panic. See the header.
+  // An onerror "RuntimeError: unreachable" whose stack carries one of OUR
+  // pkg-bundle frames is the abort()-propagation of a panic the hook already
+  // reported as an actionable RustWasmPanic — a guaranteed duplicate that
+  // fragments per deploy. Drop it. Unlike the category-3 onerror prong (which
+  // is fingerprint-gated to preserve a possible real bug), this is safe to drop
+  // UNCONDITIONALLY because the actionable copy is retained: the panic hook is
+  // browser-agnostic, so even a clean current browser still emits the kept
+  // RustWasmPanic. Scoped to our bundle (a frameless or third-party-framed
+  // RuntimeError is preserved) and to the `unreachable` value (other wasm traps
+  // from our bundle, e.g. "memory access out of bounds", still report). The
+  // value is matched loosely so SpiderMonkey's "unreachable executed" and JSC's
+  // "Unreachable code should not be executed" are covered too.
+  function isRedundantWasmUnreachableTrap(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex) return false;
+      if (ex.type !== "RuntimeError" || typeof ex.value !== "string")
+        return false;
+      if (!/unreachable/i.test(ex.value)) return false;
+      var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+      for (var i = 0; i < frames.length; i++) {
+        var fname = frames[i] && frames[i].filename;
+        if (typeof fname === "string" && ULTROS_PKG_FRAME_RE.test(fname)) {
+          return true;
+        }
+      }
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
   function isEmptyPromiseRejection(event) {
     try {
       var ex = firstException(event);
@@ -452,6 +507,7 @@
       isStrippedHydrationBootstrap(event) ||
       isInjectedDocumentTypeError(event) ||
       isInjectedTachysHydrationPanic(event) ||
+      isRedundantWasmUnreachableTrap(event) ||
       isEmptyPromiseRejection(event)
     );
   };

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -607,5 +607,13 @@ mod error_filter_wiring {
         assert!(FILTER_JS.contains("getElementsByTagName"));
         // Category 4: empty promise rejections.
         assert!(FILTER_JS.contains("Non-Error promise rejection captured with value: undefined"));
+        // Category 5: leptos hydration-bootstrap ReferenceErrors stripped by a
+        // proxy/crawler. Removing it re-opens the #6620/#6667/#6760/#6761 flood.
+        assert!(FILTER_JS.contains("isStrippedHydrationBootstrap"));
+        // Category 6: the redundant onerror wasm `unreachable` trap dedup —
+        // drops the per-deploy duplicate of every Rust panic (the #6781–#6828
+        // rotation) via a pkg-bundle stack frame. Removing it re-opens it.
+        assert!(FILTER_JS.contains("isRedundantWasmUnreachableTrap"));
+        assert!(FILTER_JS.contains("ULTROS_PKG_FRAME_RE"));
     }
 }


### PR DESCRIPTION
## Problem

Every Rust/wasm panic produces **two** Sentry events:

1. **`RustWasmPanic`** via `window.__ultrosReportRustPanic` — the actionable copy. Carries `contexts.rust_panic.location` and a stable per-location fingerprint (PR #787), so it collapses to one issue per panic site (#6757, #6758, #6800, #6801). **Kept.**
2. **`RuntimeError: unreachable`** — after the panic hook reports, Rust's `abort()` executes the wasm `unreachable` instruction; that trap reaches the browser's global `onerror` (`auto.browser.global_handlers.onerror`) with **no `rust_panic` context**. It never gets the #787 fingerprint, and its `filename` embeds `/pkg/<hash>/ultros.wasm:wasm-function[N]`, so GlitchTip groups it into a **new issue every deploy** — the **#6781–#6828 fleet (~46 issues, tens of thousands of events)** that triage has had to ignore by hand each release.

The current filter already recognizes this onerror shape (category-3 prong (c)), but only suppresses it **behind an injecting-population fingerprint** (`<font>` / `translated-*` / stale-Chrome ≤124 / stability breadcrumb), to preserve a possibly-real bug. The live flood is the Chrome-133 Tencent-Cloud scraper fleet (`Asia/Shanghai`, `43.172/173.x`), which matches **none** of those fingerprints — so it leaks.

## Fix

Add **category 6** to the `beforeSend` filter (`error_filter.js`): when an `unreachable` `RuntimeError`'s stack carries one of **our own** `/pkg/<hash>/ultros.{js,wasm}` frames, it is provably our wasm trap — a **guaranteed duplicate** of the `RustWasmPanic` the hook already reported. Drop it **unconditionally** (no fingerprint gate), which the gated category-3 prong cannot do.

Why unconditional is safe — it does **not** override the "preserve real clean-browser bugs" design, it refines it:
- The panic hook is **browser-agnostic**, so even a clean current browser still emits the actionable `RustWasmPanic`. The onerror copy adds nothing it doesn't already have (anonymized wasm frames, no Rust location).
- **Scoped to our bundle** (`ULTROS_PKG_FRAME_RE`, tolerant of the `:wasm-function[N]` suffix): a frameless or third-party-framed `RuntimeError: unreachable` is preserved (the existing frameless test still passes).
- **`unreachable` value only** (matched loosely for V8 / SpiderMonkey / JSC phrasings): other wasm traps from our bundle (e.g. `memory access out of bounds`) still report.

This is the de-dup counterpart to PR #787: #787 stabilized the *good* copy's fingerprint; this removes the leftover per-deploy *onerror* noise the fingerprint never reached.

## Context (not changed here)

The underlying panics are the documented **Tencent-Cloud scraper fleet** injecting a DOM-mutating overlay before Leptos hydrates, tripping `tachys hydration.rs` `unreachable!()`. The durable fix for *that* is server-side scraper blocking (infra-level, out of scope). This PR only removes the redundant client-side noise; #6757/#6758 (`RustWasmPanic`) remain as scraper canaries.

## Verification

- `npm --prefix integration run test:error-filter` → **46/46**. 4 new cases; the 2 drop cases were confirmed **RED against the unmodified filter first** (the existing fingerprint-gated path does not drop them), then GREEN with the fix.
- Replayed **verbatim real event payloads**: #6827 (onerror `RuntimeError: unreachable`, Chrome 133) → **dropped**; #6800 (`RustWasmPanic`) → **preserved**.
- `cargo fmt --all -- --check` clean. Added category-5/6 guards to the `error_filter_wiring` Rust contract test. (clippy/`cargo test` not run locally — workspace needs the datamining submodule; the load-bearing logic is JS, gated by the Node suite.)

## Backlog triage (done alongside)

Ignored the **46** stale `RuntimeError: unreachable` issues (#6781–#6828) this filter now suppresses going forward. Left #6757/#6758/#6800/#6801 (`RustWasmPanic`) unresolved as scraper canaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)