### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure session management in logout endpoint

### DIFF
--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -264,6 +264,7 @@ pub async fn redirect(
     Ok((cookies, Redirect::to(&redirect_to)))
 }
 
+#[allow(clippy::collapsible_if)]
 pub async fn logout(
     cookie_jar: PrivateCookieJar,
     State(config): State<DiscordAuthConfig>,

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -267,18 +267,23 @@ pub async fn redirect(
 pub async fn logout(
     cookie_jar: PrivateCookieJar,
     State(config): State<DiscordAuthConfig>,
+    State(cache): State<AuthUserCache>,
 ) -> Result<(PrivateCookieJar, Redirect), WebError> {
     let cookie = cookie_jar
         .get("discord_auth")
         .ok_or(WebError::NotAuthenticated)?;
-    let token = AccessToken::new(cookie.value().to_string());
+
+    let token_value = cookie.value().to_string();
+    cache.remove_token(&token_value).await;
+
+    let token = AccessToken::new(token_value);
     // now try to revoke it async style
-    config
-        .inner
-        .client
-        .revoke_token(StandardRevocableToken::AccessToken(token))?
-        .request_async(&config.inner.http_client)
-        .await?;
+    if let Ok(revocable_token) = config.inner.client.revoke_token(StandardRevocableToken::AccessToken(token)) {
+        if let Err(e) = revocable_token.request_async(&config.inner.http_client).await {
+            tracing::warn!("Failed to revoke discord token on logout: {}", e);
+        }
+    }
+
     let cookie_jar = cookie_jar.remove(cookie);
     Ok((cookie_jar, Redirect::to("/")))
 }

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -278,8 +278,15 @@ pub async fn logout(
 
     let token = AccessToken::new(token_value);
     // now try to revoke it async style
-    if let Ok(revocable_token) = config.inner.client.revoke_token(StandardRevocableToken::AccessToken(token)) {
-        if let Err(e) = revocable_token.request_async(&config.inner.http_client).await {
+    if let Ok(revocable_token) = config
+        .inner
+        .client
+        .revoke_token(StandardRevocableToken::AccessToken(token))
+    {
+        if let Err(e) = revocable_token
+            .request_async(&config.inner.http_client)
+            .await
+        {
             tracing::warn!("Failed to revoke discord token on logout: {}", e);
         }
     }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure session management in logout endpoint

Severity: HIGH
Vulnerability: Insecure Session Management (Improper Logout)
Impact: If an attacker steals a user's `discord_auth` cookie before logout, they can continue using it indefinitely even after the legitimate user logs out. Additionally, if the Discord API fails to revoke the token, the logout endpoint throws an error, leaving the cookie on the user's browser (a "fail open" vulnerability for session termination).
Fix: Removed the token from the server's `AuthUserCache` to invalidate the session locally on the server. Also caught errors from Discord's revocation endpoint so the local browser cookie is guaranteed to be cleared regardless of upstream API issues ("fail securely").
Verification: Compiled locally via `cargo check`. Tested the logic via code review.

---
*PR created automatically by Jules for task [7510736387454618341](https://jules.google.com/task/7510736387454618341) started by @akarras*