### PR TITLE
⚡ Bolt: Optimize median finding with `select_nth_unstable`

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,8 @@ In `ultros-frontend/ultros-app/src/components/list/list_summary.rs`'s `get_cheap
 
 **Action:**
 Always make sure to filter collections as small as possible *before* running expensive operations on them like `sort_by_key` or `sort_by`, especially when the filtering criteria are strict. Also, prefer `sort_unstable_by_key` when possible over `sort_by_key` to save allocations.
+## 2024-11-20 - Finding Medians in O(N) instead of O(N log N)
+**Learning:**
+In `ultros-frontend/ultros-app/src/components/sale_history_table.rs`, we computed the median unit price and median stack size by completely sorting the arrays (`sort_unstable()`) and taking the middle element. Since finding a median is a classic selection problem, fully sorting the array does O(N log N) work when only O(N) is required. Rust's slice API provides `select_nth_unstable`, which rearranges the slice so that the element at the given index is the one that would be there if the slice were fully sorted, doing it in `O(N)` average time.
+**Action:**
+When computing medians or any k-th order statistic, always use `select_nth_unstable` (or `select_nth_unstable_by_key`) rather than fully sorting the collection to save unnecessary CPU cycles.

--- a/ultros-frontend/ultros-app/src/components/sale_history_table.rs
+++ b/ultros-frontend/ultros-app/src/components/sale_history_table.rs
@@ -158,12 +158,12 @@ impl SalesWindow {
             unit_prices_f64.push(price as f64);
         }
 
-        unit_prices.sort_unstable();
-        let median_unit_price = unit_prices[count / 2];
+        // ⚡ Bolt: Optimization: Use select_nth_unstable instead of sort_unstable for median calculation.
+        // This reduces time complexity from O(N log N) to O(N).
+        let (_, &mut median_unit_price, _) = unit_prices.select_nth_unstable(count / 2);
         let avg_sale_price = total_sale_price as f64 / count as f64;
 
-        stack_sizes.sort_unstable();
-        let median_stack_size = stack_sizes[count / 2];
+        let (_, &mut median_stack_size, _) = stack_sizes.select_nth_unstable(count / 2);
 
         let duration = *date_range.end() - *date_range.start();
         let avg_duration = duration / count as i32;


### PR DESCRIPTION
💡 **What**: Switched `sort_unstable` to `select_nth_unstable` when computing medians for `unit_prices` and `stack_sizes` in `SalesWindow::try_new`.
🎯 **Why**: When finding the median (or any k-th order statistic) of a collection, fully sorting the array does O(N log N) work. `select_nth_unstable` performs a partial sort to find the requested element in O(N) average time. Since `SalesWindow` takes in the list of all historic sales in a date range, N can be relatively large here.
📊 **Impact**: Expected performance improvement is reducing time complexity from O(N log N) to O(N) for constructing a new `SalesWindow` inside `SaleHistoryTable`. This slightly reduces blocking work on the main thread.
🔬 **Measurement**: Verify by seeing the sale history render correctly with the correct median unit price and stack size when viewing an item's detail. Run tests with `cargo test --package ultros-app test_sales_window_try_new`.

---
*PR created automatically by Jules for task [15900579655432022126](https://jules.google.com/task/15900579655432022126) started by @akarras*