### PR TITLE
fix(jobset): gear-set card totals stuck on "—" after a direct load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,21 @@ To exercise login flow locally:
 LEPTOS_FEATURES=test-auth ./scripts/run_e2e.sh
 ```
 
+### Targeted probes
+
+The runner only asserts on titles and body substrings, which can't see values that
+hydration silently drops. [integration/jobset-card-hydration.cjs](integration/jobset-card-hydration.cjs)
+covers that seam for the gear-set cards on `/items/jobset/<JOB>`: it reads the NQ/HQ
+totals after a direct (SSR + hydrate) load and again after a client-side navigation to
+the same route, and fails if they disagree. It needs market data to be meaningful but
+passes rather than failing when there is none, so it's safe against an empty dev DB.
+
+```bash
+BASE_URL=http://127.0.0.1:8080 npm --prefix integration run test:jobset-card-hydration
+```
+
+`JOBSET` (default `SAM`) and `WORLD` (default `Gilgamesh`) pick the route.
+
 ### Caveats
 
 - Requires a populated `.env` (DATABASE_URL, DISCORD_*, KEY) — or those vars exported directly.

--- a/integration/jobset-card-hydration.cjs
+++ b/integration/jobset-card-hydration.cjs
@@ -1,0 +1,153 @@
+// Regression probe for the gear-set cards on `/items/jobset/<JOB>` losing
+// their NQ/HQ totals on a direct (SSR + hydrate) load.
+//
+// The totals render outside any <Suspense>, so SSR ships the "—" placeholder
+// with the cheapest-listings resource still pending, while the client has the
+// resolved resource on its first render. tachys *adopts* the SSR text node
+// during hydration without writing to it, so the DOM stayed on "—" even though
+// the reactive graph held the real total — and only a later *change* to the
+// value (switching worlds, hence a refetch) ever patched it in.
+//
+// Unit tests can't see this: it only exists in the SSR-payload/hydration seam.
+// So we compare the same component reached two ways:
+//
+//   direct load  -> hydrated from SSR markup   (the broken path)
+//   client nav   -> built fresh by the router  (the known-good path)
+//
+// If they disagree, hydration dropped the values. The check is deliberately
+// data-independent: against a server with no market data both paths render
+// "—" and the probe passes rather than failing spuriously.
+const puppeteer = require('puppeteer');
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:8080';
+const JOBSET = process.env.JOBSET || 'SAM';
+const WORLD = process.env.WORLD || 'Gilgamesh';
+const TIMEOUT_MS = Number(process.env.TIMEOUT_MS || 60000);
+// Hydration + the cheapest-listings fetch both have to land before we read.
+const SETTLE_MS = Number(process.env.SETTLE || 8000);
+
+const ROUTE = `/items/jobset/${JOBSET}?world=${encodeURIComponent(WORLD)}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Scrape one row per gear-set card: its heading plus the rendered NQ/HQ
+ * totals. Keyed on the card's stem so a differing set order between the two
+ * loads can't produce a false mismatch.
+ */
+function readCards() {
+  const heading = [...document.querySelectorAll('h4')].find((el) =>
+    /gear sets/i.test(el.textContent || ''),
+  );
+  if (!heading || !heading.nextElementSibling) return null;
+  return [...heading.nextElementSibling.children].map((card) => {
+    const lines = (card.innerText || '')
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const totalAfter = (label) => {
+      const i = lines.findIndex((l) => l.toUpperCase() === label);
+      return i >= 0 && i + 1 < lines.length ? lines[i + 1] : '?';
+    };
+    return {
+      // The set name sits after the "iLvl N" and "N pieces" chips.
+      stem: lines[2] || '?',
+      nq: totalAfter('NQ TOTAL'),
+      hq: totalAfter('HQ TOTAL'),
+    };
+  });
+}
+
+async function main() {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  const failures = [];
+
+  try {
+    const page = await browser.newPage();
+    page.setDefaultTimeout(TIMEOUT_MS);
+    const { hostname } = new URL(BASE_URL);
+    await page.setCookie({ name: 'HIDE_ADS', value: 'true', domain: hostname, path: '/' });
+
+    // 1. Direct load: SSR markup, hydrated in place. This is the path that regressed.
+    await page.goto(`${BASE_URL}${ROUTE}`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
+    await sleep(SETTLE_MS);
+    const hydrated = await page.evaluate(readCards);
+
+    if (!hydrated) {
+      throw new Error(`no "Gear sets" section rendered at ${ROUTE}`);
+    }
+    if (!hydrated.length) {
+      throw new Error(`"Gear sets" section at ${ROUTE} rendered no cards`);
+    }
+
+    // 2. Client-side nav to the same route. Leaving and coming back rebuilds
+    //    the cards through the router instead of hydrating them, so the
+    //    resource value reaches the DOM the normal reactive way.
+    await page.goto(`${BASE_URL}/items`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
+    await sleep(SETTLE_MS);
+    const navigated = await page.evaluate(async (route) => {
+      const link = document.createElement('a');
+      link.href = route;
+      document.body.appendChild(link);
+      link.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true, view: window, button: 0 }),
+      );
+      // The router updates history asynchronously — poll rather than read
+      // location straight back, which still shows the old URL.
+      const deadline = Date.now() + 10000;
+      while (Date.now() < deadline && location.pathname === '/items') {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      link.remove();
+      return location.pathname;
+    }, ROUTE);
+    if (!navigated.includes(JOBSET)) {
+      throw new Error(`client-side navigation to ${ROUTE} did not take (at ${navigated})`);
+    }
+    await sleep(SETTLE_MS);
+    const fresh = await page.evaluate(readCards);
+    if (!fresh || !fresh.length) {
+      throw new Error(`"Gear sets" section rendered no cards after client-side nav`);
+    }
+
+    // 3. Differential. Every set present on both paths must show the same totals.
+    const freshByStem = new Map(fresh.map((c) => [c.stem, c]));
+    for (const card of hydrated) {
+      const other = freshByStem.get(card.stem);
+      if (!other) continue;
+      if (card.nq !== other.nq || card.hq !== other.hq) {
+        failures.push(
+          `"${card.stem}": direct load showed NQ=${card.nq} HQ=${card.hq}, ` +
+            `client-side nav showed NQ=${other.nq} HQ=${other.hq} ` +
+            `— hydration dropped the totals`,
+        );
+      }
+    }
+
+    const withPrices = fresh.filter((c) => c.nq !== '—' || c.hq !== '—').length;
+    console.log(
+      `[info] ${hydrated.length} card(s) on direct load, ${fresh.length} after client-side nav, ` +
+        `${withPrices} with price data`,
+    );
+    if (!withPrices) {
+      console.log('[info] no market data for this job set — differential is vacuous here');
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (failures.length) {
+    console.error(`[fail] ${failures.length} gear-set card(s) lost their totals on hydration:`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('[done] gear-set card totals survive hydration');
+}
+
+main().catch((err) => {
+  console.error(`[fail] ${err && err.stack ? err.stack : err}`);
+  process.exit(1);
+});

--- a/integration/package.json
+++ b/integration/package.json
@@ -19,6 +19,7 @@
     "test:list-bulk-edit": "node ./list-bulk-edit.cjs",
     "test:fc-crafting-breakdown": "node ./fc-crafting-breakdown.cjs",
     "test:dashboard": "node ./dashboard.cjs",
+    "test:jobset-card-hydration": "node ./jobset-card-hydration.cjs",
     "test:group-shared-list": "node ./group-shared-list.cjs",
     "test:error-filter": "node --test ./error-filter.test.cjs",
     "diag:ooo-hydration-race": "node ./ooo-hydration-race.cjs",

--- a/ultros-frontend/ultros-app/src/components/job_set_card.rs
+++ b/ultros-frontend/ultros-app/src/components/job_set_card.rs
@@ -37,6 +37,27 @@ fn set_total(group: &JobSetGroup, prices: &CheapestListingsMap, hq_only: bool) -
     had_any.then_some(total)
 }
 
+/// The NQ/HQ pair the card renders, gated on whether the first client
+/// render has already happened.
+///
+/// Before hydration this deliberately reports `(None, None)` — i.e. the
+/// same "—" placeholder the server ships — regardless of what the price
+/// resource holds. See the gate comment in [`JobSetCard`] for why the
+/// first CSR render *must* agree with SSR here.
+fn card_totals(
+    hydrated: bool,
+    prices: Option<&CheapestListingsMap>,
+    group: &JobSetGroup,
+) -> (Option<i64>, Option<i64>) {
+    if !hydrated {
+        return (None, None);
+    }
+    match prices {
+        Some(map) => (set_total(group, map, false), set_total(group, map, true)),
+        None => (None, None),
+    }
+}
+
 /// Stable URL slug for the per-set detail page. We key on `ilvl`
 /// rather than the (locale-dependent) stem so links survive language
 /// switches and so deep-links don't break if the prefix detection
@@ -151,6 +172,43 @@ mod tests {
     }
 
     #[test]
+    fn card_totals_are_empty_until_hydrated() {
+        // Regression for the gear-set cards rendering a permanent "—" on a
+        // direct load of `/items/jobset/<JOB>`: SSR ships the placeholder
+        // (resource still pending) and tachys *adopts* the SSR text node
+        // during hydration without rewriting it, so a first CSR render that
+        // already knows the total leaves the DOM stuck on "—" forever. The
+        // first client render therefore has to report exactly what the
+        // server did, even with a fully populated price map in hand.
+        let group = JobSetGroup {
+            stem: "x".to_string(),
+            ilvl: 770,
+            items: vec![item(1, "a"), item(2, "b")],
+        };
+        let prices = map_with(&[(1, false, 100), (1, true, 200), (2, true, 50)]);
+
+        assert_eq!(card_totals(false, Some(&prices), &group), (None, None));
+        // NQ: 100 (item 1's lower NQ) + 50 (item 2's only listing).
+        // HQ: 200 + 50, both items' HQ listings.
+        assert_eq!(
+            card_totals(true, Some(&prices), &group),
+            (Some(150), Some(250))
+        );
+    }
+
+    #[test]
+    fn card_totals_are_empty_without_a_price_map() {
+        // The resource can be absent (no `CheapestPrices` context) or still
+        // erroring/pending after hydration — both render the placeholder.
+        let group = JobSetGroup {
+            stem: "x".to_string(),
+            ilvl: 770,
+            items: vec![item(1, "a")],
+        };
+        assert_eq!(card_totals(true, None, &group), (None, None));
+    }
+
+    #[test]
     fn set_total_handles_partial_coverage() {
         // Only one of three items has a listing — total still
         // returns Some, summed over what's known. The UI labels
@@ -181,16 +239,44 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
     let ilvl = group.ilvl;
     let href = detail_href(&jobset, &group_for_href);
 
+    // Defer reading the cheapest-listings resource until after the first
+    // client render.
+    //
+    // There is no `<Suspense>` around these totals, so SSR renders the body
+    // with the resource still pending and always ships the "—" placeholder
+    // (`card_totals` -> `GilOrDash`). The client, by contrast, has the
+    // resolved resource in the hydration payload on its very first render.
+    // That divergence doesn't panic here — `GilOrDash` keeps the element
+    // shape stable (see #696) — but it silently loses the value: tachys
+    // *adopts* the SSR text node during hydration without writing to it
+    // (`tachys/src/view/strings.rs`: `if !FROM_SERVER { set_text }`) while
+    // storing the client-computed string as the node's state. The DOM keeps
+    // showing "—" even though the reactive graph thinks it rendered the
+    // total, and `rebuild` only patches the node once the value *changes* —
+    // which is exactly why switching worlds (a refetch, hence a different
+    // total) makes the prices finally appear.
+    //
+    // Same `Effect`-driven `hydrated` gate as #730 (relative-time) and #740
+    // (`<CheapestPrice>`, whose skeleton is why the sortable list below the
+    // cards was never affected): effects run client-only, after the initial
+    // view is rendered, so SSR and the first CSR render both emit "—", and a
+    // frame later the flag flips, the memo recomputes to a genuinely
+    // different value, and tachys patches the DOM.
+    let hydrated = RwSignal::new(false);
+    Effect::new(move |_| {
+        hydrated.set(true);
+    });
+
     let totals = Memo::new(move |_| {
+        if !hydrated.get() {
+            return card_totals(false, None, &group_for_total);
+        }
         let Some(listings) = read_listings else {
-            return (None, None);
+            return card_totals(true, None, &group_for_total);
         };
-        listings.with(|data| match data {
-            Some(Ok(map)) => (
-                set_total(&group_for_total, map, false),
-                set_total(&group_for_total, map, true),
-            ),
-            _ => (None, None),
+        listings.with(|data| {
+            let map = data.as_ref().and_then(|result| result.as_ref().ok());
+            card_totals(true, map, &group_for_total)
         })
     });
 


### PR DESCRIPTION
Fixes the report that `https://ultros.app/items/jobset/SAM?world=Gilgamesh` shows no prices in the gear-set cards on a direct load — the table below them works, and changing the world makes the card prices appear.

## Root cause

The gear-set cards render their NQ/HQ totals **outside any `<Suspense>`**. That's the whole difference:

1. SSR renders the body with the cheapest-listings resource still pending, so it ships `—` and `class="hidden"`.
2. The client has the resolved resource in the hydration payload on its *first* render — but tachys **adopts** the SSR text node without writing to it (`tachys/src/view/strings.rs`: `if !FROM_SERVER { set_text }`), while storing the *client-computed* string as that node's state.
3. So the DOM keeps `—` even though the reactive graph believes it already rendered the total. `rebuild` only patches the node when the value *changes* — which is exactly why switching worlds (a refetch, hence a different total) made the prices finally appear.

`GilOrDash` (#696) keeps the element shape stable, so this never panicked like the rest of the hydration cluster — it just silently dropped the values.

Evidence beyond reading the code:

- Direct load of `/items/jobset/SAM?world=Gilgamesh` → all 13 cards `—`. A client-side nav to the same component → real totals. So the memo, the context and the resource were all fine; only the hydration path lost the value.
- `/items/jobset/PLD/set/740` works on a direct load, and its SSR markup shows why: those totals sit inside a `<Suspense>`, so SSR emitted the fallback (`<!--s-47-o-->…`) and hydration *replaced* it rather than adopting it.

## Fix

The same `Effect`-driven `hydrated` gate already used by `<CheapestPrice>` (#740), `<RelativeTime>` (#730) and the item-explorer price sort. Effects run client-only, after the initial view is rendered, so SSR and the first CSR render both emit `—`; a frame later the flag flips, the memo recomputes to a genuinely different value, and tachys patches the DOM. Cost is one frame of `—`, same as the skeleton in the table below.

## Notes for review

- The sortable list below the cards was never affected — `<CheapestPrice>` already has this gate.
- I deliberately left the set-detail page's two `set_total` columns alone. The comment there claims they don't need the gate; I checked rather than assumed, and it's correct — they're inside a `<Suspense>`.

## Tests

- Two unit tests pin the gate: `card_totals` reports `(None, None)` pre-hydration even holding a fully populated price map.
- Unit tests structurally cannot see this seam, so `integration/jobset-card-hydration.cjs` diffs a direct (SSR + hydrate) load against a client-side navigation to the same route. **Run against production, where the bug is still live, it fails on all 13 SAM cards** with the exact symptom. It's data-independent — an empty dev DB makes it pass rather than fail spuriously.

```
BASE_URL=http://127.0.0.1:8080 npm --prefix integration run test:jobset-card-hydration
```

## Verification

- `./check_ci.sh` → exit 0 (fmt + clippy clean).
- `cargo test -p ultros-app --lib job_set_card` → 8 passed.
- **Not** verified end-to-end against a built binary — that needs `cargo leptos build` plus a DB with market data, which I didn't have. Worth running the probe against a real server before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)