### PR TITLE
feat(retainers): add empty states to retainer listing tables

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "全部在售",
     "retainers_all_listings_desc": "无需变成第二份工作，也能查看你的雇员在售物品！",
     "retainers_add_to_start": "添加一个雇员开始使用！",
+    "retainers_undercuts_empty": "没有被压价的物品——该雇员的在售物品仍是最低价。",
+    "retainers_listings_empty": "该雇员当前没有在售物品。",
     "retainers_edit_tab": "编辑",
     "retainers_all_listings_tab": "全部在售",
     "retainers_undercuts_tab": "压价",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "Alle Angebote",
     "retainers_all_listings_desc": "Sieh die Angebote deiner Gehilfen ein, ohne dass es zum zweiten Job wird!",
     "retainers_add_to_start": "Füge einen Gehilfen hinzu, um loszulegen!",
+    "retainers_undercuts_empty": "Keine Unterbietungen — die Angebote dieses Gehilfen sind weiterhin die günstigsten.",
+    "retainers_listings_empty": "Dieser Gehilfe hat keine aktiven Angebote.",
     "retainers_edit_tab": "Bearbeiten",
     "retainers_all_listings_tab": "Alle Angebote",
     "retainers_undercuts_tab": "Unterboten",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -584,6 +584,8 @@
     "retainers_all_listings_title": "All Listings",
     "retainers_all_listings_desc": "View your retainer's listings without making it a second job!",
     "retainers_add_to_start": "Add a retainer to get started!",
+    "retainers_undercuts_empty": "No undercut listings — this retainer still has the lowest prices.",
+    "retainers_listings_empty": "This retainer has no active listings.",
     "retainers_edit_tab": "Edit",
     "retainers_all_listings_tab": "All Listings",
     "retainers_undercuts_tab": "Undercuts",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "Toutes les annonces",
     "retainers_all_listings_desc": "Consultez les annonces de vos servants sans que ça devienne un second métier !",
     "retainers_add_to_start": "Ajoutez un servant pour commencer !",
+    "retainers_undercuts_empty": "Aucune sous-cote — les annonces de ce servant sont toujours les moins chères.",
+    "retainers_listings_empty": "Ce servant n’a aucune annonce en cours.",
     "retainers_edit_tab": "Modifier",
     "retainers_all_listings_tab": "Toutes les annonces",
     "retainers_undercuts_tab": "Sous-cotes",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "すべての出品",
     "retainers_all_listings_desc": "リテイナーの出品を、もう一つの仕事にせずまとめて確認！",
     "retainers_add_to_start": "リテイナーを追加してはじめましょう！",
+    "retainers_undercuts_empty": "値下げされた出品はありません。このリテイナーの出品はすべて最安値です。",
+    "retainers_listings_empty": "このリテイナーには出品中のアイテムがありません。",
     "retainers_edit_tab": "編集",
     "retainers_all_listings_tab": "すべての出品",
     "retainers_undercuts_tab": "値下げ",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "모든 판매 목록",
     "retainers_all_listings_desc": "친구상인 판매 목록을 두 번째 일거리로 만들지 않고 편하게 확인하세요!",
     "retainers_add_to_start": "친구상인을 추가해 시작하세요!",
+    "retainers_undercuts_empty": "가격이 인하된 판매품이 없습니다. 이 친구상인의 판매품이 모두 최저가입니다.",
+    "retainers_listings_empty": "이 친구상인은 판매 중인 물품이 없습니다.",
     "retainers_edit_tab": "편집",
     "retainers_all_listings_tab": "모든 판매 목록",
     "retainers_undercuts_tab": "가격 인하",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -581,6 +581,8 @@
     "retainers_all_listings_title": "全部在售",
     "retainers_all_listings_desc": "不必把它當成第二份工作，也能查看雇員的所有在售物品！",
     "retainers_add_to_start": "新增一個雇員開始使用！",
+    "retainers_undercuts_empty": "沒有被壓價的物品——該雇員的在售物品仍是最低價。",
+    "retainers_listings_empty": "該雇員目前沒有在售物品。",
     "retainers_edit_tab": "編輯",
     "retainers_all_listings_tab": "全部在售",
     "retainers_undercuts_tab": "壓價",

--- a/ultros-frontend/ultros-app/src/routes/retainers.rs
+++ b/ultros-frontend/ultros-app/src/routes/retainers.rs
@@ -60,6 +60,7 @@ fn RetainerUndercutTable(retainer: Retainer, listings: Vec<UndercutData>) -> imp
     let worlds = use_context::<LocalWorldData>().unwrap().0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
     let world_name = world.as_ref().map(|w| w.get_name()).unwrap_or_default();
+    let is_empty = listings.is_empty();
     let listings: Vec<_> = listings
         .into_iter()
         .map(|undercut_data| {
@@ -126,7 +127,18 @@ fn RetainerUndercutTable(retainer: Retainer, listings: Vec<UndercutData>) -> imp
                         <th scope="col">{t!(i18n, retainers_undercut_by_one)}</th>
                     </tr>
                 </thead>
-                <tbody>{listings}</tbody>
+                <tbody>
+                    {is_empty
+                        .then(|| {
+                            view! {
+                                <tr>
+                                    <td colspan="6" class="p-4 text-center opacity-70">
+                                        {t!(i18n, retainers_undercuts_empty)}
+                                    </td>
+                                </tr>
+                            }
+                        })} {listings}
+                </tbody>
             </table>
         </div>
     }
@@ -144,6 +156,7 @@ fn RetainerTable(retainer: Retainer, listings: Vec<ActiveListing>) -> impl IntoV
     let worlds = world_data.0.unwrap();
     let world = worlds.lookup_selector(AnySelector::World(retainer.world_id));
     let world_name = world.as_ref().map(|w| w.get_name()).unwrap_or_default();
+    let is_empty = listings.is_empty();
     let listings: Vec<_> = listings
         .into_iter()
         .map(|listing| {
@@ -201,7 +214,18 @@ fn RetainerTable(retainer: Retainer, listings: Vec<ActiveListing>) -> impl IntoV
                         <th scope="col">{t!(i18n, retainers_total)}</th>
                     </tr>
                 </thead>
-                <tbody>{listings}</tbody>
+                <tbody>
+                    {is_empty
+                        .then(|| {
+                            view! {
+                                <tr>
+                                    <td colspan="5" class="p-4 text-center opacity-70">
+                                        {t!(i18n, retainers_listings_empty)}
+                                    </td>
+                                </tr>
+                            }
+                        })} {listings}
+                </tbody>
             </table>
         </div>
     }


### PR DESCRIPTION
## What changed

When a retainer has no rows to display, its table on the retainers pages previously rendered just a bare header row (see the Undercuts tab with retainers that aren't undercut). Each retainer table now shows a centered, muted empty-state row spanning the table instead:

- **Undercuts tab** (`RetainerUndercutTable`): "No undercut listings — this retainer still has the lowest prices." — reassuring copy, since an empty table here is good news.
- **All Listings tab / single-retainer page** (`RetainerTable`): "This retainer has no active listings."

## i18n

Two new keys, `retainers_undercuts_empty` and `retainers_listings_empty`, added to **all seven** locale files (`en`, `fr`, `de`, `ja`, `cn`, `ko`, `tc`) with real translations following each locale's existing terminology (servant / Gehilfe / リテイナー / 雇员 / 친구상인 / 雇員).

Translations were machine-authored — a native-speaker sanity check is welcome, particularly for ko.

## Notes for review

- `./check_ci.sh` (fmt + clippy `-D warnings`) passes locally.
- The empty state follows the existing repo pattern (`opacity-70` muted text, cf. `history_panel.rs`), rendered as a `colspan` row inside `<tbody>` so the column headers stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)