### PR TITLE
Fix world picker dropdown rendering under sibling panels (z-index/stacking)

### DIFF
--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -1,5 +1,6 @@
 use leptos::{
     html::{Div, Input},
+    portal::Portal,
     prelude::*,
     reactive::wrappers::write::SignalSetter,
 };
@@ -31,10 +32,32 @@ where
     #[cfg(feature = "hydrate")]
     let hovered = leptos_use::use_element_hover(dropdown);
     #[cfg(not(feature = "hydrate"))]
-    let hovered = {
-        let _ = dropdown;
-        ArcSignal::derive(move || false)
+    let hovered = Signal::derive(move || false);
+
+    // The dropdown is rendered in a portal at the document body so ancestor
+    // stacking contexts (e.g. `.panel`'s backdrop-filter) and overflow clipping
+    // can't hide it. Position it under the input in viewport coordinates.
+    #[cfg(feature = "hydrate")]
+    let (dropdown_position, update_dropdown_position) = {
+        let leptos_use::UseElementBoundingReturn {
+            bottom,
+            left,
+            width,
+            update,
+            ..
+        } = leptos_use::use_element_bounding(input);
+        let position = Signal::derive(move || {
+            format!(
+                "top: {}px; left: {}px; width: {}px;",
+                bottom.get() + 4.0,
+                left.get(),
+                width.get()
+            )
+        });
+        (position, update)
     };
+    #[cfg(not(feature = "hydrate"))]
+    let (dropdown_position, update_dropdown_position) = (Signal::derive(String::new), || {});
 
     let labels = Memo::new(move |_| {
         items.with(|i| {
@@ -132,7 +155,7 @@ where
 
     let default_input_class = "input w-full";
     let default_dropdown_class =
-        "absolute w-full max-h-96 overflow-y-auto top-12 panel rounded-lg shadow-lg z-[100]";
+        "fixed max-h-96 overflow-y-auto panel rounded-lg shadow-lg z-[100]";
     let combined_input_class = format!("{} {}", default_input_class, class.unwrap_or(""));
     let combined_dropdown_class = format!(
         "{} {}",
@@ -157,13 +180,94 @@ where
     });
     let is_selected_selector = Selector::new(move || selected_index_memo.get());
 
+    let dropdown_panel = {
+        let is_selected_selector = is_selected_selector.clone();
+        move || {
+            let is_selected_selector = is_selected_selector.clone();
+            view! {
+                <div
+                    node_ref=dropdown
+                    class=combined_dropdown_class.clone()
+                    class:hidden=move || !has_focus() && !hovered()
+                    style=move || dropdown_position.get()
+                    role="listbox"
+                >
+                    <For each=move || final_result.get().into_iter().enumerate() key=move |(_, (l, _))| *l let:data>
+                        {
+                            let (render_idx, (original_idx, label)) = data;
+                            let is_selected_selector = is_selected_selector.clone();
+                            view! {
+                                <button
+                                    id=format!("select-item-{}", render_idx)
+                                    class="w-full text-left scroll-mt-2"
+                                    role="option"
+                                    aria-selected={
+                                        let is_selected_selector = is_selected_selector.clone();
+                                        move || is_selected_selector.selected(&Some(original_idx)).to_string()
+                                    }
+                                    on:click=move |_| {
+                                        if let Some(item) = items.with(|i| i.get(original_idx).cloned()) {
+                                            set_choice(Some(item));
+                                            set_focused(false);
+                                            set_current_input("".to_string());
+                                            if let Some(element) = document()
+                                                .active_element()
+                                                .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+                                            {
+                                                let _ = element.blur();
+                                            }
+                                        }
+                                    }
+                                    on:mousemove=move |_| {
+                                        set_highlighted_index(render_idx);
+                                    }
+                                >
+                                    <div class={
+                                        let is_selected_selector = is_selected_selector.clone();
+                                        move || {
+                                            let is_selected = is_selected_selector.selected(&Some(original_idx));
+                                            let is_highlighted = highlighted_index() == render_idx;
+
+                                            if is_highlighted {
+                                                 "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] ring-1 ring-[color:var(--brand-ring)]"
+                                            } else if is_selected {
+                                                "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)]"
+                                            } else {
+                                                "flex items-center rounded-lg p-2 transition-colors duration-200 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]"
+                                            }
+                                        }
+                                    }>
+                                        {move || items
+                                            .with(|i| i.get(original_idx).cloned())
+                                            .map(|c| children(
+                                                c,
+                                                {
+                                                    view! { <div>{label.clone()}</div> }.into_any()
+                                                }
+                                            ))}
+                                    </div>
+                                </button>
+                            }
+                        }
+                    </For>
+                </div>
+            }
+        }
+    };
+
     view! {
         <div class="relative">
             <input
                 node_ref=input
                 class=combined_input_class
                 class:cursor=move || !has_focus()
-                on:focus=move |_| set_focused(true)
+                on:focus=move |_| {
+                    // Re-measure before opening: the bounding signals start at
+                    // zero when the node ref was already set before the
+                    // watcher's first run (hydration).
+                    update_dropdown_position();
+                    set_focused(true)
+                }
                 on:focusout=move |_| set_focused(false)
                 on:input=move |e| {
                     set_current_input(event_target_value(&e));
@@ -173,11 +277,7 @@ where
                 prop:value=current_input
                 role="combobox"
                 aria-autocomplete="list"
-                aria-expanded={
-                    #[cfg(not(feature = "hydrate"))]
-                    let hovered = hovered.clone();
-                    move || (has_focus() || hovered()).to_string()
-                }
+                aria-expanded=move || (has_focus() || hovered()).to_string()
                 aria-activedescendant=move || format!("select-item-{}", highlighted_index())
             />
             <div
@@ -191,71 +291,7 @@ where
             >
                 {current_choice_view}
             </div>
-            <div
-                node_ref=dropdown
-                class=combined_dropdown_class
-                class:hidden=move || !has_focus() && !hovered()
-                role="listbox"
-            >
-                <For each=move || final_result.get().into_iter().enumerate() key=move |(_, (l, _))| *l let:data>
-                    {
-                        let (render_idx, (original_idx, label)) = data;
-                        let is_selected_selector = is_selected_selector.clone();
-                        view! {
-                            <button
-                                id=format!("select-item-{}", render_idx)
-                                class="w-full text-left scroll-mt-2"
-                                role="option"
-                                aria-selected={
-                                    let is_selected_selector = is_selected_selector.clone();
-                                    move || is_selected_selector.selected(&Some(original_idx)).to_string()
-                                }
-                                on:click=move |_| {
-                                    if let Some(item) = items.with(|i| i.get(original_idx).cloned()) {
-                                        set_choice(Some(item));
-                                        set_focused(false);
-                                        set_current_input("".to_string());
-                                        if let Some(element) = document()
-                                            .active_element()
-                                            .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
-                                        {
-                                            let _ = element.blur();
-                                        }
-                                    }
-                                }
-                                on:mousemove=move |_| {
-                                    set_highlighted_index(render_idx);
-                                }
-                            >
-                                <div class={
-                                    let is_selected_selector = is_selected_selector.clone();
-                                    move || {
-                                        let is_selected = is_selected_selector.selected(&Some(original_idx));
-                                        let is_highlighted = highlighted_index() == render_idx;
-
-                                        if is_highlighted {
-                                             "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)] ring-1 ring-[color:var(--brand-ring)]"
-                                        } else if is_selected {
-                                            "flex items-center rounded-lg p-2 transition-colors duration-200 bg-[color:color-mix(in_srgb,var(--brand-ring)_18%,transparent)]"
-                                        } else {
-                                            "flex items-center rounded-lg p-2 transition-colors duration-200 hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]"
-                                        }
-                                    }
-                                }>
-                                    {move || items
-                                        .with(|i| i.get(original_idx).cloned())
-                                        .map(|c| children(
-                                            c,
-                                            {
-                                                view! { <div>{label.clone()}</div> }.into_any()
-                                            }
-                                        ))}
-                                </div>
-                            </button>
-                        }
-                    }
-                </For>
-            </div>
+            <Portal>{dropdown_panel.clone()}</Portal>
         </div>
     }
     .into_any()


### PR DESCRIPTION
## What changed

The shared `Select` component (used by `WorldPicker`/`WorldOnlyPicker`) now renders its dropdown through a leptos `Portal` at `document.body` with `position: fixed`, anchored under the input via `leptos-use`'s `use_element_bounding`. This is the same pattern `Tooltip` already uses.

## Why

The `.panel` utility applies `backdrop-filter: blur(4px)`, which makes every panel card its own CSS stacking context. On `/welcome`, each step is a sibling `.panel`, so the world picker dropdown — despite `z-[100]` — was trapped inside the Step 1 card's stacking context and painted **underneath** the later Step 2/3 cards. The same trap exists anywhere the picker sits inside a panel or drawer (drawers also clip the old `absolute` dropdown with `overflow-y-auto`). Portaling out of the tree fixes both the stacking and the clipping generically, on every page that uses the component.

## Notes for review

- **Hydration race fixed along the way:** `use_element_bounding` only updates on element *change*, and on a hydrated page the input's `NodeRef` is already filled before the watcher's first run — so the position signals stayed at zero until the first scroll/resize. The input's `on:focus` now calls the hook's returned `update()` so the dropdown measures itself synchronously when it opens.
- The bounding hook listens to scroll with `capture: true`, so the open dropdown follows scrolling inside inner containers (e.g. drawers), not just the window.
- SSR renders nothing for the portal (leptos `Portal` is a no-op server-side) — the dropdown was `hidden` and inert without JS anyway, so no hydration mismatch.
- Open/close semantics (`has_focus`/`hovered`, keyboard nav, aria attributes) are unchanged; the listbox markup moved verbatim into the portal.

Verified in the running app: dropdown opens glued under the input, paints over sibling panels (confirmed visually and via `elementFromPoint`), repositions on scroll, and selecting a world still commits the choice and closes the menu. `cargo check` passes for both `ssr` and `hydrate` (wasm) feature sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)