### PR TITLE
fix(error-reporting): dedup wasm://wasm-framed onerror unreachable traps (#6848)

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -537,6 +537,104 @@ const cases = [
     expectDrop: false,
   },
   {
+    // GlitchTip #6848 (Mediapartners-Google crawler hitting the #6831 hydration
+    // panic on /item/Zeromus/34430, release 8ccc782). Same redundant onerror
+    // trap as #6827 above, but the browser named EVERY wasm frame with the
+    // engine-internal `wasm://wasm/<hash>:wasm-function[N]` scheme instead of the
+    // `/pkg/<hash>/ultros.wasm` source-URL form — so the pkg-frame check never
+    // fired and the twin leaked. A RuntimeError "unreachable" whose stack is
+    // ENTIRELY wasm-module frames is a wasm abort trap; the only wasm on an
+    // Ultros page is our bundle, so it is the guaranteed duplicate of the kept
+    // RustWasmPanic and safe to drop.
+    name: "onerror RuntimeError unreachable with ONLY wasm://wasm module frames is dropped (real #6848 crawler variant)",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "unreachable",
+            mechanism: {
+              type: "auto.browser.global_handlers.onerror",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "wasm://wasm/02e8784e:wasm-function[14091]:0x844cae",
+                  function: "?",
+                },
+                {
+                  filename: "wasm://wasm/02e8784e:wasm-function[5503]:0x5eaa4c",
+                  function: "?",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+    },
+    expectDrop: true,
+  },
+  {
+    // Over-drop guard: the all-wasm-module rule must require EVERY frame to be a
+    // wasm-module frame. A stack that reaches even one third-party JS frame is
+    // not provably ours (and could be a genuine error worth seeing), so it is
+    // preserved — mirroring the "any app/pkg frame preserves" spirit of the
+    // pkg-frame branch and category 8.
+    name: "RuntimeError unreachable with a wasm://wasm frame BUT also a third-party JS frame is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "unreachable",
+            stacktrace: {
+              frames: [
+                { filename: "wasm://wasm/deadbeef:wasm-function[3]:0x40" },
+                {
+                  filename: "https://cdn.example.com/widget.js",
+                  function: "w",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  {
+    // Value-scope guard for the wasm://wasm branch: only the `unreachable` abort
+    // signature is a known RustWasmPanic twin. Another wasm trap value (e.g.
+    // "memory access out of bounds") from wasm://wasm frames is a distinct fault
+    // with no retained copy, so it still reports.
+    name: "a non-unreachable RuntimeError from only wasm://wasm frames is preserved",
+    ua: CURRENT_CHROME,
+    document: fakeDocumentEx({ fontCount: 0 }),
+    event: {
+      exception: {
+        values: [
+          {
+            type: "RuntimeError",
+            value: "memory access out of bounds",
+            stacktrace: {
+              frames: [
+                { filename: "wasm://wasm/02e8784e:wasm-function[42]:0x1234" },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    expectDrop: false,
+  },
+  {
     name: "a genuine non-unreachable RuntimeError from our bundle is preserved",
     ua: CURRENT_CHROME,
     document: fakeDocumentEx({ fontCount: 0 }),

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -82,8 +82,14 @@
 //      provably our wasm, hence a guaranteed duplicate of the kept
 //      RustWasmPanic, so it is dropped unconditionally — no injecting-
 //      population fingerprint needed: a real hydration bug on a current
-//      browser still reaches GlitchTip via the untouched RustWasmPanic. A
-//      frameless or third-party-framed RuntimeError is left untouched.
+//      browser still reaches GlitchTip via the untouched RustWasmPanic. Some
+//      browsers and crawlers instead name every wasm frame with the engine-
+//      internal `wasm://wasm/<hash>:wasm-function[N]` scheme (the Mediapartners-
+//      Google crawler variant, #6848), so the pkg-frame test never fires; a
+//      RuntimeError "unreachable" whose stack is ENTIRELY such wasm-module
+//      frames is likewise our abort trap and is dropped too. A frameless or
+//      third-party-JS-framed RuntimeError (and a third-party wasm loaded from an
+//      https URL, which keeps its source-URL frame form) is left untouched.
 //   7. The "RefCell already borrowed" panic in the wasm-bindgen-futures
 //      single-threaded executor (js-sys .../futures/task/singlethread.rs).
 //      Every Rust panic that unwinds through a running future poll re-enters
@@ -122,6 +128,13 @@
   // frame, so `/pkg/<hash>/ultros.wasm:wasm-function[5501]` still counts as
   // originating in our bundle.
   var ULTROS_PKG_FRAME_RE = /\/pkg\/[a-f0-9]+\/ultros\.(?:js|wasm)\b/;
+  // Engine-internal wasm-module stack-frame scheme. Some browsers — and the
+  // Mediapartners-Google crawler (GlitchTip #6848) — name wasm frames
+  // `wasm://wasm/<module-hash>:wasm-function[N]:0xADDR` rather than attributing
+  // them to the /pkg/<hash>/ultros.wasm source URL, so ULTROS_PKG_FRAME_RE never
+  // matches. On an Ultros page the only wasm is our own bundle, so a stack made
+  // ENTIRELY of these frames is still ours (see isRedundantWasmUnreachableTrap).
+  var ULTROS_WASM_MODULE_FRAME_RE = /^wasm:\/\/wasm\/[^:]+:wasm-function\[\d+\]/;
   // Third-party analytics / ads / consent / CDN-telemetry hosts. Ultros loads
   // scripts from these (Cloudflare Web Analytics' beacon, Google Analytics /
   // gtag, AdSense, the funding-choices consent frame, ad-traffic-quality), but
@@ -508,12 +521,34 @@
         return false;
       if (!/unreachable/i.test(ex.value)) return false;
       var frames = (ex.stacktrace && ex.stacktrace.frames) || [];
+      if (frames.length === 0) return false;
+      // (i) Any frame attributable to our pkg bundle (the JS glue or the wasm)
+      //     proves the trap is ours — the #6781–#6828 per-deploy fleet.
+      // (ii) Otherwise fall back to the frame-scheme test: some browsers /
+      //     crawlers name wasm frames `wasm://wasm/<hash>:wasm-function[N]`
+      //     rather than /pkg/<hash>/ultros.wasm (GlitchTip #6848,
+      //     Mediapartners-Google hitting the #6831 hydration panic), so the pkg
+      //     check never fires. A RuntimeError "unreachable" whose stack is
+      //     ENTIRELY such wasm-module frames is a wasm abort trap, and the only
+      //     wasm on an Ultros page is our bundle, so it too is the guaranteed
+      //     duplicate of the kept RustWasmPanic. Requiring EVERY frame to be a
+      //     wasm-module frame preserves a stack that reaches any third-party JS
+      //     frame; and a third-party wasm loaded from an https URL keeps its
+      //     `…/foo.wasm:wasm-function[N]` source-URL form (not wasm://wasm/), so
+      //     it is not swept up either.
+      var allWasmModuleFrames = true;
       for (var i = 0; i < frames.length; i++) {
         var fname = frames[i] && frames[i].filename;
         if (typeof fname === "string" && ULTROS_PKG_FRAME_RE.test(fname)) {
           return true;
         }
+        if (
+          !(typeof fname === "string" && ULTROS_WASM_MODULE_FRAME_RE.test(fname))
+        ) {
+          allWasmModuleFrames = false;
+        }
       }
+      return allWasmModuleFrames;
     } catch (_) {
       /* never let the filter throw */
     }


### PR DESCRIPTION
## What

Extends the `beforeSend` noise filter's **Category 6** dedup (`isRedundantWasmUnreachableTrap`) to recognize the redundant `RuntimeError: unreachable` onerror twin when the browser names wasm stack frames with the engine-internal `wasm://wasm/<hash>:wasm-function[N]` scheme (in addition to the existing `/pkg/<hash>/ultros.wasm` source-URL form).

## Why — GlitchTip #6848

Every Rust panic emits **two** Sentry events: the actionable, fingerprinted `RustWasmPanic` (kept — e.g. #6831) **and** a redundant unhandled `RuntimeError: unreachable` that `window.onerror` recaptures after `abort()` runs the wasm `unreachable` instruction. Category 6 drops that twin so it doesn't fragment into a fresh count=1 issue every deploy.

It matched the twin only via a `/pkg/<hash>/ultros.{js,wasm}` stack frame. But [GlitchTip #6848](https://glitchtip.ultros.app/ultros/issues/6848) — the **Mediapartners-Google (AdSense) crawler** hitting the #6831 hydration panic on `/item/Zeromus/34430` (release `8ccc782`) — has an exception stack whose **46 frames are all `wasm://wasm/02e8784e:wasm-function[N]:0xADDR`**, with no `/pkg/` frame (the `/pkg/8ccc782/ultros.js` glue only appears in a breadcrumb, which the SDK does not reliably hand `beforeSend`). So the pkg check never fired and the twin leaked. Its breadcrumbs confirm the root: `panicked at tachys-0.2.18/src/hydration.rs:163:9: internal error: entered unreachable code`.

## The fix

Fall back to a frame-scheme test: a `RuntimeError: unreachable` whose stack is **entirely** `wasm://wasm/...:wasm-function[N]` frames is a wasm abort trap, and the only wasm on an Ultros page is our own bundle — so it is the guaranteed duplicate of the retained `RustWasmPanic` and safe to drop. The actionable copy is always kept (browser-agnostic panic hook), so a real hydration bug on a clean current browser still reaches GlitchTip.

Requiring **every** frame to be a wasm-module frame keeps the guarantees intact:
- a stack reaching any third-party JS frame → **preserved**
- a third-party wasm from an https URL (`…/widget.wasm:wasm-function[N]`, not `wasm://wasm/`) → **preserved** (existing test still green)
- a frameless `RuntimeError` → **preserved**
- a non-`unreachable` wasm trap (e.g. `memory access out of bounds`) → **preserved**

## Tests

JS-only change; gate is `npm --prefix integration run test:error-filter`. Added a #6848 repro (TDD: confirmed RED first) plus over-drop guards. **57/57 pass.**

## Note

This is the onerror twin of #6831; once #6831 is fixed (PR #933) its twins stop, but this closes the `wasm://wasm/`-scheme gap durably for **any** future wasm panic twin from crawlers/older engines. Leaving #6848 unresolved as the post-deploy verification canary (its count should stop climbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)