### PR TITLE
⚡ Bolt: [Performance Improvement] Replace O(N log N) sorts on large collections with select_nth_unstable_by for Top N results

### DIFF
--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -792,25 +792,43 @@ impl AnalyzerService {
             }
         }
 
-        high_velocity.sort_by(|a, b| {
+        // ⚡ Bolt: Optimization: Use select_nth_unstable_by before sorting to extract the top N elements.
+        // This reduces time complexity from O(N log N) (full sort) to O(N) (partial select) + O(k log k)
+        // (sorting the selected subset, where k=50).
+        let cmp_velocity = |a: &TrendItem, b: &TrendItem| {
             b.sales_per_week
                 .partial_cmp(&a.sales_per_week)
                 .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        rising_price.sort_by(|a, b| {
+        };
+        if high_velocity.len() > 50 {
+            high_velocity.select_nth_unstable_by(50, cmp_velocity);
+            high_velocity.truncate(50);
+        }
+        high_velocity.sort_unstable_by(cmp_velocity);
+
+        // ⚡ Bolt: Optimization: Use select_nth_unstable_by to avoid O(N log N) sorting.
+        let cmp_rising = |a: &TrendItem, b: &TrendItem| {
             (b.price as f32 / b.average_sale_price)
                 .partial_cmp(&(a.price as f32 / a.average_sale_price))
                 .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        falling_price.sort_by(|a, b| {
+        };
+        if rising_price.len() > 50 {
+            rising_price.select_nth_unstable_by(50, cmp_rising);
+            rising_price.truncate(50);
+        }
+        rising_price.sort_unstable_by(cmp_rising);
+
+        // ⚡ Bolt: Optimization: Use select_nth_unstable_by to avoid O(N log N) sorting.
+        let cmp_falling = |a: &TrendItem, b: &TrendItem| {
             (a.price as f32 / a.average_sale_price)
                 .partial_cmp(&(b.price as f32 / b.average_sale_price))
                 .unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        high_velocity.truncate(50);
-        rising_price.truncate(50);
-        falling_price.truncate(50);
+        };
+        if falling_price.len() > 50 {
+            falling_price.select_nth_unstable_by(50, cmp_falling);
+            falling_price.truncate(50);
+        }
+        falling_price.sort_unstable_by(cmp_falling);
 
         // === Phase 2 deep-scan enrichment for trends ===
         //
@@ -1025,8 +1043,15 @@ impl AnalyzerService {
         // Default sort: units traded descending — the most useful
         // initial view ("what's actually moving"). FE applies further
         // sort/filter locally.
-        items.sort_by(|a, b| b.unit_volume_window.cmp(&a.unit_volume_window));
-        items.truncate(500);
+        // ⚡ Bolt: Optimization: Use select_nth_unstable_by to avoid O(N log N) sorting.
+        let cmp_unit_volume = |a: &SalesVolumeItem, b: &SalesVolumeItem| {
+            b.unit_volume_window.cmp(&a.unit_volume_window)
+        };
+        if items.len() > 500 {
+            items.select_nth_unstable_by(500, cmp_unit_volume);
+            items.truncate(500);
+        }
+        items.sort_unstable_by(cmp_unit_volume);
 
         Some(items)
     }
@@ -1164,8 +1189,13 @@ impl AnalyzerService {
         // caller. We sort by profit first so the deep-scan only fires for
         // the N candidates a user would actually see.
         const DEEP_SCAN_TOP_N: usize = 200;
-        possible_sales.sort_by_key(|s| std::cmp::Reverse(s.profit));
-        possible_sales.truncate(DEEP_SCAN_TOP_N);
+        // ⚡ Bolt: Optimization: Use select_nth_unstable_by_key to avoid O(N log N) sorting.
+        if possible_sales.len() > DEEP_SCAN_TOP_N {
+            possible_sales
+                .select_nth_unstable_by_key(DEEP_SCAN_TOP_N, |s| std::cmp::Reverse(s.profit));
+            possible_sales.truncate(DEEP_SCAN_TOP_N);
+        }
+        possible_sales.sort_unstable_by_key(|s| std::cmp::Reverse(s.profit));
 
         // Read the sale_world_id off `world_id` arg — `s.world_id` on the
         // stats is the *source* world (where the cheapest listing is), but

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -1044,9 +1044,8 @@ impl AnalyzerService {
         // initial view ("what's actually moving"). FE applies further
         // sort/filter locally.
         // ⚡ Bolt: Optimization: Use select_nth_unstable_by to avoid O(N log N) sorting.
-        let cmp_unit_volume = |a: &SalesVolumeItem, b: &SalesVolumeItem| {
-            b.unit_volume_window.cmp(&a.unit_volume_window)
-        };
+        let cmp_unit_volume =
+            |a: &TrendItem, b: &TrendItem| b.unit_volume_window.cmp(&a.unit_volume_window);
         if items.len() > 500 {
             items.select_nth_unstable_by(500, cmp_unit_volume);
             items.truncate(500);


### PR DESCRIPTION
💡 What: Refactored `sort_by(...)` / `sort_by_key(...)` followed by `.truncate(...)` to first utilize `.select_nth_unstable_by(...)` (or `select_nth_unstable_by_key`) to extract the top items in `O(N)` average time, and only sorting the final subset in `ultros/src/analyzer_service.rs`. Added necessary code comments.
🎯 Why: This avoids doing an expensive `O(N log N)` fully sorted pass over potentially thousands of items when only the top 50/200/500 items are ever needed. 
📊 Impact: Expected to reduce CPU cycle time during data fetches in the analyzer service significantly. Specifically during hot path iterations that handle high data volumes like fetching `get_market_trends` and `get_best_resale`.
🔬 Measurement: Verify functionality by ensuring analyzer dashboards still correctly retrieve data on time and no compilation errors arise. Code checks execute successfully.

---
*PR created automatically by Jules for task [238583772767689489](https://jules.google.com/task/238583772767689489) started by @akarras*