### PR TITLE
fix(scrip-sources): deterministic row ranking + working dedup (and: the page renders zero rows in prod)

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
+++ b/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
@@ -21,7 +21,7 @@ use leptos_router::{
     NavigateOptions,
     hooks::{query_signal, use_navigate, use_query_map},
 };
-use std::{cmp::Reverse, sync::Arc};
+use std::{cmp::Reverse, collections::HashSet, sync::Arc};
 use ultros_api_types::cheapest_listings::{CheapestListings, CheapestListingsMap};
 use xiv_gen::{CollectablesShopRewardScripId, ItemId, Recipe};
 
@@ -104,6 +104,49 @@ impl std::fmt::Display for SortMode {
         };
         f.write_str(val)
     }
+}
+
+/// Maximum rows rendered by the table.
+const ROW_LIMIT: usize = 100;
+
+/// Rank the collected rows, collapse repeated items, and cap the list.
+///
+/// The ranking has to be a *total* order. Rows are collected by iterating
+/// `collectables_shop_items`, a `std::collections::HashMap`, so they arrive
+/// here in an order that `RandomState` randomizes per process. The SSR server
+/// and the hydrating wasm client each build their own copy of the game data,
+/// so ranking that leaves ties unresolved puts different rows in different
+/// places — and, at the `limit` boundary, drops a different *set* of rows
+/// entirely — on the two sides. That is the hydration-mismatch class fixed for
+/// the item page in #960. Tie-breaking on the stable item id pins one order.
+fn rank_scrip_sources(
+    mut results: Vec<ScripSourceData>,
+    sort_mode: SortMode,
+    limit: usize,
+) -> Vec<ScripSourceData> {
+    match sort_mode {
+        // `total_cmp` rather than `partial_cmp().unwrap()`: the unwrap was a
+        // latent panic if a cost ever produced a NaN ratio.
+        SortMode::CostPerScrip => results.sort_unstable_by(|a, b| {
+            a.cost_per_scrip
+                .total_cmp(&b.cost_per_scrip)
+                .then_with(|| a.item_id.0.cmp(&b.item_id.0))
+        }),
+        SortMode::ScripAmount => {
+            results.sort_unstable_by_key(|d| (Reverse(d.scrip_amount), d.item_id.0))
+        }
+        SortMode::Cost => results.sort_unstable_by_key(|d| (d.cost, d.item_id.0)),
+    }
+
+    // An item stocked by several collectables shops yields one row per shop.
+    // After a metric sort those rows are not adjacent, so the previous
+    // `dedup_by_key` — which only removes *consecutive* duplicates — left them
+    // on screen. Keep the first, i.e. best-ranked, row for each item.
+    let mut seen = HashSet::with_capacity(results.len());
+    results.retain(|r| seen.insert(r.item_id));
+
+    results.truncate(limit);
+    results
 }
 
 #[component]
@@ -263,31 +306,15 @@ fn ScripSourceTable(
             }
         }
 
-        // ⚡ Bolt: Optimization: In-place filtering and truncation for Top N lists using select_nth_unstable.
-        // We first fully sort since dedup_by_key requires it, but we can do a faster un-stable sort.
-        // Then we can dedup, and then truncate the list.
-
-        // Sort
-        match sort_mode().unwrap_or(SortMode::CostPerScrip) {
-            SortMode::CostPerScrip => results
-                .sort_unstable_by(|a, b| a.cost_per_scrip.partial_cmp(&b.cost_per_scrip).unwrap()),
-            SortMode::ScripAmount => results.sort_unstable_by_key(|d| Reverse(d.scrip_amount)),
-            SortMode::Cost => results.sort_unstable_by_key(|d| d.cost),
-        }
-
-        // Deduplicate by item_id (since item may appear in multiple shop lists)
-        results.dedup_by_key(|r| r.item_id);
-
-        let limit = 100;
-        if results.len() > limit {
-            results.truncate(limit);
-        }
-
-        results
-            .into_iter()
-            .map(Arc::new)
-            .enumerate()
-            .collect::<Vec<_>>()
+        rank_scrip_sources(
+            results,
+            sort_mode().unwrap_or(SortMode::CostPerScrip),
+            ROW_LIMIT,
+        )
+        .into_iter()
+        .map(Arc::new)
+        .enumerate()
+        .collect::<Vec<_>>()
     });
 
     view! {
@@ -579,5 +606,119 @@ pub fn ScripSources() -> impl IntoView {
                 </Suspense>
             </div>
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(item_id: i32, scrip_amount: u32, cost: i32) -> ScripSourceData {
+        ScripSourceData {
+            item_id: ItemId(item_id),
+            item_name: format!("Item {item_id}"),
+            level: 90,
+            craft_type: Some(0),
+            scrip_type: ScripType::PurpleCrafters,
+            scrip_amount,
+            cost,
+            cost_per_scrip: cost as f32 / scrip_amount as f32,
+            cheapest_world_id: 0,
+            recipe: None,
+        }
+    }
+
+    fn ids(rows: &[ScripSourceData]) -> Vec<i32> {
+        rows.iter().map(|r| r.item_id.0).collect()
+    }
+
+    /// `collectables_shop_items` is a `std::collections::HashMap`, so the order
+    /// rows are collected in is randomized per process (`RandomState`). The SSR
+    /// server and the hydrating wasm client each build their own copy of the
+    /// game data, so the same rows arrive here in different orders. If the
+    /// ranking is not a total order, the two sides render different rows in
+    /// different positions and tachys' hydration walker trips — the #6831
+    /// crash class fixed for the item page by #960.
+    #[test]
+    fn ranking_is_independent_of_input_order() {
+        for mode in [
+            SortMode::ScripAmount,
+            SortMode::Cost,
+            SortMode::CostPerScrip,
+        ] {
+            // Every row ties on every sort key, which is what game data
+            // actually looks like: `high_reward` is a small integer shared by
+            // hundreds of items.
+            let forward = vec![row(1, 20, 1000), row(2, 20, 1000), row(3, 20, 1000)];
+            let reversed: Vec<_> = forward.iter().rev().cloned().collect();
+
+            assert_eq!(
+                ids(&rank_scrip_sources(forward, mode, ROW_LIMIT)),
+                ids(&rank_scrip_sources(reversed, mode, ROW_LIMIT)),
+                "{mode:?} ranking changed with input order"
+            );
+        }
+    }
+
+    /// The truncation boundary is the sharp edge of the same bug: with ties
+    /// spanning the cap, an unstable ranking changes *which* rows survive, so
+    /// the two sides render genuinely different items.
+    #[test]
+    fn truncation_keeps_the_same_rows_regardless_of_input_order() {
+        let forward: Vec<_> = (1..=10).map(|i| row(i, 20, 1000)).collect();
+        let reversed: Vec<_> = forward.iter().rev().cloned().collect();
+
+        assert_eq!(
+            ids(&rank_scrip_sources(forward, SortMode::ScripAmount, 5)),
+            ids(&rank_scrip_sources(reversed, SortMode::ScripAmount, 5)),
+        );
+    }
+
+    /// An item sold by several collectables shops at different reward tiers
+    /// produces several rows. Those rows are not adjacent after a metric sort,
+    /// so consecutive-only dedup leaves the duplicates on screen.
+    #[test]
+    fn repeated_items_collapse_even_when_not_adjacent() {
+        // Item 1 at two reward tiers, with item 2 ranking between them.
+        let rows = vec![row(1, 40, 1000), row(2, 30, 1000), row(1, 20, 1000)];
+
+        let ranked = rank_scrip_sources(rows, SortMode::ScripAmount, ROW_LIMIT);
+
+        assert_eq!(ids(&ranked), vec![1, 2], "item 1 rendered twice");
+    }
+
+    /// Dedup must keep the best-ranked row for an item, not an arbitrary one.
+    #[test]
+    fn dedup_keeps_the_best_ranked_row_for_an_item() {
+        let rows = vec![row(1, 40, 1000), row(2, 30, 1000), row(1, 20, 1000)];
+
+        let ranked = rank_scrip_sources(rows, SortMode::ScripAmount, ROW_LIMIT);
+
+        assert_eq!(ranked[0].scrip_amount, 40);
+    }
+
+    #[test]
+    fn sort_modes_still_rank_by_their_metric() {
+        let rows = vec![row(1, 10, 3000), row(2, 30, 1000), row(3, 20, 2000)];
+
+        // Most scrips first.
+        assert_eq!(
+            ids(&rank_scrip_sources(
+                rows.clone(),
+                SortMode::ScripAmount,
+                ROW_LIMIT
+            )),
+            vec![2, 3, 1]
+        );
+        // Cheapest total cost first.
+        assert_eq!(
+            ids(&rank_scrip_sources(rows.clone(), SortMode::Cost, ROW_LIMIT)),
+            vec![2, 3, 1]
+        );
+        // Best gil-per-scrip first: 1000/30 < 2000/20 < 3000/10.
+        assert_eq!(
+            ids(&rank_scrip_sources(rows, SortMode::CostPerScrip, ROW_LIMIT)),
+            vec![2, 3, 1]
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two bugs on `/scrip-sources`. **One is fixed here and fully verified. The second — the page renders *zero rows* in production — is diagnosed but deliberately not fixed, because the correct fix needs a game-data judgement call I can't verify autonomously.** Details in the second section; please read it, it's the bigger of the two.

## 1. Fixed: non-deterministic row ranking + ineffective dedup

`ScripSourceTable` collects rows by iterating `data.collectables_shop_items`, a `std::collections::HashMap`. `RandomState` randomizes that iteration per process, and the SSR server and the hydrating wasm client each build their own copy of the game data — so rows reach the ranking step in a **different order on the two sides**.

The ranking left ties unresolved:

```rust
SortMode::ScripAmount => results.sort_unstable_by_key(|d| Reverse(d.scrip_amount)),
SortMode::Cost        => results.sort_unstable_by_key(|d| d.cost),
```

`high_reward` is a small integer shared by hundreds of items, so ties are the common case, not the edge case. Unstable sort + tied keys = tied rows stay in *input* order, which differs per process. The list is then cut to 100, so the two sides don't merely order rows differently — they keep a **different set of rows**. That order reaches the DOM via the `VirtualScroller`'s `<For>` key, i.e. the hydration-mismatch class fixed for the item page in #960.

**Fix:** tie-break every sort mode on the stable `item_id`. `CostPerScrip` also moves from `partial_cmp().unwrap()` to `total_cmp`, dropping a latent NaN panic.

**Also fixed:** the dedup never worked. `dedup_by_key` removes only *consecutive* duplicates, but the list is sorted by a cost/scrip metric, not by item id — so an item stocked by several shops at different reward tiers rendered twice. Replaced with a first-wins `retain`, keeping the best-ranked row per item. (The existing comment already documented the intent: *"since item may appear in multiple shop lists"*.)

Three of the five new tests fail on the previous code:

| test | before | after |
|---|---|---|
| `ranking_is_independent_of_input_order` | `[1,2,3]` vs `[3,2,1]` | equal |
| `truncation_keeps_the_same_rows_regardless_of_input_order` | `[1,2,3,4,5]` vs `[10,9,8,7,6]` | equal |
| `repeated_items_collapse_even_when_not_adjacent` | `[1,2,1]` | `[1,2]` |

## 2. NOT fixed — `/scrip-sources` renders zero rows in production

While verifying the above I found the page is **completely dead**, and has to be:

```rust
41784 => ScripType::OrangeCrafters,
25199 => ScripType::WhiteCrafters,   // ...etc — these are scrip *item ids*
_     => ScripType::Other(id),
```

...is called as `ScripType::from_id(reward.currency)`. But `CollectablesShopRewardScrip.Currency` is **a small enum index, not an item id**. Every value in the current pinned game data:

```
$ awk -F, 'NR>1 {print $2}' csv/en/CollectablesShopRewardScrip.csv | sort -n | uniq -c
      1 0
    537 2
    119 4
     31 6
     13 7
```

So `from_id` returns `Other(_)` for **every** row, and both filter branches then drop it — the `else` branch does `if matches!(scrip_type, ScripType::Other(_)) { continue; }`, and with a filter active no `Other` row can equal a named variant either. **No row can ever pass, under any filter.**

Confirmed live on `https://ultros.app/scrip-sources?world=Gilgamesh` (release `698f0ed`): column headers render, `role="row-group"` count is **0**. Not an API problem — `/api/v1/cheapest/Gilgamesh` returns 200 with ~984KB of listings.

**Why I didn't fix it:** the fix is a `Currency` → scrip-type table, and I can't establish the colour tiers to a standard I'd ship user-facing labels at. What the data *does* support, unambiguously:

| Currency | rows | crafted / gathered | job level range |
|---|---|---|---|
| 2 | 1149 | 1067 / 82 | 50–98 |
| 4 | 250 | 59 / 191 | 50–98 |
| 6 | 93 | 87 / 6 | 80–100 |
| 7 | 18 | 0 / 18 | 100 |

So 2/6 are Crafters' and 4/7 are Gatherers' — that part is solid. For the tier my best guess is `2→Purple Crafters, 4→Purple Gatherers, 6→Orange Crafters, 7→Orange Gatherers` (four live scrip types post-7.0 with White removed; currency 7 being all-level-100-gathered fits Orange Gatherers' exactly). But currency 6 includes level-80 Shadowbringers items like *Lignum Vitae Lumber*, which argues against a clean Orange reading — so I'd be guessing, and a wrong guess mislabels every row. **Your call / a 2-minute in-game check settles it.**

Worth noting the structural lesson regardless of the mapping: an unrecognized `Currency` currently causes the row to be *silently dropped*, so one new expansion adding `Currency = 8` blanks the whole page again. Whatever mapping lands, unknown values should probably stay visible rather than filtered out.

## GlitchTip triage: blocked this run

No issues could be triaged — every `glitchtip_issues` call returned `Authentication failed`. Not an outage: `glitchtip.ultros.app` and `ultros.app` both return 200. `.mcp.json` resolves the token from `${GLITCHTIP_TOKEN}`, which isn't set in this environment — looks like fallout from the #991 token leak being sanitized to an env-var reference without the var being provisioned for the scheduled task. **The backlog was untouched this run; no issues were ignored or resolved.** Worth re-provisioning that env var before the next run.

Both bugs here were found by code inspection instead, using the durable rule from #960/#6831: *any HashMap iteration whose order reaches the DOM is an SSR/CSR bug in this repo.*

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test -p ultros-app --lib` — **300 passed, 0 failed** (5 new)
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean (exit 0)

Workspace-wide clippy was not run (a stale `cargo` process held the shared target lock, so this built against an isolated target dir); the change is confined to one file in `ultros-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
