### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content-Security-Policy header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Denial of Service (DoS) via Server Tarpitting / SSRF
 **Learning:** `reqwest::Client::new()` in Rust does not have a default timeout. If a user sets a malicious webhook URL that holds the connection open, it could exhaust server resources and block other alerts from being sent.
 **Prevention:** Always configure an explicit `.timeout()` when instantiating `reqwest::Client` for outbound HTTP requests to user-controlled URLs.
+
+## 2024-05-24 - [Add Content-Security-Policy Header]
+**Vulnerability:** Missing Content-Security-Policy (CSP)
+**Learning:** The application lacked a CSP header, which provides defense-in-depth against XSS and data injection attacks by restricting the sources of executable scripts, stylesheets, and images.
+**Prevention:** Always add a `Content-Security-Policy` header configured securely and permissively enough for frontend needs via web framework middleware.

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -1676,6 +1676,10 @@ pub(crate) async fn start_web(state: WebState) {
         .layer(SetResponseHeaderLayer::overriding(
             axum::http::header::STRICT_TRANSPORT_SECURITY,
             HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static("default-src 'self'; img-src 'self' data: https:; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https:;"),
         ));
 
     // run our app with hyper


### PR DESCRIPTION
🚨 **Severity:** MEDIUM (Security Enhancement)

💡 **Vulnerability:** Missing Content-Security-Policy (CSP) headers

🎯 **Impact:** Without a CSP, the application relies solely on input validation and output encoding to prevent Cross-Site Scripting (XSS). If a vulnerability is found, an attacker could inject malicious scripts that execute in users' browsers.

🔧 **Fix:** Added a `Content-Security-Policy` header in `ultros/src/web.rs` using the `tower_http::set_header` middleware. The policy restricts where resources can be loaded from (e.g., scripts, styles, images) to `self` and specifically allowed sources (`https:`, `data:`), providing defense-in-depth against XSS while allowing the Leptos WASM application to function correctly (`wasm-unsafe-eval`, `unsafe-inline`). Also updated `.jules/sentinel.md` with the new learning.

✅ **Verification:** After running the web server (`cargo run`), making a curl request to any endpoint (e.g., `curl -I localhost:8080`) shows the `content-security-policy` header present in the response.

---
*PR created automatically by Jules for task [1552508065489226960](https://jules.google.com/task/1552508065489226960) started by @akarras*