### PR TITLE
fix(error-reporting): instrument #6831 hydration panics with a DOM-injection snapshot

### DIFF
--- a/integration/error-filter.test.cjs
+++ b/integration/error-filter.test.cjs
@@ -1261,3 +1261,103 @@ for (const c of cases) {
     );
   });
 }
+
+// ── contexts.dom_injection annotation (diagnostic instrumentation) ──
+// __ultrosAnnotateEvent attaches a DOM-injection snapshot to hydration-class
+// panics (and nothing else), so the #6831 residual flood — modern-Chrome
+// injection that evades every existing fingerprint — becomes diagnosable on the
+// events that still reach GlitchTip. It must never change the drop decision.
+
+// Load the filter and return the whole fake `window`, so tests can reach
+// window.__ultrosAnnotateEvent alongside window.__ultrosShouldDropEvent.
+function loadWindow(userAgent, documentObj) {
+  const win = {};
+  if (documentObj !== undefined) win.document = documentObj;
+  // eslint-disable-next-line no-new-func
+  const factory = new Function("window", "navigator", SRC);
+  factory(win, { userAgent: userAgent || "" });
+  return win;
+}
+
+// A document stand-in exposing the surfaces domInjectionSnapshot reads: the
+// injected <font> count, <html>/<body> classes, and <body>'s direct children.
+function snapshotDocument(opts) {
+  const o = opts || {};
+  const childTags = o.bodyChildTags || [];
+  return {
+    getElementsByTagName(tag) {
+      return { length: tag === "font" ? o.fontCount || 0 : 0 };
+    },
+    documentElement: { className: o.htmlClass || "" },
+    body: {
+      className: o.bodyClass || "",
+      children: childTags.map((t) => ({ tagName: t })),
+    },
+  };
+}
+
+test("annotate attaches contexts.dom_injection to a hydration-class panic", () => {
+  const win = loadWindow(
+    CURRENT_CHROME,
+    snapshotDocument({
+      fontCount: 3,
+      htmlClass: "notranslate",
+      bodyClass: "notranslate injected-overlay",
+      bodyChildTags: ["DIV", "X-INJECT", "SCRIPT"],
+    }),
+  );
+  assert.strictEqual(typeof win.__ultrosAnnotateEvent, "function");
+  const event = rustPanic(HYDRATION_LOC, {
+    breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+  });
+  win.__ultrosAnnotateEvent(event);
+  const snap = event.contexts.dom_injection;
+  assert.ok(snap, "expected contexts.dom_injection to be attached");
+  assert.strictEqual(snap.fontCount, 3);
+  assert.strictEqual(snap.htmlClass, "notranslate");
+  assert.strictEqual(snap.bodyClass, "notranslate injected-overlay");
+  assert.deepStrictEqual(snap.bodyChildTags, ["div", "x-inject", "script"]);
+  assert.strictEqual(snap.bodyChildCount, 3);
+});
+
+test("annotate leaves non-hydration events untouched", () => {
+  const win = loadWindow(CURRENT_CHROME, snapshotDocument({ fontCount: 9 }));
+  // An ordinary application panic — not a tachys hydration path.
+  const APP_LOC =
+    "/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/" +
+    "leptos-0.8.20/src/foo.rs:10:1";
+  const event = rustPanic(APP_LOC, {});
+  win.__ultrosAnnotateEvent(event);
+  assert.strictEqual(
+    event.contexts.dom_injection,
+    undefined,
+    "non-hydration panics must not be annotated",
+  );
+});
+
+test("annotate never changes the drop decision and never throws (no document)", () => {
+  const win = loadWindow(CURRENT_CHROME); // no document
+  const event = rustPanic(HYDRATION_LOC, {
+    breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+  });
+  // Preserved before annotation (current browser, no injector fingerprint)...
+  assert.strictEqual(win.__ultrosShouldDropEvent(event), false);
+  // ...annotation runs without a document and does not throw...
+  assert.doesNotThrow(() => win.__ultrosAnnotateEvent(event));
+  assert.ok(event.contexts.dom_injection, "snapshot still attached (empty-ish)");
+  // ...and the drop decision is unchanged.
+  assert.strictEqual(win.__ultrosShouldDropEvent(event), false);
+});
+
+test("annotate is idempotent — an existing dom_injection is not overwritten", () => {
+  const win = loadWindow(CURRENT_CHROME, snapshotDocument({ fontCount: 2 }));
+  const event = rustPanic(HYDRATION_LOC, {
+    contexts: {
+      rust_panic: { location: HYDRATION_LOC },
+      dom_injection: { sentinel: true },
+    },
+    breadcrumbs: { values: [{ category: "console", message: "app run!" }] },
+  });
+  win.__ultrosAnnotateEvent(event);
+  assert.deepStrictEqual(event.contexts.dom_injection, { sentinel: true });
+});

--- a/ultros-frontend/ultros-app/src/error_filter.js
+++ b/ultros-frontend/ultros-app/src/error_filter.js
@@ -457,6 +457,71 @@
     }
   }
 
+  // Diagnostic snapshot of the live DOM at the moment a hydration-class panic is
+  // reported. #6831 — the tachys `failed_to_cast_element` hydration panic
+  // (tachys-0.2.18/src/hydration.rs:163, the release `unreachable!()` behind
+  // "the framework expected an HTML <TAG> element, but found this instead") — is
+  // the single largest issue by orders of magnitude, yet a clean, current
+  // browser hydrates the failing /item/<world>/<id> URLs with no error (verified
+  // live). The crash only fires once an external translation / injection tool
+  // mutates the SSR DOM before Leptos hydrates. The four existing injector
+  // fingerprints — a live <font>, html.translated-ltr/rtl, the page-stability
+  // breadcrumb, an implausibly stale Chrome (<=124) — all MISS the current
+  // flood: it is modern Chrome (131) carrying NONE of them, so we cannot yet
+  // write a precise fingerprint for whatever tool this population runs. This
+  // captures the DOM's injection surface — tag names and class attributes only,
+  // never any text content — onto the event as contexts.dom_injection so the
+  // injector's actual signature becomes visible on the events that still reach
+  // GlitchTip and a targeted fingerprint can follow. Diagnostic only: it changes
+  // nothing about what is dropped.
+  function domInjectionSnapshot() {
+    var snap = {};
+    try {
+      var doc = typeof window !== "undefined" && window.document;
+      if (!doc) return snap;
+      try {
+        var fonts =
+          doc.getElementsByTagName && doc.getElementsByTagName("font");
+        snap.fontCount = fonts ? fonts.length : 0;
+      } catch (_) {
+        /* ignore */
+      }
+      try {
+        var html = doc.documentElement;
+        if (html && typeof html.className === "string") {
+          snap.htmlClass = html.className.slice(0, 200);
+        }
+      } catch (_) {
+        /* ignore */
+      }
+      var body = doc.body;
+      if (body) {
+        try {
+          if (typeof body.className === "string") {
+            snap.bodyClass = body.className.slice(0, 200);
+          }
+        } catch (_) {
+          /* ignore */
+        }
+        try {
+          var kids = body.children || [];
+          var tags = [];
+          for (var i = 0; i < kids.length && tags.length < 40; i++) {
+            var t = kids[i] && kids[i].tagName;
+            if (typeof t === "string") tags.push(t.toLowerCase());
+          }
+          snap.bodyChildTags = tags;
+          snap.bodyChildCount = kids.length;
+        } catch (_) {
+          /* ignore */
+        }
+      }
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return snap;
+  }
+
   function isInjectedTachysHydrationPanic(event) {
     try {
       if (!isTachysHydrationPanicEvent(event)) return false;
@@ -646,6 +711,27 @@
     }
     return false;
   }
+
+  // Attach the injection snapshot to hydration-class panics so the invisible
+  // injector behind the #6831 residual flood (see domInjectionSnapshot) becomes
+  // diagnosable on the events that still reach GlitchTip. Called from the
+  // Sentry beforeSend wrapper (see shell() in lib.rs) BEFORE the drop check, so
+  // the leaked-through events carry it; annotating an event that is then dropped
+  // is harmless. Scoped to the same classifier the suppression uses, so ordinary
+  // panics are never touched. Mutates the event in place and returns it.
+  window.__ultrosAnnotateEvent = function (event) {
+    try {
+      if (event && isTachysHydrationPanicEvent(event)) {
+        event.contexts = event.contexts || {};
+        if (!event.contexts.dom_injection) {
+          event.contexts.dom_injection = domInjectionSnapshot();
+        }
+      }
+    } catch (_) {
+      /* never let the filter throw */
+    }
+    return event;
+  };
 
   window.__ultrosShouldDropEvent = function (event) {
     return (

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -190,6 +190,12 @@ fn error_reporting_script() -> Option<String> {
     var existingBeforeSend = config && config.beforeSend;
     config = config || {{}};
     config.beforeSend = function(event, hint) {{
+        // Diagnostic-only: annotate hydration-class panics with a DOM-injection
+        // snapshot (contexts.dom_injection) BEFORE the drop check, so the
+        // #6831 events that still leak through carry the injector's signature.
+        if (window.__ultrosAnnotateEvent) {{
+            window.__ultrosAnnotateEvent(event);
+        }}
         if (window.__ultrosShouldDropEvent && window.__ultrosShouldDropEvent(event)) {{
             return null;
         }}


### PR DESCRIPTION
## What

Adds **diagnostic instrumentation** for GlitchTip **#6831** — `RustWasmPanic: internal error: entered unreachable code`, the single largest issue by orders of magnitude (**21,094 and climbing**, last seen today). Every hydration-class panic now carries a small `contexts.dom_injection` snapshot so we can finally *see* what mutates the DOM on the sessions that crash.

## Why this, and not another component/SSR fix

This run re-diagnosed #6831 from the deployed build and prior fixes:

- **Prod is on `b2de121` = PR #946 (`SsrMode::InOrder`)** and the crash **continues unchanged** at `tachys-0.2.18/src/hydration.rs:163`. The three prior fixes — #933 and #939 (listings `<For>` marker reshaping) and #946 (InOrder streaming) — are all deployed and none stopped it.
- **`hydration.rs:163` in tachys 0.2.18 is `failed_to_cast_element`** — the release `unreachable!()` behind *"the framework expected an HTML `<TAG>` element, but found this instead."* That is a **different assertion** than the `failed_to_cast_marker_node` ("expected marker, found `<tr>`") the earlier fixes chased — that diagnosis came from a debug harness run on the older tachys **0.2.15**, so the fixes targeted the wrong failure mode.
- **A clean, current browser hydrates the failing URLs fine.** I loaded the exact URL from the latest event, `/item/Midgardsormr/27079`, in a clean Chrome: 0 injected `<font>` tags, `translate="no"` honored, page fully interactive (theme toggle reacts). So the crash is **environmental** — an external translation / injection tool mutates the SSR DOM before Leptos hydrates.

The `beforeSend` filter already drops these panics when an injector fingerprint is present (a live `<font>`, `html.translated-ltr/rtl`, the page-stability breadcrumb, or stale Chrome ≤124). But the current flood is **modern Chrome (131) carrying none of them**, so the filter correctly leaves them alone (to preserve genuine clean-browser mismatches). We can't write a precise fingerprint for this population **because we can't see what its tool does to the DOM.**

## The change

`window.__ultrosAnnotateEvent(event)` attaches, to hydration-class panics only, a compact **PII-free** snapshot:

- `fontCount` — injected `<font>` elements (Ultros never emits `<font>`)
- `htmlClass` / `bodyClass` — the class attributes (truncated), to catch unknown translation markers
- `bodyChildTags` / `bodyChildCount` — `<body>`'s direct-child **tag names** (capped), to reveal injected wrapper/overlay elements

It runs in `beforeSend` **before** the drop check, so the events that still reach GlitchTip carry it. **It is diagnostic only — it changes nothing about what is dropped,** so a genuine hydration mismatch on a clean browser is still reported. It never reads text content and is fully try/caught.

Once a few real events land, `contexts.dom_injection` should show the injector's signature (e.g. an unexpected child tag or a translation class), and a targeted `beforeSend` fingerprint can follow.

## Verification

- `npm --prefix integration run test:error-filter` → **61/61 pass** (4 new: attaches on hydration panics; leaves non-hydration events untouched; never changes the drop decision and never throws without a `document`; idempotent).
- `cargo fmt --all -- --check` → clean.
- Full clippy/build not run locally (no warm target in this environment). The Rust change is 6 additive lines inside the existing error-reporting `format!` string (balanced `{{`/`}}`, no new placeholders); `error_filter.js` is exercised end-to-end by the passing unit tests.

## Also in this triage run (not in this PR)

Ignored **92** stale `HTMLDocument.c "reading 'document'"` scraper-flood issues (#3282→#3191, count-1 May-12/13 fragments). Canaries #6849/#6850 (currency-exchange, fixed by #942) confirmed not recurred; left as canaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
