### PR TITLE
⚡ Bolt: Remove unnecessary reactive formats

### DIFF
--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -326,7 +326,7 @@ fn WindowStats(#[prop(into)] sales: Signal<SalesWindow>) -> impl IntoView {
             </div>
             <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,_var(--color-text)_5%,_transparent)] px-3 py-2">
                 <div class="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">{t!(i18n, sale_history_stat_hq_percent)}</div>
-                <div class="mt-1 font-semibold tabular-nums">{move || format!("{}%", hq_percent())}</div>
+                <div class="mt-1 font-semibold tabular-nums">{move || hq_percent()} "%"</div>
             </div>
             <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] px-3 py-2">
                 <div class="text-xs uppercase tracking-wide text-[color:var(--color-text-muted)]">{t!(i18n, sale_history_stat_next_sale)}</div>

--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -133,6 +133,12 @@ where
     let default_input_class = "input w-full";
     let default_dropdown_class =
         "absolute w-full max-h-96 overflow-y-auto top-12 panel rounded-lg shadow-lg z-[100]";
+    let combined_input_class = format!("{} {}", default_input_class, class.unwrap_or(""));
+    let combined_dropdown_class = format!(
+        "{} {}",
+        default_dropdown_class,
+        dropdown_class.unwrap_or("")
+    );
 
     let current_choice_view = move || {
         choice()
@@ -155,7 +161,7 @@ where
         <div class="relative">
             <input
                 node_ref=input
-                class=move || format!("{} {}", default_input_class, class.unwrap_or(""))
+                class=combined_input_class
                 class:cursor=move || !has_focus()
                 on:focus=move |_| set_focused(true)
                 on:focusout=move |_| set_focused(false)
@@ -187,7 +193,7 @@ where
             </div>
             <div
                 node_ref=dropdown
-                class=move || format!("{} {}", default_dropdown_class, dropdown_class.unwrap_or(""))
+                class=combined_dropdown_class
                 class:hidden=move || !has_focus() && !hovered()
                 role="listbox"
             >


### PR DESCRIPTION
⚡ Bolt: Remove unnecessary reactive formats

💡 What: Removed `format!` macros inside reactive `move ||` closures for static strings in `select.rs` and replaced a reactive `format!` with separate reactive and static nodes in `sale_history_table.rs`.
🎯 Why: Leptos creates reactive Effects for closures. In `select.rs`, formatting static strings inside a closure creates unnecessary effects and allocations. In `sale_history_table.rs`, formatting a signal into a new string causes a heap allocation on every update.
📊 Impact: Reduces effect allocations and memory churn in Select and Sale History components.
🔬 Measurement: Profile rendering of these components.

---
*PR created automatically by Jules for task [3162936278250715759](https://jules.google.com/task/3162936278250715759) started by @akarras*