### PR TITLE
fix(catch-up): don't mark an item ingested when its write failed

### DIFF
--- a/ultros-db/src/sales.rs
+++ b/ultros-db/src/sales.rs
@@ -31,13 +31,31 @@ impl UltrosDb {
     #[instrument(skip(self, sales))]
     pub async fn update_sales(
         &self,
-        mut sales: Vec<SaleView>,
+        sales: Vec<SaleView>,
         item_id: ItemId,
         world_id: WorldId,
     ) -> Result<Vec<(SaleHistory, UnknownCharacter)>> {
         let instant = Instant::now();
-        use sale_history::*;
+        let recorded_sales = self
+            .insert_unrecorded_sales(sales, item_id, world_id)
+            .await?;
+        // Only claim the item as ingested once the sales have actually landed.
+        // `listing_last_updated` is the marker the catch-up service diffs against
+        // Universalis' recently-updated feed, so bumping it ahead of a write that
+        // then fails makes the resulting gap invisible to every later catch-up
+        // pass -- the item looks fresher than their upload and is never retried.
         self.set_last_updated(world_id, item_id).await?;
+        histogram!("ultrso_db_update_sales_duration_seconds").record(instant.elapsed());
+        Ok(recorded_sales)
+    }
+
+    async fn insert_unrecorded_sales(
+        &self,
+        mut sales: Vec<SaleView>,
+        item_id: ItemId,
+        world_id: WorldId,
+    ) -> Result<Vec<(SaleHistory, UnknownCharacter)>> {
+        use sale_history::*;
         // check if the sales have already been logged
         if sales.is_empty() {
             return Ok(vec![]);
@@ -102,7 +120,6 @@ impl UltrosDb {
         }))
         .exec_without_returning(&self.db)
         .await?;
-        histogram!("ultrso_db_update_sales_duration_seconds").record(instant.elapsed());
         Ok(recorded_sales)
     }
 

--- a/ultros/src/item_update_service.rs
+++ b/ultros/src/item_update_service.rs
@@ -203,7 +203,14 @@ impl UpdateService {
                                 )));
                             }
                             Err(e) => {
-                                error!(error = ?e, item_id = item_id.0, world_id = world_id.0, "catch-up listing update failed")
+                                error!(error = ?e, item_id = item_id.0, world_id = world_id.0, "catch-up listing update failed");
+                                // Storing the sales would bump `listing_last_updated`,
+                                // the very marker this service diffs against Universalis
+                                // to decide what still needs recovering. Bumping it after
+                                // a failed listing write would make the item look freshly
+                                // ingested and hide the gap from every later pass, so
+                                // leave it untouched and retry on the next cycle.
+                                return;
                             }
                         }
                         match self.db.update_sales(sales, item_id, world_id).await {
@@ -306,6 +313,28 @@ mod tests {
             vec![theirs(1, 1_000 + UPLOAD_TIME_SLACK_SECONDS)],
         );
         assert!(missed.is_empty());
+    }
+
+    /// The `listing_last_updated` marker is the *only* signal that an item still
+    /// needs recovering, and it is compared against Universalis' upload time. If a
+    /// failed write stamps it anyway, the item reads as in-sync from then on and no
+    /// later pass retries it. That is why `update_sales` waits until the sales have
+    /// landed before writing the marker, and why the catch-up loop skips the sales
+    /// update entirely when the listing update failed.
+    #[test]
+    fn marker_bumped_by_a_failed_write_permanently_hides_the_gap() {
+        let their_upload = 1_000;
+        // A catch-up attempt runs well after their upload, fails to write, but
+        // still stamps `listing_last_updated` with "now".
+        let failed_attempt_at = their_upload + UPLOAD_TIME_SLACK_SECONDS + 500;
+        let missed = missed_updates(
+            vec![ours(1, failed_attempt_at)],
+            vec![theirs(1, their_upload)],
+        );
+        assert!(
+            missed.is_empty(),
+            "a prematurely bumped marker makes the still-missing item invisible to catch-up"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The signal

Two new GlitchTip issues appeared 2026-07-26, the only new class in the backlog:

| Issue | Title | Count |
|---|---|---|
| [#6869](https://glitchtip.ultros.app/ultros/issues/6869) | `catch-up listing update failed` | 37 |
| [#6868](https://glitchtip.ultros.app/ultros/issues/6868) | `catch-up sale update failed` | 3 |

Both land on `ultros/src/item_update_service.rs:206`/`:216` with
`Failed to acquire connection from pool: Connection pool timed out`.

These fired on the dev box (`environment:development` / `Bahamut`), which
normally means "leave it alone". I checked the reported lines against
`origin/main` first, and they land on real shipped code — and the bug they
exposed is environment-independent.

## The bug

The pool timeout is the trigger, not the damage. `listing_last_updated` is the
single marker that tells the catch-up service an item still needs recovering:
`missed_updates` reports an item as missed only while Universalis' upload time
is newer than our stored ingest time.

A failed catch-up pass was bumping that marker anyway, so the item reads as
in-sync from then on and **no later pass ever retries it**. The data we failed
to write is gone for good — the catch-up service silently stops catching up,
and it does so without emitting anything new (the one error is logged, then
the item goes quiet forever).

Two paths bumped the marker without a successful write:

1. **`update_sales` wrote the marker first.** `set_last_updated` was the very
   first statement, ahead of the buyer lookup and the insert itself, so any
   failure after it left the item stamped as freshly ingested.
   `update_listings` already gets this right — it writes the marker only after
   its writes land (`listings.rs:430`). This makes the sales path symmetric.

2. **A failed listing update was masked by the following sales update.** In
   `check_items`, `update_sales` ran unconditionally after `update_listings`
   failed, and its marker write erased the evidence of the listing failure.
   This is the dominant case — note #6869 (listings, 37) vs #6868 (sales, 3).
   The catch-up loop now skips the sales update for an item whose listing
   update failed, leaving it visible to the next pass.

## Changes

- `ultros-db/src/sales.rs` — split the insert into `insert_unrecorded_sales`;
  `update_sales` now writes `set_last_updated` only after it returns `Ok`.
  No behaviour change on the success path; the websocket ingest path
  (`main.rs:157`) keeps the same semantics.
- `ultros/src/item_update_service.rs` — return early from the per-item task
  when the listing update fails.
- One test pinning the invariant that makes this data loss rather than a
  logged blip: once the marker is newer than their upload, the item is
  invisible to catch-up forever.

## Verification

- `cargo fmt --all -- --check` — **passes**.
- `cargo clippy -p ultros-db --all-targets -- -D warnings` — **passes**.
- `cargo clippy -p ultros --all-targets -- -D warnings` — **passes**
  (exit 0, zero warnings, 5m23s). Together these cover both changed files.
- **The new test was not executed.** It lives in the `ultros` bin crate, whose
  test binary does not link on Windows/MSVC (the pre-existing `_10ultros_app`
  leptos wall), and CI does not run `cargo test`. It is a characterization test
  of `missed_updates`, which this PR does not modify — it documents *why* a
  premature marker write is unrecoverable rather than proving the fix
  red-then-green. Please don't read it as evidence the fix was exercised.
- The fix itself has no unit-level repro: both functions are thin wrappers over
  sea-orm against a live Postgres. The argument for it is the ordering
  invariant above plus the symmetry with `update_listings`.

## Backlog triage (same run)

Ignored **410** stale flood fragments, `#1790` → `#1380` contiguous, in ≤10
batches, zero denials. Spot-checked `#1680` before clearing: release
`c88703d8`, Chrome 111, `Asia/Shanghai`, tachys-0.2.11 `hydration.rs:227`,
fetching `/static/data/<ver>/en.bincode` — a path deleted by #679's rkyv
migration, so the whole window is provably stale. Root causes long fixed
(#628/#634/#791, #636, #960). Flood tail continues below `#1380`.

Left alone per convention: #2209, #6851–#6854, #2210, #2219, #2220 (dev
machine); #6778 kept as the canary. #6868/#6869 left **unresolved** on
purpose — this fix is not deployed yet, so they should stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

