### PR TITLE
fix(hydration): don't hydrate a truncated SSR document (#6831)

### DIFF
--- a/integration/hydrate-timing.cjs
+++ b/integration/hydrate-timing.cjs
@@ -1,0 +1,116 @@
+// #6831 residual probe: is hydration starting before the (1.3MB) SSR body has
+// finished parsing? Hooks console in page context so we can snapshot
+// document.readyState + body child count SYNCHRONOUSLY at the moment wasm logs
+// "hydrating body" and at the moment it logs the hydration.rs panic.
+const puppeteer = require('puppeteer');
+
+const BASE_URL = process.env.BASE_URL || 'https://ultros.app';
+const ITEM_PATH = process.env.ITEM_PATH || '/item/Twintania/13114';
+const N = Number(process.env.N || 10);
+const CPU = Number(process.env.CPU || 1);
+const MOBILE = (process.env.MOBILE || 'on') === 'on';
+
+const initScript = () => {
+  window.__marks = [];
+  const snap = (label) => {
+    window.__marks.push({
+      label,
+      t: Math.round(performance.now()),
+      readyState: document.readyState,
+      bodyKids: document.body ? document.body.childNodes.length : -1,
+      // Has the SSR document finished? The last body child on a complete page
+      // is a <script>; while streaming, the tail is still missing.
+      lastKid: document.body && document.body.lastChild
+        ? (document.body.lastChild.nodeName || '?')
+        : '?',
+    });
+  };
+  const wrap = (fn) =>
+    function (...args) {
+      try {
+        const s = args.map((a) => (typeof a === 'string' ? a : '')).join(' ');
+        if (s.indexOf('hydrating body') !== -1) snap('hydrating-body');
+        if (s.indexOf('SSR document truncated') !== -1) snap('GUARD-skipped');
+        if (s.indexOf('hydration.rs:163') !== -1) snap('PANIC-163');
+        if (s.indexOf('RefCell already borrowed') !== -1) snap('refcell');
+      } catch (_) {}
+      return fn.apply(this, args);
+    };
+  console.info = wrap(console.info);
+  console.log = wrap(console.log);
+  console.error = wrap(console.error);
+  document.addEventListener('DOMContentLoaded', () => snap('DCL'));
+  window.addEventListener('load', () => snap('load'));
+};
+
+(async () => {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  const rows = [];
+  for (let i = 0; i < N; i++) {
+    const page = await browser.newPage();
+    await page.setUserAgent(
+      'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/537.36 (KHTML, like Gecko; Mediapartners-Google) Chrome/149.0.7827.200 Mobile Safari/537.36'
+    );
+    if (MOBILE) await page.setViewport({ width: 360, height: 640, isMobile: true });
+    await page.evaluateOnNewDocument(initScript);
+    const { hostname } = new URL(BASE_URL);
+    await page.setCookie({ name: 'HIDE_ADS', value: 'true', domain: hostname, path: '/' });
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      if (/googlesyndication|doubleclick|adtrafficquality|googletagservices|google-analytics|fundingchoices/.test(req.url()))
+        return req.abort().catch(() => {});
+      req.continue().catch(() => {});
+    });
+    const client = await page.target().createCDPSession();
+    if (CPU > 1) await client.send('Emulation.setCPUThrottlingRate', { rate: CPU });
+
+    // Ground-truth detector (same one that caught panics in ad-race.cjs), kept
+    // alongside the in-page console wrapper so a missed wrap can't read as clean.
+    let cdpPanic = false;
+    page.on('console', (m) => { if (/hydration\.rs:163/.test(m.text())) cdpPanic = true; });
+    page.on('pageerror', (e) => { if (/unreachable/i.test(String(e))) cdpPanic = true; });
+
+    try {
+      await page.goto(`${BASE_URL}${ITEM_PATH}?cb=${Date.now()}-${i}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+      });
+    } catch (_) {}
+    await new Promise((r) => setTimeout(r, Number(process.env.SETTLE || 12000)));
+
+    let marks = [];
+    try { marks = await page.evaluate(() => window.__marks); } catch (_) {}
+    const hyd = marks.find((m) => m.label === 'hydrating-body');
+    const guard = marks.find((m) => m.label === 'GUARD-skipped');
+    const panic = marks.find((m) => m.label === 'PANIC-163') || cdpPanic;
+    rows.push({ panicked: !!panic, hyd, guard: !!guard });
+    console.log(
+      `trial ${String(i).padStart(2)}: panic=${panic ? 'YES' : 'no '} guardSkipped=${guard ? 'YES' : 'no '} ` +
+        `| at hydrating-body: readyState=${hyd ? hyd.readyState : '?'} bodyKids=${hyd ? hyd.bodyKids : '?'} lastKid=${hyd ? hyd.lastKid : '?'} t=${hyd ? hyd.t : '?'}ms`
+    );
+    await page.close();
+  }
+  await browser.close();
+
+  const grp = (f) => rows.filter(f);
+  const summarize = (label, list) => {
+    if (!list.length) return console.log(`${label}: n=0`);
+    const states = {};
+    const kids = {};
+    for (const r of list) {
+      const s = r.hyd ? r.hyd.readyState : '?';
+      states[s] = (states[s] || 0) + 1;
+      const k = r.hyd ? r.hyd.bodyKids : -1;
+      kids[k] = (kids[k] || 0) + 1;
+    }
+    console.log(`${label}: n=${list.length} readyState@hydrate=${JSON.stringify(states)} bodyKids@hydrate=${JSON.stringify(kids)}`);
+  };
+  console.log('');
+  summarize('PANICKED ', grp((r) => r.panicked));
+  summarize('CLEAN    ', grp((r) => !r.panicked));
+  console.log(`\ntotal: ${grp((r) => r.panicked).length}/${rows.length} panicked  (CPU=${CPU}x MOBILE=${MOBILE})`);
+  process.exit(0);
+})();

--- a/integration/package.json
+++ b/integration/package.json
@@ -21,7 +21,9 @@
     "test:dashboard": "node ./dashboard.cjs",
     "test:group-shared-list": "node ./group-shared-list.cjs",
     "test:error-filter": "node --test ./error-filter.test.cjs",
-    "diag:ooo-hydration-race": "node ./ooo-hydration-race.cjs"
+    "diag:ooo-hydration-race": "node ./ooo-hydration-race.cjs",
+    "diag:hydrate-timing": "node ./hydrate-timing.cjs",
+    "diag:truncation-proxy": "node ./truncation-proxy.mjs"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/integration/truncation-proxy.mjs
+++ b/integration/truncation-proxy.mjs
@@ -1,0 +1,83 @@
+// Proves the #6831 residual mechanism: serve prod's REAL SSR page to prod's
+// REAL wasm, but cut the HTML off mid-body (simulating the stalled/truncated
+// SSR stream observed in hydrate-timing.cjs, where panicking loads hydrated
+// with bodyKids=2). Everything else (pkg/, static/, api/) forwards to prod.
+//
+//   node truncation-proxy.mjs            # then load http://127.0.0.1:8799<path>
+//   TRUNCATE=off node truncation-proxy.mjs   # control: serve the page intact
+import http from 'node:http';
+
+const UPSTREAM = 'https://ultros.app';
+const PORT = Number(process.env.PORT || 8799);
+const TRUNCATE = (process.env.TRUNCATE || 'on') === 'on';
+
+const server = http.createServer(async (req, res) => {
+  const url = UPSTREAM + req.url;
+  let upstream;
+  try {
+    upstream = await fetch(url, {
+      headers: {
+        'user-agent': req.headers['user-agent'] || 'Mozilla/5.0',
+        accept: req.headers.accept || '*/*',
+        'accept-encoding': 'identity',
+        // MUST forward cookies: the SSR render is cookie-dependent (HIDE_ADS,
+        // theme, home world, locale). Dropping them makes prod render a page
+        // the client would never produce, which is itself a hydration mismatch
+        // and silently confounds the experiment.
+        ...(req.headers.cookie ? { cookie: req.headers.cookie } : {}),
+      },
+      redirect: 'follow',
+    });
+  } catch (e) {
+    res.writeHead(502).end(String(e));
+    return;
+  }
+
+  const ct = upstream.headers.get('content-type') || 'application/octet-stream';
+  const headers = { 'content-type': ct, 'cache-control': 'no-store' };
+  // Strip the policies that would block a localhost-origin copy of the page.
+  // (content-security-policy / x-frame-options are simply not copied.)
+
+  const isDoc = ct.includes('text/html');
+  if (!isDoc) {
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.writeHead(upstream.status, headers).end(buf);
+    return;
+  }
+
+  let html = await upstream.text();
+  if (TRUNCATE) {
+    // Cut immediately after the 2nd top-level <div> under <body> closes —
+    // exactly the shape the panicking prod loads showed (bodyKids=2, lastKid=DIV).
+    const bodyStart = html.indexOf('<body');
+    const bodyOpenEnd = html.indexOf('>', bodyStart) + 1;
+    let i = bodyOpenEnd;
+    let depth = 0;
+    let closedTopLevel = 0;
+    const tagRe = /<(\/?)(\w+)[^>]*?(\/?)>/g;
+    tagRe.lastIndex = bodyOpenEnd;
+    let m;
+    const VOID = new Set(['br', 'img', 'input', 'meta', 'link', 'hr', 'source', 'path', 'circle', 'use']);
+    while ((m = tagRe.exec(html))) {
+      const [full, slash, name, selfClose] = m;
+      if (VOID.has(name.toLowerCase()) || selfClose) continue;
+      if (slash) {
+        depth--;
+        if (depth === 0) {
+          closedTopLevel++;
+          i = m.index + full.length;
+          if (closedTopLevel === 2) break;
+        }
+      } else {
+        depth++;
+      }
+    }
+    html = html.slice(0, i); // abrupt end: no </body>, no </html>, no resource scripts
+  }
+  headers['content-type'] = 'text/html; charset=utf-8';
+  res.writeHead(200, headers).end(html);
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`truncation-proxy on http://127.0.0.1:${PORT} TRUNCATE=${TRUNCATE ? 'on' : 'off'}`);
+});

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -66,6 +66,15 @@ use leptos_router::components::{A, ParentRoute, Route, Router, Routes};
 use leptos_router::{SsrMode, path};
 use log::info;
 
+/// Id of the sentinel element `shell()` renders as the final child of `<body>`.
+///
+/// Its presence in the parsed document is the client's proof that the SSR
+/// response arrived complete rather than truncated mid-stream. Shared between
+/// the server-rendered shell and the client's pre-hydration guard so the two
+/// can never drift apart. See the sentinel in `shell()` and the guard in
+/// `ultros-client`'s `hydrate()` for the full story (GlitchTip #6831).
+pub const SSR_END_SENTINEL_ID: &str = "ultros-ssr-end";
+
 #[cfg(feature = "hydrate")]
 mod sentry_tags {
     use wasm_bindgen::{JsCast, JsValue};
@@ -323,6 +332,21 @@ pub fn shell(options: LeptosOptions, bootstrap_script: String) -> impl IntoView 
             </head>
             <body translate="no" class="notranslate">
                 <App />
+                // End-of-document sentinel for the client's truncation guard
+                // (GlitchTip #6831). The wasm bootstrap `HydrationScripts`
+                // emits is a *deferred module script in `<head>`*, so it runs
+                // as soon as parsing finishes — and a stalled or cut-off SSR
+                // response still "finishes" parsing, just with most of the
+                // body missing (`document.readyState === "complete"` with two
+                // body children instead of ~10). Hydrating that partial DOM
+                // walks tachys straight into `failed_to_cast_element` and
+                // panics at `hydration.rs:163`. This element streams last, so
+                // the client can tell a complete document from a truncated one
+                // by asking whether it arrived. See `hydrate()` in
+                // ultros-client. Item routes are `SsrMode::InOrder`, so
+                // "sentinel present" really does mean "everything before it
+                // arrived".
+                <div id=SSR_END_SENTINEL_ID hidden></div>
             </body>
         </html>
     }

--- a/ultros-frontend/ultros-client/src/lib.rs
+++ b/ultros-frontend/ultros-client/src/lib.rs
@@ -383,6 +383,37 @@ pub fn hydrate() {
             return;
         }
 
+        // The SSR response can end early — a stalled render, a dropped
+        // connection, a proxy cutting the stream — and the browser still
+        // reports `readyState === "complete"` for whatever it managed to
+        // parse. The bootstrap `HydrationScripts` emits is a deferred module
+        // script in `<head>`, so it fires on that truncated document just the
+        // same, and `hydrate_body` then walks a DOM missing nearly everything
+        // it expects: tachys hits `failed_to_cast_element` and panics at
+        // `hydration.rs:163`, which cascades into `RefCell already borrowed`
+        // from the wasm-bindgen-futures executor. That is GlitchTip #6831 —
+        // measured on prod, every panicking load hydrated with 2 body children
+        // where a healthy load has 9-12, and serving a deliberately truncated
+        // copy of the same page reproduced it 4/4 against an intact-page
+        // control of 0/4.
+        //
+        // `shell()` renders `SSR_END_SENTINEL_ID` as the last child of
+        // `<body>`, so its absence means the document we were handed is
+        // incomplete. There is nothing coherent to hydrate against; keep the
+        // partial server-rendered markup rather than panicking on it.
+        if document().get_element_by_id(SSR_END_SENTINEL_ID).is_none() {
+            error!(
+                "SSR document truncated (missing #{SSR_END_SENTINEL_ID}); \
+                 skipping hydration to avoid a tachys hydration panic"
+            );
+            // Deliberately *not* dispatching "ultros:hydrated": this page is
+            // genuinely broken, and letting the boot-progress watchdog surface
+            // its existing "taking longer than expected — reload" affordance
+            // gives the reader a way out. A truncated response is transient,
+            // so a reload almost always succeeds.
+            return;
+        }
+
         info!("hydrating body");
         let world_data = match worlds {
             Ok(worlds) => LocalWorldData(Ok(worlds)),


### PR DESCRIPTION
## The problem

GlitchTip **#6831 reopened on `50f757f`** — the release that was supposed to fix it. The HashMap DOM-order bug [#960](https://github.com/akarras/ultros/pull/960) addressed was real, but it wasn't the only cause. Latest event: `/item/Twintania/13114`, `release ultros@50f757f`, `hydration.rs:163`.

**Root cause: we hydrate documents that arrived truncated.**

The wasm bootstrap `HydrationScripts` emits is a *deferred `<script type="module">` in `<head>`* (prod offset ~54095, vs `<body>` at ~55789). Deferred means "runs when parsing finishes" — but a stalled or cut-off SSR response still *finishes* parsing. The browser reports `readyState === "complete"` over a body missing nearly all its content. `hydrate_body()` walks that partial DOM, tachys hits `failed_to_cast_element`, and we panic at `hydration.rs:163` — which cascades into `RefCell already borrowed` from the wasm-bindgen-futures executor.

## Evidence

Sampling `document.readyState` and `body.childNodes.length` **synchronously** at the moment wasm logs `hydrating body`, against prod on `/item/Twintania/13114`:

| | n | bodyKids @ hydrate | lastKid |
|---|---|---|---|
| **panicked** | 3/3 | `2` | `DIV` |
| **clean** | 13/13 | `9`–`12` | `SCRIPT` |

Perfect separation. Then, causally: serving a **deliberately truncated** copy of the same page to the same wasm reproduced the panic **4/4**, against an intact-page control of **0/4**.

## The fix

`shell()` renders a sentinel as the final child of `<body>`. `hydrate()` returns early when it's absent, keeping the partial server-rendered markup instead of panicking on it.

It deliberately does **not** dispatch `ultros:hydrated` — the page is genuinely broken, so letting the existing boot-progress watchdog surface its "reload" affordance gives the reader a way out. A truncated response is transient, so a reload almost always succeeds.

If the sentinel is present (every healthy load), behavior is byte-for-byte what it is today.

## Verification

Built the client wasm **with this change** and served it over prod's real SSR HTML:

- truncated → guard fires, hydration skipped, **0 panics** (was 4/4)
- intact + sentinel → hydrates normally, guard silent, **0 panics**

Both CI gates pass locally: `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` (exit 0, all crates).

## Ruled out first

Not guesses — each checked and discarded: a 4th unsorted-HashMap site (`related_items.rs` sorts `special_shops`/`e_npc_bases`/`leves`/`related_items_data`; the `.values().any()` calls in `item_view.rs` are booleans, order-irrelevant); `BaseParam.OrderPriority` ties (still **74/74 distinct**, so `stats_display.rs` is still safe); any UA-dependent SSR (none exists); ad DOM injection (SSR body children match the crash event's `bodyChildTags` exactly, and it repros with ads blocked); CPU throttling (panics at CPU=1).

## Note for reviewers

`truncation-proxy.mjs` forwards the `Cookie` header **on purpose**. The SSR render is cookie-dependent (`HIDE_ADS`, theme, home world, locale). An earlier version that dropped cookies made prod render an ads-on page while the client rendered ads-off — a hydration mismatch of its own that panicked **both** arms of the experiment 3/3 and nearly passed for a confirmed result. Any future SSR-replay harness needs to forward cookies and run its negative control.

## Follow-up not in scope

This is the defensive half. The other half is *why* prod truncates the stream in the first place — I could only observe it from outside (correlates with slow/loaded renders of a ~1.3 MB page). Worth a server-side look; this PR stops it from being a crash either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)