### PR TITLE
fix(sparkline): portal the hover tooltip so table rows can't clip it

### DIFF
--- a/ultros-frontend/ultros-app/src/components/sparkline.rs
+++ b/ultros-frontend/ultros-app/src/components/sparkline.rs
@@ -6,6 +6,7 @@
 //! a dot on the trace and a micro-tooltip with the value and how long ago
 //! that sample was. Sparkline series are hourly VWAP, oldest first.
 
+use leptos::portal::Portal;
 use leptos::prelude::*;
 
 use ultros_charts::charts::sparkline::build_sparkline;
@@ -13,6 +14,17 @@ use ultros_charts::components::color_attr;
 use ultros_charts::scale::short_number;
 
 use crate::i18n::{t_string, use_i18n};
+
+/// Hover state for the tooltip. Carries the sparkline's viewport-space
+/// geometry alongside the index so the portalled tooltip — which lives on
+/// `<body>`, not next to the `<svg>` — can position itself.
+#[derive(Clone, Copy, PartialEq)]
+struct SparkHover {
+    index: usize,
+    left: f64,
+    top: f64,
+    width: f64,
+}
 
 #[component]
 pub fn Sparkline(
@@ -49,7 +61,10 @@ pub fn Sparkline(
         .join(" ");
     let stroke = color_attr(&model.color);
     let model = StoredValue::new(model);
-    let hover = RwSignal::new(None::<usize>);
+    let hover = RwSignal::new(None::<SparkHover>);
+    // Split out so the portal mounts/unmounts once per hover rather than on
+    // every index change as the pointer travels along the trace.
+    let is_hovered = Memo::new(move |_| hover.with(|h| h.is_some()));
 
     let on_pointer_move = move |evt: web_sys::PointerEvent| {
         use web_sys::wasm_bindgen::JsCast;
@@ -65,12 +80,17 @@ pub fn Sparkline(
         }
         let x_css = evt.client_x() - rect.left();
         let index = model.with_value(|m| m.nearest_index((x_css / rect.width()) as f32 * m.width));
-        hover.set(index);
+        hover.set(index.map(|index| SparkHover {
+            index,
+            left: rect.left(),
+            top: rect.top(),
+            width: rect.width(),
+        }));
     };
 
     view! {
         <span
-            class="relative inline-block align-middle"
+            class="inline-block align-middle"
             on:pointermove=on_pointer_move
             on:pointerleave=move |_| hover.set(None)
         >
@@ -92,10 +112,10 @@ pub fn Sparkline(
                 {move || {
                     hover
                         .get()
-                        .and_then(|i| {
+                        .and_then(|h| {
                             model
                                 .with_value(|m| {
-                                    let (x, y) = *m.points.get(i)?;
+                                    let (x, y) = *m.points.get(h.index)?;
                                     Some(view! {
                                         <circle
                                             cx=format!("{x:.1}")
@@ -108,40 +128,78 @@ pub fn Sparkline(
                         })
                 }}
             </svg>
+            // Portalled onto <body> rather than absolutely positioned in the
+            // cell. The analyzer table's scroll container carries
+            // `overflow-x-auto contain-paint`, both of which clip descendants
+            // outright — no z-index can escape them, and `contain: paint`
+            // even traps `position: fixed`. Only leaving the subtree works.
             {move || {
-                hover
+                is_hovered
                     .get()
-                    .and_then(|i| {
-                        model
-                            .with_value(|m| {
-                                let value = *m.values.get(i)?;
-                                let steps_back = (m.values.len() - 1 - i) as u32 * hours_per_point;
-                                let when = if steps_back == 0 {
-                                    t_string!(i18n, sparkline_now).to_string()
-                                } else {
-                                    t_string!(i18n, sparkline_hours_ago)
-                                        .to_string()
-                                        .replace("{n}", &steps_back.to_string())
-                                };
-                                let left_pct = if m.points.len() > 1 {
-                                    i as f32 / (m.points.len() as f32 - 1.0) * 100.0
-                                } else {
-                                    50.0
-                                };
-                                let style = if left_pct > 50.0 {
-                                    format!("left:{left_pct:.0}%;transform:translate(-100%,-100%)")
-                                } else {
-                                    format!("left:{left_pct:.0}%;transform:translateY(-100%)")
-                                };
-                                Some(view! {
-                                    <span
-                                        class="pointer-events-none absolute top-0 z-20 whitespace-nowrap rounded border border-[color:var(--color-outline)] bg-violet-950/95 px-1.5 py-0.5 text-[10px] tabular-nums text-[color:var(--color-text)] shadow"
-                                        style=style
-                                    >
-                                        {format!("{} · {}", short_number(value.round() as i32), when)}
-                                    </span>
-                                })
-                            })
+                    .then(|| {
+                        view! {
+                            <Portal>
+                                <span
+                                    class="pointer-events-none fixed z-50 whitespace-nowrap rounded border border-[color:var(--color-outline)] bg-violet-950/95 px-1.5 py-0.5 text-[10px] tabular-nums text-[color:var(--color-text)] shadow"
+                                    style=move || {
+                                        hover
+                                            .get()
+                                            .map(|h| {
+                                                let frac = model
+                                                    .with_value(|m| {
+                                                        if m.points.len() > 1 {
+                                                            h.index as f64 / (m.points.len() as f64 - 1.0)
+                                                        } else {
+                                                            0.5
+                                                        }
+                                                    });
+                                                // Flip the anchor past the midpoint so the tooltip
+                                                // grows back over the sparkline instead of off-screen.
+                                                let transform = if frac > 0.5 {
+                                                    "translate(-100%,-100%)"
+                                                } else {
+                                                    "translateY(-100%)"
+                                                };
+                                                let x = h.left + frac * h.width;
+                                                format!(
+                                                    "left:{:.1}px;top:{:.1}px;transform:{}",
+                                                    x,
+                                                    h.top,
+                                                    transform,
+                                                )
+                                            })
+                                            .unwrap_or_default()
+                                    }
+                                >
+                                    {move || {
+                                        hover
+                                            .get()
+                                            .and_then(|h| {
+                                                model
+                                                    .with_value(|m| {
+                                                        let value = *m.values.get(h.index)?;
+                                                        let steps_back = (m.values.len() - 1 - h.index) as u32
+                                                            * hours_per_point;
+                                                        let when = if steps_back == 0 {
+                                                            t_string!(i18n, sparkline_now).to_string()
+                                                        } else {
+                                                            t_string!(i18n, sparkline_hours_ago)
+                                                                .to_string()
+                                                                .replace("{n}", &steps_back.to_string())
+                                                        };
+                                                        Some(
+                                                            format!(
+                                                                "{} · {}",
+                                                                short_number(value.round() as i32),
+                                                                when,
+                                                            ),
+                                                        )
+                                                    })
+                                            })
+                                    }}
+                                </span>
+                            </Portal>
+                        }
                     })
             }}
         </span>


### PR DESCRIPTION
The sparkline tooltip on the analyzer table gets clipped by the surrounding rows — the value bubble is sliced in half by the row below it.

## Why z-index couldn't fix it

The analyzer's scroll container ([`analyzer.rs:1239`](https://github.com/akarras/ultros/blob/main/ultros-frontend/ultros-app/src/routes/analyzer.rs#L1239)) carries `overflow-x-auto contain-layout contain-paint`. Both `overflow` and `contain: paint` clip descendants outright — stacking order never enters into it. `contain: paint` also makes the container a containing block for `position: fixed` descendants, so escaping via fixed positioning inside the cell wouldn't have worked either. The only way out is to leave the subtree.

## What changed

`ultros-frontend/ultros-app/src/components/sparkline.rs`:

- The tooltip renders through `leptos::portal::Portal` onto `<body>` with `position: fixed`, instead of `absolute` + `z-20` inside the cell.
- Hover state went from `Option<usize>` to `Option<SparkHover>`, which also carries the sparkline's viewport-space `left`/`top`/`width`, captured from `getBoundingClientRect()` on each `pointermove`. The portalled tooltip anchors off those coordinates.
- The midpoint flip (`translate(-100%,-100%)` past the halfway point) is preserved, so the tooltip still grows back over the trace rather than off toward the screen edge.
- The portal is gated on an `is_hovered` memo rather than the full hover state — otherwise the portal container would be torn down and remounted on every index change as the pointer slides along the trace. Now it mounts once per hover and only the inner style/text react.
- Dropped the now-meaningless `relative` from the wrapper span.

This is the shared `<Sparkline>` component, so Market Movers, Trends, and Recently Viewed get the same fix.

## Reviewer notes

- **One known limitation:** because positioning is captured at pointermove time, scrolling while the pointer sits motionless over a sparkline leaves the tooltip briefly stale. In practice Chrome and Firefox dispatch boundary/pointer events after a scroll changes what's under the cursor, so it re-anchors or dismisses itself. I opted not to add a window scroll listener for this — it would need `cfg`-gating for the non-hydrate build (see `components/tooltip.rs`) for a case that self-corrects.
- The existing `<Tooltip>` component already portals the same way, so this brings the sparkline in line with it. It uses `use_element_bounding` (which does track scroll); the sparkline needs per-sample x positions rather than element-center, hence the hand-rolled rect.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean
- `cargo clippy -p ultros-app --target wasm32-unknown-unknown --no-default-features --features hydrate -- -D warnings` — running at the time of writing; I'll follow up on this PR if it turns up anything. There are no `cfg` branches in the change, and `Portal` is not feature-gated, so ssr and hydrate compile the same code.

Not visually verified in a running browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)