### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix authentication cookie path scope

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Denial of Service (DoS) via Server Tarpitting / SSRF
 **Learning:** `reqwest::Client::new()` in Rust does not have a default timeout. If a user sets a malicious webhook URL that holds the connection open, it could exhaust server resources and block other alerts from being sent.
 **Prevention:** Always configure an explicit `.timeout()` when instantiating `reqwest::Client` for outbound HTTP requests to user-controlled URLs.
+
+## 2024-05-24 - [Fix Cookie Path Scoping]
+**Vulnerability:** Incomplete Cookie Scope Configuration
+**Learning:** The `discord_auth` cookie was being set during a `/redirect` endpoint without an explicitly set `Path=/`. This scopes the cookie to the `/redirect` path, meaning the browser wouldn't send the auth cookie to other paths (like `/api/v1/user`), effectively breaking authentication outside that route. Other cookies in the same file were properly using `cookie.set_path("/")` or `CookieBuilder` with `.path("/")`.
+**Prevention:** Always explicitly set `cookie.set_path("/")` for application-wide authentication or session cookies to ensure they are sent to all relevant routes.

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -259,6 +259,7 @@ pub async fn redirect(
     cookie.set_secure(true);
     cookie.set_same_site(SameSite::Lax);
     cookie.set_http_only(true);
+    cookie.set_path("/");
     cookie.make_permanent();
     cookies = cookies.add(cookie);
     Ok((cookies, Redirect::to(&redirect_to)))


### PR DESCRIPTION
🛡️ Sentinel: [HIGH/MEDIUM] Fix authentication cookie path scope
    * 🚨 Severity: HIGH/MEDIUM
    * 💡 Vulnerability: `discord_auth` authentication cookie missing explicit `Path=/`.
    * 🎯 Impact: Without an explicit path, the browser limits the cookie to the route that created it (e.g., `/redirect`). The auth cookie wouldn't be sent to other endpoints like `/api/v1/user`, silently failing authentication.
    * 🔧 Fix: Added `cookie.set_path("/")` when setting the `discord_auth` cookie during the OAuth redirect flow.
    * ✅ Verification: Verified code logic now mirrors `test_auth_login`'s path configuration logic.

---
*PR created automatically by Jules for task [8273717906986622983](https://jules.google.com/task/8273717906986622983) started by @akarras*