### PR TITLE
ci: stop the Actions cache quota from killing every main Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,14 +52,15 @@ jobs:
               with:
                   submodules: recursive
 
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+            # No QEMU: we build linux/amd64 only, on an amd64 runner. It bought
+            # us nothing and parked a 32MB binfmt cache on every ref.
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
+            # PRs log in too — they don't push, but they read the registry
+            # build cache below, which needs auth if the package is private.
             - name: Log in to registry
-              if: github.event_name != 'pull_request'
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
@@ -81,10 +82,16 @@ jobs:
                   push: ${{ github.event_name != 'pull_request' }}
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
+                  # Registry cache, not type=gha. A mode=max export of this
+                  # cargo-chef build is multiple GB and shares the repo's 10GB
+                  # Actions cache quota with rust.yml; once that filled up,
+                  # GitHub evicted blobs mid-export and every main build died
+                  # with `failed to solve: not_found`. GHCR storage is outside
+                  # that quota, so the two workflows stop competing.
+                  cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
                   # PRs read main's cache but don't write — avoids thrashing
                   # the shared cache from short-lived branches.
-                  cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
+                  cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
             - name: Install cosign
               if: github.event_name != 'pull_request'
@@ -128,7 +135,7 @@ jobs:
                   outputs: type=local,dest=./debug
                   # Reuse the layer cache the main build already populated;
                   # this step just emits the unstripped binary as a local file.
-                  cache-from: type=gha
+                  cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
 
             - name: Upload debug symbols to GlitchTip
               if: steps.glitchtip-check.outputs.configured == 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,15 @@ jobs:
               with:
                   toolchain: nightly-2026-01-06
                   components: rustfmt, clippy
-            - name: Cache cargo registry and build artifacts
-              uses: actions/cache@v4.2.0
+            # Restore on every run, but only *save* from main. Actions caches
+            # are scoped per-ref, so a plain actions/cache here wrote a fresh
+            # ~1.2GB copy of this key for every PR — six of them filled 69% of
+            # the repo's 10GB quota, and GitHub's LRU then evicted the Docker
+            # workflow's buildkit blobs mid-export (`failed to solve:
+            # not_found`). PRs still get a warm cache: restore-keys falls back
+            # to main's copy.
+            - name: Restore cargo registry and build artifacts
+              uses: actions/cache/restore@v4.2.0
               with:
                   path: |
                       ~/.cargo/bin
@@ -78,6 +85,21 @@ jobs:
             - name: Run Clippy
               # it would be good to support --all-features, but xiv-gen is a little unstable.
               run: cargo clippy --all-targets -- -D warnings
+
+            # Only main writes the cache (see the restore step above). Runs on
+            # failure too, so a red lint run still leaves the next build warm;
+            # skipped when the key already exists, hence continue-on-error.
+            - name: Save cargo registry and build artifacts
+              if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+              continue-on-error: true
+              uses: actions/cache/save@v4.2.0
+              with:
+                  path: |
+                      ~/.cargo/bin
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                      target
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
             #- name: Run cargo-deny, outdated, udeps, audit, and pants
             #  run: |


### PR DESCRIPTION
## What was breaking

Every push to `main` since 2026-07-24 12:20 failed the Docker workflow. Five consecutive main builds, ~90 minutes each, identical failure at the last step:

```
#40 exporting to GitHub Actions Cache
#40 preparing build cache for export 289.4s done
#40 sending cache export 0.1s done
#40 ERROR: not_found
ERROR: failed to build: failed to solve: not_found
```

PRs passed the whole time, which was the tell — PRs set `cache-to: ''`, so they only read. A missing blob on import is recoverable; a missing blob on export is fatal.

## Root cause

The shared **10GB Actions cache quota**, not the Dockerfile.

`rust.yml` used a plain `actions/cache`, and Actions caches are **scoped per-ref** — every PR run wrote its own full ~1.2GB copy of the same key. Six copies of `Linux-cargo-4170fe27…` (one per ref, identical hash) held **7.22GB of the 10GB budget**, and the repo sat pinned at 10.44GB. That left under 3GB for buildkit, so a `mode=max` export of the cargo-chef build evicted its own already-uploaded blobs and then 404'd finalizing the manifest.

The same eviction shows up earlier in every failing log on the import side, where `#28 CACHED` is immediately followed by `#28 ERROR: not_found` — the index survived, the blob didn't.

Timeline fits: green through 07-21, then the #966–#977 PR burst deposited those cargo caches on 07-23/24, and main has failed every build since.

**Why #977 didn't fix it:** it serialized docker-vs-docker, but the competitor was `rust.yml`. Run `30175930394` was the only build in flight and still failed. Keeping the concurrency block regardless — three 90-minute builds at once is still bad.

## Changes

- **`rust.yml`** — split into `cache/restore` + `cache/save`, saving only on main pushes. PRs stay warm via `restore-keys` against main's copy. Frees ~6GB. Save runs on lint failure too (`!cancelled()`) so a red run still leaves the next build warm.
- **`docker-publish.yml`** — buildkit cache moved from `type=gha` to a GHCR registry cache, which is outside the Actions quota, so the two workflows stop competing entirely. Registry login is ungated so PRs can read it.
- **`docker-publish.yml`** — dropped `setup-qemu-action`. We build `linux/amd64` on an amd64 runner; it did nothing but park a 32MB binfmt cache on every ref (13 of them, 419MB).

Also pruned out of band: the five merged-PR cargo caches and the stale binfmt entries. **Repo cache is now 4.0GB across 18 entries**, down from 10.44GB/36.

## Verification

Diff is YAML-only, so clippy is unaffected; `cargo fmt --all -- --check` passes. Both files validated as parseable YAML with correct step ordering.

The real proof is a green main build, which can't be had before merge — this workflow only exports cache on push. Two things to watch on the first post-merge run:

1. The registry cache starts empty, so that build is cold end-to-end and will be slow. Subsequent ones should be normal or better.
2. If `ghcr.io/akarras/ultros` is a **private** package, confirm the ungated login gives PRs read access to the `:buildcache` tag. I couldn't check visibility — my token lacks `read:packages`. `cache-from` failures are non-fatal warnings, so a wrong guess costs cache hits, not a red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
