### PR TITLE
fix(item-explorer): key the category route on an id, not a localized name

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -26,7 +26,9 @@ use leptos_router::location::Location;
 use paginate::Pages;
 use percent_encoding::percent_decode_str;
 use ultros_api_types::world_helper::AnySelector;
-use xiv_gen::{ClassJobCategory, ClassJobCategoryId, Item, ItemId};
+use xiv_gen::{
+    ClassJobCategory, ClassJobCategoryId, Item, ItemId, ItemSearchCategory, ItemSearchCategoryId,
+};
 
 /// Return true if the given acronym is in the given class job category
 pub(crate) fn job_category_lookup(
@@ -167,6 +169,40 @@ pub(crate) fn collect_job_items_sorted<'a>(
     items
 }
 
+/// Resolve the `/items/category/:category` route param to its
+/// [`ItemSearchCategory`].
+///
+/// The canonical param is the **numeric** `ItemSearchCategory` id, because ids
+/// are locale-independent. `ItemSearchCategory::name` is a *localized display
+/// string* ("Shields" / "盾" / "Schilde"), and the two renderers of a page do
+/// not share a locale: the server initializes `xiv_gen_db` to `Language::En`
+/// and never swaps it, while the client calls `try_init` with the visitor's
+/// locale *before* hydrating. A name-keyed param therefore resolves on exactly
+/// one of the two sides — SSR renders an empty list where the client builds a
+/// full one (a chip minted by a non-English client), or the reverse (the
+/// English links in the sitemap and the search index). Either way the client's
+/// view tree disagrees with the SSR DOM and tachys panics in
+/// `failed_to_cast_element`, the same class as #960.
+///
+/// The name match is kept as a fallback so links minted before the switch to
+/// ids keep resolving; it carries exactly the locale caveat it always had.
+/// Duplicate names (`Primary Tools` is both id 2 and id 3) are broken by
+/// lowest id rather than by `HashMap` iteration order, so the fallback is at
+/// least deterministic across the two processes.
+pub(crate) fn resolve_category_param<'a>(
+    data: &'a xiv_gen::Data,
+    raw_param: &str,
+) -> Option<&'a ItemSearchCategory> {
+    let decoded = percent_decode_str(raw_param).decode_utf8().ok()?;
+    if let Ok(id) = decoded.parse::<i32>() {
+        return data.item_search_categorys.get(&ItemSearchCategoryId(id));
+    }
+    data.item_search_categorys
+        .values()
+        .filter(|category| category.name == decoded)
+        .min_by_key(|category| category.key_id.0)
+}
+
 #[component]
 pub fn CategoryItems() -> impl IntoView {
     let i18n = crate::i18n::use_i18n();
@@ -175,17 +211,12 @@ pub fn CategoryItems() -> impl IntoView {
     let items = Memo::new(move |_| {
         let cat = params()
             .get_str("category")
-            .and_then(|cat| percent_encoding::percent_decode_str(cat).decode_utf8().ok())
-            .and_then(|cat| {
-                data.item_search_categorys
-                    .iter()
-                    .find(|(_id, category)| category.name == cat)
-            })
-            .map(|(id, _)| {
+            .and_then(|cat| resolve_category_param(data, cat))
+            .map(|category| {
                 let mut items: Vec<_> = data
                     .items
                     .iter()
-                    .filter(|(_, item)| item.item_search_category == id.0)
+                    .filter(|(_, item)| item.item_search_category == category.key_id.0)
                     .collect();
                 // See note in `JobItems::items` — pin a stable order across
                 // the SSR and CSR HashMap iterations to keep hydration in
@@ -196,11 +227,20 @@ pub fn CategoryItems() -> impl IntoView {
         cat.unwrap_or_default()
     });
     let category_view_name = Memo::new(move |_| {
+        // Resolve the id back to a display name. Falls through to the raw
+        // param for legacy name-keyed links that no longer resolve, so an
+        // unrecognised category still names itself in the heading.
         params()
-            .get("category")
-            .as_ref()
-            .and_then(|cat| percent_decode_str(cat).decode_utf8().ok())
-            .map(|c| c.to_string())
+            .get_str("category")
+            .and_then(|cat| resolve_category_param(data, cat))
+            .map(|category| category.name.clone())
+            .or_else(|| {
+                params()
+                    .get("category")
+                    .as_ref()
+                    .and_then(|cat| percent_decode_str(cat).decode_utf8().ok())
+                    .map(|c| c.to_string())
+            })
             .unwrap_or_else(|| crate::i18n::t_string!(i18n, category_view_default).to_string())
     });
     view! {
@@ -1006,8 +1046,127 @@ pub fn ItemExplorer() -> impl IntoView {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_job_items_sorted;
+    use super::{collect_job_items_sorted, resolve_category_param};
     use paginate::Pages;
+    use xiv_gen::Language;
+
+    /// Lowest-id category that the toolbar actually links to (`category`
+    /// 1..=4), so the locale tests below key off a real navigable page
+    /// rather than a hardcoded id that a game-data bump could retire.
+    fn first_linkable_category(data: &xiv_gen::Data) -> &xiv_gen::ItemSearchCategory {
+        data.item_search_categorys
+            .values()
+            .filter(|cat| (1..=4).contains(&cat.category))
+            .min_by_key(|cat| cat.key_id.0)
+            .expect("game data must have at least one linkable item search category")
+    }
+
+    /// The bug this route key was changed to avoid. The server renders SSR
+    /// with English game data while the client hydrates with the visitor's
+    /// locale, so a *name*-keyed param resolves on exactly one of the two
+    /// sides — SSR emits an empty list where the client builds a full one,
+    /// and tachys panics walking the mismatch.
+    #[test]
+    fn a_localized_category_name_only_resolves_in_its_own_locale() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let ja = xiv_gen_db::data_for(Language::Ja);
+        let sample = first_linkable_category(en);
+        let ja_name = ja
+            .item_search_categorys
+            .get(&sample.key_id)
+            .expect("the same id exists in every locale")
+            .name
+            .clone();
+        assert_ne!(
+            ja_name, sample.name,
+            "sanity: this category's display name must actually differ between locales",
+        );
+
+        // A chip minted by a Japanese client carries the Japanese name...
+        assert!(
+            resolve_category_param(ja, &ja_name).is_some(),
+            "the minting locale resolves its own name",
+        );
+        // ...but SSR answers that URL with English data and finds nothing.
+        assert!(
+            resolve_category_param(en, &ja_name).is_none(),
+            "English SSR cannot resolve a Japanese category name — the mismatch",
+        );
+    }
+
+    /// The fix: an id resolves to the same category in every locale, so SSR
+    /// and the client agree on the item list regardless of who minted the
+    /// link.
+    #[test]
+    fn a_category_id_resolves_identically_in_every_locale() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let expected = first_linkable_category(en).key_id;
+        let param = expected.0.to_string();
+        for lang in [
+            Language::En,
+            Language::Ja,
+            Language::De,
+            Language::Fr,
+            Language::Cn,
+            Language::Ko,
+            Language::Tc,
+        ] {
+            let data = xiv_gen_db::data_for(lang);
+            assert_eq!(
+                resolve_category_param(data, &param).map(|cat| cat.key_id),
+                Some(expected),
+                "id param must resolve to the same category under {lang:?}",
+            );
+        }
+    }
+
+    /// Links minted before the switch to ids are percent-encoded localized
+    /// names; they must keep working for the locale that minted them.
+    #[test]
+    fn legacy_percent_encoded_name_params_still_resolve() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let sample = en
+            .item_search_categorys
+            .values()
+            .filter(|cat| (1..=4).contains(&cat.category) && cat.name.contains(' '))
+            .min_by_key(|cat| cat.key_id.0)
+            .expect("at least one linkable category name contains a space");
+        let encoded = sample.name.replace(' ', "%20").replace('\'', "%27");
+        assert_eq!(
+            resolve_category_param(en, &encoded).map(|cat| cat.key_id),
+            Some(sample.key_id),
+        );
+    }
+
+    /// `Primary Tools` is the name of both id 2 and id 3. The name fallback
+    /// must not pick between them by `HashMap` iteration order, or it
+    /// reintroduces the very SSR/CSR divergence the id key removes.
+    #[test]
+    fn duplicate_category_names_resolve_to_the_lowest_id() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let mut by_name: std::collections::HashMap<&str, Vec<i32>> =
+            std::collections::HashMap::new();
+        for cat in en.item_search_categorys.values() {
+            by_name
+                .entry(cat.name.as_str())
+                .or_default()
+                .push(cat.key_id.0);
+        }
+        let Some((name, ids)) = by_name
+            .iter()
+            .filter(|(name, ids)| ids.len() > 1 && !name.is_empty())
+            .min_by_key(|(name, _)| *name)
+        else {
+            // No duplicate names in this data revision — nothing to pin.
+            return;
+        };
+        let lowest = ids.iter().copied().min().expect("non-empty");
+        assert_eq!(
+            resolve_category_param(en, name).map(|cat| cat.key_id.0),
+            Some(lowest),
+            "duplicate name {name:?} must resolve deterministically to the lowest id",
+        );
+    }
 
     /// Regression for the `?page=35` family of GlitchTip hydration
     /// panics on `/items/jobset/<JOB>`. `paginate::Pages::with_offset`

--- a/ultros-frontend/ultros-app/src/routes/item_explorer_toolbar.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer_toolbar.rs
@@ -7,6 +7,7 @@ use crate::components::toolbar::{Toolbar, ToolbarField, ToolbarPills, ToolbarSpa
 use crate::components::world_picker::WorldPicker;
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::{t, t_string, use_i18n};
+use crate::routes::item_explorer::resolve_category_param;
 use crate::routes::item_explorer_roles::{RoleGroup, role_for_job_abbr, role_for_weapon_category};
 use crate::routes::item_explorer_scope::{ExplorerPriceScope, href_with_world};
 use leptos::prelude::*;
@@ -22,15 +23,8 @@ pub(crate) fn active_group_from_route(jobset: Option<&str>, category: Option<&st
     if jobset.is_some() {
         return Some(5);
     }
-    let cat_raw = category?;
-    let cat_name = percent_encoding::percent_decode_str(cat_raw)
-        .decode_utf8()
-        .ok()?;
     let data = xiv_gen_db::data();
-    data.item_search_categorys
-        .values()
-        .find(|cat| cat.name == cat_name)
-        .map(|cat| cat.category)
+    resolve_category_param(data, category?).map(|cat| cat.category)
 }
 
 /// Return the search categories that belong to a non-job group
@@ -175,13 +169,19 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                     // belongs to the selected group, else a browse prompt.
                     let button_label = if active_group.get() == Some(group) {
                         let p = params.get();
-                        p.get("jobset")
-                            .or_else(|| p.get("category"))
-                            .as_ref()
-                            .and_then(|s| {
-                                percent_encoding::percent_decode_str(s).decode_utf8().ok()
-                            })
-                            .map(|s| s.to_string())
+                        match p.get("jobset") {
+                            Some(jobset) => percent_encoding::percent_decode_str(&jobset)
+                                .decode_utf8()
+                                .ok()
+                                .map(|s| s.to_string()),
+                            // The category param is an id, so resolve it back
+                            // to the localized name instead of labelling the
+                            // trigger with a bare number.
+                            None => p.get("category").and_then(|cat| {
+                                resolve_category_param(data, &cat)
+                                    .map(|category| category.name.clone())
+                            }),
+                        }
                     } else {
                         None
                     }
@@ -228,7 +228,7 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                             .collect();
                         for (name, id) in category_chips_for_group(1) {
                             let href = href_with_world(
-                                format!("/items/category/{}", name.replace('/', "%2F")),
+                                format!("/items/category/{}", id.0),
                                 world.as_deref(),
                             );
                             let role = data
@@ -263,7 +263,7 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                                 .map(|(name, id)| PopoverLink {
                                     label: name.to_string(),
                                     href: href_with_world(
-                                        format!("/items/category/{}", name.replace('/', "%2F")),
+                                        format!("/items/category/{}", id.0),
                                         world.as_deref(),
                                     ),
                                     icon: PopoverIcon::Category(id),
@@ -277,7 +277,7 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                                 .into_iter()
                                 .map(|(name, id)| {
                                     let href = href_with_world(
-                                        format!("/items/category/{}", name.replace('/', "%2F")),
+                                        format!("/items/category/{}", id.0),
                                         world.as_deref(),
                                     );
                                     view! {
@@ -320,6 +320,31 @@ mod tests {
             active_group_from_route(None, Some("Pugilist%27s%20Arms")),
             Some(1),
         );
+    }
+
+    /// Category ids are the canonical route key — resolving them is what
+    /// keeps the toolbar's selected group identical between the English SSR
+    /// render and a localized client.
+    #[test]
+    fn active_group_resolves_a_numeric_category_id() {
+        let data = xiv_gen_db::data();
+        let weapon = data
+            .item_search_categorys
+            .values()
+            .filter(|cat| cat.category == 1)
+            .min_by_key(|cat| cat.key_id.0)
+            .expect("weapons group must have categories");
+        assert_eq!(
+            active_group_from_route(None, Some(&weapon.key_id.0.to_string())),
+            Some(1),
+            "a numeric category id must select the category's own group",
+        );
+    }
+
+    #[test]
+    fn active_group_for_unknown_category_id_is_none() {
+        // Well past the end of the sheet; must not select a group.
+        assert_eq!(active_group_from_route(None, Some("999999")), None);
     }
 
     #[test]

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1783,8 +1783,7 @@ pub fn ItemView() -> impl IntoView {
                                                 view! {
                                                     <a
                                                         class="text-brand-300 hover:text-brand-200 transition-colors"
-                                                        href=["/items/category/", &s.name.replace("/", "%2F")]
-                                                            .concat()
+                                                        href=format!("/items/category/{}", s.key_id.0)
                                                     >
                                                         {c.name.as_str()}
                                                     </a>

--- a/ultros/src/search_service.rs
+++ b/ultros/src/search_service.rs
@@ -70,7 +70,11 @@ impl SearchService {
             index_writer.add_document(doc!(
                 title_field => cat.name.as_str(),
                 type_field => "category",
-                url_field => format!("/items/category/{}", cat.name),
+                // Keyed by id: this index is built from English game data, so
+                // a name-keyed URL would send every non-English visitor to a
+                // category their client cannot resolve. See
+                // `resolve_category_param` in `item_explorer.rs`.
+                url_field => format!("/items/category/{}", cat.key_id.0),
                 // Categories don't have a direct icon, maybe use a default or 0
                 icon_id_field => 0i64,
                 category_field => "",

--- a/ultros/src/web/sitemap.rs
+++ b/ultros/src/web/sitemap.rs
@@ -190,7 +190,14 @@ pub(crate) async fn generic_pages_sitemap() -> Result<Xml, WebError> {
         .values()
         .filter(|cat| (1..=4).contains(&cat.category))
     {
-        let mut builder = Url::builder(["https://ultros.app/items/category/", &cat.name].concat());
+        // Keyed by id, not `cat.name`: the name is localized, and the SSR that
+        // answers these URLs always renders with English game data, so a
+        // name-keyed link only resolves for English visitors. See
+        // `resolve_category_param` in `item_explorer.rs`.
+        let mut builder = Url::builder(format!(
+            "https://ultros.app/items/category/{}",
+            cat.key_id.0
+        ));
         builder.priority(0.6);
         builder.change_frequency(ChangeFrequency::Weekly);
         if let Ok(url) = builder.build() {


### PR DESCRIPTION
## The bug

`/items/category/:category` is keyed on `ItemSearchCategory::name` — a **localized display string**. The two renderers of that page do not share a locale:

- **SSR** initializes `xiv_gen_db` to `Language::En` and never swaps it (`ultros-app`'s `ssr` feature turns on `xiv-gen-db/embed`; `data()` inits to `En`, and the only `try_init` in the app is `#[cfg(not(feature = "ssr"))]`).
- **The client** calls `try_init` with the visitor's locale from the `i18n_pref_locale` cookie *before* hydrating (`ultros-client/src/lib.rs::init_data`).

So a name-keyed param resolves on exactly one of the two sides.

Measured on prod (`ultros.app`), same category (id 17), counting distinct `/item/<world>/<id>` links in the SSR body:

| URL | SSR item rows |
|---|---|
| `/items/category/Shields` (English name) | **51** |
| `/items/category/%E7%9B%BE` (`盾`, the Japanese name for the same category) | **0** |

The chip a Japanese client mints links to `盾`, so a direct load, refresh, shared link or crawler hit gets an **empty SSR list while the client builds a full one**. The sitemap and the search index emit the *English* name, so the same page breaks in the opposite direction for a non-English visitor. Either way the client's view tree disagrees with the SSR DOM and tachys panics in `failed_to_cast_element` — the same class as #960 — on top of the page simply being wrong on first paint.

This affects **all six non-English locales**, because `ItemSearchCategory::name` is translated in every one of them.

That SSR is locale-blind for game data is directly observable: `curl -H 'Cookie: i18n_pref_locale=ja' https://ultros.app/item/Sargatanas/23539` returns `<html lang="ja">` with Japanese UI chrome but the **English** item name in `<title>`.

## The fix

Make the canonical route key the **numeric `ItemSearchCategory` id**, which is locale-independent, and resolve it through one shared helper:

```rust
pub(crate) fn resolve_category_param<'a>(
    data: &'a xiv_gen::Data,
    raw_param: &str,
) -> Option<&'a ItemSearchCategory>
```

- id param → direct `HashMap` lookup (identical in every locale)
- otherwise → name match, kept so links minted before this change keep resolving, with a **lowest-id tie-break** (`Primary Tools` is the name of both id 2 and id 3, and the old `.values().find(..)` picked between them by `HashMap` iteration order — nondeterminism of exactly the kind this PR is removing)

Call sites moved onto ids: the three toolbar chip/popover hrefs, the item page's category link, `sitemap.rs`, and the search index in `search_service.rs`. `CategoryItems` and `active_group_from_route` now resolve through the helper, and the page heading + popover trigger label resolve the id back to the **localized** name rather than echoing the raw param (so they now show `盾` to a Japanese visitor following a sitemap link, where before they showed `Shields`).

## Verification

Genuine red → green, `cargo test -p ultros-app --lib`:

- **RED** (with `active_group_from_route` temporarily restored to the pre-fix name-only resolution): `active_group_resolves_a_numeric_category_id` **FAILED** — `left: None, right: Some(1)`; exit **101**.
- **GREEN** (fix restored): **307 passed / 0 failed** (base on this branch point was 301; 6 tests added, none removed).

Also green: `cargo fmt --all -- --check` (exit 0), `cargo clippy -p ultros-app --all-targets -- -D warnings` (exit 0), `cargo clippy -p ultros --all-targets -- -D warnings` (exit 0 — this PR touches `search_service.rs` and `sitemap.rs`).

Two of the new tests pin the mechanism itself rather than just the fix:

- `a_localized_category_name_only_resolves_in_its_own_locale` — asserts a Japanese category name resolves under `data_for(Ja)` and **not** under `data_for(En)`, i.e. reproduces the SSR/CSR split directly.
- `a_category_id_resolves_identically_in_every_locale` — asserts the id resolves to the same category under all seven locales.

Neither hardcodes an id; both pick the lowest-id linkable category out of the shipped game data, so a data bump can't silently retire them.

## Tradeoff

The sitemap now advertises `/items/category/17` instead of `/items/category/Shields`, losing a keyword from the URL. Taken deliberately: the old URL is only correct for English visitors, and the page's `<title>`/`<h1>` still carry the category name. Old name URLs keep returning 200 through the fallback, so nothing 404s — `integration/runner.cjs` still drives `/items/category/Gunbreaker's Arms` unchanged.

## Not fixed here — same root cause, filed for follow-up

Found while confirming the above; deliberately left out to keep this reviewable.

1. **`/items/jobset/:jobset` is dead for German and French users.** The key is `ClassJob::abbreviation`, which is *also* localized — **23 of 36** visible jobs differ from English in `de`, **22 of 36** in `fr` (`CRP`→`ZMR`, `BSM`→`GRS`, `LTW`→`GER`, …; `ja`/`cn`/`ko` happen to match English). The toolbar mints `/items/jobset/FST` for a German user, and `job_category_lookup` matches a **hardcoded English acronym table**, so that page renders empty on *both* sides — no hydration panic, just a dead nav entry. Confirmed on prod: `/items/jobset/PGL` → 50 SSR rows, `/items/jobset/FST` → 0.
2. **Role bucketing mis-groups the same jobs.** `role_for_job_abbr` matches hardcoded English acronyms against the localized abbreviation, so those 23/22 jobs fall into `RoleGroup::Other` in the popover for `de`/`fr`. The existing `every_visible_job_maps_to_a_role` test passes only because it runs against English data. Fixing this means re-keying the hand-written table on `ClassJobId`.
3. **The root cause itself**: SSR renders all game data in English regardless of the visitor's locale, so every non-English page ships English item names in its SSR HTML. Making `tracked_data()` locale-aware under `ssr` would subsume all of the above, but it is a wide change — many call sites read `xiv_gen_db::data()` directly rather than through `tracked_data()` — and a partial conversion would create *new* mismatches, so it wants its own PR.

## Triage note

The GlitchTip MCP server is still unreachable this run — no `glitchtip_*` tool is exposed and `.mcp.json` is absent from both the repo root and the main clone, so the server is unregistered rather than misauthenticated. Zero issues could be triaged; this fix came from code inspection plus the prod measurements above. Re-adding the MCP server config (with the token from an env var) is needed before backlog triage can resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
