### PR TITLE
feat(analyzer): default the sale-velocity filter to 1d

### DIFF
--- a/docs/superpowers/specs/2026-07-25-analyzer-velocity-default-design.md
+++ b/docs/superpowers/specs/2026-07-25-analyzer-velocity-default-design.md
@@ -36,9 +36,22 @@ scope. No filter logic changes; no new locale keys.
 ### Seeding the default
 
 New module `ultros-frontend/ultros-app/src/query_defaults.rs`, a sibling of
-`math.rs` and `freshness.rs`, exposing one helper. On mount, if the query
-parameter is absent from the URL, the helper writes the default value. Each of
-the four routes calls it once, next to its existing `query_signal` declaration.
+`math.rs` and `freshness.rs`, exposing two helpers:
+
+- `filter_query_signal(key)` — a `query_signal` carrying the nav options below.
+  Used wherever a filter is read or written.
+- `seed_query_default(key, default)` — writes `default` into the URL if `key` is
+  absent when it mounts.
+
+**Seeding belongs to the route component, not the filter's own component.** The
+filter toolbars live in `AnalyzerTable`, `VendorResaleTable`,
+`RecipeAnalyzerTable`, and `FCCraftingAnalyzerTable`, all of which are rendered
+inside a `Suspense` closure that re-runs whenever its resources change — a world
+switch, or a live market refetch on the analyzer pages. Seeding there would
+remount and re-seed on every refresh, silently reinstating a filter the user had
+just cleared. `seed_query_default` is therefore called from `AnalyzerWorldView`,
+`VendorWorldView`, `RecipeAnalyzer`, and `FCCraftingAnalyzer`, which mount once
+per navigation — the granularity a default wants.
 
 Everything downstream is untouched. The input box, the `Next Sale ≤ 1d` chip and
 its X button, and Clear All all keep operating on the same query signal, and the

--- a/docs/superpowers/specs/2026-07-25-analyzer-velocity-default-design.md
+++ b/docs/superpowers/specs/2026-07-25-analyzer-velocity-default-design.md
@@ -1,0 +1,134 @@
+# Default sale-velocity filter on the analyzer tools
+
+**Date:** 2026-07-25
+**Status:** Approved, ready for implementation
+
+## Problem
+
+A user who opens `/analyzer` or `/vendor-resale` for the first time sees every
+item that clears the profit threshold, including items that sell once a month.
+Those rows look like the best flips on the page — high profit, high ROI — and
+they are the ones a newcomer is most likely to buy and then sit on. The tools
+already have a sale-velocity filter that fixes this, but it is off by default and
+buried behind "More Filters," so the people who need it most never find it.
+
+## Goal
+
+A bare visit to any of the four analyzer tools lands on a velocity-filtered view,
+and the control that produced that view is visible without opening a drawer.
+
+## Scope
+
+Four pages, two equivalent filters:
+
+| Page | Param seeded | Meaning |
+|---|---|---|
+| `/analyzer` | `next-sale=1d` | avg sale duration < 1 day |
+| `/vendor-resale` | `next-sale=1d` | avg sale duration < 1 day |
+| `/recipe-analyzer` | `min-sales=1` | at least 1 sale/day |
+| `/fc-crafting-analyzer` | `min-sales=1` | at least 1 sale/day |
+
+Leve Analyzer and Venture Analyzer have no sale-velocity filter and are out of
+scope. No filter logic changes; no new locale keys.
+
+## Design
+
+### Seeding the default
+
+New module `ultros-frontend/ultros-app/src/query_defaults.rs`, a sibling of
+`math.rs` and `freshness.rs`, exposing one helper. On mount, if the query
+parameter is absent from the URL, the helper writes the default value. Each of
+the four routes calls it once, next to its existing `query_signal` declaration.
+
+Everything downstream is untouched. The input box, the `Next Sale ≤ 1d` chip and
+its X button, and Clear All all keep operating on the same query signal, and the
+URL stays honest and shareable.
+
+Two details, both from `leptos_router` 0.8.14's `query_signal`:
+
+- Its default `NavigateOptions` is `replace: false, scroll: true`. Seeding with
+  those would push a history entry — one wasted back press before the user
+  leaves the page — and scroll the window to top on load. The helper uses
+  `query_signal_with_options` with `replace: true, scroll: false`.
+- The helper reads the parameter untracked, so the effect has no reactive
+  dependencies and fires exactly once per mount. Clearing the filter mid-session
+  sticks; it is not re-seeded.
+
+### Absent vs. explicitly empty
+
+The seed fires only when the parameter is **absent**. A link that carries the
+parameter is honored verbatim, which gives shared links a way to say "no limit":
+
+- `?next-sale=` — present but unparseable, so `predicted_time` is `None` and the
+  filter is skipped.
+- `?min-sales=0` — every item has `daily_sales >= 0`.
+
+Both forms already arise naturally when a user empties the input box.
+
+Seeding cannot instead key off "the URL has no query string at all": the side
+nav links to these routes with `?world={world}` already attached.
+
+### Lifting the control out of "More Filters"
+
+**Vendor Resale** — the secondary toolbar holds nothing but the Max Sale Time
+field. Lifting it empties the drawer, so the `show_more` signal, the
+"More Filters" button, and the secondary `<Toolbar>` are all deleted.
+
+**Analyzer** — the drawer also holds Min Profit/Day, Min Buy, Last Sold Within,
+and Show Suspicious, so the button stays; only Max Sale Time moves up.
+
+Placement in both: immediately after "Min Sales" in the primary toolbar. The two
+are the page's "how well does this actually sell" controls, and it puts the
+seeded `1d` in a newcomer's line of sight, which is what makes the default
+legible rather than mysterious.
+
+Recipe Analyzer and FC Crafting Analyzer have no drawer — `min-sales` is already
+in their primary row.
+
+### Bundled fixes
+
+- The four velocity params move to `query_signal_with_options` with
+  `replace: true, scroll: false` for **all** writes, not just seeding. Today
+  every keystroke in a duration or min-sales box pushes a history entry and
+  scrolls the page to top.
+- `vendor_resale.rs` has a hardcoded `placeholder="e.g. 7d 12h"` inside the block
+  being moved; it becomes `t_string!(i18n, analyzer_placeholder_7d_12h)`.
+  `vendor_resale.rs` already borrows analyzer keys such as
+  `analyzer_tooltip_duration_format`, so no new locale entries are needed.
+
+## Accepted consequence
+
+The next-sale filter drops items whose `avg_sale_duration` is unknown —
+`analyzer.rs:595` and `vendor_resale.rs:307` both end in `unwrap_or(false)`.
+Making the filter a default therefore hides no-data items by default, and on
+Vendor Resale, where `sale_summary` is an `Option`, that may shorten the list
+noticeably.
+
+The semantics stay as they are. An item with no sales data is not a good
+recommendation for a newcomer, which is the audience this default serves. The
+mitigation is visibility: the chip renders with a working X, and the control now
+sits in the primary toolbar, so a user who wants the long tail can get it in one
+click.
+
+## Out of scope
+
+`"More Filters"` / `"Fewer Filters"` are hardcoded English in `analyzer.rs`,
+which violates the no-hardcoded-strings rule in CLAUDE.md. Vendor Resale's copy
+disappears with the button. Analyzer's needs two new keys across seven locales
+and is unrelated to this change; it gets its own task.
+
+## Verification
+
+- `./check_ci.sh` (fmt + clippy).
+- Drive the app and confirm:
+  - A bare `/analyzer` lands on `?next-sale=1d`, with the chip showing and the
+    Max Sale Time field visible in the primary toolbar without expanding
+    "More Filters".
+  - The chip's X removes the filter and it stays removed while navigating within
+    the page.
+  - Back from a seeded page goes to the previous *page*, not to the unfiltered
+    URL, and loading the page does not scroll the window.
+  - `?next-sale=` renders unfiltered.
+  - `/vendor-resale` no longer shows a "More Filters" button.
+  - `/recipe-analyzer` and `/fc-crafting-analyzer` land on `?min-sales=1` with
+    `1` in the Min Daily Sales box.

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod error;
 pub(crate) mod freshness;
 pub(crate) mod global_state;
 pub(crate) mod math;
+pub(crate) mod query_defaults;
 pub(crate) mod routes;
 pub(crate) mod sales_cadence;
 pub(crate) mod ws;

--- a/ultros-frontend/ultros-app/src/query_defaults.rs
+++ b/ultros-frontend/ultros-app/src/query_defaults.rs
@@ -1,0 +1,83 @@
+//! Opinionated defaults for URL-backed filters.
+//!
+//! The analyzer tools land first-time visitors on a sale-velocity-filtered view
+//! instead of a list topped by items that sell once a month. The default lives
+//! in the URL rather than in the filter logic, so chips, Clear All, and shared
+//! links all keep behaving exactly as they do for a hand-typed filter.
+
+use std::str::FromStr;
+
+use leptos::prelude::*;
+use leptos_router::NavigateOptions;
+use leptos_router::hooks::query_signal_with_options;
+
+/// Default ceiling on predicted time to next sale: items that sell at least
+/// once a day. Parsed with `humantime`, same as anything typed into the box.
+pub const DEFAULT_MAX_SALE_TIME: &str = "1d";
+
+/// The same velocity floor, expressed as the crafting analyzers' daily-sales
+/// metric rather than as a duration.
+pub const DEFAULT_MIN_DAILY_SALES: f32 = 1.0;
+
+/// Navigation options for filter query params.
+///
+/// `query_signal`'s defaults (`replace: false`, `scroll: true`) mean every
+/// keystroke in a filter box pushes a history entry and yanks the window back
+/// to the top. Filters are not navigation.
+fn filter_nav_options() -> NavigateOptions {
+    NavigateOptions {
+        replace: true,
+        scroll: false,
+        ..Default::default()
+    }
+}
+
+/// A [`query_signal`](leptos_router::hooks::query_signal) for a filter param,
+/// using [`filter_nav_options`].
+pub fn filter_query_signal<T>(key: &'static str) -> (Memo<Option<T>>, SignalSetter<Option<T>>)
+where
+    T: FromStr + ToString + PartialEq + Send + Sync + 'static,
+{
+    query_signal_with_options::<T>(key, filter_nav_options())
+}
+
+/// Write `default` into the URL if `key` is absent when this mounts.
+///
+/// Seeding fires only when the param is *absent*, so a link that carries the
+/// param is honored verbatim — `?next-sale=` (unparseable) and `?min-sales=0`
+/// both mean "no limit", and both are what the input box produces when a user
+/// empties it.
+///
+/// Call this from the **route** component. Anything rendered inside a
+/// `Suspense`/resource closure remounts whenever its resource changes — a live
+/// market refetch, a world switch — and seeding there would silently reinstate
+/// a filter the user had just cleared. The route component mounts once per
+/// navigation, which is the granularity a default wants.
+pub fn seed_query_default<T>(key: &'static str, default: T)
+where
+    T: FromStr + ToString + PartialEq + Clone + Send + Sync + 'static,
+{
+    let (value, set_value) = filter_query_signal::<T>(key);
+    Effect::new(move |_| {
+        if value.get_untracked().is_none() {
+            set_value.set(Some(default.clone()));
+        }
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The seeded value goes through the same `humantime` parse as anything
+    /// typed into the box, and an unparseable duration doesn't error — it just
+    /// leaves `predicted_time` as `None`, i.e. no filter at all. A typo in the
+    /// constant would silently undo the default, so pin it.
+    #[test]
+    fn default_max_sale_time_parses_to_one_day() {
+        assert_eq!(
+            humantime::parse_duration(DEFAULT_MAX_SALE_TIME).expect("default must parse"),
+            std::time::Duration::from_secs(60 * 60 * 24),
+        );
+    }
+}

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -29,6 +29,7 @@ use crate::{
     error::AppError,
     global_state::LocalWorldData,
     math::filter_outliers_iqr_in_place,
+    query_defaults::{DEFAULT_MAX_SALE_TIME, filter_query_signal, seed_query_default},
 };
 use ultros_api_types::{
     resale_quality::ResaleQualityRow, sparklines::SparklinesRequest, trends::ConfidenceBand,
@@ -451,7 +452,10 @@ fn AnalyzerTable(
     let (minimum_profit, set_minimum_profit) = query_signal::<i32>("profit");
     let (minimum_profit_per_day, set_minimum_profit_per_day) = query_signal::<i32>("ppd");
     let (minimum_roi, set_minimum_roi) = query_signal::<i32>("roi");
-    let (max_predicted_time, set_max_predicted_time) = query_signal::<String>("next-sale");
+    // Seeded to 1d by AnalyzerWorldView so a first-time visitor isn't shown
+    // items that sell once a month. The field sits in the primary toolbar and
+    // the chip has an X, so the default is visible and one click from gone.
+    let (max_predicted_time, set_max_predicted_time) = filter_query_signal::<String>("next-sale");
     let (world_filter, set_world_filter) = query_signal::<String>("world");
     let (datacenter_filter, set_datacenter_filter) = query_signal::<String>("datacenter");
     let (tax_enabled, set_tax_enabled) = query_signal::<bool>("tax");
@@ -868,6 +872,18 @@ fn AnalyzerTable(
                         }
                     />
                 </ToolbarField>
+                <ToolbarField label=t_string!(i18n, analyzer_filter_max_sale_time_label).to_string()>
+                    <input
+                        class="input input-sm w-32"
+                        placeholder=t_string!(i18n, analyzer_placeholder_7d_12h)
+                        title=t_string!(i18n, analyzer_tooltip_duration_format)
+                        prop:value=move || max_predicted_time().unwrap_or_default()
+                        on:input=move |input| {
+                            let value = event_target_value(&input);
+                            set_max_predicted_time(Some(value));
+                        }
+                    />
+                </ToolbarField>
                 <ToolbarField label=t_string!(i18n, analyzer_filter_buy_max_label).to_string()>
                     <input
                         class="input input-sm w-32"
@@ -1043,18 +1059,6 @@ fn AnalyzerTable(
                                 } else if value.is_empty() {
                                     set_min_buy_price(None);
                                 }
-                            }
-                        />
-                    </ToolbarField>
-                    <ToolbarField label=t_string!(i18n, analyzer_filter_max_sale_time_label).to_string()>
-                        <input
-                            class="input input-sm w-32"
-                            placeholder=t_string!(i18n, analyzer_placeholder_7d_12h)
-                            title=t_string!(i18n, analyzer_tooltip_duration_format)
-                            prop:value=move || max_predicted_time().unwrap_or_default()
-                            on:input=move |input| {
-                                let value = event_target_value(&input);
-                                set_max_predicted_time(Some(value));
                             }
                         />
                     </ToolbarField>
@@ -1613,6 +1617,10 @@ fn AnalyzerTable(
 #[component]
 pub fn AnalyzerWorldView() -> impl IntoView {
     let i18n = use_i18n();
+    // Seeded here rather than in AnalyzerTable: that lives inside the Suspense
+    // closure and remounts on every market refetch, which would keep undoing a
+    // filter the user had cleared.
+    seed_query_default("next-sale", DEFAULT_MAX_SALE_TIME.to_string());
     let params = use_params_map();
     let world = Signal::derive(move || params.with(|p| p.get("world").clone()).unwrap_or_default());
     let (market_refresh_version, set_market_refresh_version) = signal(0_u64);

--- a/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/fc_crafting_analyzer.rs
@@ -8,6 +8,7 @@ use crate::global_state::cookies::Cookies;
 use crate::global_state::craft_options::{self, CraftOptions};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
+use crate::query_defaults::{DEFAULT_MIN_DAILY_SALES, filter_query_signal, seed_query_default};
 use crate::ws::realtime::use_realtime;
 use crate::{
     api::{get_cheapest_listings, get_recent_sales_for_world},
@@ -212,7 +213,10 @@ fn FCCraftingAnalyzerTable(
     let (sort_mode, _set_sort_mode) = query_signal::<SortMode>("sort");
     let (minimum_profit, set_minimum_profit) = query_signal::<i32>("profit");
     let (minimum_roi, set_minimum_roi) = query_signal::<i32>("roi");
-    let (min_daily_sales, set_min_daily_sales) = query_signal::<f32>("min-sales");
+    // Seeded by FCCraftingAnalyzer so a first-time visitor isn't shown recipes
+    // whose output sells once a month. Same velocity floor as the analyzer's
+    // 1d default.
+    let (min_daily_sales, set_min_daily_sales) = filter_query_signal::<f32>("min-sales");
     let (exclude_shards_url, set_exclude_shards) = query_signal::<bool>("shards-exclude");
     let (use_on_hand_url, set_use_on_hand) = query_signal::<bool>("on-hand");
     let cookies = use_context::<Cookies>().unwrap();
@@ -613,6 +617,10 @@ fn FCCraftingAnalyzerTable(
 #[component]
 pub fn FCCraftingAnalyzer() -> impl IntoView {
     let i18n = use_i18n();
+    // Seeded here rather than in FCCraftingAnalyzerTable: that lives inside the
+    // Suspense closure and remounts whenever its resources change, which would
+    // keep undoing a filter the user had cleared.
+    seed_query_default("min-sales", DEFAULT_MIN_DAILY_SALES);
     let params = use_params_map();
     let (home_world, _) = use_home_world();
 

--- a/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/recipe_analyzer.rs
@@ -7,6 +7,7 @@ use crate::components::related_items::is_shard_item;
 use crate::global_state::craft_options::{self, CraftOptions};
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
+use crate::query_defaults::{DEFAULT_MIN_DAILY_SALES, filter_query_signal, seed_query_default};
 use crate::ws::realtime::use_realtime;
 use crate::{
     analysis::{SalesStats, analyze_sales, roi_badge_class},
@@ -129,7 +130,10 @@ fn RecipeAnalyzerTable(
     let (minimum_roi, set_minimum_roi) = query_signal::<i32>("roi");
     let (job_filter, set_job_filter) = query_signal::<String>("job");
     let (use_subcrafts, set_use_subcrafts) = query_signal::<bool>("subcrafts");
-    let (min_daily_sales, set_min_daily_sales) = query_signal::<f32>("min-sales");
+    // Seeded by RecipeAnalyzer so a first-time visitor isn't shown recipes
+    // whose output sells once a month. Same velocity floor as the analyzer's
+    // 1d default.
+    let (min_daily_sales, set_min_daily_sales) = filter_query_signal::<f32>("min-sales");
     let (require_hq, set_require_hq) = query_signal::<bool>("require-hq");
     let (filter_outliers, set_filter_outliers) = query_signal::<bool>("filter-outliers");
     let (exclude_shards_url, set_exclude_shards) = query_signal::<bool>("shards-exclude");
@@ -713,6 +717,10 @@ fn CollapseIcon(collapsed: Signal<bool>) -> impl IntoView {
 #[component]
 pub fn RecipeAnalyzer() -> impl IntoView {
     let i18n = use_i18n();
+    // Seeded here rather than in RecipeAnalyzerTable: that lives inside the
+    // Suspense closure and remounts whenever its resources change, which would
+    // keep undoing a filter the user had cleared.
+    seed_query_default("min-sales", DEFAULT_MIN_DAILY_SALES);
     let params = use_params_map();
     let (home_world, _) = use_home_world();
 

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -13,13 +13,14 @@ use crate::{
         realtime_status::RealtimeStatus,
         skeleton::BoxSkeleton,
         tool_help::*,
-        toolbar::{Toolbar, ToolbarField, ToolbarPills, ToolbarSpacer},
+        toolbar::{Toolbar, ToolbarField, ToolbarPills},
         virtual_scroller::*,
         world_picker::*,
     },
     error::AppError,
     global_state::LocalWorldData,
     i18n::*,
+    query_defaults::{DEFAULT_MAX_SALE_TIME, filter_query_signal, seed_query_default},
     ws::realtime::use_realtime,
 };
 use chrono::{Duration, Utc};
@@ -236,11 +237,13 @@ fn VendorResaleTable(
     let (sort_mode, _set_sort_mode) = query_signal::<SortMode>("sort");
     let (minimum_profit, set_minimum_profit) = query_signal::<i32>("profit");
     let (minimum_roi, set_minimum_roi) = query_signal::<i32>("roi");
-    let (max_predicted_time, set_max_predicted_time) = query_signal::<String>("next-sale");
+    // Seeded to 1d by VendorWorldView so a first-time visitor isn't shown items
+    // that sell once a month. The field sits in the primary toolbar and the
+    // chip has an X, so the default is visible and one click from gone.
+    let (max_predicted_time, set_max_predicted_time) = filter_query_signal::<String>("next-sale");
     let (tax_enabled, set_tax_enabled) = query_signal::<bool>("tax");
     let (minimum_sales, set_minimum_sales) = query_signal::<usize>("sales");
     let (category_filter, set_category_filter) = query_signal::<i32>("category");
-    let show_more = RwSignal::new(false);
 
     let predicted_time =
         Memo::new(move |_| max_predicted_time().and_then(|d| parse_duration(d.as_str()).ok()));
@@ -390,6 +393,17 @@ fn VendorResaleTable(
                         }
                     />
                 </ToolbarField>
+                <ToolbarField label=t_string!(i18n, vendor_resale_filter_max_sale_time_label).to_string()>
+                    <input
+                        class="input input-sm w-32"
+                        placeholder=t_string!(i18n, analyzer_placeholder_7d_12h)
+                        title=t_string!(i18n, analyzer_tooltip_duration_format)
+                        prop:value=move || max_predicted_time().unwrap_or_default()
+                        on:input=move |input| {
+                            set_max_predicted_time(Some(event_target_value(&input)))
+                        }
+                    />
+                </ToolbarField>
                 <ToolbarField label=t_string!(i18n, vendor_resale_filter_category_label).to_string()>
                     <select
                         class="input input-sm w-48"
@@ -433,34 +447,7 @@ fn VendorResaleTable(
                         </button>
                     </ToolbarPills>
                 </ToolbarField>
-                <ToolbarSpacer />
-                <button
-                    class="btn-secondary flex items-center gap-2"
-                    on:click=move |_| show_more.update(|v| *v = !*v)
-                    aria-expanded=move || show_more.get().to_string()
-                >
-                    <Icon icon=i::FaFilterSolid />
-                    {move || if show_more.get() { "Fewer Filters" } else { "More Filters" }}
-                </button>
             </Toolbar>
-
-            // Secondary filter toolbar (expanded)
-            {move || show_more.get().then(|| view! {
-                <Toolbar>
-                    <ToolbarField label=t_string!(i18n, vendor_resale_filter_max_sale_time_label).to_string()>
-                        <input
-                            class="input input-sm w-32"
-                            placeholder="e.g. 7d 12h"
-                            title=t_string!(i18n, analyzer_tooltip_duration_format)
-                            prop:value=move || max_predicted_time().unwrap_or_default()
-                            on:input=move |input| {
-                                let value = event_target_value(&input);
-                                set_max_predicted_time(Some(value))
-                            }
-                        />
-                    </ToolbarField>
-                </Toolbar>
-            })}
 
             // Results summary
             <div class="panel px-4 py-3 flex flex-col md:flex-row md:items-center gap-3 md:gap-0 md:justify-between">
@@ -682,6 +669,10 @@ fn VendorResaleTable(
 #[component]
 pub fn VendorWorldView() -> impl IntoView {
     let i18n = use_i18n();
+    // Seeded here rather than in VendorResaleTable: that lives inside the
+    // Suspense closure and remounts on every market refetch, which would keep
+    // undoing a filter the user had cleared.
+    seed_query_default("next-sale", DEFAULT_MAX_SALE_TIME.to_string());
     let params = use_params_map();
     let world = Signal::derive(move || params.with(|p| p.get("world").clone()).unwrap_or_default());
 


### PR DESCRIPTION
## Why

Open `/flip-finder` cold today and you get every item that clears the profit threshold — including ones that sell once a month. Those rows look like the best flips on the page (high profit, high ROI) and they're exactly what a newcomer buys and then sits on for three weeks.

The filter that fixes this already existed. It was just off by default and buried behind **More Filters**, so the people who most needed it never found it.

## What changed

**Seeded defaults.** A bare visit now lands on a velocity-filtered view:

| Page | Param seeded | Meaning |
|---|---|---|
| `/flip-finder` | `next-sale=1d` | avg sale duration < 1 day |
| `/vendor-resale` | `next-sale=1d` | avg sale duration < 1 day |
| `/recipe-analyzer` | `min-sales=1` | ≥ 1 sale/day |
| `/fc-crafting-analyzer` | `min-sales=1` | ≥ 1 sale/day |

The default lives in the **URL**, not in the filter logic, so chips, Clear All, the input box, and shared links all behave exactly as they do for a hand-typed filter. Seeding fires only when the param is *absent*, so a link carrying `?next-sale=` or `?min-sales=0` still means "no limit" — and both forms are what the input box produces when you empty it.

New `ultros-app/src/query_defaults.rs` holds the two helpers and the constants.

**The control is now visible.** Max Sale Time moves into the primary toolbar on both analyzer and vendor resale — a default you can't see is just a mystery. On vendor resale that emptied the secondary toolbar entirely, so the drawer, its button, and `show_more` are deleted.

## Reviewer notes

**Seeding deliberately lives in the route components, not next to the `query_signal` declarations.** All four filter toolbars render inside a `Suspense` closure that re-runs whenever its resources change — including live market refetches on the analyzer pages. Seeding there would remount and re-seed on every refresh, silently reinstating a filter the user had just cleared. `AnalyzerWorldView` / `VendorWorldView` / `RecipeAnalyzer` / `FCCraftingAnalyzer` mount once per navigation, which is the granularity a default wants.

**Accepted behavior change:** the next-sale filter drops items whose `avg_sale_duration` is unknown (`unwrap_or(false)`, unchanged). Making it a default therefore hides no-data items by default, and on vendor resale — where `sale_summary` is an `Option` — that may shorten the list noticeably. This is intended: an item with no sales history isn't a good recommendation for the audience this default serves. The chip renders with a working X, so it's one click to undo. **Worth a sanity check on a real world that the vendor resale list doesn't get too thin.**

**Two fixes on the lines being touched:**
- Filter params now navigate with `replace: true, scroll: false`. Previously every keystroke in a duration/min-sales box pushed a history entry *and* scrolled the page to top.
- Vendor resale's hardcoded `placeholder="e.g. 7d 12h"` moves to the existing `analyzer_placeholder_7d_12h` key. No new locale entries needed — verified the key exists in all seven files.

**Out of scope:** `"More Filters"` / `"Fewer Filters"` remain hardcoded English in `analyzer.rs` (vendor resale's copy disappeared with the button). That needs 2 keys × 7 locales and is unrelated; filed separately.

## Testing

- `./check_ci.sh` — passes (fmt + clippy clean, whole workspace).
- `cargo test -p ultros-app --lib query_defaults` — passes. The test pins `DEFAULT_MAX_SALE_TIME` to parse as exactly one day; a typo there wouldn't error, it would silently turn the default into no filter at all.
- **Not yet exercised in a browser.** The URL-seeding and back-button behavior are worth a manual pass: bare `/flip-finder` should land on `?next-sale=1d` with the chip showing, the X should stay cleared across a live market refresh, and Back should leave the page rather than stepping to the unfiltered URL.

Design doc: `docs/superpowers/specs/2026-07-25-analyzer-velocity-default-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)