### PR TITLE
🎨 Palette: Add context to resend button aria-label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2026-07-28 - Explicit aria-label for Image-only Menu Buttons
 **Learning:** Found that interactive elements containing only images with alt text might still need an explicit `aria-label` if the image's alt text doesn't adequately describe the element's action (e.g. 'username' vs 'Account menu button').
 **Action:** Always add an explicit `aria-label` to avatar dropdown buttons to standardize the action's description across login states.
+## 2025-02-12 - Added ARIA label to resend button
+**Learning:** Screen readers will struggle to identify multiple identical buttons (like "Resend") across rows in a data table unless they have unique labels with context.
+**Action:** Always include row-specific context (like the item name) in the `aria-label` for buttons inside list/table rows to ensure accessibility.

--- a/ultros-frontend/ultros-app/src/components/history_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/history_panel.rs
@@ -8,7 +8,7 @@ use crate::components::icon::Icon;
 use crate::components::loading::Loading;
 use crate::global_state::toasts::use_toast;
 use crate::global_state::xiv_data::tracked_data;
-use crate::i18n::{t, use_i18n};
+use crate::i18n::{t, t_string, use_i18n};
 
 #[component]
 pub fn HistoryPanel() -> impl IntoView {
@@ -50,6 +50,7 @@ pub fn HistoryPanel() -> impl IntoView {
                                         };
                                         let event_id = e.id;
                                         let delivered = e.delivered;
+                                        let label_item_name = item_name.clone();
                                         let (is_resending, set_is_resending) = RwSignal::new(false).split();
                                         view! {
                                             <tr class="border-t">
@@ -59,9 +60,13 @@ pub fn HistoryPanel() -> impl IntoView {
                                                 <td class="p-1">{delivered_str}</td>
                                                 <td class="p-1">
                                                     <Show when=move || !delivered>
-                                                        <button
-                                                            class="btn-ghost"
-                                                            disabled=move || is_resending.get()
+                                                        {
+                                                            let label = label_item_name.clone();
+                                                            view! {
+                                                                <button
+                                                                    class="btn-ghost"
+                                                                    aria-label=move || format!("{} {}", t_string!(i18n, history_resend_button), label.clone())
+                                                                    disabled=move || is_resending.get()
                                                             on:click=move |_| {
                                                                 set_is_resending.set(true);
                                                                 spawn_local(async move {
@@ -89,10 +94,12 @@ pub fn HistoryPanel() -> impl IntoView {
                                                             }
                                                         >
                                                             <Show when=move || !is_resending.get() fallback=|| view! { <Loading /> }>
-                                                                <Icon icon=i::BsArrowRepeat />
-                                                                <span class="ml-1">{t!(i18n, history_resend_button)}</span>
-                                                            </Show>
-                                                        </button>
+                                                                    <Icon icon=i::BsArrowRepeat />
+                                                                    <span class="ml-1">{t!(i18n, history_resend_button)}</span>
+                                                                </Show>
+                                                                </button>
+                                                            }
+                                                        }
                                                     </Show>
                                                 </td>
                                             </tr>

--- a/ultros-frontend/ultros-app/src/components/history_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/history_panel.rs
@@ -65,38 +65,38 @@ pub fn HistoryPanel() -> impl IntoView {
                                                             view! {
                                                                 <button
                                                                     class="btn-ghost"
-                                                                    aria-label=move || format!("{} {}", t_string!(i18n, history_resend_button), label.clone())
+                                                                    aria-label=move || format!("{} {}", t_string!(i18n, history_resend_button), label)
                                                                     disabled=move || is_resending.get()
-                                                            on:click=move |_| {
-                                                                set_is_resending.set(true);
-                                                                spawn_local(async move {
-                                                                    match resend_alert_event(event_id).await {
-                                                                        Ok(r) if r.delivered => {
-                                                                            if let Some(t) = toasts {
-                                                                                t.success("Resent");
+                                                                    on:click=move |_| {
+                                                                        set_is_resending.set(true);
+                                                                        spawn_local(async move {
+                                                                            match resend_alert_event(event_id).await {
+                                                                                Ok(r) if r.delivered => {
+                                                                                    if let Some(t) = toasts {
+                                                                                        t.success("Resent");
+                                                                                    }
+                                                                                    version.update(|v| *v += 1);
+                                                                                }
+                                                                                Ok(r) => {
+                                                                                    if let Some(t) = toasts {
+                                                                                        t.error(r.error.unwrap_or_else(|| "Resend failed".into()));
+                                                                                    }
+                                                                                    set_is_resending.set(false);
+                                                                                }
+                                                                                Err(e) => {
+                                                                                    if let Some(t) = toasts {
+                                                                                        t.error(format!("{e}"));
+                                                                                    }
+                                                                                    set_is_resending.set(false);
+                                                                                }
                                                                             }
-                                                                            version.update(|v| *v += 1);
-                                                                        }
-                                                                        Ok(r) => {
-                                                                            if let Some(t) = toasts {
-                                                                                t.error(r.error.unwrap_or_else(|| "Resend failed".into()));
-                                                                            }
-                                                                            set_is_resending.set(false);
-                                                                        }
-                                                                        Err(e) => {
-                                                                            if let Some(t) = toasts {
-                                                                                t.error(format!("{e}"));
-                                                                            }
-                                                                            set_is_resending.set(false);
-                                                                        }
+                                                                        });
                                                                     }
-                                                                });
-                                                            }
-                                                        >
-                                                            <Show when=move || !is_resending.get() fallback=|| view! { <Loading /> }>
-                                                                    <Icon icon=i::BsArrowRepeat />
-                                                                    <span class="ml-1">{t!(i18n, history_resend_button)}</span>
-                                                                </Show>
+                                                                >
+                                                                    <Show when=move || !is_resending.get() fallback=|| view! { <Loading /> }>
+                                                                        <Icon icon=i::BsArrowRepeat />
+                                                                        <span class="ml-1">{t!(i18n, history_resend_button)}</span>
+                                                                    </Show>
                                                                 </button>
                                                             }
                                                         }


### PR DESCRIPTION
💡 **What**: Added an `aria-label` with item context to the "Resend" button in the history table.
🎯 **Why**: When navigating the table via a screen reader, multiple "Resend" buttons become confusing. Providing row-specific context (e.g., "Resend [Item Name]") ensures users know precisely what item the action corresponds to.
📸 **Before/After**: This is an accessibility update; no visual changes.
♿ **Accessibility**: Enhanced screen reader support for row-specific actions in data tables.

---
*PR created automatically by Jules for task [16861898679560115357](https://jules.google.com/task/16861898679560115357) started by @akarras*