### PR TITLE
fix(ssr): honor SsrMode::InOrder so the item page stops streaming OOO (#6831)

### DIFF
--- a/integration/ooo-hydration-race.cjs
+++ b/integration/ooo-hydration-race.cjs
@@ -1,0 +1,97 @@
+// Diagnostic for GlitchTip #6831 — "RustWasmPanic: internal error: entered
+// unreachable code" at tachys `hydration.rs:163` (`failed_to_cast_element`).
+//
+// WHAT IT MEASURES
+// Out-of-order SSR streaming emits each resolved <Suspense> as a <template>
+// plus an inline script that relocates the fragment into place
+// (`insertBefore(tpl.content.cloneNode(true), close)`). Those relocations
+// reshape the DOM that `hydrate_body()` is about to walk. This script counts
+// the relocations per page load (by hooking `Node.prototype.insertBefore` for
+// DocumentFragment inserts at document-start) and correlates them with the
+// hydration panic.
+//
+// MEASURED AGAINST PROD (release ultros@586c819, 12 loads, ads disabled):
+//   relocations >= 4 -> panic 8/8
+//   relocations <= 1 -> panic 0/3
+// i.e. the panic is caused by out-of-order streaming, NOT by page translation
+// or by AdSense (it reproduces with ads fully off and zero <font> injection).
+//
+// USE
+//   BASE_URL=https://ultros.app node ./ooo-hydration-race.cjs
+//   ITEM_PATH=/item/Sargatanas/16970 N=12 node ./ooo-hydration-race.cjs
+//
+// Expected after the SsrMode::InOrder wiring fix: relocations 0 on every load,
+// and no panics.
+const puppeteer = require('puppeteer');
+
+const BASE_URL = process.env.BASE_URL || 'https://ultros.app';
+const ITEM_PATH = process.env.ITEM_PATH || '/item/%E7%90%A5%E7%8F%80%E5%8E%9F/16970';
+const N = Number(process.env.N || 10);
+
+// Count DocumentFragment insertions — the signature of a <template> relocation.
+const initScript = () => {
+  window.__ooo = 0;
+  const orig = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function (node, ref) {
+    if (node && node.nodeType === 11 /* DOCUMENT_FRAGMENT_NODE */) window.__ooo++;
+    return orig.call(this, node, ref);
+  };
+};
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  const rows = [];
+
+  for (let i = 0; i < N; i++) {
+    const page = await browser.newPage();
+    await page.setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
+    );
+    // Disable ads two ways, so AdSense cannot confound the measurement.
+    const { hostname } = new URL(BASE_URL);
+    await page.setCookie({ name: 'HIDE_ADS', value: 'true', domain: hostname, path: '/' });
+    await page.evaluateOnNewDocument(initScript);
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      const u = req.url();
+      if (/googlesyndication|doubleclick|adtrafficquality|googletagservices|google-analytics/.test(u)) {
+        return req.abort().catch(() => {});
+      }
+      req.continue().catch(() => {});
+    });
+
+    let panicked = false;
+    page.on('console', (m) => {
+      if (/hydration\.rs:163/.test(m.text())) panicked = true;
+    });
+    page.on('pageerror', (e) => {
+      if (/unreachable/i.test(String(e))) panicked = true;
+    });
+
+    // Cache-bust so each trial gets a fresh server render.
+    await page.goto(`${BASE_URL}${ITEM_PATH}?cb=${Date.now()}-${i}`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
+    await new Promise((r) => setTimeout(r, 9000));
+
+    const ooo = await page.evaluate(() => window.__ooo);
+    rows.push({ ooo, panicked });
+    console.log(`trial ${String(i).padStart(2)}: relocations=${String(ooo).padStart(2)} panicked=${panicked}`);
+    await page.close();
+  }
+  await browser.close();
+
+  const withT = rows.filter((r) => r.ooo > 0);
+  const noT = rows.filter((r) => r.ooo === 0);
+  const pct = (a) => (a.length ? Math.round((a.filter((r) => r.panicked).length / a.length) * 100) + '%' : 'n/a');
+  console.log(`\nrelocations present (n=${withT.length}): panic ${pct(withT)}`);
+  console.log(`relocations absent  (n=${noT.length}): panic ${pct(noT)}`);
+
+  const panics = rows.filter((r) => r.panicked).length;
+  console.log(`\ntotal: ${panics}/${rows.length} loads panicked`);
+  process.exit(panics > 0 ? 1 : 0);
+})();

--- a/integration/package.json
+++ b/integration/package.json
@@ -20,7 +20,8 @@
     "test:fc-crafting-breakdown": "node ./fc-crafting-breakdown.cjs",
     "test:dashboard": "node ./dashboard.cjs",
     "test:group-shared-list": "node ./group-shared-list.cjs",
-    "test:error-filter": "node --test ./error-filter.test.cjs"
+    "test:error-filter": "node --test ./error-filter.test.cjs",
+    "diag:ooo-hydration-race": "node ./ooo-hydration-race.cjs"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -15,6 +15,7 @@ use axum::{
 };
 use leptos::prelude::*;
 use leptos_axum::{LeptosRoutes, generate_route_list};
+use leptos_router::SsrMode;
 #[cfg(not(debug_assertions))]
 use tower_http::set_header::SetResponseHeader;
 use tracing::{info, instrument};
@@ -49,14 +50,24 @@ fn escape_for_script_tag(json: &str) -> String {
     out
 }
 
-#[instrument(skip(worlds, options, req, user))]
-#[axum::debug_handler(state = WebState)]
-async fn custom_handler(
-    State(worlds): State<Arc<WorldHelper>>,
-    State(options): State<LeptosOptions>,
+/// Which streaming strategy to render a route with.
+///
+/// `leptos_routes_with_handler` binds a single handler to every route and never
+/// consults the `SsrMode` a route declares, so the mode has to be threaded
+/// through by hand — see `create_leptos_app`.
+#[derive(Clone, Copy, Debug)]
+enum StreamMode {
+    OutOfOrder,
+    InOrder,
+}
+
+async fn render_leptos(
+    worlds: Arc<WorldHelper>,
+    options: LeptosOptions,
     region: Option<Region>,
     user: Result<AuthDiscordUser, ApiError>,
     req: Request<Body>,
+    mode: StreamMode,
 ) -> Response {
     info!("Custom handler");
     // The HTML now carries per-user data (region + current_user), so it must
@@ -89,21 +100,64 @@ async fn custom_handler(
 
     let region_for_ctx = region_str.clone();
     let current_user_for_ctx = current_user.clone();
-    let handler = leptos_axum::render_app_to_stream_with_context_and_replace_blocks(
-        move || {
-            provide_context(LocalWorldData(Ok(worlds.clone())));
-            provide_context(GuessedRegion(region_for_ctx.clone()));
-            provide_context(BootstrapUser(current_user_for_ctx.clone()));
-        },
-        move || shell(options.clone(), bootstrap_script.clone()),
-        true,
-    );
-    let mut response = handler(req).await.into_response();
+    let additional_context = move || {
+        provide_context(LocalWorldData(Ok(worlds.clone())));
+        provide_context(GuessedRegion(region_for_ctx.clone()));
+        provide_context(BootstrapUser(current_user_for_ctx.clone()));
+    };
+    let app_fn = move || shell(options.clone(), bootstrap_script.clone());
+    let mut response = match mode {
+        StreamMode::OutOfOrder => {
+            let handler = leptos_axum::render_app_to_stream_with_context_and_replace_blocks(
+                additional_context,
+                app_fn,
+                true,
+            );
+            handler(req).await.into_response()
+        }
+        StreamMode::InOrder => {
+            let handler =
+                leptos_axum::render_app_to_stream_in_order_with_context(additional_context, app_fn);
+            handler(req).await.into_response()
+        }
+    };
     response.headers_mut().insert(
         header::CACHE_CONTROL,
         HeaderValue::from_static("private, no-store"),
     );
     response
+}
+
+#[instrument(skip(worlds, options, req, user))]
+#[axum::debug_handler(state = WebState)]
+async fn custom_handler(
+    State(worlds): State<Arc<WorldHelper>>,
+    State(options): State<LeptosOptions>,
+    region: Option<Region>,
+    user: Result<AuthDiscordUser, ApiError>,
+    req: Request<Body>,
+) -> Response {
+    render_leptos(worlds, options, region, user, req, StreamMode::OutOfOrder).await
+}
+
+/// Handler for routes that declare `SsrMode::InOrder`.
+///
+/// Out-of-order streaming emits each resolved `<Suspense>` as a `<template>`
+/// plus an inline script that relocates the fragment into place. Those
+/// relocations race `hydrate_body()` and desync tachys' hydration walk, which
+/// panics at `hydration.rs:163` (`failed_to_cast_element`) — GlitchTip #6831.
+/// In-order streaming resolves each boundary before emitting it, so no
+/// relocation script is produced and there is nothing to race.
+#[instrument(skip(worlds, options, req, user))]
+#[axum::debug_handler(state = WebState)]
+async fn in_order_handler(
+    State(worlds): State<Arc<WorldHelper>>,
+    State(options): State<LeptosOptions>,
+    region: Option<Region>,
+    user: Result<AuthDiscordUser, ApiError>,
+    req: Request<Body>,
+) -> Response {
+    render_leptos(worlds, options, region, user, req, StreamMode::InOrder).await
 }
 
 pub(crate) async fn create_leptos_app(
@@ -152,16 +206,33 @@ pub(crate) async fn create_leptos_app(
 
     // simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
+    // `leptos_routes_with_handler` binds one handler to every route and drops
+    // the `SsrMode` each route declares — so `ssr=SsrMode::InOrder` in the app's
+    // route table was silently ignored, and the item page kept streaming
+    // out-of-order (#6831). Split the listing by mode and give the in-order
+    // routes a handler that actually streams in order.
+    let (in_order_routes, streaming_routes): (Vec<_>, Vec<_>) = routes
+        .into_iter()
+        .partition(|route| matches!(route.mode(), SsrMode::InOrder));
+    tracing::info!(
+        "leptos routes: {} in-order, {} out-of-order",
+        in_order_routes.len(),
+        streaming_routes.len()
+    );
+
     // build our application with a route
-    Ok(Router::new()
+    let mut router = Router::new()
         // `GET /` goes to `root`
         .nest_service(
             &["/", &leptos_options.site_pkg_dir].concat(),
             cargo_leptos_service.clone(),
-        ) // Only need if using wasm-pack. Can be deleted if using cargo-leptos
-        // .nest_service(&bundle_path, cargo_leptos_service) // Only needed if using cargo-leptos. Can be deleted if using wasm-pack and cargo-run
-        //.nest_service("/static", static_service)
-        .leptos_routes_with_handler(routes, custom_handler))
+        ); // Only need if using wasm-pack. Can be deleted if using cargo-leptos
+    // .nest_service(&bundle_path, cargo_leptos_service) // Only needed if using cargo-leptos. Can be deleted if using wasm-pack and cargo-run
+    //.nest_service("/static", static_service)
+    if !in_order_routes.is_empty() {
+        router = router.leptos_routes_with_handler(in_order_routes, in_order_handler);
+    }
+    Ok(router.leptos_routes_with_handler(streaming_routes, custom_handler))
     // .with_state(state)
     // .layer(Extension(Arc::new(leptos_options))))
 }


### PR DESCRIPTION
## What

`leptos_routes_with_handler` binds **one** handler to **every** route and never reads the `SsrMode` a route declares. So every route rendered through `render_app_to_stream_with_context_and_replace_blocks` — out-of-order streaming — and the `ssr=SsrMode::InOrder` added to the item routes in #946 **was dead code**.

That is why #6831 (22,260 events, the #1 issue by orders of magnitude) survived #946, and why #933/#939 before it missed too: all three fixes were aimed at the wrong layer.

This splits the generated route list by `route.mode()` and gives routes that ask for `InOrder` a handler that actually streams in order.

## Root cause

Out-of-order streaming emits each resolved `<Suspense>` as a `<template>` plus an inline script that relocates the fragment into place:

```js
insertBefore(tpl.content.cloneNode(true), close)
```

Those relocations reshape the DOM that `hydrate_body()` is about to walk. `hydrate()` `await`s the multi-MB `.rkyv` blob before hydrating (~2.7s in the sampled crash event), so there is a wide window in which relocation scripts and hydration interleave. tachys then hits a node whose tag isn't what it expected → `failed_to_cast_element` → `unreachable!()` at `hydration.rs:163`.

## Evidence

Measured against **prod** (release `ultros@586c819`), ads disabled via both the `HIDE_ADS` cookie and request blocking, 12 loads, counting DocumentFragment insertions per load:

| OOO relocations | panic |
|---|---|
| 10 | true ×5 |
| 4 | true ×3 |
| 1 | false |
| 0 | false ×2 |

**relocations ≥4 → panic 8/8. relocations ≤1 → panic 0/3.**

The SSR output is non-deterministic on the same URL — sometimes 0 templates, sometimes 4+ — depending on whether `listing_resource` resolves before the renderer reaches it. The loads that happened to render in-order (0 relocations) never panicked. That is the state this PR forces for every item-page render.

Harness added as `integration/ooo-hydration-race.cjs` (`npm --prefix integration run diag:ooo-hydration-race`).

## Two long-standing theories retired

- **Page translation** — the `contexts.dom_injection` instrumentation from #952 came back on a fresh event with `fontCount: 0`, `htmlClass: "notranslate"`, `bodyClass: "notranslate"`. No translator touched the page. The CN-locale correlation everyone read as "translation" is really *slow network → longer `.rkyv` await → wider race window*.
- **AdSense / ad injection** — the panic reproduces with ads fully off (`ins=0`, no AdSense in SSR at all): 2/5 and 3/5. Ads widen the window but are not the cause.

`#6831` is **not environmental**. It reproduces ~50–90% of the time in clean headless Chrome. The earlier "clean Chrome hydrates fine" conclusion came from a single manual load against a coin-flip bug.

## Verification

- `cargo fmt --all -- --check` → clean
- `cargo clippy -p ultros --all-targets -- -D warnings` → clean (exit 0)

**Not verified end-to-end locally**: the SSR server won't build/run on Windows/MSVC (jemalloc wall), so I could not observe the fixed server's output directly. The chain rests on: (1) OOO relocations cause the panic (measured above), (2) `render_app_to_stream_in_order_with_context` uses `to_html_stream_in_order()` and emits no relocation scripts by construction, (3) the server currently discards `SsrMode` (read from `leptos_axum` 0.8.10 source: the mode-aware `leptos_routes` dispatches on `listing.mode()` at lib.rs:1884; `leptos_routes_with_handler` does not).

After deploy, confirm with:

```
BASE_URL=https://ultros.app npm --prefix integration run diag:ooo-hydration-race
```

Expect `relocations=0` on every load and `0/N loads panicked`. The boot log also now prints the split (`leptos routes: N in-order, M out-of-order`).

## Risk / rollback

Behaviour changes only for routes that declare `InOrder` (the two item routes). In-order streaming trades a little TTFB on those pages for a DOM that hydrates deterministically. Everything else keeps the existing out-of-order handler, byte for byte. Revert = one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)