### PR TITLE
fix(item): emit real SSR values for canonical link and icon alt text

### DIFF
--- a/check_ci.sh
+++ b/check_ci.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -e
 
+# prop:href/alt/src/content sets a DOM property after wasm hydration and is a
+# no-op during SSR (tachys renders nothing for it), so crawlers/social
+# unfurlers never see the value. Use the plain attribute (reactive closures
+# work fine on regular attributes) instead of prop:.
+if grep -rEn "prop:(href|alt|src|content)=" ultros-frontend/ultros-app/src/; then
+    echo "error: found prop:href/alt/src/content in ultros-app/src -- these are SSR no-ops, see above" >&2
+    exit 1
+fi
+
 # Run cargo fmt check
 cargo fmt --all -- --check
 

--- a/ultros-frontend/ultros-app/src/components/item_icon.rs
+++ b/ultros-frontend/ultros-app/src/components/item_icon.rs
@@ -38,7 +38,7 @@ pub fn ItemIcon(
             style:height=icon_size.get_size_px()
         >
             <img
-                prop:alt=item_name
+                alt=item_name
                 class=format!("{} max-w-full max-h-full object-contain", icon_size.get_class())
                 src=move || {
                     if !failed_item() && valid_search_category.get() {

--- a/ultros-frontend/ultros-app/src/components/meta.rs
+++ b/ultros-frontend/ultros-app/src/components/meta.rs
@@ -41,7 +41,14 @@ pub fn MetaRobotsNoIndex() -> impl IntoView {
 /// Sets a canonical URL for the current page. Use on routes that may be
 /// reachable via multiple URLs (e.g. /item/{world}/{id} and /item/{id})
 /// or that accept query params that don't change page content.
+///
+/// `href` is a `TextProp` rather than a plain string because
+/// `leptos_meta::Link`'s own `href` prop only accepts a static
+/// `Oco<'static, str>` (no reactive closure support). Wrapping the `<Link>`
+/// in a reactive block here means a `move || ...` closure passed as `href`
+/// re-registers the tag (with the new value) whenever its dependencies
+/// change, instead of only ever emitting the value captured at first render.
 #[component]
-pub fn MetaCanonical(href: &'static str) -> impl IntoView {
-    view! { <Link rel="canonical" href=href /> }
+pub fn MetaCanonical(#[prop(into)] href: TextProp) -> impl IntoView {
+    view! { {move || view! { <Link rel="canonical" href=href.get() /> }} }
 }

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -22,7 +22,7 @@ use crate::i18n::{t, t_string};
 use crate::routes::item_view_scope::item_href;
 use crate::ws::realtime::{RealtimeSubscription, use_realtime};
 use leptos::prelude::*;
-use leptos_meta::{Link, Meta};
+use leptos_meta::Meta;
 use leptos_router::components::A;
 use leptos_router::hooks::{use_params_map, use_query_map};
 use leptos_router::location::Url;
@@ -1761,7 +1761,7 @@ pub fn ItemView() -> impl IntoView {
             property="thumbnail"
             content=move || format!("https://ultros.app/static/itemicon/{}?size=Large", item_id())
         />
-        <Link rel="canonical" prop:href=move || format!("https://ultros.app/item/{}", item_id()) />
+        <MetaCanonical href=move || format!("https://ultros.app/item/{}", item_id()) />
         <div class="min-h-screen">
             <div class="w-full px-0 sm:px-4 pt-4 sm:pt-5 pb-3">
                 <div class="flex flex-col gap-4 p-3 sm:p-4 border-b border-[color:var(--color-outline)] pb-6">


### PR DESCRIPTION
## Summary

Two SEO/accessibility-critical attributes were bound with Leptos `prop:`, which sets a DOM property after wasm hydration and is a no-op during SSR (tachys renders nothing for it). Crawlers and social unfurlers never saw them. Confirmed live: item pages served `<link rel="canonical">` with **no href**.

- **`ultros-frontend/ultros-app/src/components/item_icon.rs`**: `prop:alt` → `alt`. This means every item icon site-wide now ships with `alt` text in the server-rendered HTML (accessibility + image SEO — the sitemap explicitly submits these icons as images). A plain reactive attribute works fine during SSR, so this was a one-line fix.

- **`ultros-frontend/ultros-app/src/routes/item_view.rs`**: replaced `<Link rel="canonical" prop:href=...>` with `<MetaCanonical href=...>`. `leptos_meta::Link`'s own `href` prop only accepts a static `Oco<'static, str>` (verified against the leptos_meta 0.8.6 source — only `Title` and `Meta` have built-in reactive plumbing; `Link` doesn't), which is presumably why `prop:href` was used as a workaround in the first place. `MetaCanonical` (in `components/meta.rs`) is widened to accept a reactive `TextProp` and wraps the `<Link>` call in a `move ||` block, so the tag re-registers with the new value whenever its dependency changes.

  This reactivity matters: I confirmed `ItemView` does **not** remount when navigating between items via related-item links (same `<Route>` definition, `item_id` updates through a `Memo` in place). A canonical href computed once at initial render would go stale in the live DOM after client-side navigation between items, even though each fresh SSR request would still be correct.

- **`check_ci.sh`**: added a grep guard that fails the build if `prop:(href|alt|src|content)` reappears in `ultros-app/src/`, since this is a silent SSR no-op rather than a compile error and wouldn't otherwise be caught by clippy.

## Test plan

- [x] `./check_ci.sh` (fmt + clippy --all-targets, full workspace) passes clean
- [x] `cargo check --lib` on `ultros-app` passes clean
- [x] Confirmed via grep these were the only two `prop:href/alt/src/content` instances in `ultros-app/src/`
- [ ] Live `curl localhost:8080/item/...` SSR verification — not possible in the sandbox this PR was authored in (no Postgres/docker/cargo-leptos, no sudo to install them); please double check the rendered `<link rel="canonical">` and item `<img alt="...">` on a running instance before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)