### PR TITLE
fix(item): sort HashMap-sourced source lists to stop #6831 hydration crash

### DIFF
--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -462,6 +462,12 @@ fn gil_shop_to_npc(gil_shops: &[GilShopId]) -> Vec<(GilShopId, &'static ENpcBase
                 shops.into_iter().map(move |gil_shop| (gil_shop, npc))
             })
         })
+        // `e_npc_bases` is a std HashMap whose iteration order is randomized
+        // per process (RandomState). Without a stable sort the SSR server and
+        // the hydrating wasm client emit the vendor rows in different orders,
+        // desyncing the DOM and tripping tachys' hydration walker (#6831).
+        // Sort by stable ids so both sides render the same sequence.
+        .sorted_by_key(|(gil_shop, npc)| (npc.key_id.0, gil_shop.0))
         .collect()
 }
 
@@ -606,16 +612,34 @@ fn get_trade_costs(shop: &SpecialShop, item_id: i32) -> Vec<TradeCosts> {
     results
 }
 
+/// Collect the special shops that trade for `item_id`, in a stable,
+/// `key_id`-ascending order.
+///
+/// `special_shops` is a `std::collections::HashMap` whose iteration order is
+/// randomized per process (`RandomState`). The SSR server process and the
+/// client wasm instance each build their own copy of the game data, so an
+/// unsorted `.values()` yields the shops in a *different* order on each side.
+/// That makes the server-rendered DOM and the hydrating DOM disagree, tripping
+/// tachys' hydration walker (`failed_to_cast_element`) — the #6831 crash.
+/// Sorting by the stable `key_id` makes both sides render the same sequence.
+fn exchange_shops_for_item(
+    special_shops: &std::collections::HashMap<xiv_gen::SpecialShopId, SpecialShop>,
+    item_id: i32,
+) -> Vec<&SpecialShop> {
+    special_shops
+        .values()
+        .filter(|shop| special_shop_has_item(shop, item_id))
+        .sorted_by_key(|shop| shop.key_id.0)
+        .collect()
+}
+
 #[component]
 fn ExchangeSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
     let i18n = use_i18n();
     let data = tracked_data();
     let exchanges = Memo::new(move |_| {
         let item_id = item_id();
-        data.special_shops
-            .values()
-            .filter(move |shop| special_shop_has_item(shop, item_id))
-            .collect::<Vec<_>>()
+        exchange_shops_for_item(&data.special_shops, item_id)
     });
 
     let view = move || {
@@ -726,6 +750,53 @@ mod tests {
         assert_eq!(costs_789[0].len(), 1);
         assert_eq!(costs_789[0][0], (ItemId(20), 200));
     }
+
+    /// Regression guard for #6831: the exchange-source shops must come out in a
+    /// stable, `key_id`-ascending order no matter what order they sit in the
+    /// (randomly seeded) `special_shops` HashMap. If this order ever depends on
+    /// HashMap iteration order again, SSR and CSR render different DOM and the
+    /// item page crashes on hydration.
+    #[test]
+    fn exchange_shops_for_item_is_deterministically_sorted() {
+        use std::collections::HashMap;
+
+        // A shop whose first receive slot trades for `received`.
+        fn mk_shop(key_id: i32, received: u16) -> SpecialShop {
+            SpecialShop {
+                key_id: xiv_gen::SpecialShopId(key_id),
+                name: format!("Shop {key_id}"),
+                item: vec![],
+                item_receive_0: vec![received],
+                count_receive_0: vec![1],
+                item_receive_1: vec![0],
+                count_receive_1: vec![0],
+                item_cost_0: vec![10],
+                count_cost_0: vec![1],
+                item_cost_1: vec![0],
+                count_cost_1: vec![0],
+                item_cost_2: vec![0],
+                count_cost_2: vec![0],
+            }
+        }
+
+        let mut shops = HashMap::new();
+        // Insert in a deliberately non-ascending key order.
+        for key_id in [7, 2, 9, 4, 1] {
+            shops.insert(xiv_gen::SpecialShopId(key_id), mk_shop(key_id, 123));
+        }
+        // Two shops that do NOT trade for item 123 must be filtered out.
+        shops.insert(xiv_gen::SpecialShopId(50), mk_shop(50, 999));
+        shops.insert(xiv_gen::SpecialShopId(51), mk_shop(51, 888));
+
+        let ids: Vec<i32> = exchange_shops_for_item(&shops, 123)
+            .iter()
+            .map(|shop| shop.key_id.0)
+            .collect();
+
+        // Ascending key_id order regardless of HashMap seed — the deterministic
+        // sequence both SSR and CSR must produce.
+        assert_eq!(ids, vec![1, 2, 4, 7, 9]);
+    }
 }
 
 pub fn leve_rewards_item(
@@ -785,6 +856,9 @@ fn LeveSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
                     &data.leve_reward_item_groups,
                 )
             })
+            // `leves` is a randomized std HashMap; sort by stable id so SSR and
+            // CSR render the levequest rows in the same order (#6831 hydration).
+            .sorted_by_key(|leve| leve.key_id.0)
             .collect::<Vec<_>>()
     });
 


### PR DESCRIPTION
## The #1 GlitchTip issue (#6831, 22k+ events)

`RustWasmPanic` / tachys `failed_to_cast_element` hydration crash on `/item/*` pages. A debug-wasm hydration harness previously pinned the exact failing node to `related_items.rs` inside `ExchangeSources`.

## Root cause

The item page's **Exchange Sources**, **Vendor Sources**, and **Levequest Rewards** panels each build their list by iterating a `std::collections::HashMap` and rendering one DOM node per entry **in `.values()` order**:

| Component | Map iterated |
|-----------|--------------|
| `ExchangeSources` | `data.special_shops` |
| `VendorItems` (via `gil_shop_to_npc`) | `data.e_npc_bases` |
| `LeveSources` | `data.leves` |

`HashMap` uses `RandomState`, so iteration order is **randomized per process**. The SSR server process and the client wasm instance each deserialize the game data into their own map, so `.values()` yields the entries in a *different order on each side*. When an item has 2+ exchange shops / vendor NPCs / leves, the server-rendered DOM and the hydrating DOM disagree → tachys' hydration walker panics.

This is the same bug class the file *already* guards against elsewhere — `recipe_tree_iter` and `RelatedItems` both `.sorted_by_key(|i| i.key_id.0)` before rendering. These three sites were simply missed.

> Prior #6831 attempts (#955 `InOrder` streaming, #956 `listing_resource` suspend) addressed streaming/suspense timing, not the underlying nondeterministic DOM order, which is why the crash persisted.

## Fix

Sort each list by its stable `key_id` before it reaches the DOM, so SSR and CSR render the identical sequence:

- **`ExchangeSources`** — extracted `exchange_shops_for_item()` (filter + `.sorted_by_key(|s| s.key_id.0)`), now unit-tested.
- **`gil_shop_to_npc`** (Vendor Sources) — `.sorted_by_key(|(shop, npc)| (npc.key_id.0, shop.0))`.
- **`LeveSources`** — `.sorted_by_key(|l| l.key_id.0)`.

`item_view.rs`'s source-callout uses `.values().any(...)` (a boolean existence check — order never reaches the DOM) and is intentionally left unchanged.

## Verification

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test -p ultros-app --lib` — 3 passed, incl. new `exchange_shops_for_item_is_deterministically_sorted` regression guard (asserts ascending `key_id` order regardless of HashMap insertion order)
- ✅ `cargo clippy -p ultros-app --all-targets -- -D warnings`

Full-workspace clippy (incl. the `ultros` server bin) not run locally — that crate hits the jemalloc/OpenSSL/MSVC build wall on Windows; it's unaffected by this change and CI covers it on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)