### PR TITLE
fix(error-reporting): drop third-party analytics/CDN script errors (Category 8)

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -984,6 +984,153 @@ const cases = [
     expectDrop: false,
   },
 
+  // ── Category 8: third-party analytics / ads / CDN-telemetry script noise ──
+  // The Cloudflare Web Analytics beacon throwing on an ancient browser that
+  // lacks Array.prototype.at — GlitchTip #6836 (Chrome 90 / Android 5). All
+  // frames live on static.cloudflareinsights.com (host carried in absPath; the
+  // filename is path-only). Not our code, not fixable here.
+  {
+    name: "Cloudflare Web Analytics beacon TypeError (all frames third-party) is dropped",
+    ua:
+      "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) " +
+      "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 " +
+      "Mobile Safari/537.36",
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "t.entries.at is not a function",
+            mechanism: {
+              type: "auto.browser.global_handlers.onerror",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e",
+                  absPath:
+                    "https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e",
+                  function: "o",
+                },
+                {
+                  filename: "/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e",
+                  absPath:
+                    "https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e",
+                  function: "B",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  // A gtag / Google-Analytics onerror whose whole stack is on Google
+  // analytics hosts — likewise unactionable external noise.
+  {
+    name: "a gtag / Google-Analytics onerror (all frames third-party) is dropped",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Cannot read properties of null (reading 'v')",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/gtag/js",
+                  absPath:
+                    "https://www.googletagmanager.com/gtag/js?id=G-WYVZLM39M3",
+                  function: "?",
+                },
+                {
+                  filename: "/g/collect",
+                  absPath: "https://www.google-analytics.com/g/collect",
+                  function: "?",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: true,
+  },
+  // SAFETY: a mixed stack that reaches even one of our own frames is a real
+  // Ultros bug (a third-party callback into our code, or vice-versa) and MUST
+  // report — the all-frames-third-party gate preserves it.
+  {
+    name: "a mixed stack with even one app/pkg frame is preserved (real Ultros bug never swept up)",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "x is not a function",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/pkg/97f9168/ultros.js",
+                  absPath: "https://ultros.app/pkg/97f9168/ultros.js",
+                  function: "c",
+                },
+                {
+                  filename: "/beacon.min.js/v451",
+                  absPath:
+                    "https://static.cloudflareinsights.com/beacon.min.js/v451",
+                  function: "o",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  // SAFETY: our own origin (ultros.app) is deliberately NOT on the third-party
+  // host list, so an inline page-script error still reports.
+  {
+    name: "an error from an inline ultros.app page script is preserved (our origin is not third-party)",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "boom",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/item/Excalibur/2465",
+                  absPath: "https://ultros.app/item/Excalibur/2465",
+                  function: "onclick",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  // SAFETY: a frameless error carries no proof of origin — never assume
+  // third-party, always preserve.
+  {
+    name: "a third-party-looking TypeError with NO stack frames is preserved",
+    ua: CURRENT_CHROME,
+    event: {
+      exception: {
+        values: [{ type: "TypeError", value: "t.entries.at is not a function" }],
+      },
+    },
+    expectDrop: false,
+  },
+
   // ── Genuine application errors must always survive ──
   {
     name: "a genuine application Error is preserved",

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -104,6 +104,17 @@
 //      APP-code double-borrow (which panics at an app/leptos path, never
 //      singlethread.rs) and a RefCell with no rust_panic context both still
 //      report.
+//   8. An error thrown entirely inside a third-party analytics / ads / consent
+//      / CDN-telemetry script that Ultros loads but does not control and cannot
+//      fix — the JS sibling of an adblocked request. Cloudflare Web Analytics'
+//      beacon.min.js throws "TypeError: t.entries.at is not a function" on
+//      ancient browsers missing Array.prototype.at (GlitchTip #6836); gtag /
+//      AdSense / funding-choices surface onerror noise the same way. The beacon
+//      URL carries a rotating version hash, so each occurrence fragments into a
+//      fresh count=1 issue. Dropped ONLY when the exception has stack frames and
+//      EVERY one is on a known third-party host — any app/pkg frame (our bundle,
+//      an inline page script, or SSR HTML on ultros.app) preserves the event, so
+//      a real Ultros bug is never swept up.
 (function () {
   var ULTROS_PKG_BUNDLE_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)(?:$|\?)/;
   // Like ULTROS_PKG_BUNDLE_RE but tolerant of the trailing
@@ -111,6 +122,16 @@
   // frame, so `/pkg/<hash>/ultros.wasm:wasm-function[5501]` still counts as
   // originating in our bundle.
   var ULTROS_PKG_FRAME_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)\b/;
+  // Third-party analytics / ads / consent / CDN-telemetry hosts. Ultros loads
+  // scripts from these (Cloudflare Web Analytics' beacon, Google Analytics /
+  // gtag, AdSense, the funding-choices consent frame, ad-traffic-quality), but
+  // does not control their code and cannot fix a bug inside it. Matched against
+  // a frame's absPath / filename (the `//host/` in the URL). Anchored to `//`
+  // so a same-named path segment can't match; our own origin (ultros.app) and
+  // pkg bundle are deliberately absent, so any frame in our code fails the test
+  // and the whole event is preserved (see isThirdPartyScriptError).
+  var ULTROS_THIRD_PARTY_SCRIPT_HOST_RE =
+    /\/\/(?:static\.cloudflareinsights\.com|(?:www\.)?google-analytics\.com|(?:www\.)?googletagmanager\.com|pagead2\.googlesyndication\.com|[a-z0-9-]+\.googlesyndication\.com|[a-z0-9.-]*\.doubleclick\.net|fundingchoicesmessages\.google\.com|[a-z0-9.-]*\.adtrafficquality\.google|adservice\.google\.[a-z.]+)\//i;
   var ULTROS_TACHYS_HYDRATION_RE = /\/tachys-[\d.]+\/src\/hydration\.rs:/;
   // Leptos's streaming-hydration bootstrap globals. The SSR shell ALWAYS emits
   // `window.__RESOLVED_RESOURCES = []` plus `__INCOMPLETE_CHUNKS` /
@@ -531,6 +552,45 @@
     return false;
   }
 
+  // Category 8: an error thrown entirely inside a third-party analytics / ads /
+  // consent / CDN-telemetry script that Ultros loads but does not control and
+  // cannot fix — the JS sibling of an adblocked request. e.g. Cloudflare Web
+  // Analytics' beacon.min.js throwing "TypeError: t.entries.at is not a
+  // function" on an ancient browser missing Array.prototype.at (GlitchTip
+  // #6836, Chrome 90 / Android 5); gtag, AdSense, and the funding-choices
+  // consent frame surface onerror noise the same way. The beacon URL carries a
+  // rotating version hash (…/beacon.min.js/v4513226…), so each occurrence would
+  // otherwise fragment into a fresh count=1 issue — the per-hash noise the
+  // category-6 dedup was built for. Dropped ONLY when the exception carries
+  // stack frames and EVERY one originates from a known third-party host: a
+  // stack that reaches even one app / pkg frame (our bundle, an inline page
+  // script, or SSR HTML on ultros.app — none of which are on the host list)
+  // fails the check and is preserved, so a real Ultros bug can never be swept
+  // up. A frameless error is left untouched (nothing proves it third-party).
+  function isThirdPartyScriptError(event) {
+    try {
+      var ex = firstException(event);
+      if (!ex) return false;
+      var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+      if (frames.length === 0) return false;
+      for (var i = 0; i < frames.length; i++) {
+        var f = frames[i] || {};
+        var abs = typeof f.absPath === "string" ? f.absPath : "";
+        var fname = typeof f.filename === "string" ? f.filename : "";
+        if (
+          !ULTROS_THIRD_PARTY_SCRIPT_HOST_RE.test(abs) &&
+          !ULTROS_THIRD_PARTY_SCRIPT_HOST_RE.test(fname)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return false;
+  }
+
   function isEmptyPromiseRejection(event) {
     try {
       var ex = firstException(event);
@@ -561,6 +621,7 @@
       isInjectedTachysHydrationPanic(event) ||
       isRedundantWasmUnreachableTrap(event) ||
       isExecutorReentryCascade(event) ||
+      isThirdPartyScriptError(event) ||
       isEmptyPromiseRejection(event)
     );
   };

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -621,5 +621,12 @@ mod error_filter_wiring {
         // single largest issue).
         assert!(FILTER_JS.contains("isExecutorReentryCascade"));
         assert!(FILTER_JS.contains("RefCell already borrowed"));
+        // Category 8: errors thrown entirely inside a third-party analytics /
+        // ads / CDN-telemetry script (Cloudflare Insights beacon, gtag, AdSense,
+        // funding-choices). Removing it re-opens the external-script noise (the
+        // #6836 Cloudflare-beacon class). The host allowlist must NOT contain
+        // ultros.app / the pkg bundle, or a real Ultros bug could be swept up.
+        assert!(FILTER_JS.contains("isThirdPartyScriptError"));
+        assert!(FILTER_JS.contains("ULTROS_THIRD_PARTY_SCRIPT_HOST_RE"));
     }
 }


### PR DESCRIPTION
## What

Adds **Category 8** to the Sentry `beforeSend` noise filter (`error_filter.js`): drop an event when it has stack frames and **every** frame originates from a known third-party analytics / ads / consent / CDN-telemetry host that Ultros loads but does not control.

## Why

GlitchTip **#6836** — `TypeError: t.entries.at is not a function` — is thrown entirely inside Cloudflare Web Analytics' `beacon.min.js` on an ancient browser (Chrome 90 / Android 5) that lacks `Array.prototype.at`. Every stack frame is on `static.cloudflareinsights.com`; there is no Ultros frame. It's a bug in Cloudflare's injected beacon — code we can't fix — the JS sibling of an adblocked request. The beacon URL carries a rotating version hash (`…/beacon.min.js/v4513226…`), so each occurrence fragments into a fresh count=1 issue, exactly the per-hash noise the Category-6 dedup was built for. `gtag` / AdSense / funding-choices surface onerror noise the same way.

## Safety

The prong is deliberately conservative — it drops **only** when:
- the exception has ≥1 stack frame, **and**
- **every** frame's `absPath`/`filename` is on the known third-party host allowlist (Cloudflare Insights, `google-analytics`/`gtag`, AdSense/`doubleclick`, `funding-choices`, `adtrafficquality`).

Our own origin (`ultros.app`) and the `/pkg/<hash>/ultros.*` bundle are deliberately **absent** from the list, so any app frame — our bundle, an inline page script, or SSR HTML — fails the check and preserves the event. A real Ultros bug can never be swept up. Frameless errors are left untouched (nothing proves them third-party).

## Testing

The change is JS (`error_filter.js`) plus a 7-line extension to the `error_filter_wiring` guard in `lib.rs` (asserts the Cat-8 tokens are present, matching the per-category contract already asserted for categories 1–7).

- `npm --prefix integration run test:error-filter` → **54/54 pass** (5 new cases: the captured #6836 event shape, a gtag/GA drop case, and the three safety boundaries — mixed app+third-party stack → preserved, `ultros.app` inline-script origin → preserved, frameless → preserved).
- `cargo fmt --all -- --check` → clean. (clippy compiles the workspace via the game-data submodule; the guard is a `#[cfg(test)]` assert matching the ~15 existing ones, so it cannot introduce a warning. CI runs fmt+clippy, not `cargo test`.)

## Triage note

Filed alongside a GlitchTip backlog sweep (this run ignored **192** unactionable issues — the Tencent-Cloud scraper-fleet tachys-hydration flood and its now-deduped RefCell/onerror siblings, plus a deep pre-2026-06-02 per-URL count=1 tail). #6836 was ignored as external; this PR stops it (and its future version-hash rotations) from reappearing. The dominant live flood (#6831, the kept-by-design hydration primary) remains unaddressable at the `beforeSend`/app layer — the durable fix is a server-side scraper block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)