### PR TITLE
🎨 Palette: Add `aria-expanded` to filter toggle buttons

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -943,6 +943,7 @@ fn AnalyzerTable(
                 <button
                     class="btn-secondary flex items-center gap-2"
                     on:click=move |_| show_more.update(|v| *v = !*v)
+                    aria-expanded=move || show_more.get().to_string()
                 >
                     <Icon icon=i::FaFilterSolid />
                     {move || if show_more.get() { "Fewer Filters" } else { "More Filters" }}

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -431,6 +431,7 @@ fn VendorResaleTable(
                 <button
                     class="btn-secondary flex items-center gap-2"
                     on:click=move |_| show_more.update(|v| *v = !*v)
+                    aria-expanded=move || show_more.get().to_string()
                 >
                     <Icon icon=i::FaFilterSolid />
                     {move || if show_more.get() { "Fewer Filters" } else { "More Filters" }}


### PR DESCRIPTION
💡 **What:** Added `aria-expanded` attributes to the "More Filters" toggle buttons in `analyzer.rs` and `vendor_resale.rs`.
🎯 **Why:** To communicate the expanded/collapsed state of the advanced filters section to screen readers, making the interface more accessible.
♿ **Accessibility:** Users relying on assistive technology will now hear whether the additional filters are currently visible or hidden.

---
*PR created automatically by Jules for task [8693748060431023035](https://jules.google.com/task/8693748060431023035) started by @akarras*