### PR TITLE
🛡️ Sentry: Market Heat Formatter Unit Tests

### DIFF
--- a/ultros-frontend/ultros-app/src/components/market_heat.rs
+++ b/ultros-frontend/ultros-app/src/components/market_heat.rs
@@ -118,3 +118,33 @@ pub fn MarketHeat(world: Signal<Option<String>>) -> impl IntoView {
         </section>
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_category_label_key() {
+        // Test standard 1-5 categories match exactly to their i18n keys
+        assert_eq!(category_label_key(1), "market_heat_cat_weapons");
+        assert_eq!(category_label_key(2), "market_heat_cat_tools");
+        assert_eq!(category_label_key(3), "market_heat_cat_armor");
+        assert_eq!(category_label_key(4), "market_heat_cat_items");
+        assert_eq!(category_label_key(5), "market_heat_cat_housing");
+
+        // Test out-of-bounds edge cases that should fallback to "other"
+        assert_eq!(category_label_key(6), "market_heat_cat_other");
+        assert_eq!(category_label_key(0), "market_heat_cat_other");
+        assert_eq!(category_label_key(99), "market_heat_cat_other");
+    }
+
+    #[test]
+    fn test_band_classes() {
+        // Verify each heat band accurately maps to its styling class and text indicator
+        assert_eq!(band_classes(HeatBand::Hot), ("text-emerald-300", "↑↑"));
+        assert_eq!(band_classes(HeatBand::Warm), ("text-emerald-200/90", "↑"));
+        assert_eq!(band_classes(HeatBand::Stable), ("text-[color:var(--color-text)]", "→"));
+        assert_eq!(band_classes(HeatBand::Cool), ("text-red-300", "↓"));
+        assert_eq!(band_classes(HeatBand::NoData), ("text-[color:var(--color-text-muted)]", "—"));
+    }
+}

--- a/ultros-frontend/ultros-app/src/components/market_heat.rs
+++ b/ultros-frontend/ultros-app/src/components/market_heat.rs
@@ -143,8 +143,14 @@ mod tests {
         // Verify each heat band accurately maps to its styling class and text indicator
         assert_eq!(band_classes(HeatBand::Hot), ("text-emerald-300", "↑↑"));
         assert_eq!(band_classes(HeatBand::Warm), ("text-emerald-200/90", "↑"));
-        assert_eq!(band_classes(HeatBand::Stable), ("text-[color:var(--color-text)]", "→"));
+        assert_eq!(
+            band_classes(HeatBand::Stable),
+            ("text-[color:var(--color-text)]", "→")
+        );
         assert_eq!(band_classes(HeatBand::Cool), ("text-red-300", "↓"));
-        assert_eq!(band_classes(HeatBand::NoData), ("text-[color:var(--color-text-muted)]", "—"));
+        assert_eq!(
+            band_classes(HeatBand::NoData),
+            ("text-[color:var(--color-text-muted)]", "—")
+        );
     }
 }


### PR DESCRIPTION
💡 What: Implemented unit tests for `category_label_key` and `band_classes` in `market_heat.rs` to verify that category ids and HeatBands map to the correct text classes, labels, and i18n keys.
🎯 Why: Pure styling logic and formatters embedded in Leptos components dictate the visual accuracy of data. Un-tested formatters can lead to silent visual bugs or styling regressions. Testing these ensures the mapping is resilient, covering boundary/fallback conditions like out-of-bounds category ids properly defaulting to the "other" category label.
📊 Impact: `ultros-frontend/ultros-app/src/components/market_heat.rs` pure functions are now fully covered.
🔬 Verification: Run `cargo test -p ultros-app components::market_heat::tests`

---
*PR created automatically by Jules for task [227267270659180981](https://jules.google.com/task/227267270659180981) started by @akarras*