### PR TITLE
fix(api): return 401 for auth failures instead of 200

### DIFF
--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -1028,4 +1028,40 @@ mod ssr_response_tests {
             .expect_err("garbage on a 200 is an error");
         assert!(matches!(err, AppError::Json(_)), "got {err:?}");
     }
+
+    /// An unauthenticated response must surface as `NotAuthenticated` so
+    /// callers can act on it — e.g. the list-invite login redirect in
+    /// `routes/lists.rs` matches this exact variant.
+    #[test]
+    fn unauthenticated_401_maps_to_not_authenticated() {
+        let body =
+            serde_json::to_string(&JsonErrorWrapper::ApiError(ApiError::NotAuthenticated)).unwrap();
+        let err = parse_internal_api_response::<i32>(StatusCode::UNAUTHORIZED, &body)
+            .expect_err("a 401 must be an error");
+        assert_eq!(err, AppError::ApiError(ApiError::NotAuthenticated));
+    }
+
+    /// Safety proof for moving `ApiError::NoAuthCookie` from `200` to `401`
+    /// server-side (`ultros/src/web/error.rs`): callers see the *same*
+    /// `AppError` either way, because the 200 path recovers the wrapper through
+    /// `deserialize`'s fallback and the 401 path maps the status explicitly.
+    ///
+    /// The difference is only in how it gets *reported*: on a 200 the SSR fetch
+    /// helper takes its `status.is_success()` branch and logs
+    /// "Error deserializing text" at error level (GlitchTip noise), while a 401
+    /// is a plain expected error response.
+    #[test]
+    fn unauthenticated_200_and_401_produce_the_same_app_error() {
+        let body =
+            serde_json::to_string(&JsonErrorWrapper::ApiError(ApiError::NotAuthenticated)).unwrap();
+        let legacy_200 = parse_internal_api_response::<i32>(StatusCode::OK, &body)
+            .expect_err("an auth failure is always an error");
+        let fixed_401 = parse_internal_api_response::<i32>(StatusCode::UNAUTHORIZED, &body)
+            .expect_err("an auth failure is always an error");
+        assert_eq!(
+            legacy_200, fixed_401,
+            "changing the status must not change what callers observe"
+        );
+        assert_eq!(fixed_401, AppError::ApiError(ApiError::NotAuthenticated));
+    }
 }

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -106,7 +106,18 @@ define_error_enum!(ApiError {
 impl ApiError {
     fn as_status_code(&self) -> StatusCode {
         match self {
-            ApiError::NoAuthCookie => StatusCode::OK, // In this case I don't want a real error.
+            // Auth failures are 401 — the same status `WebError::NotAuthenticated`
+            // already uses for page routes. This used to answer `200` to avoid
+            // "a real error", but a 401 achieves that intent without lying about
+            // the status: it's a *client* error, so it never trips the
+            // `is_server_error()` branches below that log at error level.
+            //
+            // Answering 200 made an auth failure indistinguishable from success
+            // at the HTTP layer, so the SSR fetch helper took its
+            // `status.is_success()` branch and reported the structured
+            // `{"ApiError":"NotAuthenticated"}` body as a *deserialization*
+            // failure at error level (the GlitchTip 2218/2210 lineage).
+            ApiError::NoAuthCookie | ApiError::DiscordTokenInvalid(_) => StatusCode::UNAUTHORIZED,
             ApiError::Forbidden(_) => StatusCode::FORBIDDEN,
             ApiError::AnyhowError(e) => match e.downcast_ref::<ListError>() {
                 Some(ListError::Forbidden(_)) => StatusCode::FORBIDDEN,
@@ -180,7 +191,11 @@ impl IntoResponse for ApiError {
             // remove the discord user cookie
             info!("Removed invalid Discord token");
             cookies = cookies.remove(Cookie::from("discord_auth"));
+            // An expired/revoked token is an auth failure like any other, so it
+            // gets the same 401. Without an explicit status this tuple response
+            // defaulted to `200`.
             return (
+                StatusCode::UNAUTHORIZED,
                 cookies,
                 Json(JsonErrorWrapper::ApiError(
                     ultros_api_types::result::ApiError::NotAuthenticated,
@@ -255,5 +270,70 @@ impl IntoResponse for WebError {
             tracing::debug!(error = %self, %status, "Returning web error");
         }
         (status, message).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An unauthenticated request must answer `401`, not `200`.
+    ///
+    /// `AuthDiscordUser`'s extractor rejection is `ApiError::NoAuthCookie`, so
+    /// this is the status every logged-out request to every authenticated API
+    /// route gets. Answering `200` with an `{"ApiError":"NotAuthenticated"}`
+    /// body makes an auth failure indistinguishable from success at the HTTP
+    /// layer: the SSR fetch helper takes its `status.is_success()` branch, the
+    /// structured error then looks like a *deserialization* failure, and it
+    /// gets reported at error level (the GlitchTip 2218 / 2210 lineage that
+    /// `ultros-app/src/api.rs` carries two separate workaround comments for).
+    #[test]
+    fn no_auth_cookie_is_unauthorized_not_ok() {
+        let err = ApiError::NoAuthCookie;
+        assert_eq!(err.as_status_code(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::UNAUTHORIZED,
+            "the response status must match as_status_code()"
+        );
+    }
+
+    /// An expired/revoked Discord token is also an auth failure, so it gets the
+    /// same `401`. This arm returns early in `into_response` to attach the
+    /// cookie removal, and previously returned no status at all — which axum
+    /// defaults to `200`.
+    ///
+    /// Only the status is asserted: the cookie-clearing behaviour is untouched
+    /// by this change, and an empty test jar can't reproduce it anyway —
+    /// `CookieJar::remove` only emits a removal `Set-Cookie` when the name is
+    /// already in `original_cookies`, which in production it is (we only reach
+    /// this variant when a `discord_auth` cookie was present but Discord
+    /// rejected the token).
+    #[test]
+    fn discord_token_invalid_is_unauthorized() {
+        let jar = PrivateCookieJar::new(Key::generate());
+        let response = ApiError::DiscordTokenInvalid(jar).into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// The wire body is unchanged — clients match on `NotAuthenticated` (e.g.
+    /// the list-invite login redirect in `ultros-app/src/routes/lists.rs`), so
+    /// only the status moves.
+    #[test]
+    fn auth_failures_keep_their_structured_body() {
+        assert_eq!(
+            ApiError::NoAuthCookie.as_api_error(),
+            ultros_api_types::result::ApiError::NotAuthenticated
+        );
+    }
+
+    /// 401 is a *client* error, so it must not trip the `is_server_error()`
+    /// paths that log at error level and replace the message with a generic
+    /// "Internal server error". This is what preserves the original intent of
+    /// the `NoAuthCookie => OK` mapping ("I don't want a real error") without
+    /// lying about the status.
+    #[test]
+    fn auth_failure_is_not_reported_as_a_server_error() {
+        assert!(!ApiError::NoAuthCookie.as_status_code().is_server_error());
     }
 }


### PR DESCRIPTION
## The bug

`ApiError::NoAuthCookie` mapped to `StatusCode::OK`:

```rust
ApiError::NoAuthCookie => StatusCode::OK, // In this case I don't want a real error.
```

That variant is the `FromRequestParts` rejection for `AuthDiscordUser`, so it is the status **every logged-out request to every authenticated API route** receives — `/api/v1/current_user`, `/api/v1/endpoints`, alerts, lists, retainers, push. Each answered `200 OK` with a body of `{"ApiError":"NotAuthenticated"}`, making an auth failure indistinguishable from success at the HTTP layer.

`ApiError::DiscordTokenInvalid` (expired/revoked token) returned `(cookies, Json(..))` with **no status**, which axum defaults to `200` as well.

Meanwhile `WebError::NotAuthenticated` in the same file already used `401` for page routes — so the API enum was the inconsistent one.

## Why it matters

The SSR fetch helper branches on `status.is_success()`. On a 200 it takes the success path, fails to deserialize the wrapper as the payload type, and reports it **at error level** as a deserialization bug. Both `parse_internal_api_response` and the `deserialize` fallback already carry comments about working around this exact shape (GlitchTip 2218 / 2210) — this fixes the source instead of compensating downstream.

A `200` auth failure is also heuristically cacheable by shared caches; a `401` is not. API responses here set no `Cache-Control`.

## The fix

Both auth-failure variants now return `401`.

The original intent of the `OK` mapping is preserved: `401` is a *client* error, so it never trips the `is_server_error()` branches that log at error level or swap the message for a generic "Internal server error".

## Callers are unaffected — proven, not assumed

`deserialize` already recovered the wrapper from a 200, and `parse_internal_api_response` maps a non-success status explicitly. Both yield the **same** `AppError::ApiError(NotAuthenticated)`. The new `unauthenticated_200_and_401_produce_the_same_app_error` test asserts that equivalence directly, so the status move is behaviour-preserving for callers by construction.

Checked every client path:

| Path | Before | After |
|---|---|---|
| SSR `fetch_api` | 200 → error-level "Error deserializing text" | 401 → `warn!`, same `AppError` |
| wasm `fetch_api` | reads `.text()` regardless of status → wrapper | unchanged |
| `post_api` / `patch_api` / `delete_api` | read body regardless of status | unchanged |
| `fetch_current_user_fallback` (ultros-client) | 200 → `json::<UserData>()` fails → error log → `None` | `!response.ok()` → `None`, no spurious log |
| SSR page render (`leptos.rs`) | handlers take `Result<AuthDiscordUser, ApiError>` and call `user.ok()` — the rejection never becomes a response | **unchanged** |

That last row is the one that matters for blast radius: page rendering for logged-out visitors does not go through `IntoResponse` at all, so it cannot regress.

Consumers that match on the structured `NotAuthenticated` variant (e.g. the list-invite login redirect in `routes/lists.rs`) keep working — the wire body is untouched, only the status moves.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (full workspace)
- `cargo test -p ultros-app --lib --features ssr ssr_response_tests` — **6 passed**, including the two new ones

Note on the 4 tests added to `ultros/src/web/error.rs`: they are type-checked by `clippy --all-targets` but **not executed locally** — the `ultros` bin test target does not link on Windows/MSVC (54 unresolved `ultros_app` symbols, the same wall that keeps `main.rs`'s existing tests unrun), and `cargo test` is commented out in `rust.yml`. The safety-critical half of the contract is asserted by the `ultros-app` tests above, which do run.

One assertion was deliberately left out: `discord_token_invalid_is_unauthorized` checks only the status, not that `Set-Cookie` is emitted. `CookieJar::remove` only produces a removal cookie when the name is already in `original_cookies`, which an empty test jar cannot reproduce; the cookie-clearing code is unchanged by this diff either way.

## Backlog triage in the same pass

161 stale issues marked **ignored** — the 2026-05-12 scraper flood, per-URL fragmented (pre-`#787` fingerprinting), all `count=1` on release `c88703d8`:

- `RustWasmPanic: unwrap() on Err ... "Failed to fetch"` — panicked at the old `lib.rs:186` world_data unwrap; current code handles that `Err` via `LocalWorldData::failed` (#628/#634/#791 lineage)
- `RustWasmPanic: RefCell already borrowed` — the executor re-entry cascade off that primary panic, fixed by #636 and Cat7-suppressed
- `RustWasmPanic: entered unreachable code` — the tachys DOM-order class fixed by #960
- `#3148 I18n context is missing` — provably stale: its events fetch `.bincode` game data, a path removed by #679's rkyv migration

Left untouched: `#2209`, `#6851`–`#6854`, `#2210`, `#2219`, `#2220` are all `environment:development` / `server_name:Bahamut` / `release 0.1.0` — the dev box, not prod. `#6778` kept as a canary. The tail below `#2032` is more of the same flood and can be swept next run.

Worth noting: those `#6851`–`#6854` events are dated 2026-07-14, *after* #783 added the `GLITCHTIP_ENVIRONMENT=development` init guard. The guard on `main` is correct and its unit tests pass, so they came from a build off a stale branch — which is a good argument for rebasing local worktrees before running the app against the shared DSN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
