### PR TITLE
fix(related-items): stop exchange cost pills overflowing their card

### DIFF
--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -659,8 +659,8 @@ fn ExchangeSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
                                             costs.into_iter().map(|(item_id, count)| {
                                                 if let Some(item) = data.items.get(&item_id) {
                                                     view! {
-                                                        <div class="flex items-center gap-1 px-2 py-1 rounded border border-[color:var(--color-outline)] hover:border-brand-300/60 transition-colors">
-                                                            <span class="font-bold text-brand-200">{count} "x"</span>
+                                                        <div class="flex min-w-0 items-center gap-1 px-2 py-1 rounded border border-[color:var(--color-outline)] hover:border-brand-300/60 transition-colors">
+                                                            <span class="shrink-0 whitespace-nowrap font-bold text-brand-200">{count} "x"</span>
                                                             <SmallItemDisplay item />
                                                         </div>
                                                     }.into_any()


### PR DESCRIPTION
## What

The cost pills in the **Exchange Sources** card break out of the card and out of the surrounding panel:

<img width="500" alt="cost pill escaping the card border" src="https://github.com/user-attachments/assets/placeholder" />

(reported with a screenshot showing `60x Irregular Tomestone of Pageantry` extending past both the card border and the panel edge)

## Why

The cost pill is a flex item of the `Costs:` row, but it had no `min-w-0`. Its default `min-width: auto` meant it could never shrink below its min-content width, so it pushed straight through the card border.

`SmallItemDisplay` already does the right thing — it threads `min-w-0` down through every level to a `truncate` on the item name. But that chain only works if *every* flex ancestor can shrink. The pill was the one link that couldn't, so the truncation never got a chance to engage.

## The fix

```diff
- <div class="flex items-center gap-1 px-2 py-1 rounded border ...">
-     <span class="font-bold text-brand-200">{count} "x"</span>
+ <div class="flex min-w-0 items-center gap-1 px-2 py-1 rounded border ...">
+     <span class="shrink-0 whitespace-nowrap font-bold text-brand-200">{count} "x"</span>
```

The `shrink-0 whitespace-nowrap` on the quantity is the second half of the fix. Once the pill *can* shrink, `60 x` otherwise breaks onto two lines and the pill grows two rows tall. Pinning it makes the item name absorb the truncation instead, and the quantity stays intact.

## Verification

I reproduced the bug standalone with the exact class chain from the component before touching the source, and measured the boxes:

| | card right edge | pill width | pill right edge |
|---|---|---|---|
| before | 295 | 315px | **373** (78px outside the card) |
| after | 295 | 224px | 282 (inside) |

At the narrow width the item level number was being shoved off-screen entirely, matching the report. After the fix the pill sits inside the card with the name ellipsized.

`./check_ci.sh` passes in full — `cargo fmt --all -- --check` **and** `cargo clippy --all-targets -D warnings`, clean. (I initialized the `ffxiv-datamining` and `universalis-assets` submodules locally to get clippy running; both were empty in this worktree.)

## Notes for the reviewer

- The `?` placeholder visible in the original screenshot is the item icon failing to load for Irregular Tomestone of Pageantry. Unrelated to layout, not addressed here.
- The `"Exchange Sources"` and `"Vendor Sources"` headings in this same file are hardcoded English literals despite `related_exchange_sources_title` already existing translated in all 7 locale files. Being fixed in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
