### PR TITLE
fix(item): stop SSR panics on disposed `filtered_listings` reads (#6864/#6865/#6867)

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -36,6 +36,36 @@ type ListingRows = Vec<(ActiveListing, Arc<Retainer>)>;
 
 const MEANINGFUL_CROSS_WORLD_SAVINGS_GIL: i32 = 1_000;
 
+/// Applies `fun` to a reactive value that may already have been disposed,
+/// falling back to `fallback` instead of panicking.
+///
+/// The `<Suspense>`/`<Transition>` bodies on this page are walked by tachys'
+/// `dry_resolve` twice: once inline, and again from the detached
+/// `Effect::new_isomorphic` leptos keeps alive until the boundary resolves.
+/// That second walk can outlive the owner that created props like
+/// `filtered_listings`, and `With::with` on a disposed signal panics.
+///
+/// A panic there aborts `to_html_async` partway through the body, so the
+/// server ships a *truncated* document and the browser hydrates a half-written
+/// DOM — the tachys `unreachable!()` flood in GlitchTip #6831. The request is
+/// already being torn down whenever this fires, so degrading to `fallback`
+/// costs nothing user-visible and keeps the response whole.
+fn with_or<S, U>(signal: &S, fallback: U, fun: impl FnOnce(&S::Value) -> U) -> U
+where
+    S: With,
+{
+    signal.try_with(fun).unwrap_or(fallback)
+}
+
+/// [`Get`] counterpart to [`with_or`] for values that are cloned out anyway.
+fn get_or_default<S>(signal: &S) -> S::Value
+where
+    S: Get,
+    S::Value: Default,
+{
+    signal.try_get().unwrap_or_default()
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct SavingsVerdict {
     cheapest_listing: ActiveListing,
@@ -522,7 +552,7 @@ fn DecisionHeader(
                 listing_resource
                     .with(|data_ref| {
                         if let Some(Ok(data)) = data_ref.as_ref() {
-                            let listings = filtered_listings.get();
+                            let listings = get_or_default(&filtered_listings);
                             let current_world_id = {
                                 let world_name = Url::unescape(&world());
                                 world_data
@@ -675,7 +705,7 @@ fn MarketStatsPanel(
                     .with(|data_ref| {
                         if let Some(Ok(data)) = data_ref.as_ref() {
                             let data = data.clone();
-                            let listings = filtered_listings.get();
+                            let listings = get_or_default(&filtered_listings);
                             let cheapest_nq = cheapest_listing_for_quality(&listings, false);
                             let cheapest_hq = cheapest_listing_for_quality(&listings, true);
                             let listings_count = listings.len();
@@ -1264,7 +1294,11 @@ pub fn ChartWrapper(
                                 }}
 
                                 {move || {
-                                    let no_listings = filtered_listings.with(|listings| listings.is_empty());
+                                    let no_listings = with_or(
+                                        &filtered_listings,
+                                        true,
+                                        |listings| listings.is_empty(),
+                                    );
                                     no_listings.then(|| view! {
                                         <div role="status" class="text-amber-200 border border-amber-500/40 rounded-xl px-3 py-2 text-sm">
                                             {move || t_string!(i18n, no_active_listings_found).to_string()}
@@ -1302,7 +1336,7 @@ fn HighQualityTable(
                         return ().into_any();
                     }
                     let hq_listings = Memo::new(move |_| {
-                        filtered_listings.with(|listings| {
+                        with_or(&filtered_listings, Vec::new(), |listings| {
                             listings
                                 .iter()
                                 .filter(|(listing, _)| listing.hq)
@@ -1348,7 +1382,7 @@ fn LowQualityTable(
                         return ().into_any();
                     }
                     let lq_listings = Memo::new(move |_| {
-                        filtered_listings.with(|listings| {
+                        with_or(&filtered_listings, Vec::new(), |listings| {
                             listings
                                 .iter()
                                 .filter(|(listing, _)| !listing.hq)
@@ -1455,26 +1489,31 @@ fn ListingsContent(
     let excluded_datacenters = RwSignal::new(HashSet::<String>::new());
     let filtered_listings = Memo::new({
         let world_data = world_data.clone();
+        // Every read in here goes through a `try_*` accessor. `ArcMemo` `take()`s
+        // its cached value before running this closure, so a panic in the body
+        // leaves the memo permanently holding `None` — every later read then dies
+        // on the `t.as_ref().unwrap()` inside `try_read_untracked` (GlitchTip
+        // #6865), including reads that go through `try_get`. Keeping the body
+        // infallible is what stops that cascade.
         move |_| {
-            let listings = listing_resource
-                .with(|listing| {
-                    listing.as_ref().and_then(|result| {
-                        result.as_ref().ok().map(|item| {
-                            item.listings
-                                .iter()
-                                .map(|(listing, retainer)| {
-                                    (listing.clone(), Arc::new(retainer.clone()))
-                                })
-                                .collect::<ListingRows>()
-                        })
+            let listings = with_or(&listing_resource, None, |listing| {
+                listing.as_ref().and_then(|result| {
+                    result.as_ref().ok().map(|item| {
+                        item.listings
+                            .iter()
+                            .map(|(listing, retainer)| {
+                                (listing.clone(), Arc::new(retainer.clone()))
+                            })
+                            .collect::<ListingRows>()
                     })
                 })
-                .unwrap_or_default();
+            })
+            .unwrap_or_default();
             filter_listing_rows(
                 listings,
                 Some(world_data.as_ref()),
-                &excluded_worlds.get(),
-                &excluded_datacenters.get(),
+                &get_or_default(&excluded_worlds),
+                &get_or_default(&excluded_datacenters),
             )
         }
     });
@@ -1954,5 +1993,28 @@ mod tests {
         assert_eq!(format_savings_percent(15.5), "16"); // Rounds up
         assert_eq!(format_savings_percent(15.4), "15"); // Rounds down
         assert_eq!(format_savings_percent(99.9), "100");
+    }
+
+    /// Reproduces GlitchTip #6864/#6867: the server walks a `<Transition>`
+    /// body after the owner that created the `filtered_listings` prop has been
+    /// cleaned up. A bare `.with()`/`.get()` panics there and truncates the SSR
+    /// response; the accessors used on this page must degrade instead.
+    #[test]
+    fn item_view_listing_reads_survive_a_disposed_owner() {
+        let owner = Owner::new();
+        let filtered_listings: Signal<ListingRows> = owner.with(|| {
+            let rows = RwSignal::new(vec![listing(1, 100, 100, false)]);
+            Memo::new(move |_| rows.get()).into()
+        });
+
+        // While the owner is alive the reads behave exactly like `.with()`/`.get()`.
+        assert!(!with_or(&filtered_listings, true, |listings| listings.is_empty()));
+        assert_eq!(get_or_default(&filtered_listings).len(), 1);
+
+        owner.cleanup();
+
+        // Once it is disposed they must fall back rather than panic.
+        assert!(with_or(&filtered_listings, true, |listings| listings.is_empty()));
+        assert!(get_or_default(&filtered_listings).is_empty());
     }
 }


### PR DESCRIPTION
## What

Three server-side panics on `/item/*` in GlitchTip all trace to one signal:

| Issue | Panic | Site |
|---|---|---|
| [#6864](https://glitchtip.ultros.app/ultros/issues/6864) | `...has already been disposed` | `item_view.rs:1305` (`HighQualityTable`) |
| [#6867](https://glitchtip.ultros.app/ultros/issues/6867) | `...has already been disposed` | `item_view.rs:1267` (`ChartWrapper`) |
| [#6865](https://glitchtip.ultros.app/ultros/issues/6865) | `Option::unwrap()` on `None` | `item_view.rs:678` (`MarketStatsPanel`) |

Every stack ends on the same `Signal<ListingRows>` — the `filtered_listings` prop created in `ListingsContent`. These are native (`sentry_panic`) events, i.e. **SSR**, not wasm.

## Root cause

The reads happen under tachys' `dry_resolve`, which leptos' `SuspenseBoundary::to_html_async_with_buf` runs **twice** — once inline, and again from the detached `Effect::new_isomorphic` it keeps alive until the boundary resolves ([`suspense_component.rs:353-383`](https://docs.rs/leptos/0.8.20/src/leptos/suspense_component.rs.html)). That second walk can outlive the owner that created the prop, and `With::with` / `Get::get` on a disposed signal panics.

The workspace builds with `panic = "unwind"`, so this aborts `to_html_async` **partway through the body** rather than killing the process. The server ships a truncated document, the browser hydrates a half-written DOM, and tachys hits `unreachable!()` — the shape of the [#6831](https://glitchtip.ultros.app/ultros/issues/6831) flood (22.8k events) that #961 guards against on the client side. This PR removes one of the things producing those truncated bodies; the two changes are complementary.

**#6865 is the cascade.** `ArcMemo::update_if_necessary` `take()`s the cached value *before* running the compute closure ([`inner.rs:121`](https://docs.rs/reactive_graph/0.2.14/src/reactive_graph/computed/inner.rs.html)), so one panic inside the memo body leaves it permanently holding `None`. Every later read then dies on the `t.as_ref().unwrap()` inside `try_read_untracked` — **including reads that go through `try_get`**, since the unwrap is inside the guard closure. Keeping the memo body infallible is the only thing that stops it.

## Change

- add `with_or` / `get_or_default` — `try_*` accessors with an explicit fallback
- use them at the five `filtered_listings` read sites inside Suspense bodies
- route every read inside the `filtered_listings` memo body (`listing_resource`, `excluded_worlds`, `excluded_datacenters`) through them too, so the memo can no longer be poisoned

Behaviour is unchanged while the owner is live. The fallbacks only apply to a request that is already being torn down, where a whole-but-empty document strictly beats a truncated one — so this can't introduce a *new* hydration mismatch.

## Verification

The regression test builds a `Signal` inside an `Owner`, cleans the owner up, and asserts the accessors degrade. Against the **bare** accessors it reproduces the production panic exactly:

```
panicked at reactive_graph-0.2.14/src/traits.rs:328:43:
At ...item_view.rs:2009:35, you tried to access a reactive value which was
defined at ...item_view.rs:1998:44, but it has already been disposed.
```

Same frame (`traits.rs:328` = `With::with`'s `unwrap_or_else(unwrap_signal!)`), same message shape as #6864/#6867. With the helpers it passes.

- `cargo test -p ultros-app --lib` → **201 passed, 0 failed**
- `cargo clippy -p ultros-app --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

## Known remaining

The bare `listing_resource.with(...)` reads in the same Transition bodies are the same class of hazard, but no reported event names them — `listing_resource` survived in #6865's stack while `filtered_listings` did not. Left alone to keep this reviewable; worth a follow-up if new events point there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
