### PR TITLE
feat(ingest): instrument and harden the five silent market-data failure modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10302,6 +10302,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "metrics",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/docs/ingest-observability.md
+++ b/docs/ingest-observability.md
@@ -1,0 +1,68 @@
+# Ingest observability
+
+Market-data ingest fails silently by default. The app keeps serving, requests
+keep returning 200, and the numbers simply stop moving — serving stale data is
+not an error, so nothing in the request path can notice. These metrics exist to
+turn each of those silent modes into something alertable. They are exported on
+the Prometheus endpoint at `:9091/metrics` (see `ultros/src/web_metrics.rs`).
+
+## Metrics
+
+| Metric | Type | Labels | What it means |
+| --- | --- | --- | --- |
+| `ultros_world_ingest_staleness_seconds` | gauge | `world` | Seconds since the newest `listing_last_updated` row for that world. The single best "is ingest alive" signal. |
+| `ultros_worlds_never_ingested` | gauge | — | Worlds in `WorldCache` with no `listing_last_updated` rows at all. |
+| `ultros_analyzer_bus_lagged_total` | counter | `bus` | Events the analyzer's broadcast receiver was too slow to read, and the channel discarded. Nonzero means the in-RAM caches and ClickHouse have drifted from Postgres. |
+| `ultros_analyzer_skipped_events_total` | counter | `op`, `reason` | Listing/sale events dropped because a world, datacenter or region was missing from the analyzer's maps. |
+| `ultros_analyzer_snapshot_rejected_total` | counter | `reason` | Startup snapshots refused (`too_old`, `unparseable_name`), causing a fall back to the Postgres reload. |
+| `ultros_analyzer_snapshot_age_seconds` | gauge | — | Age of the snapshot this process booted from. Set once at startup. |
+| `universalis_websocket_liveness_timeouts_total` | counter | — | Websocket connections torn down for delivering no frames within the liveness deadline. |
+
+Pre-existing and still useful alongside these:
+`ultros_websocket_rx{WorldId}`, `ultros_catchup_items_recovered{world}`,
+`ultros_catchup_window_saturated{world}`.
+
+## Suggested alerts
+
+`ultros_world_ingest_staleness_seconds` is the one to page on. Everything else
+explains *why* it went up.
+
+- **A world went silent** — `max_over_time(ultros_world_ingest_staleness_seconds[15m]) > 3600`.
+  Quiet worlds do go an hour without a listing change; a whole datacenter going
+  quiet at once does not.
+- **Every world went silent** — the same expression firing across most series at
+  once points at the websocket or the process, not the market. Correlate with
+  `universalis_websocket_liveness_timeouts_total`.
+- **Silent data loss** — `increase(ultros_analyzer_bus_lagged_total[1h]) > 0` or
+  `increase(ultros_analyzer_skipped_events_total[1h]) > 0`. Neither should ever
+  be nonzero in steady state. Sustained `bus_lagged` means the ring sizes in
+  `ultros/src/event.rs` need revisiting; sustained `skipped_events` with
+  `reason="unknown_world"` means `WorldCache` is missing a world (see below).
+- **Booted on stale data** — `increase(ultros_analyzer_snapshot_rejected_total{reason="too_old"}[1h]) > 0`
+  is informational: the guard did its job, but the process was down long enough
+  to matter.
+
+## Known gap: `WorldCache` never refreshes
+
+`WorldCache` is built exactly once, in `main.rs`, and on a cold database that
+build races the task that populates the world table. A world it misses is absent
+from the analyzer's maps for the lifetime of the process, and every event for
+that world is dropped — visible as
+`ultros_analyzer_skipped_events_total{reason="unknown_world"}` climbing steadily.
+
+Until a refresh path exists, the fix is a restart once the world table is
+populated. Before this change these lookups panicked instead, which killed live
+sale ingestion and the ClickHouse dual-write outright while the process kept
+serving.
+
+## Tuning
+
+| Env var | Default | Effect |
+| --- | --- | --- |
+| `UNIVERSALIS_WEBSOCKET_LIVENESS_TIMEOUT_SECS` | `150` | Silence tolerated on the Universalis websocket before reconnecting. 2.5× the 60s ping interval. |
+| `UNIVERSALIS_WEBSOCKET_COOLDOWN_SECS` | `2` | Wait between reconnect attempts. |
+
+Compile-time constants worth knowing about, all documented at their definitions:
+`LISTINGS_BUS_SIZE` / `HISTORY_BUS_SIZE` (`ultros/src/event.rs`),
+`MAX_SNAPSHOT_AGE` (`ultros/src/analyzer_service.rs`), and `REFRESH_INTERVAL`
+(`ultros/src/ingest_health.rs`).

--- a/docs/ingest-observability.md
+++ b/docs/ingest-observability.md
@@ -12,11 +12,11 @@ the Prometheus endpoint at `:9091/metrics` (see `ultros/src/web_metrics.rs`).
 | --- | --- | --- | --- |
 | `ultros_world_ingest_staleness_seconds` | gauge | `world` | Seconds since the newest `listing_last_updated` row for that world. The single best "is ingest alive" signal. |
 | `ultros_worlds_never_ingested` | gauge | — | Worlds in `WorldCache` with no `listing_last_updated` rows at all. |
-| `ultros_analyzer_bus_lagged_total` | counter | `bus` | Events the analyzer's broadcast receiver was too slow to read, and the channel discarded. Nonzero means the in-RAM caches and ClickHouse have drifted from Postgres. |
+| `ultros_analyzer_bus_lagged_total` | counter | `bus` | Events the analyzer's broadcast receiver was too slow to read, and the channel discarded. Nonzero means the in-RAM caches and ClickHouse have drifted from Postgres. **Analyzer-only**: the other bus consumers (the discord alert loops and the `/alerts/websocket` fan-out) still swallow lag silently, so this counter is a floor, not the whole picture. |
 | `ultros_analyzer_skipped_events_total` | counter | `op`, `reason` | Listing/sale events dropped because a world, datacenter or region was missing from the analyzer's maps. |
-| `ultros_analyzer_snapshot_rejected_total` | counter | `reason` | Startup snapshots refused (`too_old`, `unparseable_name`), causing a fall back to the Postgres reload. |
-| `ultros_analyzer_snapshot_age_seconds` | gauge | — | Age of the snapshot this process booted from. Set once at startup. |
-| `universalis_websocket_liveness_timeouts_total` | counter | — | Websocket connections torn down for delivering no frames within the liveness deadline. |
+| `ultros_analyzer_snapshot_rejected_total` | counter | `reason` | Startup snapshots refused (`too_old`, `unparseable_name`, `future_dated`), causing a fall back to the Postgres reload. |
+| `ultros_analyzer_snapshot_age_seconds` | gauge | — | Age of the snapshot this process booted from. Set exactly once, at startup, and only when a snapshot restore succeeded — it does not tick upward afterwards, and a process that reloaded from Postgres has no sample at all. |
+| `ultros_websocket_liveness_timeouts_total` | counter | — | Websocket connections torn down for delivering no frames within the liveness deadline. |
 
 Pre-existing and still useful alongside these:
 `ultros_websocket_rx{WorldId}`, `ultros_catchup_items_recovered{world}`,
@@ -32,7 +32,7 @@ explains *why* it went up.
   quiet at once does not.
 - **Every world went silent** — the same expression firing across most series at
   once points at the websocket or the process, not the market. Correlate with
-  `universalis_websocket_liveness_timeouts_total`.
+  `ultros_websocket_liveness_timeouts_total`.
 - **Silent data loss** — `increase(ultros_analyzer_bus_lagged_total[1h]) > 0` or
   `increase(ultros_analyzer_skipped_events_total[1h]) > 0`. Neither should ever
   be nonzero in steady state. Sustained `bus_lagged` means the ring sizes in

--- a/ultros-db/src/recently_updated.rs
+++ b/ultros-db/src/recently_updated.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{NaiveDateTime, Utc};
 use sea_orm::{
     ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect,
     sea_query::OnConflict,
@@ -30,6 +30,23 @@ impl UltrosDb {
             .exec(&self.db)
             .await?;
         Ok(())
+    }
+
+    /// Newest `listing_last_updated` row per world, i.e. the last time anything
+    /// at all was ingested for that world.
+    ///
+    /// Worlds we have never ingested for are simply absent from the result.
+    pub async fn get_last_ingest_per_world(
+        &self,
+    ) -> Result<Vec<(i32, NaiveDateTime)>, anyhow::Error> {
+        Ok(listing_last_updated::Entity::find()
+            .select_only()
+            .column(listing_last_updated::Column::WorldId)
+            .column_as(listing_last_updated::Column::DateTime.max(), "last_ingest")
+            .group_by(listing_last_updated::Column::WorldId)
+            .into_tuple::<(i32, NaiveDateTime)>()
+            .all(&self.db)
+            .await?)
     }
 
     pub async fn get_recently_updated_listings_for_world(

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use poise::serenity_prelude::Timestamp;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
-use tracing::log::{error, info};
+use tracing::{error, info, warn};
 use ultros_api_types::{ActiveListing, Retainer, websocket::ListingEventData};
 use ultros_db::{
     UltrosDb,
@@ -26,7 +26,7 @@ use ultros_db::{
 };
 use universalis::{ItemId, WorldId};
 
-use crate::event::EventReceivers;
+use crate::event::{EventReceivers, handle_bus_recv};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -291,12 +291,19 @@ impl CheapestListings {
                 // only remove a listing if we see a lower price
                 if listing.price_per_unit <= entry.get().price {
                     entry.remove();
-                    let worlds = world_cache
+                    let Some(worlds) = world_cache
                         .lookup_selector(&id)
                         .map(|r| world_cache.get_all_worlds_in(&r))
                         .ok()
                         .flatten()
-                        .expect("Should have worlds");
+                    else {
+                        // Same outcome as the DB query below failing: the entry
+                        // stays removed and the next listing event for this item
+                        // refills it.
+                        warn!(selector = ?id, "no worlds for selector, skipping cheapest-listing refill");
+                        skipped_event("remove_listing", "unknown_selector");
+                        return;
+                    };
                     if let Ok(listings) = ultros_db
                         .get_multiple_listings_for_worlds_hq_sensitive(
                             worlds.iter().map(|w| WorldId(*w)),
@@ -331,6 +338,58 @@ fn calculate_valuation(median_price: i32, current_listing_price: Option<i32>) ->
         Some(price) => std::cmp::min(std::cmp::max(1, price - 1), median_price),
         None => (median_price as f32 * 1.2) as i32,
     }
+}
+
+/// Oldest snapshot we're willing to boot from instead of reloading Postgres.
+///
+/// Restoring a snapshot skips the database load entirely (see `run_worker`), so
+/// whatever prices it holds become "live" the moment `initiated` flips — with no
+/// visible symptom, because the analyzer answers normally, just with old
+/// numbers. Snapshots are written every 15 minutes and on shutdown, so any gap
+/// past a couple of hours means the process was down and the market has moved on.
+///
+/// Three hours keeps a fast restart cheap (the common case: a deploy, a crash
+/// loop, an OOM restart — all far under an hour) while capping how wrong the
+/// served data can be. The fallback costs a full `cheapest_listings` +
+/// `last_n_sales` stream, which is slow but correct.
+const MAX_SNAPSHOT_AGE: Duration = Duration::hours(3);
+
+/// Age of a snapshot from its filename, which `serialize_state` writes as
+/// `snapshot-<unix seconds>.bin.gz`.
+///
+/// `None` means the name didn't match — callers treat that as "unknown age",
+/// which is not the same as "fresh".
+fn snapshot_age(file_name: &str, now: chrono::DateTime<Utc>) -> Option<Duration> {
+    let timestamp: i64 = file_name
+        .strip_prefix("snapshot-")?
+        .split('.')
+        .next()?
+        .parse()
+        .ok()?;
+    Some(now - chrono::DateTime::from_timestamp(timestamp, 0)?)
+}
+
+/// Counts an event the analyzer had to drop, so a lookup miss shows up on
+/// `/metrics` instead of only in the logs.
+///
+/// Every `cheapest_items` / `recent_sale_history` key is materialised once at
+/// startup from `WorldCache`, which is itself built exactly once in `main` — and
+/// on a cold database that build races the task that populates the world table
+/// (see the comment above `WorldCache::new` in `main.rs`). A world the cache
+/// missed is therefore absent from these maps *for the lifetime of the process*.
+///
+/// These lookups used to `.expect()`. In the history loop that is fatal in the
+/// worst possible way: the panic unwinds the spawned task, so live sale ingestion
+/// and the ClickHouse dual-write both stop for good while axum keeps serving
+/// requests from a frozen cache — the process looks perfectly healthy. Dropping
+/// one event costs one sale; panicking costs every sale from then on.
+fn skipped_event(op: &'static str, reason: &'static str) {
+    metrics::counter!(
+        "ultros_analyzer_skipped_events_total",
+        "op" => op,
+        "reason" => reason,
+    )
+    .increment(1);
 }
 
 /// Build a short list of all the items in the game that we think would sell well.
@@ -488,6 +547,11 @@ impl AnalyzerService {
     }
 
     async fn try_restore_from_snapshot(&self) -> bool {
+        self.try_restore_from_snapshot_at(Utc::now()).await
+    }
+
+    /// `now` is injected so the age check can be tested without sleeping.
+    async fn try_restore_from_snapshot_at(&self, now: chrono::DateTime<Utc>) -> bool {
         let mut dir = match fs::read_dir("analyzer-data").await {
             Ok(dir) => dir,
             Err(_) => return false,
@@ -499,6 +563,37 @@ impl AnalyzerService {
         entries.sort_by_key(|x| x.file_name());
         for entry in entries.iter().rev() {
             let path = entry.path();
+
+            // Filenames are `snapshot-<unix seconds>.bin.gz`, so age comes
+            // straight off the name — no stat, and no chance of a file copy
+            // resetting mtime and making a stale snapshot look fresh.
+            let file_name = entry.file_name();
+            let age = match snapshot_age(&file_name.to_string_lossy(), now) {
+                Some(age) => age,
+                None => {
+                    warn!(
+                        ?path,
+                        "snapshot filename has no parseable timestamp, ignoring"
+                    );
+                    metrics::counter!("ultros_analyzer_snapshot_rejected_total", "reason" => "unparseable_name").increment(1);
+                    continue;
+                }
+            };
+            if age > MAX_SNAPSHOT_AGE {
+                // Entries are sorted by name, i.e. by timestamp, and we walk them
+                // newest-first — so everything left is older still.
+                warn!(
+                    ?path,
+                    age_hours = age.num_hours(),
+                    max_age_hours = MAX_SNAPSHOT_AGE.num_hours(),
+                    "newest analyzer snapshot is too old to serve as live data, \
+                     falling back to a full database load"
+                );
+                metrics::counter!("ultros_analyzer_snapshot_rejected_total", "reason" => "too_old")
+                    .increment(1);
+                return false;
+            }
+
             let file = match fs::read(&path).await {
                 Ok(f) => f,
                 Err(e) => {
@@ -538,6 +633,12 @@ impl AnalyzerService {
                     *write = value;
                 }
             }
+            info!(
+                ?path,
+                age_seconds = age.num_seconds(),
+                "restored analyzer snapshot"
+            );
+            metrics::gauge!("ultros_analyzer_snapshot_age_seconds").set(age.num_seconds() as f64);
             return true;
         }
         false
@@ -563,24 +664,34 @@ impl AnalyzerService {
                 Ok(mut listings) => {
                     let writer = &self.cheapest_items;
                     while let Some(Ok(value)) = listings.next().await {
-                        let world = world_cache
-                            .lookup_selector(&AnySelector::World(value.world_id))
-                            .unwrap();
-                        let region = world_cache.get_region(&world).unwrap();
-                        let datacenters = world_cache.get_datacenters(&world).unwrap();
-                        let region_listings = writer
-                            .get(&AnySelector::Region(region.id))
-                            .expect("Region not found");
+                        // The database can hold listings for worlds this process'
+                        // `WorldCache` never saw. Panicking here aborts the whole
+                        // worker before `initiated` is ever set, so the analyzer
+                        // both serves nothing and ingests nothing — forever.
+                        let Ok(world) =
+                            world_cache.lookup_selector(&AnySelector::World(value.world_id))
+                        else {
+                            skipped_event("db_reload_listing", "unknown_world");
+                            continue;
+                        };
+                        let Some(region) = world_cache.get_region(&world) else {
+                            skipped_event("db_reload_listing", "unknown_region");
+                            continue;
+                        };
+                        let datacenters = world_cache.get_datacenters(&world).unwrap_or_default();
+                        let (Some(region_listings), Some(world_listings)) = (
+                            writer.get(&AnySelector::Region(region.id)),
+                            writer.get(&AnySelector::World(value.world_id)),
+                        ) else {
+                            skipped_event("db_reload_listing", "unknown_selector");
+                            continue;
+                        };
                         region_listings.write().await.add_listing(&value);
                         for dc in datacenters {
-                            let dc_listings = writer
-                                .get(&AnySelector::Datacenter(dc.id))
-                                .expect("Datacenter not found");
-                            dc_listings.write().await.add_listing(&value);
+                            if let Some(dc_listings) = writer.get(&AnySelector::Datacenter(dc.id)) {
+                                dc_listings.write().await.add_listing(&value);
+                            }
                         }
-                        let world_listings = writer
-                            .get(&AnySelector::World(value.world_id))
-                            .expect("Unable to get world");
                         world_listings.write().await.add_listing(&value);
                     }
                 }
@@ -592,10 +703,10 @@ impl AnalyzerService {
             match sale_data {
                 Ok(mut history_stream) => {
                     while let Some(Ok(value)) = history_stream.next().await {
-                        let history = self
-                            .recent_sale_history
-                            .get(&value.world_id)
-                            .expect("Unable to get world");
+                        let Some(history) = self.recent_sale_history.get(&value.world_id) else {
+                            skipped_event("db_reload_sale", "unknown_world");
+                            continue;
+                        };
                         history.write().await.add_sale(&value);
                     }
                 }
@@ -615,7 +726,7 @@ impl AnalyzerService {
                         break;
                     }
                     history = event_receivers.history.recv() => {
-                        if let Ok(history) = history {
+                        if let Some(history) = handle_bus_recv("history", history) {
                             match history {
                                 crate::event::EventType::Remove(_) => {}
                                 crate::event::EventType::Add(sales) => {
@@ -643,7 +754,7 @@ impl AnalyzerService {
                     break;
                 }
                 listings = event_receivers.listings.recv() => {
-                    if let Ok(listings) = listings {
+                    if let Some(listings) = handle_bus_recv("listings", listings) {
                         match listings {
                             crate::event::EventType::Remove(remove) => {
                                 let region = if let Some(region) = remove
@@ -1285,22 +1396,30 @@ impl AnalyzerService {
             ))
         });
         for (world_selector, region_selector, dc_selector, listing) in listings {
-            let entry = self
-                .cheapest_items
-                .get(&region_selector)
-                .expect("Unable to get region");
-            entry.write().await.add_listing(listing);
+            // Resolve both required entries before writing either, so a missing
+            // world can't leave the region map holding a price the world map
+            // never learned about.
+            let (Some(region_entry), Some(world_entry)) = (
+                self.cheapest_items.get(&region_selector),
+                self.cheapest_items.get(&world_selector),
+            ) else {
+                warn!(
+                    ?region_selector,
+                    ?world_selector,
+                    item_id = listing.item_id,
+                    "no cheapest-listing entry for selector, skipping listing"
+                );
+                skipped_event("add_listings", "unknown_selector");
+                continue;
+            };
+            region_entry.write().await.add_listing(listing);
             if let Some(dc_selector) = dc_selector {
                 #[allow(clippy::collapsible_if)]
                 if let Some(entry) = self.cheapest_items.get(&dc_selector) {
                     entry.write().await.add_listing(listing);
                 }
             }
-            let entry = self
-                .cheapest_items
-                .get(&world_selector)
-                .expect("Unable to get world");
-            entry.write().await.add_listing(listing);
+            world_entry.write().await.add_listing(listing);
         }
     }
 
@@ -1312,22 +1431,28 @@ impl AnalyzerService {
         world_cache: &WorldCache,
         ultros_db: &UltrosDb,
     ) {
-        let entry = self
-            .cheapest_items
-            .get(&AnySelector::Region(region_id))
-            .expect("Unable to get region");
-        let mut entry = entry.write().await;
-        for (listing, _) in listings.listings.iter() {
-            entry
-                .remove_listing(
-                    listing,
-                    AnySelector::Region(region_id),
-                    world_cache,
-                    ultros_db,
-                )
-                .await;
+        // A missing region only costs us the region-level removal — keep going so
+        // the datacenter and world maps still drop the listing. Leaving a sold
+        // listing in place is what makes prices read as stale.
+        if let Some(entry) = self.cheapest_items.get(&AnySelector::Region(region_id)) {
+            let mut entry = entry.write().await;
+            for (listing, _) in listings.listings.iter() {
+                entry
+                    .remove_listing(
+                        listing,
+                        AnySelector::Region(region_id),
+                        world_cache,
+                        ultros_db,
+                    )
+                    .await;
+            }
+        } else {
+            warn!(
+                region_id,
+                "no cheapest-listing entry for region, skipping region-level removal"
+            );
+            skipped_event("remove_listings", "unknown_region");
         }
-        drop(entry);
         for (listing, _) in listings.listings.iter() {
             let world_result = world_cache.lookup_selector(&AnySelector::World(listing.world_id));
             if let Ok(w) = world_result {
@@ -1351,10 +1476,18 @@ impl AnalyzerService {
                     }
                 }
             }
-            let world = self
+            let Some(world) = self
                 .cheapest_items
                 .get(&AnySelector::World(listing.world_id))
-                .expect("Unable to find world");
+            else {
+                warn!(
+                    world_id = listing.world_id,
+                    item_id = listing.item_id,
+                    "no cheapest-listing entry for world, skipping world-level removal"
+                );
+                skipped_event("remove_listings", "unknown_world");
+                continue;
+            };
             world
                 .write()
                 .await
@@ -1368,11 +1501,21 @@ impl AnalyzerService {
         }
     }
 
+    /// Records a sale into the in-RAM history.
+    ///
+    /// Only the RAM cache is keyed by world here — the caller still mirrors the
+    /// sale into ClickHouse even when this drops it, because the ClickHouse row
+    /// carries the world id as a plain column and needs no `WorldCache` lookup.
     async fn add_sale(&self, sale: &ultros_api_types::SaleHistory) {
-        let entry = self
-            .recent_sale_history
-            .get(&sale.world_id)
-            .expect("Unknown world");
+        let Some(entry) = self.recent_sale_history.get(&sale.world_id) else {
+            warn!(
+                world_id = sale.world_id,
+                item_id = sale.sold_item_id,
+                "no sale history for world, dropping sale from the in-RAM cache"
+            );
+            skipped_event("add_sale", "unknown_world");
+            return;
+        };
         entry.write().await.add_sale(sale);
     }
 
@@ -2158,22 +2301,27 @@ mod tests {
         };
         assert!(new_analyzer_service.try_restore_from_snapshot().await);
 
-        // Check that the data was restored correctly
-        let sale_history = new_recent_sale_history.get(&1).unwrap().read().await;
-        assert_eq!(sale_history.item_map.len(), 1);
-        let cheapest_listings = new_cheapest_items
-            .get(&AnySelector::World(1))
-            .unwrap()
-            .read()
-            .await;
-        assert_eq!(cheapest_listings.item_map.len(), 1);
+        // Check that the data was restored correctly.
+        //
+        // These guards must not outlive this block. `restore_dc_analyzer_service`
+        // below shares `new_recent_sale_history`, and restoring takes a *write*
+        // lock on it — holding a read guard across that call deadlocks the test
+        // outright, which is why nothing past this point used to run.
+        let cheapest_listings = {
+            let sale_history = new_recent_sale_history.get(&1).unwrap().read().await;
+            assert_eq!(sale_history.item_map.len(), 1);
+            let cheapest_listings = new_cheapest_items
+                .get(&AnySelector::World(1))
+                .unwrap()
+                .read()
+                .await;
+            assert_eq!(cheapest_listings.item_map.len(), 1);
+            cheapest_listings.clone()
+        };
 
         // Check Datacenter support
         let mut dc_cheapest_items = BTreeMap::new();
-        dc_cheapest_items.insert(
-            AnySelector::Datacenter(1),
-            RwLock::new(cheapest_listings.clone()),
-        );
+        dc_cheapest_items.insert(AnySelector::Datacenter(1), RwLock::new(cheapest_listings));
         let dc_cheapest_items = Arc::new(dc_cheapest_items);
         let dc_analyzer_service = AnalyzerService {
             recent_sale_history: new_recent_sale_history.clone(),
@@ -2225,5 +2373,69 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 4);
+
+        // Part 3: Snapshot Age
+        // Restoring skips the Postgres reload entirely, so an old snapshot means
+        // the analyzer serves old prices as live with nothing to show for it.
+        // Every snapshot on disk was written just now, so a "now" far enough in
+        // the future makes all of them stale without touching the clock.
+        let restore_target = AnalyzerService {
+            recent_sale_history: Arc::new(
+                [(1, RwLock::new(SaleHistory::default()))]
+                    .into_iter()
+                    .collect(),
+            ),
+            cheapest_items: Arc::new(
+                [(
+                    AnySelector::World(1),
+                    RwLock::new(CheapestListings::default()),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            initiated: Arc::new(AtomicBool::new(false)),
+            ch_writer: ultros_clickhouse::writer::Writer::disabled(),
+            ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
+        };
+        assert!(
+            restore_target
+                .try_restore_from_snapshot_at(Utc::now())
+                .await,
+            "a snapshot written seconds ago must still be restorable"
+        );
+        assert!(
+            !restore_target
+                .try_restore_from_snapshot_at(
+                    Utc::now() + MAX_SNAPSHOT_AGE + chrono::Duration::minutes(1)
+                )
+                .await,
+            "a snapshot past MAX_SNAPSHOT_AGE must be rejected so run_worker falls back to the DB"
+        );
+    }
+
+    #[test]
+    fn snapshot_age_reads_the_timestamp_out_of_the_filename() {
+        let now = chrono::DateTime::from_timestamp(10_000, 0).unwrap();
+        assert_eq!(
+            snapshot_age("snapshot-9400.bin.gz", now),
+            Some(chrono::Duration::seconds(600))
+        );
+        // Uncompressed snapshots are still readable by try_restore_from_snapshot.
+        assert_eq!(
+            snapshot_age("snapshot-10000.bin", now),
+            Some(chrono::Duration::zero())
+        );
+    }
+
+    /// An unreadable name must not be treated as fresh — the whole point of the
+    /// check is that "we don't know how old this is" is a reason to reload from
+    /// Postgres, not a reason to serve it.
+    #[test]
+    fn snapshot_age_rejects_names_it_cannot_parse() {
+        let now = chrono::DateTime::from_timestamp(10_000, 0).unwrap();
+        assert_eq!(snapshot_age("snapshot.bin.gz", now), None);
+        assert_eq!(snapshot_age("snapshot-notanumber.bin.gz", now), None);
+        assert_eq!(snapshot_age("some-other-file.bin.gz", now), None);
+        assert_eq!(snapshot_age("", now), None);
     }
 }

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -26,7 +26,7 @@ use ultros_db::{
 };
 use universalis::{ItemId, WorldId};
 
-use crate::event::{EventReceivers, handle_bus_recv};
+use crate::event::{BusRecv, EventReceivers, handle_bus_recv};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -579,6 +579,22 @@ impl AnalyzerService {
                     continue;
                 }
             };
+            if age < Duration::zero() {
+                // A future-dated filename means clock skew or a file copied
+                // from another machine. A negative age would sail straight
+                // through the `> MAX_SNAPSHOT_AGE` check below no matter how
+                // wrong the clock is, and would poison the age gauge with a
+                // negative value — treat "from the future" like "unknown age":
+                // skip this file and keep looking at older ones.
+                warn!(
+                    ?path,
+                    age_seconds = age.num_seconds(),
+                    "snapshot filename is dated in the future (clock skew?), ignoring"
+                );
+                metrics::counter!("ultros_analyzer_snapshot_rejected_total", "reason" => "future_dated")
+                    .increment(1);
+                continue;
+            }
             if age > MAX_SNAPSHOT_AGE {
                 // Entries are sorted by name, i.e. by timestamp, and we walk them
                 // newest-first — so everything left is older still.
@@ -726,8 +742,8 @@ impl AnalyzerService {
                         break;
                     }
                     history = event_receivers.history.recv() => {
-                        if let Some(history) = handle_bus_recv("history", history) {
-                            match history {
+                        match handle_bus_recv("history", history) {
+                            BusRecv::Msg(history) => match history {
                                 crate::event::EventType::Remove(_) => {}
                                 crate::event::EventType::Add(sales) => {
                                     for (sale, _) in sales.sales.iter() {
@@ -742,7 +758,14 @@ impl AnalyzerService {
                                     }
                                 }
                                 crate::event::EventType::Update(_) => {}
-                            }
+                            },
+                            // Still live, positioned at the oldest survivor.
+                            BusRecv::Lagged => {}
+                            // recv() on a closed bus returns instantly forever;
+                            // looping here would hot-spin and emit one warn per
+                            // iteration. Only happens at shutdown, when the
+                            // cancellation arm above races us to the exit.
+                            BusRecv::Closed => break,
                         }
                     }
                 }
@@ -754,8 +777,8 @@ impl AnalyzerService {
                     break;
                 }
                 listings = event_receivers.listings.recv() => {
-                    if let Some(listings) = handle_bus_recv("listings", listings) {
-                        match listings {
+                    match handle_bus_recv("listings", listings) {
+                        BusRecv::Msg(listings) => match listings {
                             crate::event::EventType::Remove(remove) => {
                                 let region = if let Some(region) = remove
                                     .listings
@@ -779,7 +802,14 @@ impl AnalyzerService {
                                 self.add_listings(&add.listings, &world_cache).await;
                             }
                             crate::event::EventType::Update(_) => todo!(),
-                        }
+                        },
+                        // Still live, positioned at the oldest survivor.
+                        BusRecv::Lagged => {}
+                        // recv() on a closed bus returns instantly forever;
+                        // looping here would hot-spin and emit one warn per
+                        // iteration. Only happens at shutdown, when the
+                        // cancellation arm above races us to the exit.
+                        BusRecv::Closed => break,
                     }
                 }
             }
@@ -2411,6 +2441,13 @@ mod tests {
                 .await,
             "a snapshot past MAX_SNAPSHOT_AGE must be rejected so run_worker falls back to the DB"
         );
+        assert!(
+            !restore_target
+                .try_restore_from_snapshot_at(Utc::now() - chrono::Duration::hours(1))
+                .await,
+            "a future-dated snapshot (clock skew / copied file) must be rejected, \
+             not treated as fresh because its negative age passes the max-age check"
+        );
     }
 
     #[test]
@@ -2424,6 +2461,12 @@ mod tests {
         assert_eq!(
             snapshot_age("snapshot-10000.bin", now),
             Some(chrono::Duration::zero())
+        );
+        // A future-dated name yields a negative age, which the restore path
+        // must reject rather than let slide under MAX_SNAPSHOT_AGE.
+        assert_eq!(
+            snapshot_age("snapshot-10600.bin.gz", now),
+            Some(chrono::Duration::seconds(-600))
         );
     }
 

--- a/ultros/src/event.rs
+++ b/ultros/src/event.rs
@@ -124,7 +124,23 @@ pub(crate) struct EventReceivers {
     pub(crate) lists: EventBus<ListEventData>,
 }
 
-/// Unwraps a broadcast `recv()` result, reporting lag instead of swallowing it.
+/// Outcome of a broadcast `recv()`, distinguished so callers can react
+/// correctly to each case — see [`handle_bus_recv`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BusRecv<T> {
+    /// A value arrived; process it.
+    Msg(T),
+    /// The channel discarded events this receiver was too slow to read. The
+    /// receiver is still live and positioned at the oldest surviving value, so
+    /// the caller should keep looping.
+    Lagged,
+    /// Every sender is gone; `recv()` will return `Closed` *immediately,
+    /// forever*. The caller must break out of its loop — looping on a closed
+    /// bus is a hot spin that emits a warning per iteration.
+    Closed,
+}
+
+/// Classifies a broadcast `recv()` result, reporting lag instead of swallowing it.
 ///
 /// `if let Ok(..) = rx.recv().await` looks harmless but hides the one error that
 /// actually costs data: [`RecvError::Lagged`] means the channel already threw
@@ -132,12 +148,14 @@ pub(crate) struct EventReceivers {
 /// them (every producer writes there first), so nothing 500s — the in-RAM caches
 /// and the ClickHouse mirror just quietly drift away from the truth.
 ///
-/// Returns `Some` when a value arrived and `None` on lag or close. Callers
-/// should keep looping on `None`: after a lag the receiver is still live and
-/// positioned at the oldest surviving value.
-pub(crate) fn handle_bus_recv<T>(bus: &'static str, result: Result<T, RecvError>) -> Option<T> {
+/// Callers should keep looping on [`BusRecv::Lagged`] but **must break on
+/// [`BusRecv::Closed`]**: a closed channel fails every subsequent `recv()`
+/// immediately, so treating it like lag turns the consumer loop into a hot
+/// spin that floods tracing (and therefore Glitchtip) with one warning per
+/// iteration.
+pub(crate) fn handle_bus_recv<T>(bus: &'static str, result: Result<T, RecvError>) -> BusRecv<T> {
     match result {
-        Ok(value) => Some(value),
+        Ok(value) => BusRecv::Msg(value),
         Err(RecvError::Lagged(skipped)) => {
             metrics::counter!("ultros_analyzer_bus_lagged_total", "bus" => bus).increment(skipped);
             warn!(
@@ -146,11 +164,11 @@ pub(crate) fn handle_bus_recv<T>(bus: &'static str, result: Result<T, RecvError>
                 "consumer fell behind the event bus; dropped events never reach the \
                  in-RAM caches or ClickHouse (Postgres is unaffected)"
             );
-            None
+            BusRecv::Lagged
         }
         Err(RecvError::Closed) => {
             warn!(bus, "event bus closed, no further events will arrive");
-            None
+            BusRecv::Closed
         }
     }
 }
@@ -174,16 +192,24 @@ mod tests {
 
     #[test]
     fn a_delivered_value_passes_through() {
-        assert_eq!(handle_bus_recv::<i32>("test", Ok(7)), Some(7));
+        assert_eq!(handle_bus_recv::<i32>("test", Ok(7)), BusRecv::Msg(7));
     }
 
+    /// Lag and close are *different* outcomes and must stay distinguishable:
+    /// lag means "keep looping", close means "break". Collapsing them (the
+    /// bug this replaces) made a closed bus spin hot — `recv()` on a closed
+    /// channel returns immediately, forever, so a keep-looping caller burned a
+    /// core and emitted one warning per iteration into tracing/Glitchtip.
     #[test]
-    fn lag_and_close_yield_nothing() {
+    fn lag_and_close_are_distinguished() {
         assert_eq!(
             handle_bus_recv::<i32>("test", Err(RecvError::Lagged(12))),
-            None
+            BusRecv::Lagged
         );
-        assert_eq!(handle_bus_recv::<i32>("test", Err(RecvError::Closed)), None);
+        assert_eq!(
+            handle_bus_recv::<i32>("test", Err(RecvError::Closed)),
+            BusRecv::Closed
+        );
     }
 
     /// The bug this replaces: `if let Ok(..) = recv()` treats a lag exactly like
@@ -199,14 +225,31 @@ mod tests {
         }
 
         // The oldest three were dropped by the channel; the next recv says so.
-        assert_eq!(handle_bus_recv("test", rx.recv().await), None);
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Lagged);
 
         // Everything still in the ring is delivered normally afterwards.
-        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(3));
-        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(4));
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Msg(3));
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Msg(4));
 
         // And the receiver keeps working for values sent after the lag.
         tx.send(5).unwrap();
-        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(5));
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Msg(5));
+    }
+
+    /// Once every sender is dropped the receiver drains what's left in the
+    /// ring and then reports `Closed` on every subsequent recv — which is why
+    /// callers must break rather than loop.
+    #[tokio::test]
+    async fn a_closed_bus_drains_then_reports_closed_forever() {
+        let (tx, mut rx) = channel::<i32>(4);
+        tx.send(1).unwrap();
+        drop(tx);
+
+        // The value that was already in the ring still arrives.
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Msg(1));
+
+        // After that, Closed — immediately, on every call.
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Closed);
+        assert_eq!(handle_bus_recv("test", rx.recv().await), BusRecv::Closed);
     }
 }

--- a/ultros/src/event.rs
+++ b/ultros/src/event.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use tokio::sync::broadcast::channel;
+use tokio::sync::broadcast::{channel, error::RecvError};
+use tracing::warn;
 use ultros_api_types::{
     user::OwnedRetainer,
     websocket::{ListEventData, ListingEventData, SaleEventData},
@@ -42,12 +43,45 @@ impl<T> EventType<Arc<T>> {
     }
 }
 
+/// Ring size for the listings bus.
+///
+/// A tokio broadcast channel drops the *oldest* value once the ring is full, so
+/// anything a slow consumer hasn't drained yet is lost — see
+/// `ultros_analyzer_bus_lagged_total` for when that happens.
+///
+/// Sizing comes from the catch-up service, which bursts far harder than the
+/// websocket does: `UpdateService::check_items` walks item ids in chunks of 100
+/// and drives each chunk through `buffer_unordered(50)`, and every item emits
+/// *two* listing events (Add + Remove). So a single chunk can put ~200 events on
+/// the bus as fast as Postgres finishes writing, while the analyzer's listings
+/// loop drains them one at a time — and its `remove_listing` path does a DB
+/// round-trip per removed listing. The old value of 100 was smaller than one
+/// chunk's burst, i.e. guaranteed to lag during any full sweep.
+///
+/// 1024 gives ~5 chunks of headroom. Slots hold `Arc<ListingEventData>`, and a
+/// typical event carries only a handful of listings (~1-2 KiB), so the ring
+/// costs single-digit MiB even when completely full.
+const LISTINGS_BUS_SIZE: usize = 1024;
+
+/// Ring size for the sale-history bus.
+///
+/// Same burst source as [`LISTINGS_BUS_SIZE`] — one sale event per item, so ~100
+/// per catch-up chunk against 40 slots previously. Lag here is worse than on the
+/// listings bus because the analyzer's history loop is the *only* thing feeding
+/// the ClickHouse dual-write: dropped events vanish from both the in-RAM sale
+/// history and ClickHouse while Postgres stays correct, so the two silently
+/// drift apart.
+///
+/// 512 is ~5 chunks of headroom. `SaleEventData` is a plain vec of sales with no
+/// retainer payload, so slots are cheaper than the listings bus'.
+const HISTORY_BUS_SIZE: usize = 512;
+
 pub(crate) fn create_event_busses() -> (EventSenders, EventReceivers) {
     let (retainer_sender, retainer_receiver) = channel(10);
-    let (listing_sender, listing_receiver) = channel(100);
+    let (listing_sender, listing_receiver) = channel(LISTINGS_BUS_SIZE);
     let (alert_sender, alert_receiver) = channel(10);
     let (retainer_undercut_sender, retainer_undercut_receiver) = channel(40);
-    let (history_sender, history_receiver) = channel(40);
+    let (history_sender, history_receiver) = channel(HISTORY_BUS_SIZE);
     let (list_sender, list_receiver) = channel(40);
     (
         EventSenders {
@@ -90,6 +124,37 @@ pub(crate) struct EventReceivers {
     pub(crate) lists: EventBus<ListEventData>,
 }
 
+/// Unwraps a broadcast `recv()` result, reporting lag instead of swallowing it.
+///
+/// `if let Ok(..) = rx.recv().await` looks harmless but hides the one error that
+/// actually costs data: [`RecvError::Lagged`] means the channel already threw
+/// away `n` values because this receiver couldn't keep up. Postgres still has
+/// them (every producer writes there first), so nothing 500s — the in-RAM caches
+/// and the ClickHouse mirror just quietly drift away from the truth.
+///
+/// Returns `Some` when a value arrived and `None` on lag or close. Callers
+/// should keep looping on `None`: after a lag the receiver is still live and
+/// positioned at the oldest surviving value.
+pub(crate) fn handle_bus_recv<T>(bus: &'static str, result: Result<T, RecvError>) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(RecvError::Lagged(skipped)) => {
+            metrics::counter!("ultros_analyzer_bus_lagged_total", "bus" => bus).increment(skipped);
+            warn!(
+                bus,
+                skipped,
+                "consumer fell behind the event bus; dropped events never reach the \
+                 in-RAM caches or ClickHouse (Postgres is unaffected)"
+            );
+            None
+        }
+        Err(RecvError::Closed) => {
+            warn!(bus, "event bus closed, no further events will arrive");
+            None
+        }
+    }
+}
+
 impl Clone for EventReceivers {
     fn clone(&self) -> Self {
         Self {
@@ -100,5 +165,48 @@ impl Clone for EventReceivers {
             history: self.history.resubscribe(),
             lists: self.lists.resubscribe(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_delivered_value_passes_through() {
+        assert_eq!(handle_bus_recv::<i32>("test", Ok(7)), Some(7));
+    }
+
+    #[test]
+    fn lag_and_close_yield_nothing() {
+        assert_eq!(
+            handle_bus_recv::<i32>("test", Err(RecvError::Lagged(12))),
+            None
+        );
+        assert_eq!(handle_bus_recv::<i32>("test", Err(RecvError::Closed)), None);
+    }
+
+    /// The bug this replaces: `if let Ok(..) = recv()` treats a lag exactly like
+    /// a delivered value it happened not to match, so a burst larger than the
+    /// ring vanishes with no log, no metric, and no way to tell from the
+    /// outside. Here the lag is surfaced once and the loop keeps consuming
+    /// every value that survived in the ring.
+    #[tokio::test]
+    async fn a_burst_larger_than_the_ring_reports_lag_then_resumes() {
+        let (tx, mut rx) = channel(2);
+        for i in 0..5 {
+            tx.send(i).unwrap();
+        }
+
+        // The oldest three were dropped by the channel; the next recv says so.
+        assert_eq!(handle_bus_recv("test", rx.recv().await), None);
+
+        // Everything still in the ring is delivered normally afterwards.
+        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(3));
+        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(4));
+
+        // And the receiver keeps working for values sent after the lag.
+        tx.send(5).unwrap();
+        assert_eq!(handle_bus_recv("test", rx.recv().await), Some(5));
     }
 }

--- a/ultros/src/ingest_health.rs
+++ b/ultros/src/ingest_health.rs
@@ -1,0 +1,113 @@
+//! Per-world ingest freshness, exported to `/metrics`.
+//!
+//! Every one of the ingest failure modes this module exists for — a half-open
+//! websocket, a lagging event bus, a panicked consumer task, a stale snapshot —
+//! looks identical from outside the process: the app is up, requests succeed,
+//! and the numbers simply stop moving. Nothing in the request path can tell you
+//! that, because serving stale data is not an error.
+//!
+//! `listing_last_updated` already records an ingest timestamp per (world, item)
+//! on every successful update, so `now - max(date_time)` per world is a
+//! ready-made "seconds since we last heard anything about this world" signal.
+//! Publishing it as a gauge turns every silent failure into an alertable one.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use chrono::Utc;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, warn};
+use ultros_db::{
+    UltrosDb,
+    world_data::world_cache::{AnySelector, WorldCache},
+};
+
+/// How often the gauge is recomputed.
+///
+/// One grouped aggregate over `listing_last_updated` per tick. A minute is fast
+/// enough that a Prometheus scrape never sees a value more than one interval
+/// behind, and slow enough that the query is noise next to ingest traffic.
+const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
+/// What the previous tick reported, so a steady-state problem is logged once
+/// rather than once a minute forever.
+///
+/// This matters more than it looks: `error!` events are forwarded to Glitchtip
+/// (see `docs/error-reporting.md`), and a task on a fixed interval that logs
+/// unconditionally turns one broken dependency into an unbounded stream of
+/// issues — the exact failure the ClickHouse wiring in `main.rs` calls out.
+/// The gauges are published every tick regardless; only the logging is deduped.
+#[derive(Default)]
+struct LastReported {
+    query_failed: bool,
+    never_ingested: Option<usize>,
+}
+
+/// Publishes per-world ingest staleness until `token` is cancelled.
+pub(crate) fn spawn_staleness_gauge(
+    db: UltrosDb,
+    world_cache: Arc<WorldCache>,
+    token: CancellationToken,
+) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(REFRESH_INTERVAL);
+        let mut last_reported = LastReported::default();
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => break,
+                _ = interval.tick() => {
+                    record_staleness(&db, &world_cache, &mut last_reported).await
+                }
+            }
+        }
+    });
+}
+
+async fn record_staleness(
+    db: &UltrosDb,
+    world_cache: &WorldCache,
+    last_reported: &mut LastReported,
+) {
+    let last_ingest = match db.get_last_ingest_per_world().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            if !last_reported.query_failed {
+                error!(error = ?e, "unable to compute per-world ingest staleness");
+                last_reported.query_failed = true;
+            }
+            return;
+        }
+    };
+    last_reported.query_failed = false;
+    let now = Utc::now().naive_utc();
+    let mut ingested: HashSet<i32> = HashSet::with_capacity(last_ingest.len());
+    for (world_id, ingested_at) in &last_ingest {
+        // A world in the table but not in the cache still gets a series, keyed
+        // by id — losing the label is better than losing the alert.
+        let world_name = world_cache
+            .lookup_selector(&AnySelector::World(*world_id))
+            .ok()
+            .and_then(|r| r.as_world().ok())
+            .map(|w| w.name.clone())
+            .unwrap_or_else(|| world_id.to_string());
+        let age = (now - *ingested_at).num_seconds();
+        metrics::gauge!("ultros_world_ingest_staleness_seconds", "world" => world_name)
+            .set(age as f64);
+        ingested.insert(*world_id);
+    }
+
+    // Worlds we have never ingested for produce no row above, so they'd have no
+    // series to alert on at all. Count them instead — a nonzero value on a
+    // long-running process means a world is being ignored entirely.
+    let never_ingested = world_cache
+        .get_all_worlds()
+        .filter(|w| !ingested.contains(&w.id))
+        .count();
+    metrics::gauge!("ultros_worlds_never_ingested").set(never_ingested as f64);
+    if never_ingested > 0 && last_reported.never_ingested != Some(never_ingested) {
+        warn!(
+            never_ingested,
+            "some worlds have never had a listing ingested"
+        );
+    }
+    last_reported.never_ingested = Some(never_ingested);
+}

--- a/ultros/src/ingest_health.rs
+++ b/ultros/src/ingest_health.rs
@@ -50,6 +50,11 @@ pub(crate) fn spawn_staleness_gauge(
 ) {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(REFRESH_INTERVAL);
+        // The default (Burst) fires every missed tick back-to-back, so one
+        // slow staleness query — the very thing this task exists to notice —
+        // would be followed by a storm of catch-up queries against the same
+        // slow database. Delay just resumes the normal cadence.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let mut last_reported = LastReported::default();
         loop {
             tokio::select! {

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -282,6 +282,12 @@ async fn main() -> Result<()> {
         )
         .with(sentry_tracing::layer())
         .init();
+    // Install the Prometheus recorder before any service spawns. `metrics::`
+    // macros are no-ops against the default NoopRecorder, so anything emitted
+    // before installation vanishes — and the analyzer records its
+    // snapshot-age / snapshot-rejection samples during startup, well before
+    // `start_web` (which only *serves* the handle on /metrics) ever runs.
+    let prometheus_handle = web_metrics::setup_metrics_recorder();
     #[cfg(feature = "profiling")]
     tokio::spawn(async move { start_profiling_server().await });
     info!("Ultros starting!");
@@ -450,7 +456,7 @@ async fn main() -> Result<()> {
         universalis: universalis_client,
         price_series_cache: Default::default(),
     };
-    let web_task = tokio::spawn(web::start_web(web_state));
+    let web_task = tokio::spawn(web::start_web(web_state, prometheus_handle));
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
             info!("ctrl-c received");

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -4,6 +4,7 @@ pub(crate) mod alerts;
 pub(crate) mod analyzer_service;
 mod discord;
 pub(crate) mod event;
+mod ingest_health;
 mod item_update_service;
 pub mod leptos;
 #[cfg(feature = "profiling")]
@@ -355,6 +356,10 @@ async fn main() -> Result<()> {
         full_sweep_cooldowns: Default::default(),
     });
     UpdateService::start_service(update_service.clone(), token.clone());
+    // Exports `ultros_world_ingest_staleness_seconds`. Every silent ingest
+    // failure looks like a healthy process serving frozen numbers, so this gauge
+    // is the only thing that makes one visible from outside.
+    ingest_health::spawn_staleness_gauge(db.clone(), world_cache.clone(), token.clone());
     // begin listening to universalis events
     // load configuration from environment
     let config = envy::from_env::<Config>()?;

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -1954,7 +1954,10 @@ fn test_auth_routes() -> Router<WebState> {
     Router::new()
 }
 
-pub(crate) async fn start_web(state: WebState) {
+pub(crate) async fn start_web(
+    state: WebState,
+    prometheus_handle: metrics_exporter_prometheus::PrometheusHandle,
+) {
     // build our application with a route
     let worlds = state.world_helper.clone();
     let token = state.token.clone();
@@ -2195,7 +2198,7 @@ pub(crate) async fn start_web(state: WebState) {
                 .await
                 .unwrap();
         },
-        start_metrics_server(),
+        start_metrics_server(prometheus_handle),
     )
     .await;
 }

--- a/ultros/src/web_metrics.rs
+++ b/ultros/src/web_metrics.rs
@@ -39,12 +39,22 @@ pub(crate) async fn track_metrics(req: Request, next: Next) -> impl IntoResponse
     response
 }
 
-fn metrics_app() -> Router {
-    let recorder_handle = setup_metrics_recorder();
+fn metrics_app(recorder_handle: PrometheusHandle) -> Router {
     Router::new().route("/metrics", get(move || ready(recorder_handle.render())))
 }
 
-fn setup_metrics_recorder() -> PrometheusHandle {
+/// Installs the global Prometheus recorder and returns the handle the
+/// `/metrics` route renders from.
+///
+/// This must run in `main` *before any service is spawned*: the `metrics::`
+/// macros silently no-op against the default `NoopRecorder` until a recorder
+/// is installed, and several services emit samples during their own startup —
+/// the analyzer's `ultros_analyzer_snapshot_rejected_total` /
+/// `ultros_analyzer_snapshot_age_seconds` fire while restoring the snapshot,
+/// long before `start_web` runs. Installing here and only *serving* from
+/// `start_metrics_server` keeps startup ordering flexible without losing
+/// those samples.
+pub(crate) fn setup_metrics_recorder() -> PrometheusHandle {
     const EXPONENTIAL_SECONDS: &[f64] = &[
         0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
     ];
@@ -59,8 +69,8 @@ fn setup_metrics_recorder() -> PrometheusHandle {
         .unwrap()
 }
 
-pub(crate) async fn start_metrics_server() {
-    let app = metrics_app();
+pub(crate) async fn start_metrics_server(recorder_handle: PrometheusHandle) {
+    let app = metrics_app(recorder_handle);
 
     // NOTE: expose metrics enpoint on a different port
     let addr = SocketAddr::from(([0, 0, 0, 0], 9091));

--- a/universalis/Cargo.toml
+++ b/universalis/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 url = "2"
 tracing = { workspace = true }
+# Facade only — no-ops until a recorder is installed, which `ultros` does in
+# web_metrics.rs. Matches how ultros-db already reports from library code.
+metrics = "0.24.5"
 bson = { version = "3.1.0", features = ["serde"] }
 async-tungstenite = {version = "0.34", default-features = false, features = ["tokio-runtime", "tokio-rustls-webpki-roots"], optional = true}
 tokio = { workspace = true, optional = true }

--- a/universalis/Cargo.toml
+++ b/universalis/Cargo.toml
@@ -15,7 +15,8 @@ url = "2"
 tracing = { workspace = true }
 # Facade only — no-ops until a recorder is installed, which `ultros` does in
 # web_metrics.rs. Matches how ultros-db already reports from library code.
-metrics = "0.24.5"
+# Only the websocket module emits metrics, so REST-only consumers skip it.
+metrics = { version = "0.24.5", optional = true }
 bson = { version = "3.1.0", features = ["serde"] }
 async-tungstenite = {version = "0.34", default-features = false, features = ["tokio-runtime", "tokio-rustls-webpki-roots"], optional = true}
 tokio = { workspace = true, optional = true }
@@ -29,4 +30,4 @@ clap = {version = "4.0.18", features = ["derive"]}
 
 [features]
 default = ["websocket"]
-websocket = ["async-tungstenite", "tokio"]
+websocket = ["async-tungstenite", "tokio", "metrics"]

--- a/universalis/src/websocket/mod.rs
+++ b/universalis/src/websocket/mod.rs
@@ -21,8 +21,35 @@ use futures::stream::FusedStream;
 use std::collections::HashSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender, channel};
+
+/// How often we send a websocket Ping to keep the connection alive.
+const PING_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long the socket may go without delivering *any* frame — Pong, data, or
+/// otherwise — before we treat it as dead and reconnect.
+///
+/// Universalis' server replies to our Ping, so silence this long means the
+/// connection is gone. The failure mode this guards against is a half-open TCP
+/// connection: the peer vanished without a FIN/RST, so `websocket.next()` never
+/// yields, never errors, and `is_terminated()` stays false. The socket sits
+/// there looking connected while delivering zero market data, forever, and the
+/// existing reconnect path is never reached because nothing ever signals a
+/// close. Without this deadline the only fix is a process restart.
+///
+/// 2.5× [`PING_INTERVAL`], so one slow round-trip is tolerated and two
+/// consecutive missed Pongs trip it. Override with
+/// `UNIVERSALIS_WEBSOCKET_LIVENESS_TIMEOUT_SECS`.
+const DEFAULT_LIVENESS_TIMEOUT: Duration = Duration::from_secs(150);
+
+fn liveness_timeout() -> Duration {
+    std::env::var("UNIVERSALIS_WEBSOCKET_LIVENESS_TIMEOUT_SECS")
+        .ok()
+        .and_then(|i| i.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_LIVENESS_TIMEOUT)
+}
 
 /// Internal SocketTx. Enables the user to communicate with the worker task.
 #[derive(Debug)]
@@ -143,18 +170,40 @@ impl WebsocketClient {
                     .send(SocketTx::Ping)
                     .await
                     .expect("Unable to push message to message queue");
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(PING_INTERVAL).await;
             }
         });
         tokio::spawn(async move {
             let mut active_subscriptions = SubscriptionTracker {
                 subscriptions: HashSet::new(),
             };
+            let liveness_timeout = liveness_timeout();
+            // Last time the socket handed us anything at all. The ping task
+            // wakes this loop every PING_INTERVAL even when the socket is
+            // silent, so the check below runs on a fixed cadence.
+            let mut last_frame_at = Instant::now();
             loop {
-                if let Some(ws) = websocket {
+                if let Some(mut ws) = websocket {
                     if ws.is_terminated() {
                         websocket = None;
                         warn!("websocket terminated, restarting");
+                        continue;
+                    } else if last_frame_at.elapsed() > liveness_timeout {
+                        warn!(
+                            silent_for_secs = last_frame_at.elapsed().as_secs(),
+                            timeout_secs = liveness_timeout.as_secs(),
+                            "websocket delivered no frames within the liveness deadline, \
+                             assuming it is half-open and reconnecting"
+                        );
+                        metrics::counter!("universalis_websocket_liveness_timeouts_total")
+                            .increment(1);
+                        // Best-effort close; a half-open peer will never answer,
+                        // which is exactly why we drop the socket rather than
+                        // waiting for `is_terminated()` to become true.
+                        if let Err(e) = ws.close(None).await {
+                            warn!("error closing timed-out websocket {e:?}");
+                        }
+                        websocket = None;
                         continue;
                     } else {
                         websocket = Some(ws);
@@ -185,6 +234,9 @@ impl WebsocketClient {
                             error!("error resending subscriptions {e:?}");
                             websocket = None;
                         } else {
+                            // Start the deadline from the fresh connection, not
+                            // from whenever the dead one last spoke.
+                            last_frame_at = Instant::now();
                             websocket = Some(ws);
                         }
                     }
@@ -233,42 +285,48 @@ impl WebsocketClient {
                             break;
                         }
                     },
-                    Either::Right((Some(Ok(message)), _)) => match message {
-                        Message::Text(t) => {
-                            info!(
-                                "Received text {t}, unexpected only BSON messages were expected."
-                            );
-                        }
-                        Message::Binary(b) => {
-                            let sender = listing_sender.clone();
-                            tokio::spawn(async move {
-                                let b = bson::deserialize_from_slice::<WSMessage>(b.as_ref()).map_err(|e| {
+                    Either::Right((Some(Ok(message)), _)) => {
+                        // Any frame proves the socket is alive — a Pong is the
+                        // one we expect during a quiet market, but data, Ping
+                        // and Close all count too.
+                        last_frame_at = Instant::now();
+                        match message {
+                            Message::Text(t) => {
+                                info!(
+                                    "Received text {t}, unexpected only BSON messages were expected."
+                                );
+                            }
+                            Message::Binary(b) => {
+                                let sender = listing_sender.clone();
+                                tokio::spawn(async move {
+                                    let b = bson::deserialize_from_slice::<WSMessage>(b.as_ref()).map_err(|e| {
                                     if let Ok(document) = bson::deserialize_from_slice::<Document>(b.as_ref()) {
                                         error!("valid bson document but not valid struct {document:?}");
                                     }
                                     e.into()
                                 });
-                                if let Err(e) = sender.send(SocketRx::Event(b)).await {
-                                    error!("Error sending websocket data {e:?}");
+                                    if let Err(e) = sender.send(SocketRx::Event(b)).await {
+                                        error!("Error sending websocket data {e:?}");
+                                    }
+                                });
+                            }
+                            Message::Ping(p) => {
+                                info!("responding to ping with payload: {p:?}");
+                                if let Err(e) = websocket.send(Message::Pong(p.clone())).await {
+                                    error!("Error sending ping! {e:?}");
                                 }
-                            });
-                        }
-                        Message::Ping(p) => {
-                            info!("responding to ping with payload: {p:?}");
-                            if let Err(e) = websocket.send(Message::Pong(p.clone())).await {
-                                error!("Error sending ping! {e:?}");
+                            }
+                            Message::Pong(pong) => {
+                                info!("got pong! {pong:?}");
+                            }
+                            Message::Close(closed) => {
+                                info!("Socket closed with reason {closed:?}");
+                            }
+                            Message::Frame(frame) => {
+                                info!("received frame: {frame:?}");
                             }
                         }
-                        Message::Pong(pong) => {
-                            info!("got pong! {pong:?}");
-                        }
-                        Message::Close(closed) => {
-                            info!("Socket closed with reason {closed:?}");
-                        }
-                        Message::Frame(frame) => {
-                            info!("received frame: {frame:?}");
-                        }
-                    },
+                    }
                     Either::Right((None, _)) => {
                         warn!("Web socket closed");
                     }

--- a/universalis/src/websocket/mod.rs
+++ b/universalis/src/websocket/mod.rs
@@ -85,7 +85,12 @@ impl WebsocketClient {
     /// * `world_id` - Optional [WorldId](World ID), used if you wish to only receive data from a certain world. If None, you will receive data from all worlds.
     ///
     /// ###Example:
-    /// ```
+    ///
+    /// (`no_run`: executing this would dial the live Universalis websocket
+    /// from `cargo test` — and it panics in the doctest harness anyway, since
+    /// the workspace enables both rustls backends and only real binaries
+    /// install a process-level CryptoProvider first.)
+    /// ```no_run
     /// use universalis::{WebsocketClient, websocket::event_types::{SubscribeMode, EventChannel}, WorldId};
     ///
     /// #[tokio::main]
@@ -183,7 +188,7 @@ impl WebsocketClient {
             // silent, so the check below runs on a fixed cadence.
             let mut last_frame_at = Instant::now();
             loop {
-                if let Some(mut ws) = websocket {
+                if let Some(ws) = websocket {
                     if ws.is_terminated() {
                         websocket = None;
                         warn!("websocket terminated, restarting");
@@ -195,14 +200,16 @@ impl WebsocketClient {
                             "websocket delivered no frames within the liveness deadline, \
                              assuming it is half-open and reconnecting"
                         );
-                        metrics::counter!("universalis_websocket_liveness_timeouts_total")
-                            .increment(1);
-                        // Best-effort close; a half-open peer will never answer,
-                        // which is exactly why we drop the socket rather than
-                        // waiting for `is_terminated()` to become true.
-                        if let Err(e) = ws.close(None).await {
-                            warn!("error closing timed-out websocket {e:?}");
-                        }
+                        metrics::counter!("ultros_websocket_liveness_timeouts_total").increment(1);
+                        // Deliberately NOT `ws.close(None).await` here: close()
+                        // sends a Close frame and awaits the flush, and against
+                        // a half-open peer that write sits in the kernel's
+                        // retransmit queue for tcp_retries2 (~13-30 minutes) —
+                        // stalling this single worker loop, which is the exact
+                        // silent stall the liveness deadline exists to break.
+                        // Dropping the stream closes the fd immediately without
+                        // waiting on the vanished peer.
+                        drop(ws);
                         websocket = None;
                         continue;
                     } else {


### PR DESCRIPTION
Market-data ingest could fail in at least five ways that were invisible from outside the process: the app stays up, requests succeed, and the numbers simply stop moving. Serving stale data is not an error, so nothing in the request path could notice — and two of these modes stopped ingestion *permanently* while the process looked perfectly healthy.

No happy-path behavior changes.

## 1. Broadcast lag was swallowed

Both analyzer loops used `if let Ok(..) = recv()`, which treats `RecvError::Lagged(n)` exactly like a value that happened not to match. A burst larger than the ring vanished with no log, no metric, and no way to tell from outside — Postgres stayed correct, so the in-RAM caches and the ClickHouse dual-write just quietly drifted.

They now go through `handle_bus_recv` ([event.rs](../blob/claude/ultros-ingest-failures-7d60b2/ultros/src/event.rs)), which matches `Lagged` explicitly, increments `ultros_analyzer_bus_lagged_total{bus}` by the dropped count, warns, and continues.

The rings were also sized below one real burst. `UpdateService::check_items` walks item ids in chunks of 100 through `buffer_unordered(50)`, and each item emits two listing events plus one sale event — ~200 listing and ~100 sale events per chunk, against rings of 100 and 40. Any full sweep was *guaranteed* to lag.

- **listings: 100 → 1024** (~5 chunks of headroom; slots hold `Arc<ListingEventData>` carrying a handful of listings each, so single-digit MiB when full)
- **history: 40 → 512** (~5 chunks; `SaleEventData` has no retainer payload so slots are cheaper)

Both numbers are justified in doc comments at the constants.

## 2. No staleness gauge

`listing_last_updated` already stamps an ingest time on every update, so `now - max(date_time)` per world is a ready-made "seconds since we last heard from this world" signal. New [`ingest_health.rs`](../blob/claude/ultros-ingest-failures-7d60b2/ultros/src/ingest_health.rs) publishes it every 60s as `ultros_world_ingest_staleness_seconds{world}`, plus `ultros_worlds_never_ingested` for worlds that would otherwise have no series to alert on at all.

This is the metric to page on; everything else explains why it moved.

## 3. Websocket had no pong deadline

A half-open TCP connection yields no frames, never errors, and leaves `is_terminated()` false — so `websocket.next()` blocks forever, the existing reconnect path is never reached, and the only fix was a process restart. Pongs were logged and discarded.

The worker now tracks the last inbound frame (any frame — Pong, data, Ping, Close) and tears the socket down after **150s** of silence, reconnecting through the existing path. That's 2.5× the 60s ping interval, so one slow round-trip is tolerated and two consecutive missed pongs trip it. Override with `UNIVERSALIS_WEBSOCKET_LIVENESS_TIMEOUT_SECS`. Counted by `universalis_websocket_liveness_timeouts_total`.

This adds the `metrics` facade crate to `universalis` — it no-ops without a recorder, matching how `ultros-db` already reports from library code.

## 4. Snapshot age

Restoring a snapshot skips the Postgres reload entirely (`run_worker`), so whatever prices it holds become "live" the moment `initiated` flips — with no visible symptom. A week-old snapshot served week-old prices as live.

Snapshots older than **3 hours** are now rejected and fall through to the database load. Snapshots are written every 15 minutes and on shutdown, so any larger gap means the process was down and the market has moved on; 3h keeps a fast restart cheap (deploy, crash loop, OOM restart) while capping how wrong the served data can be. Names that don't parse are also rejected — "we don't know how old this is" is a reason to reload, not a reason to serve.

Age comes off the filename rather than mtime, so a file copy can't make a stale snapshot look fresh. Counted by `ultros_analyzer_snapshot_rejected_total{reason}`; the age booted from is reported as `ultros_analyzer_snapshot_age_seconds`.

## 5. Panics in hot loops

All converted to log-and-skip with `ultros_analyzer_skipped_events_total{op,reason}`.

The `.expect("Unknown world")` in `add_sale` was the worst of them: it ran inside the history loop, so one unknown world panicked the spawned task and **permanently stopped live sale ingestion and the ClickHouse dual-write** while axum kept serving from a frozen cache. Dropping one event costs one sale; panicking costs every sale from then on.

Sites converted: `add_sale`, `add_listings` (region + world), `remove_listings` (region + world), `CheapestListings::remove_listing`. In `add_listings` both required entries are now resolved before either is written, so a missing world can't leave the region map holding a price the world map never learned about. In `remove_listings` a missing region no longer skips the datacenter and world removals — leaving a sold listing in place is exactly what makes prices read as stale.

**Beyond the listed sites:** the four unwraps in the `run_worker` database reload (`~568-598`) fail the same way for the same reason and abort the worker *before* `initiated` is ever set, so the analyzer would both serve nothing and ingest nothing, forever. Converted those too.

### Root cause, out of scope

`WorldCache` is built exactly once in `main.rs` and never refreshes, and on a cold database that build races the task populating the world table (per the existing comment at the call site). A world it misses is absent from the analyzer's maps *for the lifetime of the process*, and every event for it is dropped.

**A refresh path is deliberately not in this PR.** Until one exists the workaround is a restart once the world table is populated — but the condition is now visible as `ultros_analyzer_skipped_events_total{reason="unknown_world"}` climbing steadily, instead of a panic that kills ingestion outright. Documented in `docs/ingest-observability.md`.

## Testing

`./check_ci.sh` passes (fmt + clippy clean). Tests run locally since CI doesn't run them:

- **ultros**: 163 passed, 1 failed
- **universalis + ultros-db**: 38 passed, 0 failed

New tests: bus lag handling over a real broadcast channel (burst larger than the ring reports lag once, then resumes and keeps delivering), snapshot filename age parsing including unparseable names, and snapshot age rejection wired through `try_restore_from_snapshot` with an injected `now`.

### Two pre-existing failures, both confirmed against an unmodified `main`

I stashed this branch, rebuilt, and ran both against `c4df0cb7` before touching either.

1. **`analyzer_service::tests::test_persistence` deadlocked** — read guards on `new_recent_sale_history` were held across a later restore that write-locks the same map, so everything past the first restore assertion was unreachable. **Fixed here** (scoped the guards), because my new snapshot-age assertions live in that test and couldn't otherwise run. It now passes in ~5s.

2. **`web::api::push::tests::label_for_safari_on_ios` fails** (`got Browser (Safari on macOS)`, `push.rs:155`). Unrelated to ingest — **left alone**, flagging it here so it isn't mistaken for fallout from this change.

## Docs

New `docs/ingest-observability.md`: metric reference, suggested alert expressions, the `WorldCache` gap, and the tunable env vars and constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
