### PR TITLE
i18n(related-items): wire up the related_*_title panel headings

### DIFF
--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -473,6 +473,7 @@ fn gil_shop_to_npc(gil_shops: &[GilShopId]) -> Vec<(GilShopId, &'static ENpcBase
 
 #[component]
 fn VendorItems(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
+    let i18n = use_i18n();
     let data = tracked_data();
     // lookup items
     let npcs = Memo::new(move |_| {
@@ -520,7 +521,7 @@ fn VendorItems(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
         <div id="vendor-sources" class:hidden=empty class="panel p-4 sm:p-6 flex flex-col gap-4 max-h-[500px] overflow-y-auto">
             <h3 class="text-lg font-bold text-brand-200 flex items-center gap-2">
                 <Icon icon=icondata::FaShopSolid attr:class="text-brand-300" />
-                "Vendor Sources"
+                {t!(i18n, related_vendor_sources_title)}
             </h3>
             <div class="grid grid-cols-1 gap-3">{data}</div>
         </div>
@@ -684,7 +685,7 @@ fn ExchangeSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
         <div id="exchange-sources" class:hidden=empty class="panel p-4 sm:p-6 flex flex-col gap-4 max-h-[500px] overflow-y-auto">
             <h3 class="text-lg font-bold text-brand-200 flex items-center gap-2">
                 <Icon icon=icondata::BsArrowLeftRight attr:class="text-brand-300" />
-                "Exchange Sources"
+                {t!(i18n, related_exchange_sources_title)}
             </h3>
             <div class="grid grid-cols-1 gap-3">
                 {view}
@@ -843,6 +844,7 @@ pub fn leve_rewards_item(
 
 #[component]
 fn LeveSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
+    let i18n = use_i18n();
     let data = tracked_data();
     let leves = Memo::new(move |_| {
         let item_id = item_id();
@@ -893,7 +895,7 @@ fn LeveSources(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
         <div id="leve-sources" class:hidden=empty class="panel p-4 sm:p-6 flex flex-col gap-4 max-h-[500px] overflow-y-auto">
             <h3 class="text-lg font-bold text-brand-200 flex items-center gap-2">
                 <Icon icon=icondata::FaScrollSolid attr:class="text-brand-300" />
-                "Levequest Rewards"
+                {t!(i18n, related_levequest_rewards_title)}
             </h3>
             <div class="grid grid-cols-1 gap-3">{view}</div>
         </div>


### PR DESCRIPTION
## What

Three panel headings on the item page were hardcoded English literals inside `view!`:

| Literal | Key that already existed |
|---|---|
| `"Vendor Sources"` | `related_vendor_sources_title` |
| `"Exchange Sources"` | `related_exchange_sources_title` |
| `"Levequest Rewards"` | `related_levequest_rewards_title` |

## Why this is a one-line-per-heading fix

All three keys **already exist with real, human translations in all seven locale files** (`en`, `fr`, `de`, `ja`, `cn`, `ko`, `tc`). They were just never referenced, so every locale rendered the English string regardless:

```
fr: 'Sources vendeurs'      / "Sources d'échange"      / 'Récompenses de mandat'
de: 'Händler-Quellen'       / 'Tausch-Quellen'         / 'Gildengeleit-Belohnungen'
ja: 'NPC販売元'              / '交換元'                  / 'リーヴクエスト報酬'
cn: '商店来源'               / '兑换来源'                / '公会令奖励'
ko: '상인 출처'              / '교환 출처'               / '임무 보상'
tc: '商人來源'               / '兌換來源'                / '公會令獎勵'
```

**No locale files needed to change.** This is purely a wiring fix — the translations were already paid for.

`VendorItems` and `LeveSources` had no `i18n` binding, so both get a `use_i18n()` call. `ExchangeSources` already had one.

## Verification

`./check_ci.sh` passes in full — `cargo fmt --all -- --check` **and** `cargo clippy --all-targets -D warnings`, clean. (I initialized the `ffxiv-datamining` and `universalis-assets` submodules locally to get clippy running; both were empty in this worktree.)

`cargo check -p ultros-app` also passes clean, which is the real proof the three `t!` keys resolve — `leptos-i18n` fails compilation on an unknown key, so a green build means all three names are correct in every locale.

## Notes for the reviewer

Three more hardcoded strings remain in this same file that I deliberately did **not** touch, because each needs a judgment call rather than a mechanical fix:

- `"Exclude shards"` (~line 234) and `"Use on-hand"` (~line 243) — identical strings exist under `recipe_analyzer_filter_*` and `fc_crafting_filter_*`, but reusing another feature's keys here felt like the wrong call to make unilaterally. These probably want their own `related_*` keys.
- `"Analyzer"` (~line 329) — no key exists at all; needs a new one added to all 7 locales.

Happy to do those in a follow-up if you'd like a particular direction.

Related: #994 (the layout fix that surfaced these).

🤖 Generated with [Claude Code](https://claude.com/claude-code)