### PR TITLE
fix(api): accept 1/0 for the show_suspicious query flag (Market Trends 400s on every load)

### DIFF
--- a/ultros/src/web/api/best_deals.rs
+++ b/ultros/src/web/api/best_deals.rs
@@ -18,6 +18,7 @@ pub(crate) struct BestDealsQuery {
     /// suspicious rows (Unusable / high-launder) appear with a chip.
     /// Default false — these are the rows the Flip Finder used to surface
     /// gil-trader laundering on (e.g. Copper Wristlets 3 → 18.9M).
+    #[serde(default, deserialize_with = "super::query::optional_flag")]
     pub(crate) show_suspicious: Option<bool>,
     /// Cap on returned rows. Default 50, clamped to [1, 200].
     pub(crate) limit: Option<u32>,
@@ -97,4 +98,53 @@ pub(crate) async fn get_best_deals(
         .collect();
 
     Ok(Json(dtos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BestDealsQuery;
+    use axum::extract::Query;
+    use axum::http::Uri;
+
+    fn extract(query: &str) -> Result<BestDealsQuery, String> {
+        let uri: Uri = format!("http://ultros.app/api/v1/best_deals/Sargatanas?{query}")
+            .parse()
+            .expect("test URI should parse");
+        Query::<BestDealsQuery>::try_from_uri(&uri)
+            .map(|Query(q)| q)
+            .map_err(|rejection| rejection.body_text())
+    }
+
+    /// `TopOpportunity` always sends `show_suspicious=0` alongside the other
+    /// params; before the flexible flag parser that 400'd the request and the
+    /// component silently rendered nothing.
+    #[test]
+    fn numeric_show_suspicious_is_accepted_with_other_params() {
+        let q = extract("min_profit=1000&filter_sale=Week&limit=5&show_suspicious=0")
+            .expect("`0` must extract");
+        assert_eq!(q.min_profit, Some(1000));
+        assert_eq!(q.filter_sale.as_deref(), Some("Week"));
+        assert_eq!(q.limit, Some(5));
+        assert_eq!(q.show_suspicious, Some(false));
+    }
+
+    #[test]
+    fn literal_show_suspicious_still_works() {
+        assert_eq!(
+            extract("show_suspicious=true")
+                .expect("`true` must extract")
+                .show_suspicious,
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn omitted_flag_defaults_to_none() {
+        assert_eq!(
+            extract("limit=10")
+                .expect("omitted flag must extract")
+                .show_suspicious,
+            None
+        );
+    }
 }

--- a/ultros/src/web/api/mod.rs
+++ b/ultros/src/web/api/mod.rs
@@ -9,6 +9,7 @@ mod market_heat;
 mod market_pulse;
 mod movers;
 pub(crate) mod push;
+mod query;
 pub(crate) mod real_time_data;
 mod recent_sales;
 mod resale_quality;

--- a/ultros/src/web/api/query.rs
+++ b/ultros/src/web/api/query.rs
@@ -1,0 +1,82 @@
+//! Query-string helpers shared by the JSON API handlers.
+
+use serde::{Deserialize, Deserializer, de};
+
+/// Deserialize an optional boolean flag that accepts both the `1`/`0` and
+/// `true`/`false` spellings.
+///
+/// `axum::extract::Query` decodes with `serde_urlencoded`, whose `bool`
+/// deserializer is `str::parse::<bool>()` — it accepts *only* the literals
+/// `true` and `false`. A plain `Option<bool>` field therefore fails on
+/// `?show_suspicious=0`, and a `Query` rejection rejects the **whole
+/// request** with a `400`; it does not fall back to the field default. Both
+/// the API design doc (`?window=7|30|90&show_suspicious=0|1`) and the
+/// frontend spell these flags numerically, so `0`/`1` has to parse.
+///
+/// A valueless `?flag=` carries no opinion and yields `None`, which leaves
+/// the caller's default in place. Anything else is a genuine client mistake
+/// and is reported as such rather than silently defaulted.
+pub(crate) fn optional_flag<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // `#[serde(default, ...)]` covers the absent-key case without calling this
+    // function at all, so a present key always carries a string value here.
+    let raw = String::deserialize(deserializer)?;
+    let value = raw.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" => Ok(Some(true)),
+        "0" | "false" => Ok(Some(false)),
+        other => Err(de::Error::custom(format!(
+            "invalid boolean flag {other:?}: expected one of 1, 0, true, false"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::de::IntoDeserializer;
+    use serde::de::value::{Error as ValueError, StringDeserializer};
+
+    fn parse(raw: &str) -> Result<Option<bool>, ValueError> {
+        let deserializer: StringDeserializer<ValueError> = raw.to_string().into_deserializer();
+        optional_flag(deserializer)
+    }
+
+    #[test]
+    fn accepts_numeric_spelling() {
+        assert_eq!(parse("1").unwrap(), Some(true));
+        assert_eq!(parse("0").unwrap(), Some(false));
+    }
+
+    #[test]
+    fn accepts_literal_spelling() {
+        assert_eq!(parse("true").unwrap(), Some(true));
+        assert_eq!(parse("false").unwrap(), Some(false));
+    }
+
+    #[test]
+    fn accepts_mixed_case_and_surrounding_space() {
+        assert_eq!(parse("True").unwrap(), Some(true));
+        assert_eq!(parse("FALSE").unwrap(), Some(false));
+        assert_eq!(parse(" 1 ").unwrap(), Some(true));
+    }
+
+    #[test]
+    fn valueless_flag_defers_to_the_default() {
+        assert_eq!(parse("").unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_nonsense() {
+        let err = parse("banana").unwrap_err().to_string();
+        assert!(
+            err.contains("expected one of 1, 0, true, false"),
+            "error should name the accepted spellings, got: {err}"
+        );
+    }
+}

--- a/ultros/src/web/api/trends.rs
+++ b/ultros/src/web/api/trends.rs
@@ -20,6 +20,7 @@ pub struct TrendsQuery {
     pub window: Option<u16>,
     /// `1` / `true` bypasses the cross-cutting `ResaleQualityFilter` so
     /// suspicious rows surface with a chip. Default false.
+    #[serde(default, deserialize_with = "super::query::optional_flag")]
     pub show_suspicious: Option<bool>,
 }
 
@@ -79,4 +80,62 @@ pub async fn get_trends(
     });
 
     Ok(Json(trends))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrendsQuery;
+    use axum::extract::Query;
+    use axum::http::Uri;
+
+    fn extract(query: &str) -> Result<TrendsQuery, String> {
+        let uri: Uri = format!("http://ultros.app/api/v1/trends/Sargatanas?{query}")
+            .parse()
+            .expect("test URI should parse");
+        Query::<TrendsQuery>::try_from_uri(&uri)
+            .map(|Query(q)| q)
+            .map_err(|rejection| rejection.body_text())
+    }
+
+    /// The frontend sends `show_suspicious=0|1`, which `serde_urlencoded`
+    /// rejects for a bare `Option<bool>` — and a `Query` rejection is a 400
+    /// for the entire request, so the Trends page rendered nothing at all.
+    #[test]
+    fn numeric_show_suspicious_is_accepted() {
+        let off = extract("window=30&show_suspicious=0").expect("`0` must extract");
+        assert_eq!(off.window, Some(30));
+        assert_eq!(off.show_suspicious, Some(false));
+
+        let on = extract("window=30&show_suspicious=1").expect("`1` must extract");
+        assert_eq!(on.show_suspicious, Some(true));
+    }
+
+    #[test]
+    fn literal_show_suspicious_still_works() {
+        assert_eq!(
+            extract("window=7&show_suspicious=true")
+                .expect("`true` must extract")
+                .show_suspicious,
+            Some(true)
+        );
+        assert_eq!(
+            extract("window=90&show_suspicious=false")
+                .expect("`false` must extract")
+                .show_suspicious,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn omitted_flag_defaults_to_none() {
+        let q = extract("window=30").expect("omitted flag must extract");
+        assert_eq!(q.show_suspicious, None);
+        // The handler treats `None` as "filter suspicious rows out".
+        assert!(!q.show_suspicious.unwrap_or(false));
+    }
+
+    #[test]
+    fn nonsense_flag_is_still_rejected() {
+        assert!(extract("window=30&show_suspicious=banana").is_err());
+    }
 }


### PR DESCRIPTION
Found while triaging the GlitchTip backlog. Not reported by an error event — it
fails as an HTTP 400 that the frontend swallows — but it takes out a whole page.

## The bug

`/api/v1/trends/{world}` and `/api/v1/best_deals/{world}` declare their
`show_suspicious` flag as a bare `Option<bool>` inside an `axum::extract::Query`
struct. `Query` decodes with `serde_urlencoded`, whose `bool` deserializer is
`str::parse::<bool>()` — it accepts **only** the literals `true` and `false`.

The frontend sends the numeric spelling:

```rust
// ultros-frontend/ultros-app/src/api.rs:220 — get_trends_v2
"/api/v1/trends/{world_name}?window={window_days}&show_suspicious={}",
if show_suspicious { 1 } else { 0 }
```

A `Query` rejection is **not** a defaulted field — it fails the whole extraction
and axum answers `400 Bad Request` for the entire request:

```
Failed to deserialize query string: show_suspicious: provided string was not `true` or `false`
```

| Caller | What it sends | Result |
| --- | --- | --- |
| `routes/trends.rs:323` → `get_trends_v2` | `show_suspicious=0` (or `1`) on **every** load | Market Trends page 400s — renders nothing |
| `components/top_opportunity.rs:43` → `get_best_deals` | `show_suspicious=0`, always | 400, swallowed by `.ok()` → card silently blank |

This is a contract mismatch, not a client mistake — the numeric form is what
both handlers' own doc comments and the design spec specify:

- `ultros/src/web/api/best_deals.rs`: ``/// `1` or `true` skips the cross-cutting `ResaleQualityFilter```
- `ultros/src/web/api/trends.rs`: ``/// `1` / `true` bypasses the cross-cutting `ResaleQualityFilter```
- `docs/superpowers/specs/2026-05-18-clickhouse-surface-integration-design.md:114`:
  `/api/v1/trends/{world_name}?window=7|30|90&show_suspicious=0|1`

Three places document `1`/`0` as valid; the implementation accepts neither.

## The fix

Fix the server, not the client — the server is the side that deviates from its
own documented contract, and fixing it also unbreaks any third-party consumer
that followed the published `0|1` spec.

New `ultros/src/web/api/query.rs` adds `optional_flag`, a `deserialize_with`
helper accepting `1`, `0`, `true`, `false` (case-insensitive, whitespace
tolerant). A valueless `?flag=` yields `None` so the handler default applies;
anything else is still a genuine `400`, now with a message naming the accepted
spellings. Both query structs gain:

```rust
#[serde(default, deserialize_with = "super::query::optional_flag")]
pub show_suspicious: Option<bool>,
```

Client code is unchanged — it was already speaking the documented protocol.

## Verification

**Please read this section — the tests added here were _not_ executed by CI or
on my machine.** The `ultros` bin test binary does not link on Windows/MSVC
(38 unresolved `..._10ultros_app` symbols — pre-existing, unrelated to this
change), and `cargo test` is commented out in `rust.yml`. So I verified the
behaviour out-of-band, with a harness that loads the **real** shipped
`query.rs` via `#[path]` (not a copy) plus verbatim copies of both query
structs, and drives them through axum 0.8.9's real `Query::try_from_uri`:

```
running 11 tests
PRE-FIX rejection: Failed to deserialize query string: show_suspicious: provided string was not `true` or `false`
test extractor_tests::red_the_unfixed_struct_rejects_what_the_frontend_sends ... ok
test extractor_tests::green_trends_numeric_flag ... ok
test extractor_tests::green_trends_literal_flag ... ok
test extractor_tests::green_trends_omitted ... ok
test extractor_tests::green_trends_nonsense_rejected ... ok
test extractor_tests::green_deals_top_opportunity_shape ... ok
test query::tests::accepts_numeric_spelling ... ok
test query::tests::accepts_literal_spelling ... ok
test query::tests::accepts_mixed_case_and_surrounding_space ... ok
test query::tests::valueless_flag_defers_to_the_default ... ok
test query::tests::rejects_nonsense ... ok

test result: ok. 11 passed; 0 failed
```

The red case reproduces the pre-fix 400 against a struct with the old bare
`Option<bool>` shape, so this is red-before-green, not green-only.

That harness run is also what caught a defect in my first attempt: the original
`optional_flag` read `Option::<String>::deserialize`, which works under
`serde_urlencoded` but not under `serde::de::value::StringDeserializer`. Since
`#[serde(default)]` already covers the absent-key case, it now reads `String`
directly — simpler, and testable through both deserializers.

The 12 in-crate tests committed here cover the same matrix and will run wherever
the crate's test binary links.

Gates run: `cargo fmt --all -- --check` clean, `cargo clippy -p ultros
--all-targets -- -D warnings` clean.

## Sweep

Checked every other `bool` in a server `Query` struct — `cheapest_per_world`'s
`hq` is a response DTO field, not a query param. These two were the only
occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
