### PR TITLE
⚡ Bolt: Remove deep clone from BuyingView memo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,10 @@
 ## 2026-06-25 - Avoid heap allocations when parsing substrings
 **Learning:** We can write a zero-allocation string search algorithm that performs identical substring matching without the need to allocate intermediate `String` instances with `format!()` in hot parsing paths.
 **Action:** When working on parsing logic (e.g. FFXIV tags parsing), prefer manual string searches using `find` and `starts_with` rather than creating `String` using `format!()` for simple matching tasks.
+## 2024-11-20 - Memoization Over-Allocation in `BuyingView`
+
+**Learning:**
+In `ultros-frontend/ultros-app/src/components/list/buying_view.rs`, a `Memo` creates a new array of grouped listings on every update. Previously, the code iterated over the input array using `items.clone()`, making an unnecessary copy of a large vector of items and their associated listings every time the memo ran (which could be frequently due to reactive signal updates like `excluded_datacenters`).
+
+**Action:**
+I removed the `clone()` on the `items` vector in the outer loop. Since we only need an iterative pass to calculate required listings, we can use `items.iter()` and then only `clone()` the individual inner `listings` vector (which needs to be cloned to be sorted). In addition, using `sort_unstable_by_key` instead of `sort_by_key` helps since stable sort allocates when it doesn't need to.

--- a/ultros-frontend/ultros-app/src/components/list/buying_view.rs
+++ b/ultros-frontend/ultros-app/src/components/list/buying_view.rs
@@ -48,7 +48,7 @@ pub fn BuyingView(
         let mut selected_listings: Vec<(i32, GroupedListing)> = Vec::new();
 
         excluded_datacenters.with(|excluded| {
-            for (list_item, mut listings) in items.clone() {
+            for (list_item, listings) in items.iter() {
                 let quantity = list_item.quantity.unwrap_or(1);
                 let acquired = list_item.acquired.unwrap_or(0);
                 let needed = quantity.saturating_sub(acquired);
@@ -56,9 +56,10 @@ pub fn BuyingView(
                     continue;
                 }
 
-                listings.sort_by_key(|l| l.price_per_unit);
+                let mut sorted_listings: Vec<_> = listings.iter().collect();
+                sorted_listings.sort_unstable_by_key(|l| l.price_per_unit);
                 let mut remaining = needed;
-                for listing in listings {
+                for listing in sorted_listings {
                     if remaining <= 0 {
                         break;
                     }
@@ -83,7 +84,7 @@ pub fn BuyingView(
                             item_name,
                             price: listing.price_per_unit,
                             quantity: buy_quantity,
-                            list_item: list_item.clone(),
+                            list_item: (*list_item).clone(),
                             hq: listing.hq,
                             listing_id: listing.id,
                         },


### PR DESCRIPTION
⚡ Bolt Optimization:

💡 What:
Replaced the deep `clone()` of the `items` vector in the `BuyingView` memo with `.iter()`. The `listings` arrays are only cloned individually for sorting, and only the required `list_item` is cloned before insertion into the `GroupedListing` struct. I've also switched `sort_by_key` to `sort_unstable_by_key` since unstable sorting has less overhead and allocations.

🎯 Why:
The `selected_listings` memo recalculates when `excluded_datacenters` and other signals change. `items` can be a relatively large vector containing many lists and their active listings. Deep cloning this array is slow and creates unnecessary allocations.

📊 Impact:
Significantly reduces GC pressure and heap allocations when generating the `selected_listings`.

🔬 Measurement:
Observe memory profile during usage of the buying list and toggling datacenters.

---
*PR created automatically by Jules for task [4339139981132639310](https://jules.google.com/task/4339139981132639310) started by @akarras*