### PR TITLE
⚡ Bolt: O(N) median calculation in item views

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -698,8 +698,10 @@ fn MarketStatsPanel(
                                     .iter()
                                     .map(|sale| sale.price_per_item)
                                     .collect::<Vec<_>>();
-                                prices.sort_unstable();
-                                Some(prices[prices.len() / 2])
+                                let len = prices.len();
+                                // ⚡ Bolt: Optimization: Use select_nth_unstable instead of sort_unstable for median calculation.
+                                let (_, &mut median, _) = prices.select_nth_unstable(len / 2);
+                                Some(median)
                             };
                             let vendor_price = tracked_data()
                                 .items

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -96,13 +96,19 @@ fn compute_summary(sale: SaleData) -> SaleSummary {
         .iter()
         .map(|price| price.price_per_unit)
         .collect::<Vec<_>>();
-    prices.sort_unstable();
-    let median_price = match prices.as_slice() {
+    // ⚡ Bolt: Optimization: Use select_nth_unstable instead of sort_unstable for median calculation.
+    let median_price = match prices.as_mut_slice() {
         [] => 0,
-        values if values.len() % 2 == 1 => values[values.len() / 2],
+        values if values.len() % 2 == 1 => {
+            let len = values.len();
+            let (_, &mut median, _) = values.select_nth_unstable(len / 2);
+            median
+        }
         values => {
-            let upper = values.len() / 2;
-            ((values[upper - 1] as i64 + values[upper] as i64) / 2) as i32
+            let mid = values.len() / 2;
+            let (left, &mut mid_val, _) = values.select_nth_unstable(mid);
+            let mid_left_val = *left.iter().max().unwrap();
+            ((mid_val as i64 + mid_left_val as i64) / 2) as i32
         }
     };
     SaleSummary {


### PR DESCRIPTION
💡 What: Replaced `sort_unstable()` with `select_nth_unstable()` when finding median values in `item_view.rs` and `vendor_resale.rs`.
🎯 Why: Finding the median of a slice by fully sorting it is an $O(N \log N)$ operation. We only need the middle element, which can be done in $O(N)$ linear time using `select_nth_unstable()`.
📊 Impact: Cuts down processing time for median calculations significantly, providing better performance on components computing median prices across large sales vectors.
🔬 Measurement: Verify rendering speed during heavy data loads on these views. Existing functionality remains exactly as-is.

---
*PR created automatically by Jules for task [218312439628110693](https://jules.google.com/task/218312439628110693) started by @akarras*