### PR TITLE
🛡️ Sentinel: [HIGH] Fix Open Redirect bypass in login parameter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,7 +12,7 @@
 **Vulnerability:** Incomplete Cookie Scope Configuration
 **Learning:** The `discord_auth` cookie was being set during a `/redirect` endpoint without an explicitly set `Path=/`. This scopes the cookie to the `/redirect` path, meaning the browser wouldn't send the auth cookie to other paths (like `/api/v1/user`), effectively breaking authentication outside that route. Other cookies in the same file were properly using `cookie.set_path("/")` or `CookieBuilder` with `.path("/")`.
 **Prevention:** Always explicitly set `cookie.set_path("/")` for application-wide authentication or session cookies to ensure they are sent to all relevant routes.
-## 2024-05-24 - [Fix Open Redirect Bypass via Whitespace]
+## 2026-07-26 - [Fix Open Redirect Bypass via Whitespace]
 **Vulnerability:** Open Redirect bypass
 **Learning:** Browsers sometimes normalize or ignore whitespace characters like tabs (`\t`) and spaces (` `) in URL paths. A URL like `/\t/evil.com` or `/ /evil.com` starts with `/` and thus bypasses a strict `starts_with("//")` protocol-relative check, but the browser may resolve it to `//evil.com` and redirect the user.
 **Prevention:** Always strip or reject raw whitespace characters (like spaces and tabs) when validating relative redirect URLs to prevent open redirect vulnerabilities.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,7 @@
 **Vulnerability:** Incomplete Cookie Scope Configuration
 **Learning:** The `discord_auth` cookie was being set during a `/redirect` endpoint without an explicitly set `Path=/`. This scopes the cookie to the `/redirect` path, meaning the browser wouldn't send the auth cookie to other paths (like `/api/v1/user`), effectively breaking authentication outside that route. Other cookies in the same file were properly using `cookie.set_path("/")` or `CookieBuilder` with `.path("/")`.
 **Prevention:** Always explicitly set `cookie.set_path("/")` for application-wide authentication or session cookies to ensure they are sent to all relevant routes.
+## 2024-05-24 - [Fix Open Redirect Bypass via Whitespace]
+**Vulnerability:** Open Redirect bypass
+**Learning:** Browsers sometimes normalize or ignore whitespace characters like tabs (`\t`) and spaces (` `) in URL paths. A URL like `/\t/evil.com` or `/ /evil.com` starts with `/` and thus bypasses a strict `starts_with("//")` protocol-relative check, but the browser may resolve it to `//evil.com` and redirect the user.
+**Prevention:** Always strip or reject raw whitespace characters (like spaces and tabs) when validating relative redirect URLs to prevent open redirect vulnerabilities.

--- a/ultros/src/web/oauth.rs
+++ b/ultros/src/web/oauth.rs
@@ -145,6 +145,8 @@ fn safe_login_next(next: Option<&str>) -> Option<String> {
         || next.contains('\\')
         || next.contains('\n')
         || next.contains('\r')
+        || next.contains('\t')
+        || next.contains(' ')
         || next.contains("://")
     {
         return None;
@@ -476,6 +478,8 @@ mod tests {
             safe_login_next(Some("/path\r\nLocation: //evil.example")),
             None
         );
+        assert_eq!(safe_login_next(Some("/\t/evil.example")), None);
+        assert_eq!(safe_login_next(Some("/ /evil.example")), None);
     }
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Open Redirect Bypass via Whitespace

🚨 Severity: HIGH
💡 Vulnerability: Open Redirect bypass in the `safe_login_next` validation function.
🎯 Impact: Attackers could craft a malicious login redirect URL using whitespace characters (e.g., `/\t/evil.com` or `/ /evil.com`) which passes the check for starting with `/` and avoiding `//`, but browsers might normalize this and redirect the user to a malicious external site.
🔧 Fix: Modified `safe_login_next` to also reject redirect URLs containing spaces and tabs (`\t`), and added test cases. Added learning to Sentinel's journal.
✅ Verification: Ran `cargo test -p ultros safe_login_next` to ensure the new tests pass.

---
*PR created automatically by Jules for task [15296084953595665188](https://jules.google.com/task/15296084953595665188) started by @akarras*