### PR TITLE
feat(universalis): identify ourselves + close catch-up gaps

### DIFF
--- a/ultros/src/item_update_service.rs
+++ b/ultros/src/item_update_service.rs
@@ -1,19 +1,32 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use futures::{StreamExt, stream};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 use ultros_api_types::websocket::{ListingEventData, SaleEventData};
 use ultros_db::{
     UltrosDb,
-    common::partial_diff_iterator::PartialDiffIterator,
+    common::partial_diff_iterator::{DiffItem, PartialDiffIterator},
     entity::{listing_last_updated::Model, world},
     world_data::world_cache::WorldCache,
 };
 use universalis::{UniversalisClient, WorldId, WorldItemRecencyView};
 
 use crate::event::{EventProducer, EventType};
+
+/// Universalis' most-recently-updated endpoint returns at most this many entries.
+const RECENTLY_UPDATED_WINDOW: u8 = 200;
+/// Our `listing_last_updated` rows store *ingest* time rather than Universalis'
+/// upload time, so an entry only counts as missed when their upload is newer
+/// than our ingest by more than this slack.
+const UPLOAD_TIME_SLACK_SECONDS: i64 = 120;
+/// Minimum time between saturation-triggered full sweeps of a single world.
+const FULL_SWEEP_COOLDOWN: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Item update service attempts to keep ultros' data in sync with Universalis' data.
 /// It does this primarily by comparing the recently updated items on Universalis with recently updated items on ultros
@@ -23,6 +36,8 @@ pub(crate) struct UpdateService {
     pub(crate) universalis: UniversalisClient,
     pub(crate) listings: EventProducer<ListingEventData>,
     pub(crate) sales: EventProducer<SaleEventData>,
+    /// Per-world timestamp of the last saturation-triggered full sweep.
+    pub(crate) full_sweep_cooldowns: Mutex<HashMap<i32, Instant>>,
 }
 
 struct CmpListing(Model);
@@ -66,14 +81,18 @@ impl UpdateService {
         });
     }
 
-    /// Sweeps over every single marketable item in the game, ignoring the recency cache. Only should be used if data is known to be lost.
-    pub(crate) async fn do_full_world_sweep(&self) -> Result<(), anyhow::Error> {
-        let all_marketable_items: Box<[i32]> = xiv_gen_db::data()
+    fn all_marketable_items() -> Box<[i32]> {
+        xiv_gen_db::data()
             .items
             .values()
             .filter(|i| i.item_search_category != 0)
             .map(|i| i.key_id.0)
-            .collect();
+            .collect()
+    }
+
+    /// Sweeps over every single marketable item in the game, ignoring the recency cache. Only should be used if data is known to be lost.
+    pub(crate) async fn do_full_world_sweep(&self) -> Result<(), anyhow::Error> {
+        let all_marketable_items = Self::all_marketable_items();
         for world in self.world_cache.get_all_worlds() {
             tracing::info!("scanning items");
             self.check_items(world, &all_marketable_items).await?;
@@ -81,48 +100,68 @@ impl UpdateService {
         Ok(())
     }
 
+    /// Claims the full-sweep slot for a world if its cooldown has elapsed.
+    fn claim_full_sweep_slot(&self, world_id: i32) -> bool {
+        let mut cooldowns = self
+            .full_sweep_cooldowns
+            .lock()
+            .expect("full_sweep_cooldowns poisoned");
+        let now = Instant::now();
+        match cooldowns.get(&world_id) {
+            Some(last) if now.duration_since(*last) < FULL_SWEEP_COOLDOWN => false,
+            _ => {
+                cooldowns.insert(world_id, now);
+                true
+            }
+        }
+    }
+
     #[instrument(level = "trace", skip(self))]
     async fn check_for_missed_items_on_world(
         &self,
         world: &world::Model,
     ) -> Result<(), anyhow::Error> {
-        let updates = self.get_missing_updates(&world.name).await?;
+        let updates = self.get_missing_updates(world).await?;
         let item_ids: Box<[i32]> = updates.into_iter().map(|i| i.item_id).collect();
+        metrics::counter!("ultros_catchup_items_recovered", "world" => world.name.clone())
+            .increment(item_ids.len() as u64);
         self.check_items(world, &item_ids).await?;
+        if item_ids.len() >= usize::from(RECENTLY_UPDATED_WINDOW) {
+            // Every entry in the recency window was one we missed, so more
+            // updates have likely scrolled past where this endpoint can see.
+            // The only way to recover those is a full sweep of the world.
+            metrics::counter!("ultros_catchup_window_saturated", "world" => world.name.clone())
+                .increment(1);
+            if self.claim_full_sweep_slot(world.id) {
+                warn!(world = %world.name, "recency window saturated, running full item sweep");
+                self.check_items(world, &Self::all_marketable_items())
+                    .await?;
+            } else {
+                warn!(world = %world.name, "recency window saturated, full sweep on cooldown");
+            }
+        }
         Ok(())
     }
 
     async fn get_missing_updates(
         &self,
-        world_name: &str,
+        world: &world::Model,
     ) -> Result<Vec<WorldItemRecencyView>, anyhow::Error> {
-        let world = self
-            .world_cache
-            .lookup_value_by_name(world_name)?
-            .as_world()?;
-        let mut recently_updated = self
+        let recently_updated = self
             .universalis
-            .recently_updated_items(universalis::WorldOrDatacenter::World(world_name), 200)
+            .recently_updated_items(
+                universalis::WorldOrDatacenter::World(&world.name),
+                RECENTLY_UPDATED_WINDOW,
+            )
             .await?;
-        let mut our_recently_updated = self
+        let our_recently_updated = self
             .db
             .get_recently_updated_listings_for_world(
                 world.id,
                 recently_updated.items.len() as u64 * 2,
             )
-            .await?
-            .into_iter()
-            .map(CmpListing)
-            .collect::<Vec<_>>();
-        our_recently_updated.sort_by_key(|i| i.0.item_id);
-        recently_updated.items.sort_by_key(|i| i.item_id);
-        let diff = PartialDiffIterator::new(
-            our_recently_updated.into_iter(),
-            recently_updated.items.into_iter(),
-        )
-        .flat_map(|i| i.right())
-        .collect();
-        Ok(diff)
+            .await?;
+        Ok(missed_updates(our_recently_updated, recently_updated.items))
     }
 
     async fn check_items(
@@ -146,28 +185,36 @@ impl UpdateService {
                 market_data
                     .items()
                     .map(|(item_id, listings, sales)| async move {
-                        if let Ok((added, removed)) =
-                            self.db.update_listings(listings, item_id, world_id).await
-                        {
-                            let _ =
-                                self.listings
-                                    .send(EventType::Add(Arc::new(ListingEventData {
-                                        item_id: item_id.0,
-                                        world_id: world_id.0,
-                                        listings: added,
-                                    })));
-                            let _ =
-                                self.listings
-                                    .send(EventType::Remove(Arc::new(ListingEventData {
+                        match self.db.update_listings(listings, item_id, world_id).await {
+                            Ok((added, removed)) => {
+                                let _ =
+                                    self.listings
+                                        .send(EventType::Add(Arc::new(ListingEventData {
+                                            item_id: item_id.0,
+                                            world_id: world_id.0,
+                                            listings: added,
+                                        })));
+                                let _ = self.listings.send(EventType::Remove(Arc::new(
+                                    ListingEventData {
                                         item_id: item_id.0,
                                         world_id: world_id.0,
                                         listings: removed,
-                                    })));
+                                    },
+                                )));
+                            }
+                            Err(e) => {
+                                error!(error = ?e, item_id = item_id.0, world_id = world_id.0, "catch-up listing update failed")
+                            }
                         }
-                        if let Ok(added) = self.db.update_sales(sales, item_id, world_id).await {
-                            let _ = self
-                                .sales
-                                .send(EventType::added(SaleEventData { sales: added }));
+                        match self.db.update_sales(sales, item_id, world_id).await {
+                            Ok(added) => {
+                                let _ = self
+                                    .sales
+                                    .send(EventType::added(SaleEventData { sales: added }));
+                            }
+                            Err(e) => {
+                                error!(error = ?e, item_id = item_id.0, world_id = world_id.0, "catch-up sale update failed")
+                            }
                         }
                     }),
             )
@@ -177,5 +224,102 @@ impl UpdateService {
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         Ok(())
+    }
+}
+
+/// Items Universalis has seen updates for that we appear to have missed:
+/// either absent from our recent-update list entirely, or present but with a
+/// Universalis upload newer than our last ingest (allowing
+/// [`UPLOAD_TIME_SLACK_SECONDS`] of slack since we store ingest time, not
+/// upload time).
+fn missed_updates(
+    ours: Vec<Model>,
+    mut theirs: Vec<WorldItemRecencyView>,
+) -> Vec<WorldItemRecencyView> {
+    let mut ours: Vec<CmpListing> = ours.into_iter().map(CmpListing).collect();
+    ours.sort_by_key(|i| i.0.item_id);
+    theirs.sort_by_key(|i| i.item_id);
+    PartialDiffIterator::new(ours.into_iter(), theirs.into_iter())
+        .filter_map(|entry| match entry {
+            DiffItem::Right(theirs) => Some(theirs),
+            DiffItem::Same(ours, theirs) => (theirs.last_upload_time.timestamp()
+                > ours.0.date_time.and_utc().timestamp() + UPLOAD_TIME_SLACK_SECONDS)
+                .then_some(theirs),
+            DiffItem::Left(_) => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Local};
+
+    const WORLD_ID: i32 = 34;
+
+    fn ours(item_id: i32, ingested_at: i64) -> Model {
+        Model {
+            item_id,
+            world_id: WORLD_ID,
+            date_time: DateTime::from_timestamp(ingested_at, 0)
+                .unwrap()
+                .naive_utc(),
+        }
+    }
+
+    fn theirs(item_id: i32, uploaded_at: i64) -> WorldItemRecencyView {
+        WorldItemRecencyView {
+            item_id,
+            last_upload_time: DateTime::from_timestamp(uploaded_at, 0)
+                .unwrap()
+                .with_timezone(&Local),
+            world_id: WORLD_ID,
+            world_name: None,
+        }
+    }
+
+    #[test]
+    fn item_unknown_to_us_is_missed() {
+        let missed = missed_updates(vec![ours(1, 1_000)], vec![theirs(2, 1_000)]);
+        assert_eq!(missed.iter().map(|i| i.item_id).collect::<Vec<_>>(), [2]);
+    }
+
+    #[test]
+    fn item_we_ingested_after_their_upload_is_in_sync() {
+        let missed = missed_updates(vec![ours(1, 1_010)], vec![theirs(1, 1_000)]);
+        assert!(missed.is_empty());
+    }
+
+    #[test]
+    fn item_with_newer_upload_than_our_ingest_is_missed() {
+        let missed = missed_updates(
+            vec![ours(1, 1_000)],
+            vec![theirs(1, 1_000 + UPLOAD_TIME_SLACK_SECONDS + 1)],
+        );
+        assert_eq!(missed.iter().map(|i| i.item_id).collect::<Vec<_>>(), [1]);
+    }
+
+    #[test]
+    fn upload_newer_within_slack_is_in_sync() {
+        let missed = missed_updates(
+            vec![ours(1, 1_000)],
+            vec![theirs(1, 1_000 + UPLOAD_TIME_SLACK_SECONDS)],
+        );
+        assert!(missed.is_empty());
+    }
+
+    #[test]
+    fn item_only_on_our_side_is_ignored() {
+        let missed = missed_updates(vec![ours(1, 1_000)], vec![]);
+        assert!(missed.is_empty());
+    }
+
+    #[test]
+    fn unsorted_inputs_still_diff_correctly() {
+        let missed = missed_updates(
+            vec![ours(5, 1_000), ours(1, 1_000), ours(3, 1_000)],
+            vec![theirs(3, 500), theirs(7, 1_000), theirs(1, 9_999)],
+        );
+        assert_eq!(missed.iter().map(|i| i.item_id).collect::<Vec<_>>(), [1, 7]);
     }
 }

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -52,6 +52,14 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[export_name = "malloc_conf"]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
+/// User-Agent sent on every Universalis request (REST + websocket), per their
+/// guidance that scripted consumers identify themselves with version + contact.
+pub(crate) const UNIVERSALIS_USER_AGENT: &str = concat!(
+    "ultros/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://ultros.app)"
+);
+
 #[derive(Debug, serde::Deserialize, Clone)]
 struct Config {
     hostname: String,
@@ -67,7 +75,7 @@ async fn run_socket_listener(
     sales_tx: EventProducer<SaleEventData>,
     token: CancellationToken,
 ) {
-    let mut socket = WebsocketClient::connect().await;
+    let mut socket = WebsocketClient::connect(UNIVERSALIS_USER_AGENT).await;
     socket
         .update_subscription(SubscribeMode::Subscribe, EventChannel::ListingsAdd, None)
         .await;
@@ -279,7 +287,8 @@ async fn main() -> Result<()> {
     info!("Connecting DB");
     let db = UltrosDb::connect().await?;
     info!("Fetching datacenters/worlds from universalis");
-    let universalis_client = UniversalisClient::new("ultros");
+    let universalis_client = UniversalisClient::new(UNIVERSALIS_USER_AGENT);
+    let startup_client = universalis_client.clone();
     let init = db.clone();
     let (senders, receivers) = create_event_busses();
     let listings_sender = senders.listings.clone();
@@ -288,8 +297,8 @@ async fn main() -> Result<()> {
     let socket_token = token.clone();
     tokio::spawn(async move {
         let (datacenters, worlds) = futures::future::join(
-            universalis_client.get_data_centers(),
-            universalis_client.get_worlds(),
+            startup_client.get_data_centers(),
+            startup_client.get_worlds(),
         )
         .await;
         info!("Initializing database with worlds/datacenters");
@@ -340,9 +349,10 @@ async fn main() -> Result<()> {
     let update_service = Arc::new(UpdateService {
         db: db.clone(),
         world_cache: world_cache.clone(),
-        universalis: UniversalisClient::new("ultros"),
+        universalis: universalis_client.clone(),
         listings: senders.listings.clone(),
         sales: senders.history.clone(),
+        full_sweep_cooldowns: Default::default(),
     });
     UpdateService::start_service(update_service.clone(), token.clone());
     // begin listening to universalis events
@@ -431,6 +441,7 @@ async fn main() -> Result<()> {
         search_service,
         token: token.clone(),
         ch_client,
+        universalis: universalis_client,
     };
     let web_task = tokio::spawn(web::start_web(web_state));
     tokio::select! {

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -296,6 +296,7 @@ async fn refresh_world_item_listings(
     State(senders): State<EventSenders>,
     Path((world, item_id)): Path<(String, i32)>,
     State(world_cache): State<Arc<WorldCache>>,
+    State(universalis): State<UniversalisClient>,
 ) -> Result<Redirect, WebError> {
     let lookup = world_cache.lookup_value_by_name(&world)?;
     let all_worlds = world_cache
@@ -303,8 +304,7 @@ async fn refresh_world_item_listings(
         .ok_or_else(|| anyhow::Error::msg("Unable to get worlds"))?;
     let world_clone = world.clone();
     let future = tokio::spawn(async move {
-        let client = UniversalisClient::new("ultros");
-        let current_data = client
+        let current_data = universalis
             .marketboard_current_data(&world_clone, &[item_id])
             .await?;
         // we can potentially get listings from multiple worlds from this call so we should group listings by world

--- a/ultros/src/web/state.rs
+++ b/ultros/src/web/state.rs
@@ -9,6 +9,7 @@ use leptos::config::LeptosOptions;
 use tokio_util::sync::CancellationToken;
 use ultros_api_types::world_helper::WorldHelper;
 use ultros_db::{UltrosDb, world_data::world_cache::WorldCache};
+use universalis::UniversalisClient;
 
 use ultros_clickhouse::ClickHouseClient;
 
@@ -37,6 +38,9 @@ pub(crate) struct WebState {
     /// ClickHouse client for analytical queries (Phase 1+ uses this; Phase 0
     /// only writes via the analyzer's dual-write path).
     pub(crate) ch_client: ClickHouseClient,
+    /// Shared Universalis client — reuses one connection pool instead of
+    /// building a reqwest client per request.
+    pub(crate) universalis: UniversalisClient,
 }
 
 impl FromRef<WebState> for UltrosDb {
@@ -114,5 +118,11 @@ impl FromRef<WebState> for SearchService {
 impl FromRef<WebState> for ClickHouseClient {
     fn from_ref(input: &WebState) -> Self {
         input.ch_client.clone()
+    }
+}
+
+impl FromRef<WebState> for UniversalisClient {
+    fn from_ref(input: &WebState) -> Self {
+        input.universalis.clone()
     }
 }

--- a/universalis/examples/websocket.rs
+++ b/universalis/examples/websocket.rs
@@ -30,7 +30,7 @@ async fn main() {
                 .expect("Unable to find a world matching name specfied")
         })
         .map(|w| w.id);
-    let mut ws = WebsocketClient::connect().await;
+    let mut ws = WebsocketClient::connect("ultros-universalis-examples").await;
     ws.update_subscription(SubscribeMode::Subscribe, EventChannel::ListingsAdd, world)
         .await;
     ws.update_subscription(

--- a/universalis/src/lib.rs
+++ b/universalis/src/lib.rs
@@ -202,6 +202,7 @@ pub struct CurrentlyShownMultiView {
     pub dc_name: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct UniversalisClient {
     client: Client,
 }

--- a/universalis/src/websocket/mod.rs
+++ b/universalis/src/websocket/mod.rs
@@ -6,6 +6,9 @@ use crate::websocket::event_types::{
 };
 use async_tungstenite::tokio::{ConnectStream, connect_async};
 use async_tungstenite::tungstenite::Message;
+use async_tungstenite::tungstenite::client::IntoClientRequest;
+use async_tungstenite::tungstenite::http::HeaderValue;
+use async_tungstenite::tungstenite::http::header::USER_AGENT;
 
 use bson::Document;
 use futures::future::Either;
@@ -60,7 +63,7 @@ impl WebsocketClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let socket_client = WebsocketClient::connect().await;
+    ///     let socket_client = WebsocketClient::connect("my-app/1.0 (contact@example.com)").await;
     ///     socket_client.update_subscription(SubscribeMode::Subscribe, EventChannel::SalesAdd, None).await;
     ///
     /// }
@@ -123,11 +126,13 @@ impl WebsocketClient {
         &mut self.listing_receiver
     }
 
-    pub async fn connect() -> Self {
-        let mut websocket: Option<WebSocketStream<ConnectStream>> = Self::start_websocket()
-            .await
-            .map_err(|e| error!("{e:?}"))
-            .ok();
+    pub async fn connect(user_agent: impl Into<String>) -> Self {
+        let user_agent: String = user_agent.into();
+        let mut websocket: Option<WebSocketStream<ConnectStream>> =
+            Self::start_websocket(&user_agent)
+                .await
+                .map_err(|e| error!("{e:?}"))
+                .ok();
         let (socket_sender, mut socket_receiver) = channel(100);
         let (listing_sender, listing_receiver) = channel(100);
         let sender = socket_sender.clone();
@@ -164,7 +169,7 @@ impl WebsocketClient {
                         .unwrap_or(2);
                     warn!("Socket terminated, waiting {cooldown_seconds} seconds and retrying.");
                     tokio::time::sleep(Duration::from_secs(cooldown_seconds)).await;
-                    websocket = Self::start_websocket()
+                    websocket = Self::start_websocket(&user_agent)
                         .await
                         .map_err(|e| error!("Error restarting socket? {e:?}"))
                         .ok();
@@ -282,8 +287,17 @@ impl WebsocketClient {
         }
     }
 
-    async fn start_websocket() -> Result<WebSocketStream<ConnectStream>, crate::Error> {
-        let (websocket, response) = connect_async("wss://universalis.app/api/ws").await?;
+    async fn start_websocket(
+        user_agent: &str,
+    ) -> Result<WebSocketStream<ConnectStream>, crate::Error> {
+        let mut request = "wss://universalis.app/api/ws".into_client_request()?;
+        match HeaderValue::from_str(user_agent) {
+            Ok(value) => {
+                request.headers_mut().insert(USER_AGENT, value);
+            }
+            Err(e) => warn!("Invalid websocket user-agent {user_agent:?}, connecting without: {e}"),
+        }
+        let (websocket, response) = connect_async(request).await?;
         info!("Connected Websocket. {} status", response.status());
         info!("Headers: ");
         for (ref header, _value) in response.headers() {


### PR DESCRIPTION
## Why

Two things came out of an audit of how we talk to Universalis:

1. **We weren't identifying ourselves properly.** The REST client sent a bare `"ultros"` User-Agent, and the websocket sent none at all — our firehose connection was anonymous. Universalis asks scripted consumers to identify with a version and a contact point.
2. **The catch-up path had a correctness hole.** `most-recently-updated` was diffed against our recency table *by item id only*. If an item appeared anywhere in our window, it looked in-sync — even when Universalis had a newer upload for it. Those missed events were silently dropped and never recovered.

## What changed

**User-Agent**

- `UNIVERSALIS_USER_AGENT` in `main.rs`: `ultros/<CARGO_PKG_VERSION> (+https://ultros.app)`.
- `WebsocketClient::connect` now takes a user-agent and sets it on the handshake via `IntoClientRequest`, threaded through both the initial connect and the reconnect loop. An invalid header value warns and connects without rather than failing the connection.
- Breaking change to the `universalis` crate: `WebsocketClient::connect()` gained a parameter. Example and doctest updated.

**Shared client**

- `UniversalisClient` derives `Clone` (it wraps a `reqwest::Client`, so clones share the pool) and is constructed once in `main`, then shared through `WebState` with a `FromRef` impl. `refresh_world_item_listings` was building a brand-new client — and connection pool — on every request.

**Catch-up correctness**

- `missed_updates` is now a pure, unit-tested function that compares timestamps in addition to item ids. An item counts as missed when their upload is newer than our ingest by more than `UPLOAD_TIME_SLACK_SECONDS` (120s). The slack exists because `listing_last_updated` stores *ingest* time, not Universalis' upload time — without it, normal ingest latency would look like a miss on every pass.
- **Window saturation.** The endpoint returns at most 200 entries. If all 200 come back as missed, updates have almost certainly scrolled past where we can see them. We now emit `ultros_catchup_window_saturated` and escalate to a full marketable-item sweep of that world, rate-limited to once per world per 6h so a persistent problem can't turn into a request storm.
- `ultros_catchup_items_recovered` (labelled by world) makes the size of the websocket gap visible in metrics instead of invisible.

**Error visibility**

- `check_items` swallowed DB failures in `if let Ok(..)` on both the listing and sale paths. Both now `tracing::error!` with item/world context. The `sentry_tracing` layer already installed in `main` turns ERROR-level events into GlitchTip issues, so these surface without any extra plumbing.

## Reviewer notes

- The 120s slack and the 6h full-sweep cooldown are judgement calls — both are single named constants at the top of `item_update_service.rs` if you want different numbers.
- Six unit tests cover `missed_updates`: unknown item, in-sync item, newer-upload-than-ingest, newer-but-within-slack, our-side-only, and unsorted inputs.
- `./check_ci.sh` passes (fmt + `clippy --all-targets -D warnings`, zero warnings). Clippy needed the `xiv-gen/ffxiv-datamining` and icon submodules, which wouldn't fetch in this sandbox — I borrowed the checkouts from the main clone via symlink for the build only. Nothing submodule-related is in this commit; `git diff` is the seven source files and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
