### PR TITLE
fix(item): stop #6831 item-page hydration crash — InOrder SSR streaming

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -63,7 +63,7 @@ use leptos::prelude::*;
 use leptos_hotkeys::{provide_hotkeys_context, scopes};
 use leptos_meta::*;
 use leptos_router::components::{A, ParentRoute, Route, Router, Routes};
-use leptos_router::path;
+use leptos_router::{SsrMode, path};
 use log::info;
 
 #[cfg(feature = "hydrate")]
@@ -495,8 +495,23 @@ pub fn AppInner(cookies: Cookies) -> impl IntoView {
                                 view=move || view! { "Choose a category to search!" }
                             />
                         </ParentRoute>
-                        <Route path=path!("item/:world/:id") view=ItemView />
-                        <Route path=path!("item/:id") view=ItemView />
+                        // #6831: the item page's data (`listing_resource`) is
+                        // slow in production, so its several `<Suspense>`/`<Transition>`
+                        // boundaries actually suspend and stream out-of-order. That OOO
+                        // template-relocation is what desyncs tachys' hydration marker
+                        // walk (`hydration.rs` `failed_to_cast_marker_node`, "expected a
+                        // marker node, found <tr>") — the single largest GlitchTip issue.
+                        // Two component-level fixes (#933, #939) that reshaped the
+                        // listings `<For>` did not stop it. Locally the resource resolves
+                        // instantly, so the page renders in document order and hydrates
+                        // cleanly — which is exactly what `InOrder` streaming reproduces
+                        // in production. Force it here so the item page never streams OOO.
+                        <Route
+                            path=path!("item/:world/:id")
+                            view=ItemView
+                            ssr=SsrMode::InOrder
+                        />
+                        <Route path=path!("item/:id") view=ItemView ssr=SsrMode::InOrder />
                         <Route path=path!("flip-finder") view=Analyzer />
                         <Route path=path!("analyzer") view=move || {
                             let nav = leptos_router::hooks::use_navigate();


### PR DESCRIPTION
## The bug

**GlitchTip [#6831](https://glitchtip.ultros.app/ultros/issues/6831)** — `RustWasmPanic: internal error: entered unreachable code` at `tachys-0.2.18/src/hydration.rs:163` (`failed_to_cast_marker_node`, "expected a marker node, found `<tr>`") — is the largest issue in the project by ~4 orders of magnitude: **20,365 events and still climbing** (last seen today), versus everything else in the live backlog at count 1–2. It fires on `/item/*` hydration on the current prod release (`89420c8`).

## Why the previous fixes didn't work

Two component-level fixes already shipped and **failed in production**:

- **#933** removed a redundant `{ move || <For/> }` wrapper around `ListingsTable`.
- **#939** made the listings "show more" row a dynamic `{ move || … }` block so it matches `SaleHistoryTable`.

Both targeted the listings `<For>` marker bounding. #939's code is live in `89420c8` and #6831 keeps climbing — so the "static `<tr>` after `<For>`" marker hypothesis is exhausted.

## Root cause: the streaming mode, not a component

The one reliably reproducible fact about this crash (from prior debugging) is that **it only happens under production out-of-order streaming**. Locally (`cargo leptos serve`) the item data resolves instantly, so the page renders in document order and hydrates cleanly — even the exact URLs that crash in prod.

The item page has several independent `<Transition>` boundaries (`HighQualityTable`, `LowQualityTable`, `SalesDetails`, the price chart, the info box), all reading the slow `listing_resource`. In production they genuinely suspend, so Leptos streams them **out-of-order**: shell + fallback first, then each `Suspense`'s resolved HTML inside a `<template>` that a script relocates into place. That template relocation is what desyncs tachys' hydration marker walk. *Which* component trips it is almost beside the point — the OOO mechanism is the trigger. And no `SsrMode` override was set anywhere in the app, so every route defaulted to `OutOfOrder`.

## The fix

Set `ssr=SsrMode::InOrder` on both item routes. `InOrder` walks the tree in document order and, at each `Suspense`, waits for its data and renders it inline — no fallback, no `<template>` relocation. That is exactly the "complete render in document order" that hydrates cleanly locally, now reproduced in production, without having to pinpoint the mismatched component.

```rust
<Route path=path!("item/:world/:id") view=ItemView ssr=SsrMode::InOrder />
<Route path=path!("item/:id")        view=ItemView ssr=SsrMode::InOrder />
```

## Trade-off

`InOrder` serializes streaming of the suspended body: it blocks at the first `Suspense` until `listing_resource` resolves, then the rest render fast (they share that one resource). The shell/header still stream immediately, so TTFB is unchanged; the item body now appears once the data loads instead of showing a fallback that's swapped in later. For a page whose entire purpose is that data, that seems a reasonable trade to eliminate a 20k-event crash. If the delay is unacceptable, `SsrMode::Async` (fully blocking) or a revert is a one-line change.

## Verification (please read before merging)

- ✅ `cargo fmt --all -- --check` passes.
- ✅ `Route`'s `#[prop(optional)] ssr: SsrMode` and `SsrMode::InOrder` verified against the pinned `leptos_router` 0.8.14 source.
- ⚠️ clippy / full build **not** run in this environment (the `xiv-gen` submodule isn't initialized) — CI will run it.
- ⚠️ **This crash does not reproduce locally**, so I could not verify the fix at runtime. Note that #939 *was* verified as far as locally possible (fmt + clippy + 195 tests + byte-identical SSR `curl` + clean local hydrate) and still failed in prod — for this bug, local verification has no predictive power. **The real signal is the post-deploy #6831 event count.** If it keeps climbing on the build that includes this, `InOrder` wasn't sufficient and the next step is the debug-repro harness for a fresh `FILE:LINE`.

Opening for review rather than auto-merging because it's an architectural/perf choice on the highest-traffic page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
