### PR TITLE
fix(analyzer): compact sales/day badge, faster CH enrichment, clipboard placement

### DIFF
--- a/ultros-clickhouse/src/queries.rs
+++ b/ultros-clickhouse/src/queries.rs
@@ -135,7 +135,17 @@ pub async fn sparklines_batch(
                 SELECT g.item_id, g.hq, g.world_id, g.slot,
                        coalesce(s.vwap, 0) AS vwap
                 FROM grid g
-                LEFT JOIN sales_hourly s FINAL
+                -- Pre-filter the join side to the requested tuples + window.
+                -- A bare `LEFT JOIN sales_hourly FINAL` hashes the ENTIRE
+                -- rollup table (every item x world x hour) on every request;
+                -- the filtered subquery prunes by the table's primary key
+                -- (item_id, hq, world_id, bucket) instead.
+                LEFT JOIN (
+                    SELECT item_id, hq, world_id, bucket, vwap
+                    FROM sales_hourly FINAL
+                    WHERE (item_id, hq, world_id) IN ({tuples})
+                      AND bucket >= toStartOfInterval(now() - INTERVAL ? HOUR, INTERVAL 1 HOUR)
+                ) s
                   ON g.item_id = s.item_id
                  AND g.hq = s.hq
                  AND g.world_id = s.world_id
@@ -164,6 +174,7 @@ pub async fn sparklines_batch(
     let rows: Vec<SparklineRow> = ch
         .client()
         .query(&sql)
+        .bind(hours as u32)
         .bind(hours as u32)
         .bind(hours as u32)
         .fetch_all()
@@ -492,7 +503,12 @@ pub async fn deep_scan_batch(
                 if(q.computed_at > 0, q.launder_suspicion_pct, toFloat32(0))
                     AS launder_suspicion_pct
          FROM item_stats_window w FINAL
-         LEFT JOIN item_quality_score q FINAL
+         LEFT JOIN (
+             SELECT item_id, hq, world_id, computed_at, quality_score,
+                    confidence_band, launder_suspicion_pct
+             FROM item_quality_score FINAL
+             WHERE (item_id, hq, world_id) IN ({tuples})
+         ) q
            ON w.item_id = q.item_id AND w.hq = q.hq AND w.world_id = q.world_id
          WHERE (w.item_id, w.hq, w.world_id) IN ({tuples})
            AND w.window_days = ?"

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/天",
     "recent_average": "近期均价",
     "real_price": "真实价格",
     "real_price_basis": "{{used}}/{{total}} 笔 · 已过滤 {{excluded}} 笔",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/Tag",
     "recent_average": "Letzter Durchschnitt",
     "real_price": "Realer Preis",
     "real_price_basis": "{{used}}/{{total}} Verkäufe · {{excluded}} gefiltert",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/day",
     "recent_average": "Recent Average",
     "real_price": "Real Price",
     "real_price_basis": "{{used}}/{{total}} sales · {{excluded}} filtered",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/j",
     "recent_average": "Moyenne récente",
     "real_price": "Prix réel",
     "real_price_basis": "{{used}}/{{total}} ventes · {{excluded}} filtrées",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/日",
     "recent_average": "直近の平均",
     "real_price": "実勢価格",
     "real_price_basis": "{{used}}/{{total}} 件 · {{excluded}} 件除外",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/일",
     "recent_average": "최근 평균",
     "real_price": "실거래가",
     "real_price_basis": "{{used}}/{{total}}건 · {{excluded}}건 제외",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -61,6 +61,7 @@
     "sales_cadence_slow": "Slow mover",
     "sales_cadence_not_enough_data": "Not enough data",
     "sales_cadence_label_with_velocity": "{{label}} ({{velocity}}/day)",
+    "sales_cadence_compact": "{{velocity}}/天",
     "recent_average": "近期均價",
     "real_price": "真實價格",
     "real_price_basis": "{{used}}/{{total}} 筆 · 已過濾 {{excluded}} 筆",

--- a/ultros-frontend/ultros-app/src/components/sales_cadence_badge.rs
+++ b/ultros-frontend/ultros-app/src/components/sales_cadence_badge.rs
@@ -11,10 +11,17 @@ pub fn SalesCadenceBadge(
 ) -> impl IntoView {
     let i18n = use_i18n();
     let display = get_sales_cadence_display(cadence, sales_per_day);
+    let full_label = display.format_label(i18n);
+    let text = if compact {
+        display.format_compact(i18n)
+    } else {
+        full_label.clone()
+    };
 
     view! {
         <span
-            class="inline-flex items-center py-0.5 rounded-full text-xs font-semibold border"
+            title=compact.then(|| full_label.clone())
+            class="inline-flex items-center py-0.5 rounded-full text-xs font-semibold border whitespace-nowrap max-w-full overflow-hidden"
             class=("px-1.5", compact)
             class=("px-2", !compact)
             class=("text-emerald-300", display.tone == SalesCadenceTone::Success)
@@ -30,7 +37,7 @@ pub fn SalesCadenceBadge(
             class=("border-[color:var(--color-outline)]", display.tone == SalesCadenceTone::Neutral)
             class=("bg-[color:color-mix(in_srgb,var(--brand-ring)_10%,transparent)]", display.tone == SalesCadenceTone::Neutral)
         >
-            {display.format_label(i18n)}
+            {text}
         </span>
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1425,7 +1425,7 @@ fn AnalyzerTable(
                             };
                             view! {
                                 <div class=classes role="row-group">
-                                    <div role="cell" class="px-2 py-2 w-[40px] flex items-center justify-center">
+                                    <div role="cell" class="px-2 py-2 w-[44px] flex items-center justify-center">
                                         {if data.inner.sale_summary.hq {
                                             Some(view! { <span class="px-2 py-0.5 rounded-full text-xs font-semibold border text-[color:var(--color-text)] border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_14%,transparent)]">{t!(i18n, analyzer_col_hq)}</span> })
                                         } else {
@@ -1434,7 +1434,7 @@ fn AnalyzerTable(
                                     </div>
                                     <div role="cell" class="px-4 py-2 flex flex-row flex-1 min-w-[14rem] items-center gap-2">
                                         <a
-                                            class="flex flex-row items-center gap-2 hover:text-brand-300 transition-colors truncate overflow-x-clip w-full"
+                                            class="flex flex-row items-center gap-2 hover:text-brand-300 transition-colors truncate overflow-x-clip min-w-0"
                                             href=format!("/item/{}/{item_id}", world())
                                         >
                                             <div class="shrink-0">
@@ -1453,8 +1453,8 @@ fn AnalyzerTable(
                                                 })
                                             }}
                                         </a>
-                                        <AddToList item_id />
                                         <Clipboard clipboard_text=item.to_string() />
+                                        <AddToList item_id />
                                     </div>
                                     <div role="cell" class="px-3 py-2 w-28 text-right flex items-center justify-end">
                                         <Gil amount=data.profit />

--- a/ultros-frontend/ultros-app/src/sales_cadence.rs
+++ b/ultros-frontend/ultros-app/src/sales_cadence.rs
@@ -51,6 +51,17 @@ impl SalesCadenceVerdictDisplay {
             label_text
         }
     }
+
+    /// Short single-line form for tight table cells: just the velocity
+    /// ("0.2/day") when known, otherwise the label. The full label belongs
+    /// in the badge's `title` so no information is lost.
+    pub fn format_compact(&self, i18n: I18nContext<Locale, I18nKeys>) -> String {
+        if let Some(velocity) = &self.velocity_formatted {
+            t_string!(i18n, sales_cadence_compact, velocity = velocity).to_string()
+        } else {
+            self.label.get_text(i18n)
+        }
+    }
 }
 
 pub fn get_sales_cadence_display(


### PR DESCRIPTION
## What changed

Fixes four Flip Finder issues reported from the screenshot review:

1. **Table layout broken by cadence badges** — the Sales/Day badge text ("Steady mover (0.2/day)", "Not enough data") wrapped to 3 lines inside the 140px column and overflowed the fixed 40px virtual-scroller rows, bleeding over neighboring rows/headers. In compact (table) mode the badge now renders a single-line `0.2/day` with the full label in a `title` tooltip, plus `whitespace-nowrap` + overflow clipping so it can never wrap again. The item page keeps the full-label badge (non-compact mode unchanged).
2. **Sales/day illegible** — the number was inside the wrapped badge and got clipped (`(0.2/` …). The compact format makes it the primary content of the cell. New `sales_cadence_compact` i18n key added to all 7 locales (en/fr/de/ja/cn/ko/tc) with per-locale day units.
3. **Slow enrichment (badges took a long time to load)** — `deep_scan_batch` and `sparklines_batch` did `LEFT JOIN <rollup table> FINAL` with **no filter on the join side**, so ClickHouse hashed the entire `item_quality_score` / `sales_hourly` table on every request (sales_hourly = every item x world x hour bucket). Both joins now read from subqueries pre-filtered to the requested `(item, hq, world)` tuples — and, for sparklines, the requested time window — pruning by each table's primary key.
4. **Clipboard placement** — the copy button now directly follows the item name (the name link no longer stretches full-width), with Add-to-List after it. Also aligned the HQ header width (44px) with its row cells (were 40px).

## Reviewer notes

- The join rewrites preserve semantics exactly: sparkline arrays stay zero-filled/index-aligned for missing hours, and missing quality rows still default-fill so the `if(q.computed_at > 0, …)` guards behave as before. `sparklines_batch` gained a third positional bind (`hours`) for the new time-window filter.
- Verified against a live ClickHouse (throwaway Docker + fixture rows): raw SQL semantics check plus the opt-in smoke suites — `hourly_smoke` and `queries_smoke` (6/6 pass) — which exercise the real bind ordering through the Rust client.
- `./check_ci.sh` passes (fmt + clippy, submodules initialized recursively).
- Not done: a full visual run of the app (needs the whole stack + live market data). The badge fix is deterministic CSS/text formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)