### PR TITLE
fix(error-reporting): dedup the redundant `RefCell already borrowed` executor cascade (#6758)

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -203,10 +203,18 @@ const cases = [
     },
     expectDrop: true,
   },
-  // Same cascade shape but on a CLEAN (untranslated) page — a genuine
-  // hydration mismatch. No injected <font>, so it must still report.
+  // Same cascade shape on a CLEAN (untranslated) page. This is NOT an
+  // independent bug: the `RefCell already borrowed` in the js-sys executor is
+  // the secondary cascade of the PRIMARY hydration panic (shown here by
+  // TACHYS_PANIC_BREADCRUMB), which is reported as its own event carrying the
+  // actionable tachys rust_panic.location and is preserved on clean browsers
+  // (see the "hydration panic on a CURRENT browser ... is preserved" case
+  // above). The executor twin points only at singlethread.rs — identical for
+  // every panic — so it adds nothing the retained primary doesn't already show.
+  // Dropped unconditionally as a redundant twin (Category 7), exactly like the
+  // RuntimeError onerror twin in Category 6 (PR #921).
   {
-    name: "RefCell-already-borrowed cascade from a genuine (untranslated) hydration mismatch is preserved",
+    name: "RefCell-already-borrowed executor cascade on a clean page is dropped (redundant twin of the retained primary)",
     ua: CURRENT_CHROME,
     document: fakeDocument(0),
     event: {
@@ -216,7 +224,7 @@ const cases = [
       },
       breadcrumbs: { values: [{ category: "console", message: "app run!" }, TACHYS_PANIC_BREADCRUMB] },
     },
-    expectDrop: false,
+    expectDrop: true,
   },
   // The unhandled wasm trap that reaches window.onerror: type RuntimeError,
   // no rust_panic context at all — recognized via the tachys breadcrumb.
@@ -406,11 +414,18 @@ const cases = [
     },
     expectDrop: true,
   },
-  // Guard: the breadcrumb-independent recognition must NOT over-suppress a
-  // genuine cascade on a clean, current browser (no font, no translate class,
-  // no stale UA) — those are the real hydration bugs the filter must preserve.
+  // The RefCell executor cascade on a clean, current browser (no font, no
+  // translate class, no stale UA, no tachys breadcrumb) — the real #6758 shape
+  // (Chrome 131, no client-side translation fingerprint at all). It is dropped
+  // unconditionally as a redundant twin (Category 7): its rust_panic.location
+  // is the js-sys executor, so it is provably the secondary cascade, never a
+  // primary fault. The genuine hydration bug it cascades from is still reported
+  // via the PRIMARY `internal error` panic at the tachys location, which is
+  // preserved on a clean browser (see the cases above) — so nothing actionable
+  // is lost. This is the same reasoning as the Category 6 RuntimeError twin
+  // (PR #921), which drops its onerror copy even on a clean browser.
   {
-    name: "RefCell cascade (js-sys loc) on a current clean browser with no fingerprint is preserved",
+    name: "RefCell executor cascade (js-sys loc) on a current clean browser is dropped (Category 7 redundant twin)",
     ua: CURRENT_CHROME,
     document: fakeDocumentEx({ fontCount: 0 }),
     event: {
@@ -420,7 +435,7 @@ const cases = [
       },
       breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
     },
-    expectDrop: false,
+    expectDrop: true,
   },
   {
     name: "onerror RuntimeError unreachable on a current clean browser with no fingerprint is preserved",
@@ -537,6 +552,67 @@ const cases = [
           },
         ],
       },
+    },
+    expectDrop: false,
+  },
+
+  // ── Category 7: the RefCell-already-borrowed executor cascade (dedup) ──
+  // A handled Rust panic whose value is "RefCell already borrowed" AND whose
+  // contexts.rust_panic.location is the wasm-bindgen-futures single-threaded
+  // executor (js-sys .../futures/task/singlethread.rs) is never a primary,
+  // actionable fault. That executor RefCell only trips "already borrowed" when
+  // run() is re-entered while a panic is unwinding through a future poll, so it
+  // is ALWAYS the secondary cascade of a primary panic the hook already
+  // reported with its own actionable location. Dropped UNCONDITIONALLY (no
+  // injecting-population fingerprint) — the retained primary keeps the bug
+  // visible. This is #6758 (23k+ events), the single largest issue, the
+  // RefCell twin of the per-deploy RuntimeError flood Category 6 / PR #921
+  // dedups. Scoped tightly: keyed on the executor location, so an APP-code
+  // double-borrow (which panics at an app/leptos path, NOT singlethread.rs)
+  // still reports, and a RefCell event with no rust_panic context is preserved.
+  {
+    name: "genuine APP RefCell double-borrow (leptos location, not the executor) is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      contexts: {
+        rust_panic: {
+          location:
+            "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/" +
+            "reactive_graph-0.2.5/src/signal/guards.rs:120:14",
+        },
+      },
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "RefCell already borrowed with NO rust_panic context is preserved (cannot prove it is the executor cascade)",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [{ type: "RustWasmPanic", value: "RefCell already borrowed" }],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: false,
+  },
+  {
+    name: "a DIFFERENT panic value at the js-sys executor location is preserved (only the RefCell cascade is a known twin)",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      contexts: { rust_panic: { location: JS_SYS_SINGLETHREAD_LOC } },
+      exception: {
+        values: [
+          { type: "RustWasmPanic", value: "some other executor invariant" },
+        ],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
     },
     expectDrop: false,
   },

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -84,6 +84,26 @@
 //      population fingerprint needed: a real hydration bug on a current
 //      browser still reaches GlitchTip via the untouched RustWasmPanic. A
 //      frameless or third-party-framed RuntimeError is left untouched.
+//   7. The "RefCell already borrowed" panic in the wasm-bindgen-futures
+//      single-threaded executor (js-sys .../futures/task/singlethread.rs).
+//      Every Rust panic that unwinds through a running future poll re-enters
+//      that executor while its task-queue RefCell is still held, tripping a
+//      SECOND, handled "RefCell already borrowed" panic. It is therefore
+//      always the cascade of a PRIMARY panic the hook already reported (e.g.
+//      the tachys hydration unreachable! at hydration.rs, kept with its own
+//      actionable contexts.rust_panic.location and stable per-location
+//      fingerprint), and its own location — singlethread.rs — is identical
+//      for every panic, so it carries no diagnostic signal of its own. Dropped
+//      UNCONDITIONALLY (no injecting-population fingerprint) when
+//      contexts.rust_panic.location is that executor path: the actionable
+//      primary copy is always retained, so a genuine hydration bug on a clean
+//      current browser still reaches GlitchTip via the primary. This is the
+//      RefCell sibling of the category-6 RuntimeError onerror twin (PR #921);
+//      it is #6758 (23k+ events), the single largest issue. Scoped to the
+//      executor location and the exact "RefCell already borrowed" value, so an
+//      APP-code double-borrow (which panics at an app/leptos path, never
+//      singlethread.rs) and a RefCell with no rust_panic context both still
+//      report.
 (function () {
   var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
   // Like ULTROS_PKG_BUNDLE_RE but tolerant of the trailing
@@ -479,6 +499,38 @@
     return false;
   }
 
+  // Category 7: the redundant "RefCell already borrowed" executor cascade. See
+  // the header. A handled panic with value "RefCell already borrowed" whose
+  // contexts.rust_panic.location is the wasm-bindgen-futures single-threaded
+  // executor is never a primary fault: that executor RefCell only reports
+  // "already borrowed" when run() is re-entered during a panic unwind, so it is
+  // always the secondary cascade of a primary panic the hook already reported
+  // (which keeps its own actionable location). Drop it UNCONDITIONALLY — unlike
+  // the category-3 onerror prong (fingerprint-gated to preserve a possible real
+  // bug), this is safe because the actionable primary copy is retained: a clean
+  // current browser still emits, and keeps, that primary panic. Scoped to the
+  // executor location (an app-code double-borrow panics at an app/leptos path,
+  // not singlethread.rs, and is preserved) and to the exact value (other
+  // executor invariants still report). The location is set by
+  // __ultrosReportRustPanic and reliably present at client-side beforeSend.
+  function isExecutorReentryCascade(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex || typeof ex.value !== "string") return false;
+      if (ex.value !== "RefCell already borrowed") return false;
+      var ctx = event && event.contexts && event.contexts.rust_panic;
+      var loc = ctx && ctx.location;
+      return (
+        typeof loc === "string" &&
+        loc.indexOf("/usr/local/cargo/registry/src/index.crates.io-") === 0 &&
+        ULTROS_JSSYS_EXECUTOR_RE.test(loc)
+      );
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
   function isEmptyPromiseRejection(event) {
     try {
       var ex = firstException(event);
@@ -508,6 +560,7 @@
       isInjectedDocumentTypeError(event) ||
       isInjectedTachysHydrationPanic(event) ||
       isRedundantWasmUnreachableTrap(event) ||
+      isExecutorReentryCascade(event) ||
       isEmptyPromiseRejection(event)
     );
   };

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -615,5 +615,11 @@ mod error_filter_wiring {
         // rotation) via a pkg-bundle stack frame. Removing it re-opens it.
         assert!(FILTER_JS.contains("isRedundantWasmUnreachableTrap"));
         assert!(FILTER_JS.contains("ULTROS_PKG_FRAME_RE"));
+        // Category 7: the redundant `RefCell already borrowed` executor cascade,
+        // dropped unconditionally when its rust_panic.location is the js-sys
+        // futures executor. Deleting it silently re-opens the #6758 flood (the
+        // single largest issue).
+        assert!(FILTER_JS.contains("isExecutorReentryCascade"));
+        assert!(FILTER_JS.contains("RefCell already borrowed"));
     }
 }


### PR DESCRIPTION
## What

Adds **Category 7** to the `beforeSend` noise filter (`error_filter.js`): drop the redundant `RefCell already borrowed` panic that the wasm-bindgen-futures executor emits as a cascade of every Rust panic.

This targets **GlitchTip [#6758](https://glitchtip.ultros.app/ultros/issues/6758) — 23,187 events, the single largest issue in the project.**

## Why it's safe (same argument as #921)

Every Rust panic that unwinds through a running future poll re-enters the js-sys single-threaded executor while its task-queue `RefCell` is still held, tripping a **second, handled** `RefCell already borrowed` panic at `.../js-sys-*/src/futures/task/singlethread.rs:142`. It is therefore **always the secondary cascade** of a primary panic the hook already reported — and `singlethread.rs` is the same location for *every* panic, so the twin carries no diagnostic signal of its own.

The latest event on #6758 proves the ordering in its own breadcrumbs:
1. `panicked at tachys-0.2.15/src/hydration.rs:163: internal error: entered unreachable code` ← **primary** (reported as its own `RustWasmPanic`, retained, carries the actionable `tachys` location + #787's stable fingerprint)
2. `RuntimeError: unreachable` onerror copy ← deduped by **#921** (Category 6)
3. `panicked at js-sys-0.3.102/.../singlethread.rs:142: RefCell already borrowed` ← **this cascade** (Category 7)

Dropped **unconditionally** (no injecting-population fingerprint) — like the Category 6 RuntimeError twin, this is safe because the actionable primary copy is always retained, so a genuine hydration bug on a clean current browser still reaches GlitchTip via the primary `internal error` panic.

Scoped tightly:
- Keyed on `contexts.rust_panic.location` = the js-sys executor path, so a genuine **app-code double-borrow** (which panics at an app/leptos path, never `singlethread.rs`) still reports.
- Keyed on the exact value `"RefCell already borrowed"`, so other executor invariants still report.
- A `RefCell` event with no `rust_panic` context is preserved (can't prove it's the executor cascade).

## Relationship to #921

This is the **RefCell sibling** of [#921](https://github.com/akarras/ultros/pull/921) (Category 6, which dedups the `RuntimeError: unreachable` onerror twin). The two are orthogonal predicates but share the "redundant twin of a retained primary panic" model. **Recommend merging #921 first**, then rebasing this — the only overlap is the header comment numbering and the one-line `||` dispatcher entry (trivial). Together they collapse the per-load 3-event scraper flood down to just the one retained primary canary.

## Testing

JS-only change to the `include_str!`'d filter. Verified locally:

```
$ npm --prefix integration run test:error-filter
ℹ tests 45
ℹ pass 45
ℹ fail 0
```

- Flips the two existing cases that previously preserved the executor cascade (with full rationale in comments) → now dropped.
- Adds guards: app-location double-borrow preserved, no-`rust_panic`-context preserved, non-`RefCell` executor value preserved.
- Extends the Rust↔JS wiring guard (`mod error_filter_wiring`) with the Category 7 token.
- `cargo fmt --all -- --check` passes. Clippy not run locally (OpenSSL-vendored + submodule build wall); change is JS + `#[cfg(test)]`-only, no Rust logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)