### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/ultros-frontend/ultros-app/src/components/confidence_badge.rs
+++ b/ultros-frontend/ultros-app/src/components/confidence_badge.rs
@@ -18,6 +18,25 @@ pub enum ConfidenceTone {
     Error,
 }
 
+impl ConfidenceTone {
+    pub fn css_classes(&self) -> &'static str {
+        match self {
+            Self::Success => {
+                "text-emerald-300 border-emerald-400/40 bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]"
+            }
+            Self::Neutral => {
+                "text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]"
+            }
+            Self::Warning => {
+                "text-amber-300 border-amber-400/40 bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]"
+            }
+            Self::Error => {
+                "text-red-300 border-red-400/40 bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]"
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfidenceLabel {
     High,
@@ -89,21 +108,11 @@ pub fn ConfidenceBadge(
         tooltip
     };
 
+    let tone_classes = tone.css_classes();
+
     view! {
         <span
-            class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold border"
-            class=("text-emerald-300", move || tone == ConfidenceTone::Success)
-            class=("border-emerald-400/40", move || tone == ConfidenceTone::Success)
-            class=("bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]", move || tone == ConfidenceTone::Success)
-            class=("text-[color:var(--color-text)]", move || tone == ConfidenceTone::Neutral)
-            class=("border-[color:var(--color-outline)]", move || tone == ConfidenceTone::Neutral)
-            class=("bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]", move || tone == ConfidenceTone::Neutral)
-            class=("text-amber-300", move || tone == ConfidenceTone::Warning)
-            class=("border-amber-400/40", move || tone == ConfidenceTone::Warning)
-            class=("bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]", move || tone == ConfidenceTone::Warning)
-            class=("text-red-300", move || tone == ConfidenceTone::Error)
-            class=("border-red-400/40", move || tone == ConfidenceTone::Error)
-            class=("bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]", move || tone == ConfidenceTone::Error)
+            class=format!("inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold border {}", tone_classes)
             title=tooltip_full>
             {label}
         </span>
@@ -114,6 +123,26 @@ pub fn ConfidenceBadge(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_confidence_tone_css_classes() {
+        assert_eq!(
+            ConfidenceTone::Success.css_classes(),
+            "text-emerald-300 border-emerald-400/40 bg-[color:color-mix(in_srgb,#10b981_14%,transparent)]"
+        );
+        assert_eq!(
+            ConfidenceTone::Neutral.css_classes(),
+            "text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]"
+        );
+        assert_eq!(
+            ConfidenceTone::Warning.css_classes(),
+            "text-amber-300 border-amber-400/40 bg-[color:color-mix(in_srgb,#f59e0b_12%,transparent)]"
+        );
+        assert_eq!(
+            ConfidenceTone::Error.css_classes(),
+            "text-red-300 border-red-400/40 bg-[color:color-mix(in_srgb,#ef4444_12%,transparent)]"
+        );
+    }
 
     #[test]
     fn test_get_confidence_verdict_display() {


### PR DESCRIPTION
💡 What: Extracted the Tailwind CSS class mapping for `ConfidenceTone` in `ultros-frontend/ultros-app/src/components/confidence_badge.rs` into a pure testable `css_classes(&self)` function. Added a unit test to verify the output for each variant.
🎯 Why: The reliability gap it covers is that embedding conditional styling directly in Leptos macros causes testability issues and creates dummy reactive effects for static enum values. Extracting the mapping allows for deterministic unit testing without Leptos reactive context, as per `sentry.md` guidelines.
📊 Impact: `ultros-frontend/ultros-app/src/components/confidence_badge.rs` (`ConfidenceTone::css_classes` and `ConfidenceBadge`) is now completely covered for its styling mapping logic.
🔬 Verification: Run `cargo test -p ultros-app components::confidence_badge` to verify the new test.

---
*PR created automatically by Jules for task [12721976015404446407](https://jules.google.com/task/12721976015404446407) started by @akarras*