### PR TITLE
🎨 Palette: Add accessible aria-labels to apps menu buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-07-07 - Accessible textareas
 **Learning:** In the MakePlaceImporter, the textarea was missing an ID and the associated label lacked a `for` attribute, which breaks form field accessibility for screen readers.
 **Action:** Ensure all form controls, such as `<textarea>` and `<input>`, have unique IDs and are properly associated with their corresponding `<label>` elements using the `for` attribute.
+
+## 2026-07-28 - Explicit aria-label for Image-only Menu Buttons
+**Learning:** Found that interactive elements containing only images with alt text might still need an explicit `aria-label` if the image's alt text doesn't adequately describe the element's action (e.g. 'username' vs 'Account menu button').
+**Action:** Always add an explicit `aria-label` to avatar dropdown buttons to standardize the action's description across login states.

--- a/ultros-frontend/ultros-app/src/components/apps_menu.rs
+++ b/ultros-frontend/ultros-app/src/components/apps_menu.rs
@@ -48,7 +48,7 @@ pub fn AppsMenu() -> impl IntoView {
                 class="nav-link"
                 aria-haspopup="menu"
                 aria-expanded=move || if is_open() { "true" } else { "false" }
-                aria_label=move || t_string!(i18n, apps)
+                aria-label=move || t_string!(i18n, apps)
                 // click naturally focuses the button; no explicit toggle required
             >
                 <Icon height="1.4em" width="1.4em" icon=i::MdiJellyfish />
@@ -227,7 +227,12 @@ pub fn UserMenu() -> impl IntoView {
                         Some(auth) => {
                             // logged in trigger: avatar circle + caret
                             view! {
-                                <button class="nav-link flex items-center gap-2" aria-haspopup="menu" aria-expanded=move || if is_open() { "true" } else { "false" }>
+                                <button
+                                    class="nav-link flex items-center gap-2"
+                                    aria-haspopup="menu"
+                                    aria-expanded=move || if is_open() { "true" } else { "false" }
+                                    aria-label=move || t_string!(i18n, account)
+                                >
                                     <img class="avatar" src=auth.avatar alt=auth.username />
                                     <Icon height="1em" width="1em" icon=i::BiChevronDownSolid />
                                 </button>
@@ -240,7 +245,7 @@ pub fn UserMenu() -> impl IntoView {
                                     class="nav-link flex items-center gap-2"
                                     aria-haspopup="menu"
                                     aria-expanded=move || if is_open() { "true" } else { "false" }
-                                    aria_label=move || t_string!(i18n, account)
+                                    aria-label=move || t_string!(i18n, account)
                                 >
                                     <Icon height="1.5em" width="1.5em" icon=i::BsPersonCircle />
                                     <Icon height="1em" width="1em" icon=i::BiChevronDownSolid />


### PR DESCRIPTION
💡 **What:** The UX enhancement added:
Added an explicit `aria-label` to the logged-in UserMenu avatar button and fixed typos where `aria_label` was incorrectly written with an underscore on other dropdowns in `apps_menu.rs`. 

🎯 **Why:** The user problem it solves:
Without an `aria-label`, the avatar button relied solely on the image's alt text (the username), which doesn't convey that the element is an interactive menu button. Additionally, the underscore typos `aria_label` generated invalid HTML attributes that screen readers ignore. This unifies and corrects the accessible name.

♿ **Accessibility:**
Screen readers will now properly announce "Account" (or the localized equivalent) when focusing the user menu button, regardless of login state, and will announce "Apps" correctly for the apps dropdown.

---
*PR created automatically by Jules for task [10821452213618192823](https://jules.google.com/task/10821452213618192823) started by @akarras*