### PR TITLE
fix(clickhouse): thread real Postgres sale ids into the dual-write

### DIFF
--- a/ultros-clickhouse/src/backfill.rs
+++ b/ultros-clickhouse/src/backfill.rs
@@ -5,9 +5,12 @@
 //! in the `_backfill_state` table and skipped.
 //!
 //! Idempotent: the `sales` table is a `ReplacingMergeTree` keyed on
-//! `(item_id, hq, world_id, sold_date, buying_character_id)`, so re-streaming
-//! the same rows just merges into no-ops. That means dual-writes overlapping
-//! the backfill window are safe too.
+//! `(item_id, hq, world_id, sold_date, pg_id)`, so re-streaming the same rows
+//! just merges into no-ops. Dual-writes overlapping the backfill window are
+//! safe *because* both paths key on the same Postgres `sale_history.id` — see
+//! [`SaleRow::from_db_model`] (this path) and [`SaleRow::from_api_sale`] (the
+//! live path). If either ever writes a placeholder id, the two paths stop
+//! agreeing on row identity and the overlap double-counts instead of merging.
 
 use std::time::Instant;
 

--- a/ultros-clickhouse/src/rows.rs
+++ b/ultros-clickhouse/src/rows.rs
@@ -21,10 +21,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Row, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct SaleRow {
     /// Carries the Postgres `sale_history.id` so each PG row maps to a
-    /// distinct CH row. Without this, two sales sharing
-    /// `(item_id, hq, world_id, sold_date, buying_character_id)` collapse
-    /// under the `ReplacingMergeTree` dedup — and Universalis-side replays
-    /// produce a non-trivial number of those.
+    /// distinct CH row. It is the last component of the `sales` ORDER BY key,
+    /// so without a real value two sales sharing
+    /// `(item_id, hq, world_id, sold_date)` collapse under the
+    /// `ReplacingMergeTree` dedup — and Universalis-side replays produce a
+    /// non-trivial number of those. Every producer must supply the real id:
+    /// a placeholder makes the live path and the backfill disagree on row
+    /// identity, so the same sale is stored twice and never merges.
     pub pg_id: i32,
     #[serde(with = "clickhouse::serde::chrono::datetime")]
     pub sold_date: chrono::DateTime<chrono::Utc>,
@@ -113,6 +116,67 @@ mod tests {
         assert_eq!(row.hq, 1);
         assert_eq!(row.buying_character_id, 42);
         assert_eq!(row.buyer_name, "Test Buyer");
+    }
+
+    /// The dual-write path is `update_sales` -> `sale_history::Model` (from
+    /// `INSERT ... RETURNING`) -> `SaleHistory` -> `SaleRow`. `pg_id` has to
+    /// survive all of it: it's the last component of the `sales` ORDER BY key,
+    /// so a zero here collapses distinct sales on merge *and* leaves the
+    /// backfill (which reads real ids from Postgres) writing a second copy of
+    /// every row that never merges with the live one.
+    #[test]
+    fn freshly_recorded_sale_carries_a_nonzero_pg_id() {
+        let recorded = ultros_db::entity::sale_history::Model {
+            id: 918_273,
+            quantity: 3,
+            price_per_item: 2500,
+            buying_character_id: 42,
+            hq: false,
+            sold_item_id: 7,
+            sold_date: NaiveDate::from_ymd_opt(2026, 5, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+            world_id: 40,
+        };
+        let api_sale: ultros_api_types::SaleHistory =
+            ultros_db::common_type_conversions::SaleHistoryReturn(recorded, None).into();
+
+        let row = SaleRow::from_api_sale(&api_sale);
+
+        assert_ne!(row.pg_id, 0, "pg_id must not be a placeholder");
+        assert_eq!(row.pg_id, 918_273);
+    }
+
+    /// Both writers must agree on `pg_id` for the same Postgres row, otherwise
+    /// the live insert and the backfill insert are two distinct keys and
+    /// ReplacingMergeTree never collapses them.
+    #[test]
+    fn live_and_backfill_paths_agree_on_pg_id() {
+        let recorded = ultros_db::entity::sale_history::Model {
+            id: 555,
+            quantity: 1,
+            price_per_item: 100,
+            buying_character_id: 42,
+            hq: true,
+            sold_item_id: 7,
+            sold_date: NaiveDate::from_ymd_opt(2026, 5, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap(),
+            world_id: 40,
+        };
+        let backfill_row = SaleRow::from_db_model(&recorded, "Test Buyer".to_string());
+        let api_sale: ultros_api_types::SaleHistory =
+            ultros_db::common_type_conversions::SaleHistoryReturn(recorded.clone(), None).into();
+        let live_row = SaleRow::from_api_sale(&api_sale);
+
+        assert_eq!(live_row.pg_id, backfill_row.pg_id);
+        // Every column of the ReplacingMergeTree sort key must match.
+        assert_eq!(live_row.item_id, backfill_row.item_id);
+        assert_eq!(live_row.hq, backfill_row.hq);
+        assert_eq!(live_row.world_id, backfill_row.world_id);
+        assert_eq!(live_row.sold_date, backfill_row.sold_date);
     }
 
     #[test]

--- a/ultros-clickhouse/src/schema.rs
+++ b/ultros-clickhouse/src/schema.rs
@@ -23,10 +23,19 @@ pub async fn apply(client: &Client) -> Result<(), ClickHouseError> {
 
 /// Raw mirror of Postgres `sale_history`.
 ///
-/// Engine: `ReplacingMergeTree(inserted_at)` on the natural key
-/// `(item_id, hq, world_id, sold_date, buying_character_id)` makes dual-writes
-/// idempotent — replaying the event bus or re-running backfill against an
-/// already-populated partition is a no-op on merge.
+/// Engine: `ReplacingMergeTree(inserted_at)` on the key
+/// `(item_id, hq, world_id, sold_date, pg_id)` makes dual-writes idempotent —
+/// replaying the event bus or re-running backfill against an already-populated
+/// partition is a no-op on merge.
+///
+/// `pg_id` (the Postgres `sale_history.id`) is the discriminator that keeps two
+/// distinct same-second sales of the same item/hq/world apart, and it's what
+/// lets the live dual-write and the backfill agree on a row identity. Both
+/// paths must therefore supply the *real* Postgres id — a placeholder `0`
+/// silently merges distinct sales together and makes the backfill write a
+/// second, never-merging copy of every row the live path already inserted.
+/// `buying_character_id` is deliberately *not* in the key: it's a payload
+/// column only.
 ///
 /// Partitioning by month keeps retention / drop operations cheap and aligns
 /// with the backfill chunk size.

--- a/ultros-db/src/sales.rs
+++ b/ultros-db/src/sales.rs
@@ -21,7 +21,7 @@ use migration::{
 use sea_orm::{
     ActiveModelTrait, ActiveValue, DbBackend, FromQueryResult, QueryOrder, QuerySelect, Statement,
 };
-use tracing::instrument;
+use tracing::{instrument, warn};
 use ultros_api_types::{SaleHistory, UnknownCharacter};
 use universalis::{ItemId, SaleView, WorldId};
 
@@ -81,8 +81,14 @@ impl UltrosDb {
         if sales.is_empty() {
             return Ok(vec![]);
         }
-        let mut recorded_sales = vec![];
-        let _ = Entity::insert_many(sales.into_iter().map(|sale| {
+        // Insert with RETURNING so the rows we hand back carry their real
+        // Postgres ids. The ClickHouse dual-write uses `sale_history.id` as the
+        // discriminator in the `sales` ORDER BY key, so returning `id: 0` here
+        // would (a) collapse distinct same-second sales of the same
+        // item/hq/world into one ClickHouse row and (b) make the backfill --
+        // which reads real ids straight out of Postgres -- write a *second*,
+        // never-merging copy of every sale the live path already wrote.
+        let inserted = Entity::insert_many(sales.into_iter().map(|sale| {
             let buyer = buyers
                 .get(&sale.buyer_name)
                 .expect("Should always have a buyer model");
@@ -92,21 +98,6 @@ impl UltrosDb {
                 quantity,
                 ..
             } = sale;
-            let record: SaleHistory = SaleHistoryReturn(
-                Model {
-                    id: 0,
-                    quantity,
-                    price_per_item: price_per_unit,
-                    buying_character_id: buyer.id,
-                    hq,
-                    sold_item_id: item_id.0,
-                    sold_date: sale.timestamp.naive_utc(),
-                    world_id: world_id.0,
-                },
-                Some(buyer.clone()),
-            )
-            .into();
-            recorded_sales.push((record, buyer.into()));
             ActiveModel {
                 id: Default::default(),
                 quantity: Set(quantity),
@@ -118,9 +109,10 @@ impl UltrosDb {
                 world_id: Set(world_id.0),
             }
         }))
-        .exec_without_returning(&self.db)
+        .exec_with_returning(&self.db)
         .await?;
-        Ok(recorded_sales)
+        let buyers_by_id: HashMap<i32, _> = buyers.into_values().map(|b| (b.id, b)).collect();
+        Ok(attach_buyers(inserted, &buyers_by_id))
     }
 
     pub async fn get_sale_history_from_multiple_worlds(
@@ -283,6 +275,38 @@ impl UltrosDb {
     }
 }
 
+/// Pair freshly inserted `sale_history` rows back up with their buyers to form
+/// the event payload.
+///
+/// The rows come straight out of `INSERT ... RETURNING`, so `model.id` is the
+/// real Postgres id — that id is what the ClickHouse dual-write puts in
+/// `SaleRow::pg_id`, and it is the discriminator in the `sales` ORDER BY key.
+/// Anything that loses it here silently corrupts ClickHouse dedup.
+///
+/// Postgres doesn't promise RETURNING row order matches the VALUES order, so
+/// buyers are re-attached by id rather than zipped positionally.
+fn attach_buyers(
+    inserted: Vec<sale_history::Model>,
+    buyers_by_id: &HashMap<i32, unknown_final_fantasy_character::Model>,
+) -> Vec<(SaleHistory, UnknownCharacter)> {
+    inserted
+        .into_iter()
+        .filter_map(|model| {
+            let Some(buyer) = buyers_by_id.get(&model.buying_character_id) else {
+                // Unreachable: every id here came from a buyer we just looked
+                // up or created. Skip rather than panic on the ingest path.
+                warn!(
+                    buying_character_id = model.buying_character_id,
+                    "recorded sale references an unknown buyer; dropping from event payload"
+                );
+                return None;
+            };
+            let record: SaleHistory = SaleHistoryReturn(model, Some(buyer.clone())).into();
+            Some((record, buyer.into()))
+        })
+        .collect()
+}
+
 #[derive(Debug, FromQueryResult)]
 pub struct AbbreviatedSaleData {
     pub sold_item_id: i32,
@@ -290,4 +314,86 @@ pub struct AbbreviatedSaleData {
     pub price_per_item: i32,
     pub sold_date: NaiveDateTime,
     pub world_id: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn buyer(id: i32, name: &str) -> unknown_final_fantasy_character::Model {
+        unknown_final_fantasy_character::Model {
+            id,
+            name: name.to_string(),
+        }
+    }
+
+    fn inserted_row(id: i32, buyer_id: i32, second: u32) -> sale_history::Model {
+        sale_history::Model {
+            id,
+            quantity: 1,
+            price_per_item: 1000,
+            buying_character_id: buyer_id,
+            hq: false,
+            sold_item_id: 5,
+            sold_date: NaiveDate::from_ymd_opt(2026, 5, 15)
+                .unwrap()
+                .and_hms_opt(12, 0, second)
+                .unwrap(),
+            world_id: 40,
+        }
+    }
+
+    #[test]
+    fn attach_buyers_preserves_the_postgres_ids() {
+        // Regression guard: this used to hand back `id: 0` for every sale,
+        // which made the ClickHouse `sales` ORDER BY key non-unique.
+        let buyers = HashMap::from([(7, buyer(7, "Buyer One"))]);
+        let rows = vec![inserted_row(101, 7, 0), inserted_row(102, 7, 1)];
+
+        let attached = attach_buyers(rows, &buyers);
+
+        let ids: Vec<i32> = attached.iter().map(|(sale, _)| sale.id).collect();
+        assert_eq!(ids, vec![101, 102]);
+        assert!(ids.iter().all(|id| *id != 0));
+    }
+
+    #[test]
+    fn attach_buyers_keeps_same_second_sales_distinct() {
+        // Two sales of the same item/hq/world in the same second: `id` is the
+        // only thing telling them apart, both in PG and in the CH sort key.
+        let buyers = HashMap::from([(7, buyer(7, "Buyer One"))]);
+        let rows = vec![inserted_row(101, 7, 30), inserted_row(102, 7, 30)];
+
+        let attached = attach_buyers(rows, &buyers);
+
+        assert_eq!(attached.len(), 2);
+        assert_ne!(attached[0].0.id, attached[1].0.id);
+        assert_eq!(attached[0].0.sold_date, attached[1].0.sold_date);
+    }
+
+    #[test]
+    fn attach_buyers_matches_by_id_not_position() {
+        // RETURNING order isn't guaranteed to match the VALUES order.
+        let buyers = HashMap::from([(7, buyer(7, "Buyer One")), (9, buyer(9, "Buyer Two"))]);
+        let rows = vec![inserted_row(101, 9, 0), inserted_row(102, 7, 1)];
+
+        let attached = attach_buyers(rows, &buyers);
+
+        assert_eq!(attached[0].0.buyer_name.as_deref(), Some("Buyer Two"));
+        assert_eq!(attached[1].0.buyer_name.as_deref(), Some("Buyer One"));
+        assert_eq!(attached[0].1.name, "Buyer Two");
+        assert_eq!(attached[1].1.name, "Buyer One");
+    }
+
+    #[test]
+    fn attach_buyers_drops_rows_with_no_known_buyer() {
+        let buyers = HashMap::from([(7, buyer(7, "Buyer One"))]);
+        let rows = vec![inserted_row(101, 7, 0), inserted_row(102, 999, 1)];
+
+        let attached = attach_buyers(rows, &buyers);
+
+        assert_eq!(attached.len(), 1);
+        assert_eq!(attached[0].0.id, 101);
+    }
 }


### PR DESCRIPTION
## Problem

The live sale-ingest path wrote every ClickHouse row with `pg_id = 0`, which breaks
`sales` dedup in both directions.

`update_sales` / `insert_unrecorded_sales` (`ultros-db/src/sales.rs`) built its return
values from a hand-rolled `Model { id: 0, .. }` and then inserted with
`.exec_without_returning()`, so the real Postgres ids never came back. Those return
values are exactly what both live producers (`ultros/src/main.rs` websocket handler and
`ultros/src/item_update_service.rs` catch-up) publish on the sale event bus, and what the
analyzer's dual-write feeds to `SaleRow::from_api_sale` — which sets `pg_id: s.id`.

`sales` is `ReplacingMergeTree(inserted_at) ORDER BY (item_id, hq, world_id, sold_date, pg_id)`,
so `pg_id` is the only discriminator between two sales of the same item/hq/world in the
same second. Consequences:

- **(a) Live path loses sales.** Two distinct same-second sales of the same
  `(item, hq, world)` share the whole sort key when `pg_id` is constant `0`, and collapse
  to one row on merge.
- **(b) Backfill double-counts.** `backfill.rs` goes through `SaleRow::from_db_model`,
  which carries the *real* `sale_history.id`. Same logical sale, different sort key →
  ReplacingMergeTree never merges the two, so every sale the live path already wrote gets
  a second copy.

Every rollup reads `FROM sales FINAL` (`item_stats_window`, `sales_hourly`,
`world_kpi_5min`, and `item_quality_score` derived from the first), so all of them inherit
both errors.

## Changes

1. **`ultros-db/src/sales.rs`** — `insert_unrecorded_sales` now uses
   `InsertMany::exec_with_returning` (SeaORM 2.0; Postgres supports `INSERT ... RETURNING`)
   and builds the returned `SaleHistory` values from the rows Postgres actually inserted.
   Buyers are re-attached by `buying_character_id` via a new `attach_buyers` helper rather
   than zipped positionally, because Postgres does not promise RETURNING row order matches
   the VALUES order.
2. **Analyzer path confirmed end-to-end.** Both producers of `SaleEventData`
   (`main.rs:157`, `item_update_service.rs:216`) forward the `update_sales` return value
   unchanged, and `analyzer_service.rs:629` calls `SaleRow::from_api_sale` on each element,
   so real ids now reach `pg_id`. No changes needed there.
3. **Comment fixes.** `schema.rs`, `backfill.rs`, and the `SaleRow::pg_id` doc all claimed
   the idempotency key included `buying_character_id`, which is not in the `ORDER BY`. They
   now describe the actual key and spell out why a placeholder `pg_id` is corrupting.
4. **Tests** — see below.

No schema changes (ClickHouse is Tier 1).

## Tests

`cargo test -p ultros-db -p ultros-clickhouse --lib`

- `ultros-db`: `attach_buyers_preserves_the_postgres_ids` (direct regression guard for the
  old `id: 0`), `attach_buyers_keeps_same_second_sales_distinct`,
  `attach_buyers_matches_by_id_not_position`, `attach_buyers_drops_rows_with_no_known_buyer`.
- `ultros-clickhouse`: `freshly_recorded_sale_carries_a_nonzero_pg_id` — runs a recorded
  `sale_history::Model` through the real dual-write conversion chain
  (`SaleHistoryReturn` → `SaleHistory` → `SaleRow::from_api_sale`) and asserts a nonzero,
  correct `pg_id`; plus `live_and_backfill_paths_agree_on_pg_id`, which asserts
  `from_api_sale` and `from_db_model` produce an identical sort key for the same PG row.

**Not covered:** no Postgres was available in this environment, so `exec_with_returning`
itself was not exercised against a live database. Worth one manual smoke run against dev
before the remediation below (`clickhouse_parity_check` is the fastest check — see step 5).

## Remediation plan for existing data — DO NOT RUN AGAINST PROD WITHOUT THE OWNER

**This fix must land and be deployed before the planned full one-shot backfill.** The prod
backfill has so far covered only ~7% of items; running the complete one against the current
data would double-count every sale the live path has already written this month.

Existing prod `sales` contains two kinds of damage:

- `pg_id = 0` rows written by the live path — some fraction of them silently merged, so the
  rows are both mislabelled *and* undercounted. They cannot be repaired in place; they have
  to be deleted and re-derived from Postgres.
- For any `(world, month)` the backfill already covered, a duplicate real-`pg_id` copy of
  the same sales. Deleting the `pg_id = 0` rows resolves this: the surviving real-id rows
  are the correct ones.

### Steps

1. **Snapshot the blast radius** (read-only; run first, keep the output):
   ```sql
   SELECT toYYYYMM(sold_date) AS ym, world_id, count() AS bad_rows
   FROM sales WHERE pg_id = 0
   GROUP BY ym, world_id ORDER BY ym, world_id;
   ```
   The `(world_id, ym)` tuples this returns are exactly the chunks that need re-backfilling
   in step 3.

2. **Delete the placeholder rows.** `ALTER TABLE ... DELETE` is a mutation — schedule it
   off-peak and let it finish before step 3:
   ```sql
   ALTER TABLE sales DELETE WHERE pg_id = 0;
   ```
   Watch it with `SELECT * FROM system.mutations WHERE table = 'sales' AND NOT is_done`.
   (`DELETE FROM sales WHERE pg_id = 0` — lightweight delete — is an option if the volume
   is large, but the mutation is simpler to reason about and the row count here should be
   modest.)

3. **Clear `_backfill_state` for the affected chunks** so `backfill_sales` will rewrite them
   instead of skipping. `_backfill_state` is `ReplacingMergeTree(completed_at)`, so a delete
   is required — inserting a "not done" marker is not expressive in that schema:
   ```sql
   ALTER TABLE _backfill_state DELETE
   WHERE (world_id, year_month) IN (
     -- the tuples from step 1
     (40, 202607), ...
   );
   ```
   If the affected set turns out to be "everything", `TRUNCATE TABLE _backfill_state` is
   equivalent and cheaper. Verify with
   `SELECT count() FROM _backfill_state FINAL WHERE ...` before moving on.

4. **Re-run the backfill** for the cleared range. This is the same run the owner already
   planned, now safe:
   ```bash
   cargo run --release --bin clickhouse_backfill 2022
   ```
   Chunks outside the cleared set are skipped, so the incremental cost is bounded by the
   damage found in step 1.

5. **Verify parity** before touching rollups:
   ```bash
   cargo run --release --bin clickhouse_parity_check
   ```
   Exits nonzero on mismatch. Any remaining `(world, ym)` mismatch means a chunk was missed
   in step 3.

6. **Rebuild the rollups.** They all read `FROM sales FINAL`, so they self-heal once `sales`
   is correct — but only over their trailing windows (`world_kpi_5min` 50h, `sales_hourly`
   30h, `item_stats_window` 1/7/30/90d). Historical buckets outside those windows are
   immutable and keep the bad numbers until explicitly recomputed. Either accept that for
   pre-window history, or truncate and rebuild:
   ```sql
   TRUNCATE TABLE item_stats_window;
   TRUNCATE TABLE item_quality_score;
   TRUNCATE TABLE sales_hourly;
   TRUNCATE TABLE world_kpi_5min;
   ```
   then a `rollups::refresh_all` (a web-server restart does the seed run) — noting that this
   only repopulates the trailing windows, so `sales_hourly` / `world_kpi_5min` history older
   than 30h/50h would need a widened one-off backfill query if the owner wants it restored.
   Recommendation: **don't truncate `sales_hourly` / `world_kpi_5min`** unless the owner
   wants to write that one-off; the bad history is bounded and the trailing windows correct
   themselves within a refresh cycle. `item_stats_window` and `item_quality_score` are fully
   recomputed from `sales` on every refresh, so those two are safe to truncate.

### Ordering constraint

Steps 2–4 must happen **after** this PR is deployed. If the live path is still writing
`pg_id = 0` while the backfill runs, the cleanup re-creates the exact problem it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
