### PR TITLE
🎨 Palette: Add explicit label associations to forms for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-02-12 - Added ARIA label to resend button
 **Learning:** Screen readers will struggle to identify multiple identical buttons (like "Resend") across rows in a data table unless they have unique labels with context.
 **Action:** Always include row-specific context (like the item name) in the `aria-label` for buttons inside list/table rows to ensure accessibility.
+## 2024-07-23 - Add explicit input associations
+**Learning:** In Leptos, when defining `for` and `id` attributes that need dynamic values within `move ||` closures, ensure you do not inadvertently move an entire struct (like `group`) multiple times, which causes E0382. Instead, extract the required value (e.g. `let group_id = group.id;`) beforehand so it can be copied into the closures.
+**Action:** Always extract and copy small values before using them inside Leptos closures to avoid ownership issues.

--- a/ultros-frontend/ultros-app/src/routes/groups.rs
+++ b/ultros-frontend/ultros-app/src/routes/groups.rs
@@ -196,12 +196,10 @@ fn GroupCard(
     );
 
     let (new_member_id, set_new_member_id) = signal(String::new());
+    let group_id = group.id;
 
     view! {
         <div class="panel p-4 rounded-xl flex flex-col gap-4">
-            {
-                let group_id = group.id;
-                view! {
             <div class="flex justify-between items-start gap-2">
                 <div class="flex flex-col gap-1 overflow-hidden">
                     <span class="text-xl font-bold truncate text-[color:var(--brand-fg)]">
@@ -310,8 +308,6 @@ fn GroupCard(
                     </div>
                 </div>
             </Show>
-                }
-            }
         </div>
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/groups.rs
+++ b/ultros-frontend/ultros-app/src/routes/groups.rs
@@ -199,6 +199,9 @@ fn GroupCard(
 
     view! {
         <div class="panel p-4 rounded-xl flex flex-col gap-4">
+            {
+                let group_id = group.id;
+                view! {
             <div class="flex justify-between items-start gap-2">
                 <div class="flex flex-col gap-1 overflow-hidden">
                     <span class="text-xl font-bold truncate text-[color:var(--brand-fg)]">
@@ -282,9 +285,10 @@ fn GroupCard(
 
             <Show when=move || user_id().map(|uid| uid as i64 == group.owner_id).unwrap_or(false)>
                 <div class="flex flex-col gap-2 pt-2 border-t border-gray-700/50">
-                    <label class="text-xs font-semibold text-gray-400">{t!(i18n, groups_add_member)}</label>
+                    <label for=format!("add-member-{}", group_id) class="text-xs font-semibold text-gray-400">{t!(i18n, groups_add_member)}</label>
                     <div class="flex gap-2">
                         <input
+                            id=format!("add-member-{}", group_id)
                             class="input input-sm flex-1"
                             placeholder=t_string!(i18n, groups_discord_id_placeholder)
                             prop:value=new_member_id
@@ -296,7 +300,7 @@ fn GroupCard(
                             prop:disabled=move || new_member_id().is_empty()
                             on:click=move |_| {
                                 if let Ok(uid) = new_member_id().parse::<u64>() {
-                                    add_member_action.dispatch((group.id, uid));
+                                    add_member_action.dispatch((group_id, uid));
                                     set_new_member_id(String::new());
                                 }
                             }
@@ -306,6 +310,8 @@ fn GroupCard(
                     </div>
                 </div>
             </Show>
+                }
+            }
         </div>
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -432,6 +432,7 @@ pub fn EditLists() -> impl IntoView {
                 </div>
                 <input
                     class="input w-full pl-10"
+                    aria-label=move || t_string!(i18n, search_your_lists).to_string()
                     placeholder=move || t_string!(i18n, search_your_lists).to_string()
                     prop:value=filter
                     on:input=move |ev| set_filter(event_target_value(&ev))
@@ -440,8 +441,9 @@ pub fn EditLists() -> impl IntoView {
 
             <div class="panel p-4 rounded-xl flex flex-col md:flex-row gap-3 md:items-end">
                 <div class="flex-1">
-                    <label class="label text-sm font-semibold">{t!(i18n, lists_redeem_invite_label)}</label>
+                    <label for="invite-code-input" class="label text-sm font-semibold">{t!(i18n, lists_redeem_invite_label)}</label>
                     <input
+                        id="invite-code-input"
                         class="input w-full"
                         placeholder=t_string!(i18n, lists_invite_code_placeholder)
                         prop:value=invite_id

--- a/ultros-frontend/ultros-app/src/routes/settings.rs
+++ b/ultros-frontend/ultros-app/src/routes/settings.rs
@@ -82,10 +82,13 @@ fn AddCharacterMenu(claim_character: Action<i32, AppResult<(i32, String)>>) -> i
                     view! {
                         <div class="mt-4 p-6 rounded-xl bg-brand-900/20 border border-white/10 ">
                             <h3 class="text-xl font-bold text-brand-300 mb-4">
-                                {t!(i18n, search_character)}
+                                <label for="search-character-input">
+                                    {t!(i18n, search_character)}
+                                </label>
                             </h3>
                             <div class="flex gap-2">
                                 <input
+                                    id="search-character-input"
                                     class="flex-grow p-2 rounded-lg bg-brand-950/50 border border-white/10
                                     focus:outline-none focus:border-brand-300/30 transition-colors"
                                     placeholder=move || t_string!(i18n, enter_character_name).to_string()


### PR DESCRIPTION
💡 What: The UX enhancement adds explicit `for` and `id` attributes to input fields and labels in groups, lists, and settings. It also adds an `aria-label` to the search list input.
🎯 Why: The user problem it solves is improving accessibility by ensuring screen readers correctly associate labels with inputs and increasing the clickable area for users.
📸 Before/After: Inputs had preceding labels without direct associations.
♿ Accessibility: Improved screen reader compatibility and keyboard navigation.

---
*PR created automatically by Jules for task [463696556744764594](https://jules.google.com/task/463696556744764594) started by @akarras*