### PR TITLE
fix(currency-exchange): match ItemUICategory by stable ID, not localized name

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -919,16 +919,16 @@ pub fn CurrencySelection() -> impl IntoView {
     let data = tracked_data();
     let ui_categories = &data.item_ui_categorys;
     let disallowed_items = &["Gil", "MGP"];
-    let allowed_item_ui_categories = ["Currency", "Miscellany", "Other"]
-        .into_iter()
-        .map(|category| {
-            ui_categories
-                .iter()
-                .find(|f| f.1.name == category)
-                .map(|(id, _)| *id)
-                .unwrap()
-        })
-        .collect::<Vec<_>>();
+    // `ItemUICategory` row IDs are stable across game locales; only the `name`
+    // column is translated. Matching by the English name panicked on every
+    // non-English dataset (e.g. `cn` names these "货币"/"杂货"/"其他"), which
+    // crashed `/currency-exchange` for all localized users — GlitchTip #6849.
+    // Match by the stable IDs instead: Currency = 100, Miscellany = 61, Other = 63.
+    let allowed_item_ui_categories = [
+        ItemUiCategoryId(100),
+        ItemUiCategoryId(61),
+        ItemUiCategoryId(63),
+    ];
     let currencies = data
         .special_shops
         .iter()
@@ -1066,4 +1066,66 @@ pub fn CurrencyExchange() -> impl IntoView {
             <Outlet />
         </div>
     }.into_any()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `CurrencySelection` builds its category whitelist from the stable
+    /// `ItemUICategory` row IDs (Currency = 100, Miscellany = 61, Other = 63)
+    /// rather than the localized `name`, because matching the English name
+    /// panicked on non-English datasets (GlitchTip #6849 → cascade #6850). This
+    /// pins the ID→name mapping in the embedded (English) dataset so a future
+    /// game-data bump that renumbers these categories fails loudly here instead
+    /// of silently emptying the currency list.
+    #[test]
+    fn allowed_currency_category_ids_match_expected_names() {
+        let data = xiv_gen_db::data();
+        let cats = &data.item_ui_categorys;
+        for (id, expected) in [(100, "Currency"), (61, "Miscellany"), (63, "Other")] {
+            let cat = cats
+                .get(&ItemUiCategoryId(id))
+                .unwrap_or_else(|| panic!("ItemUICategory {id} missing from embedded data"));
+            assert_eq!(
+                cat.name, expected,
+                "ItemUICategory {id} should be '{expected}' but was '{}'; \
+                 update allowed_item_ui_categories in CurrencySelection",
+                cat.name
+            );
+        }
+    }
+
+    /// Regression for GlitchTip #6849: on a non-English locale the category
+    /// `name`s are translated, so the old
+    /// `find(|c| c.name == "Currency").unwrap()` hit `None` and panicked,
+    /// crashing `/currency-exchange`. Confirm both the crash precondition (the
+    /// English names are absent from the `cn` dataset) and that the stable IDs
+    /// the fix uses still resolve there.
+    #[test]
+    fn currency_categories_resolve_by_id_on_localized_data() {
+        let cn = xiv_gen_db::data_for(xiv_gen::Language::Cn);
+        let cats = &cn.item_ui_categorys;
+
+        // Precondition that made the old name-based lookup unwrap `None`.
+        for english in ["Currency", "Miscellany", "Other"] {
+            assert!(
+                !cats.values().any(|c| c.name == english),
+                "the `cn` dataset should have no category literally named \
+                 '{english}' (names are translated); the old name-based lookup \
+                 unwrapped None here and panicked",
+            );
+        }
+
+        // The IDs the fix uses must still exist (and be named) on `cn`.
+        for id in [100, 61, 63] {
+            let cat = cats
+                .get(&ItemUiCategoryId(id))
+                .unwrap_or_else(|| panic!("ItemUICategory {id} missing from cn dataset"));
+            assert!(
+                !cat.name.is_empty(),
+                "ItemUICategory {id} should have a localized name on cn",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`/currency-exchange` panicked (white-screen) for **every non-English locale**. GlitchTip surfaced it today as **#6849** (`RustWasmPanic: called Option::unwrap() on a None value` at `currency_exchange.rs:929`) with a downstream cascade **#6850** (`RefCell already borrowed`).

### Root cause

`CurrencySelection` built its category whitelist by looking up `ItemUICategory` rows by their **English** `name` and unwrapping:

```rust
let allowed_item_ui_categories = ["Currency", "Miscellany", "Other"]
    .into_iter()
    .map(|category| {
        ui_categories.iter()
            .find(|f| f.1.name == category)   // name is localized!
            .map(|(id, _)| *id)
            .unwrap()                          // ← None on non-EN → panic
    })
    .collect::<Vec<_>>();
```

`ItemUICategory.csv` is loaded **per locale**, so `name` is translated. On the `cn` dataset these categories are `"货币"` / `"杂货"` / `"其他"`, so `.find(|c| c.name == "Currency")` returns `None` and `.unwrap()` panics. Verified against the actual game CSVs — the row **IDs are identical across locales**, only the name changes:

| ID  | en          | cn      |
|-----|-------------|---------|
| 100 | Currency    | 货币    |
| 61  | Miscellany  | 杂货    |
| 63  | Other       | 其他    |

The GlitchTip event confirms it: `locale: cn`, `route: /currency-exchange`, panic at `currency_exchange.rs:929:18`. #6850 is the same session — the unwind left the reactive runtime borrowed, so subsequent navigations panicked in `tachys` `suspense.rs`.

### Fix

Match by the **stable row IDs** instead of the localized name — no `.unwrap()`, works on every locale.

### Tests

- `allowed_currency_category_ids_match_expected_names` — pins ID→name in the embedded EN data so a future game-data bump that renumbers these categories fails loudly instead of silently emptying the currency list.
- `currency_categories_resolve_by_id_on_localized_data` — loads the `cn` dataset and asserts the crash precondition (no category literally named "Currency"/"Miscellany"/"Other") **and** that IDs 100/61/63 still resolve there. This reproduces the old failure mode and proves the fix.

### Verification

- `cargo fmt -p ultros-app -- --check` ✓
- `cargo clippy -p ultros-app --all-targets -- -D warnings` ✓
- `cargo test -p ultros-app currency_` → 2 passed ✓

(Full-workspace clippy not run locally — the `ultros` server crate needs the vendored-OpenSSL/Perl build; this change is confined to `ultros-app`.)

Closes #6849. Should also clear the #6850 cascade once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)