### PR TITLE
fix(item): suspend HQ/LQ tables on listing_resource — the real #6831 hydration crash (post-#955)

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1281,7 +1281,10 @@ pub fn ChartWrapper(
 }
 
 #[component]
-fn HighQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> impl IntoView {
+fn HighQualityTable(
+    listing_resource: Resource<Result<Arc<CurrentlyShownItem>, AppError>>,
+    #[prop(into)] filtered_listings: Signal<ListingRows>,
+) -> impl IntoView {
     let i18n = crate::i18n::use_i18n();
     view! {
         <div class="space-y-6">
@@ -1289,6 +1292,15 @@ fn HighQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> imp
                 view! { <BoxSkeleton /> }
             }>
                 {move || {
+                    // Read `listing_resource` inside the Transition so this section
+                    // actually suspends on it during SSR. `filtered_listings` is a Memo
+                    // created outside any Suspense boundary, so reading it alone does NOT
+                    // subscribe this Transition to the resource — the server would then
+                    // render an empty table while the client hydrates a populated one,
+                    // tripping the tachys hydration `unreachable!()` panic (GlitchTip #6831).
+                    if !listing_resource.with(|r| matches!(r, Some(Ok(_)))) {
+                        return ().into_any();
+                    }
                     let hq_listings = Memo::new(move |_| {
                         filtered_listings.with(|listings| {
                             listings
@@ -1309,6 +1321,7 @@ fn HighQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> imp
                             <ListingsTable listings=hq_listings />
                         </div>
                     }
+                        .into_any()
                 }}
             </Transition>
         </div>
@@ -1317,7 +1330,10 @@ fn HighQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> imp
 }
 
 #[component]
-fn LowQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> impl IntoView {
+fn LowQualityTable(
+    listing_resource: Resource<Result<Arc<CurrentlyShownItem>, AppError>>,
+    #[prop(into)] filtered_listings: Signal<ListingRows>,
+) -> impl IntoView {
     let i18n = crate::i18n::use_i18n();
     view! {
         <div class="space-y-6">
@@ -1325,6 +1341,12 @@ fn LowQualityTable(#[prop(into)] filtered_listings: Signal<ListingRows>) -> impl
                 view! { <BoxSkeleton /> }
             }>
                 {move || {
+                    // Suspend on `listing_resource` here too (see HighQualityTable) so the
+                    // server does not emit an empty table that the client then hydrates as
+                    // populated — the tachys hydration mismatch behind GlitchTip #6831.
+                    if !listing_resource.with(|r| matches!(r, Some(Ok(_)))) {
+                        return ().into_any();
+                    }
                     let lq_listings = Memo::new(move |_| {
                         filtered_listings.with(|listings| {
                             listings
@@ -1540,8 +1562,8 @@ fn ListingsContent(
 
             <div id="listings" class="grid grid-cols-1 gap-6 mt-6">
                 <DatacenterExclusionControls world excluded_datacenters />
-                <HighQualityTable filtered_listings />
-                <LowQualityTable filtered_listings />
+                <HighQualityTable listing_resource filtered_listings />
+                <LowQualityTable listing_resource filtered_listings />
             </div>
 
             <div class="grid grid-cols-1 gap-6 mt-8">


### PR DESCRIPTION
## Problem — GlitchTip #6831 (22.5k+ events, the #1 issue)

`RustWasmPanic: internal error: entered unreachable code` at `tachys-0.2.18/src/hydration.rs:163` (`failed_to_cast_element`), firing on `/item/*` page hydration.

**PR #955 (`SsrMode::InOrder`) did not fix it.** The latest event (`2026-07-16T03:49:33Z`) is on release `ultros@25bd36b`, which already includes #955, and still panics at `hydration.rs:163` with `dom_injection.fontCount:0` / `notranslate` intact — so this is neither translation nor the out-of-order `<template>` relocations #955 removed.

## Root cause

In `ListingsContent`, `filtered_listings` is a `Memo` created **outside any `<Suspense>`**. `HighQualityTable` and `LowQualityTable` read **only** that Memo inside their `<Transition>` — they never touch `listing_resource` directly. Because the Memo's reactive owner has no `SuspenseContext`, reading it does not register `listing_resource` as a pending resource with those tables' Transitions.

Consequently, during SSR the tables render **whatever `filtered_listings` currently holds** the moment their closure runs. When the listings future hasn't resolved yet (a timing race — worse on slow connections, which matches the crawler/slow-network correlation and the ~50–90% reproduction rate), the server emits an **empty** table, while the client — where the resource is already serialized/resolved — hydrates a **populated** one. Different DOM node counts → tachys `failed_to_cast_element` → `unreachable!()`.

Every other section (`DecisionHeader`, `MarketStatsPanel`, `ChartWrapper`, `SalesDetails`) reads `listing_resource` directly inside its Transition and therefore suspends correctly — only the two tables were missing that dependency.

## Fix

Thread `listing_resource` into `HighQualityTable`/`LowQualityTable` and read it inside the Transition to establish the Suspense dependency (rendering nothing until `Some(Ok(_))`), mirroring the pattern the sibling sections already use. This keeps the shared `filtered_listings` Memo (no extra filtering work) and makes SSR wait for the resource before emitting the tables, so server and client hydrate identical markup.

## Verification

- `cargo check -p ultros-app --lib` — clean (`Finished`, exit 0).
- `cargo clippy -p ultros-app --lib -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Root cause corroborated by the production event trail (post-#955 release, `fontCount:0`), by direct reading of the reactive-ownership semantics, and by Leptos's own "resource read outside Suspense … can cause hydration mismatch errors" warning previously observed at this Memo.

Note: the crash is a hydration race that only manifests against a live SSR server; the prod-repro harness (`integration/ooo-hydration-race.cjs`) can't run from this sandbox (no egress to ultros.app). Recommend confirming on a prod canary that #6831's event rate drops after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
