### PR TITLE
fix(item): resolve #6831 universal /item/* hydration crash (For wrapper)

### DIFF
--- a/ultros-frontend/ultros-app/src/components/listings_table.rs
+++ b/ultros-frontend/ultros-app/src/components/listings_table.rs
@@ -49,43 +49,60 @@ pub fn ListingsTable(
                 </tr>
             </thead>
             <tbody>
-                {move || {
-                    view! {
-                        <For
-                            each=listings
-                            key=move |(listing, _retainer)| listing.id
-                            children=move |(listing, retainer)| {
-                                let total = listing.price_per_unit * listing.quantity;
-                                view! {
-                                    <tr>
-                                        <td>
-                                            <Gil amount=listing.price_per_unit />
-                                        </td>
-                                        <td>{listing.quantity}</td>
-                                        <td>
-                                            <Gil amount=total />
-                                        </td>
-                                        <td>
-                                            <A href=format!(
-                                                "/retainers/listings/{}",
-                                                retainer.id,
-                                            )>{retainer.name.clone()}</A>
-                                        </td>
-                                        <td>
-                                            <WorldName id=AnySelector::World(listing.world_id) />
-                                        </td>
-                                        <td>
-                                            <DatacenterName world_id=listing.world_id />
-                                        </td>
-                                        <td>
-                                            <RelativeToNow timestamp=listing.timestamp />
-                                        </td>
-                                    </tr>
-                                }
-                            }
-                        />
+                // Render `<For>` as a direct child of `<tbody>`, NOT wrapped in
+                // a redundant `{move || view! { <For/> } }` closure.
+                //
+                // That dynamic-block wrapper was the root cause of #6831
+                // (`RustWasmPanic: internal error: entered unreachable code` =
+                // tachys `hydration.rs` `failed_to_cast_marker_node`) — by far
+                // the largest GlitchTip issue, firing on essentially every
+                // `/item/*` page under production's out-of-order streaming SSR.
+                // A debug-build hydration harness pinned the mismatch to this
+                // table: "expected a marker node, found <tr>". The extra dynamic
+                // layer desyncs the `<For>` marker walk against the SSR DOM
+                // (`[<tr>…][<!---->][show-more <tr>]`).
+                //
+                // The sibling `SaleHistoryTable` reads the *same* resource
+                // pattern (`listing_resource.with(..).unwrap_or_default()` in a
+                // `Memo` inside a `<Transition>`), hydrates *before* this table
+                // under the same streaming, and never crashes — its only
+                // structural difference is that its `<For>` is a direct `<tbody>`
+                // child. Matching that here removes the crash. `For` is reactive
+                // to `listings` directly, so dropping the dependency-free closure
+                // is behavior-neutral.
+                <For
+                    each=listings
+                    key=move |(listing, _retainer)| listing.id
+                    children=move |(listing, retainer)| {
+                        let total = listing.price_per_unit * listing.quantity;
+                        view! {
+                            <tr>
+                                <td>
+                                    <Gil amount=listing.price_per_unit />
+                                </td>
+                                <td>{listing.quantity}</td>
+                                <td>
+                                    <Gil amount=total />
+                                </td>
+                                <td>
+                                    <A href=format!(
+                                        "/retainers/listings/{}",
+                                        retainer.id,
+                                    )>{retainer.name.clone()}</A>
+                                </td>
+                                <td>
+                                    <WorldName id=AnySelector::World(listing.world_id) />
+                                </td>
+                                <td>
+                                    <DatacenterName world_id=listing.world_id />
+                                </td>
+                                <td>
+                                    <RelativeToNow timestamp=listing.timestamp />
+                                </td>
+                            </tr>
+                        }
                     }
-                }}
+                />
                 <tr
                     on:click=show_click
                     class:hidden=move || { listing_count() < 10 || show_more() }


### PR DESCRIPTION
## Fix #6831 — universal `/item/*` hydration crash

**GlitchTip [#6831](https://glitchtip.ultros.app/ultros/issues/6831)** — `RustWasmPanic: internal error: entered unreachable code` — is the single largest issue by ~3 orders of magnitude (**~9,500 events and climbing**, `lastSeen` today). It fires on essentially every `/item/<world>/<id>` page load: the page's SSR content is readable but hydration aborts ("Failed to load app — reload"), so the item view is non-interactive.

### Root cause
`ListingsTable` wrapped its `<For>` in a **redundant** `{move || view! { <For .../> } }` closure:

```rust
<tbody>
    {move || { view! { <For each=listings .../> } }}   // ← redundant dynamic-block wrapper
    <tr class:hidden=…>…show-more…</tr>                 // static sibling
</tbody>
```

The panic is the release `unreachable!()` in tachys `hydration.rs` (`failed_to_cast_marker_node`). Under production's **out-of-order streaming SSR**, that extra dynamic-block layer desyncs the `<For>` hydration marker walk against the SSR DOM (`[<tr>…][<!---->][show-more <tr>]`) → *"expected a marker node, found `<tr>`"* → panic, aborting hydration for the whole page.

### Why this is the cause (isolation)
The sibling **`SaleHistoryTable`** on the same page feeds its `<For>` from the *identical* data pattern — `listing_resource.with(..).unwrap_or_default()` in a `Memo` inside a `<Transition>` — but places `<For>` as a **direct `<tbody>` child**. It hydrates *before* the listings tables under the same streaming and **never** appears in #6831. The only structural difference is the wrapper, which rules out a resource/timing cause and pins it to the `{move||}` layer.

### Fix
Drop the redundant closure so `<For>` is a direct `<tbody>` child, matching `SaleHistoryTable`. `For` is reactive to the `listings` memo directly, so removing the dependency-free wrapper is **behavior-neutral** (no SSR content change, no reactivity change).

### How it was diagnosed & verified
- **Diagnosis:** a debug-build hydration harness — a local `debug_assertions` client wasm (which makes tachys `console.error` its `hydrate an element defined at FILE:LINE, expected …, found …` diagnostic) hydrating **production's** SSR HTML behind a CSP-stripping proxy — pinpointed `listings_table.rs` and the exact mismatch (*"expected a marker node, found HTMLTableRowElement"*).
- **Isolation:** the `SaleHistoryTable` equivalence above (same data pattern, direct `<For>`, hydrates first, never crashes) — Phase-2 "match the working reference".
- **Local full-stack `cargo leptos serve`:** confirms the app hydrates cleanly (`app run!`, no panic) with 10+ listing rows, and that the change compiles + `cargo fmt --all --check` + `cargo clippy -p ultros-app --all-targets` are green.
- **Note on repro:** the crash only manifests under prod's out-of-order streaming (a resource pending at shell flush — prod's `__INCOMPLETE_CHUNKS`); a local in-order `cargo leptos serve` renders everything inline and does not stream, so it does not reproduce the panic directly. The definitive confirmation is #6831's event count dropping after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
