### PR TITLE
🎨 Palette: Fix MakePlaceImporter textarea accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2023-11-20 - Accessible Icon-Only Buttons
 **Learning:** Found that some icon-only interactive elements like 'Delete Group' and 'Add Member' in the groups component lacked `aria-label`s, making them invisible to screen readers.
 **Action:** Always add reactive `aria-label` properties to icon-only buttons to ensure they are fully accessible, especially when their function might change based on state (e.g. asking for confirmation).
+
+## 2026-07-07 - Accessible textareas
+**Learning:** In the MakePlaceImporter, the textarea was missing an ID and the associated label lacked a `for` attribute, which breaks form field accessibility for screen readers.
+**Action:** Ensure all form controls, such as `<textarea>` and `<input>`, have unique IDs and are properly associated with their corresponding `<label>` elements using the `for` attribute.

--- a/ultros-frontend/ultros-app/src/components/make_place_importer.rs
+++ b/ultros-frontend/ultros-app/src/components/make_place_importer.rs
@@ -88,10 +88,11 @@ where
     };
     view! {
         <div class="flex-column">
-            <label>
+            <label for="make-place-textarea">
                 {t!(i18n, make_place_instructions)}
             </label>
             <textarea
+                id="make-place-textarea"
                 class="input h-96"
                 on:input=move |input| set_list(event_target_value(&input))
             ></textarea>


### PR DESCRIPTION
💡 What: Added a `for` attribute to the `<label>` and a matching `id` to the `<textarea>` in the `MakePlaceImporter` component.
🎯 Why: Textareas without an associated label are difficult to use for screen reader users, breaking standard form accessibility.
♿ Accessibility: Ensures the textarea is properly announced by screen readers when navigating the form.

---
*PR created automatically by Jules for task [1641511248669025118](https://jules.google.com/task/1641511248669025118) started by @akarras*