### PR TITLE
ci(docker): serialize image builds per ref

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,17 @@ on:
             - ".github/workflows/book.yml"
             - ".github/workflows/book-check.yml"
 
+# Serialize builds per ref. Batched merges used to fire three ~90-minute main
+# builds at once, all exporting `type=gha,mode=max` into the same 10GB Actions
+# cache; they evicted each other's blobs mid-build and buildx died with
+# `failed to solve: not_found` (plus occasional runner disk exhaustion).
+# Queueing them keeps every merged commit's image published, one at a time.
+# PR re-pushes cancel instead of queueing — only the tip of a PR is worth
+# building, and queueing there would slow PR feedback.
+concurrency:
+    group: docker-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
     # Use ghcr.io for GitHub Container Registry
     REGISTRY: ghcr.io


### PR DESCRIPTION
## Problem

No container image has published from `main` since 2026-07-21. Every push build fails at the **Build and push Docker image** step after ~86 minutes with:

```
buildx failed with: ERROR: failed to build: failed to solve: not_found
```

Affected runs: [30092736081](https://github.com/akarras/ultros/actions/runs/30092736081), [30096305827](https://github.com/akarras/ultros/actions/runs/30096305827), [30096309682](https://github.com/akarras/ultros/actions/runs/30096309682), [30107934411](https://github.com/akarras/ultros/actions/runs/30107934411), [30110085032](https://github.com/akarras/ultros/actions/runs/30110085032), [30110089944](https://github.com/akarras/ultros/actions/runs/30110089944). Two sibling runs ([30096301968](https://github.com/akarras/ultros/actions/runs/30096301968), [29348329250](https://github.com/akarras/ultros/actions/runs/29348329250)) died on runner disk exhaustion (`No space left on device`) instead.

## Diagnosis

Not a code regression — `git diff 7f9c6e8..205e4c0 -- Dockerfile Cargo.lock Cargo.toml rust-toolchain .github/` is empty, so nothing feeding the image build changed between the last green `main` run and the failures. The same trees build fine on branches: [30098507158](https://github.com/akarras/ultros/actions/runs/30098507158) succeeded in 82 min, and its merge commit on `main` failed.

The only difference between the passing PR path and the failing push path is `push: true` plus `cache-to: type=gha,mode=max`. Batched merges fire three or four ~90-minute `main` builds simultaneously, all exporting max-mode cache into the same 10GB Actions cache. They evict each other's blobs mid-build, and the subsequent import 404s — `not_found`.

## Fix

Queue builds per ref so only one runs at a time. Each merged commit still gets its image published, just serially.

PR re-pushes cancel rather than queue — only a PR's tip is worth building, and queueing there would make PR feedback slower than it is today.

## Tradeoffs

- **Batched merges take longer to all publish.** Four merges now serialize to ~6 hours wall-clock instead of ~1.5. That's the cost of not thrashing the cache.
- **This treats the trigger, not the root cause.** The real fix is moving off the GHA cache backend to a registry cache (`type=registry,ref=ghcr.io/akarras/ultros:buildcache`), which has no 10GB quota and no eviction race. That's a follow-up.
- **Runner disk exhaustion is untouched.** The two `No space left on device` failures need a separate free-disk-space step.

## Verification

Not verified end-to-end — the failure only reproduces on `main` after a merge, so the real test is the first batched merge after this lands. The workflow's top-level key structure parses as expected (`name`, `on`, `concurrency`, `env`, `jobs`); this PR's own build exercises the YAML being valid, but not the queueing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)