### PR TITLE
feat(build): worktree fallback for submodule data dirs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ This repository enforces strict CI checks. Before committing any code, you **mus
 
 Failure to follow these steps will result in CI failures.
 
+Note on feature-gated code: `xiv-gen`'s `csv_to_rkyv` module is behind the
+non-default `csv_to_rkyv` feature, so plain `cargo test -p xiv-gen` compiles
+its tests out (and CI's test step is disabled entirely). When touching that
+module, run `cargo test -p xiv-gen --features csv_to_rkyv` locally —
+`check_ci.sh` lints it, but nothing else executes its tests.
+
 ## Git hooks (optional but recommended)
 
 Tracked hooks live under `scripts/hooks/`. One-time install:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ Run `./check_ci.sh` from the repo root. It runs `cargo fmt --all -- --check` and
 
 ## When the submodule isn't initialized
 
+**Worktrees usually need no submodule setup.** The `xiv-gen-db` and `ultros-xiv-icons` build scripts resolve their data dirs with a fallback chain: `FFXIV_DATAMINING_DIR` / `UNIVERSALIS_ASSETS_DIR` env override → the local submodule if populated → **the main worktree's copy** (discovered via `git worktree list`). As long as the main checkout has its submodules populated, builds in a linked worktree just work; a `cargo:warning` tells you when the fallback (or a pin drift between the worktree's recorded submodule SHA and what main has checked out) is in play. `ultros/static/classjob-icons` is runtime-only static content — not needed to build.
+
+The rest of this section is about populating the **main checkout** (or a standalone clone).
+
 `./check_ci.sh` runs clippy which compiles the whole workspace, and the `xiv-gen-db` build script reads from `xiv-gen/ffxiv-datamining/` — a git submodule. The csv data for `cn`, `ko`, `tc` lives in *nested* submodules of `ffxiv-datamining` (separate xivapi-adjacent repos), so a non-recursive init only gets you en/ja/de/fr and the build still panics on `cn/Item.csv`.
 
 ### Use `--reference`, not `--init --recursive`

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -6,3 +6,10 @@ cargo fmt --all -- --check
 
 # Run cargo clippy check
 cargo clippy --all-targets -- -D warnings
+
+# xiv-gen's csv_to_rkyv module (and its tests) only compile under this
+# non-default feature, so the workspace clippy above never sees it. Lint it
+# explicitly; the matching test gate is:
+#   cargo test -p xiv-gen --features csv_to_rkyv
+# (CI's test step is disabled, so run that locally when touching the module.)
+cargo clippy -p xiv-gen --features csv_to_rkyv --all-targets -- -D warnings

--- a/docs/superpowers/specs/2026-07-30-game-data-packs-design.md
+++ b/docs/superpowers/specs/2026-07-30-game-data-packs-design.md
@@ -42,10 +42,21 @@ resolve their data dirs through a fallback chain:
 1. `FFXIV_DATAMINING_DIR` / `UNIVERSALIS_ASSETS_DIR` env override
    (`cargo:rerun-if-env-changed` wired in the consuming build scripts);
 2. the local submodule, when populated (probe: `csv/{en,cn,tc}/Item.csv` +
-   `csv/ko/csv/Item.csv`; for icons a non-empty `icon2x/`);
+   `csv/ko/csv/Item.csv`; for icons an `icon2x/` holding ≥10k files — the full
+   set is ~17.2k, so an interrupted fetch falls back instead of shipping a
+   truncated tarball);
 3. the main git worktree's copy, discovered via `git worktree list --porcelain`
    — with a `cargo:warning` when the fallback engages and another when the
-   worktree's pinned submodule SHA differs from what main has checked out.
+   worktree's pinned submodule SHA differs from what main has checked out
+   (both build paths).
+
+The worktree-discovery/pin-drift mechanics live once, in
+`xiv-gen/src/worktree_fallback.rs`, `include!`d by both sides; its tests run
+via `cargo test -p xiv-gen --features csv_to_rkyv`. Both consuming build
+scripts register the *resolved* data dir with `cargo:rerun-if-changed`
+(un-canonicalized — `\\?\` paths from Windows canonicalization confuse cargo),
+so a datamining/assets bump re-runs them even when the data lives outside the
+package under the fallback.
 
 CI and Docker (`actions/checkout` with `submodules: recursive`) hit case 2 and
 are unaffected. The env overrides double as the seam Phase 2's generator uses.

--- a/docs/superpowers/specs/2026-07-30-game-data-packs-design.md
+++ b/docs/superpowers/specs/2026-07-30-game-data-packs-design.md
@@ -1,0 +1,158 @@
+# Game-data handling: worktree fallback + LFS data packs
+
+Date: 2026-07-30
+Status: Phase 1 implemented; Phase 2 approved in principle, pending spec review
+
+## Problem
+
+The repo bundles game data via three git submodules totaling ~2.1GB of working
+tree (`xiv-gen/ffxiv-datamining` 1.6GB + nested cn/ko/tc, `universalis-assets`
+498MB, `classjob-icons` 28MB). Every linked git worktree had to re-initialize
+them by hand (the `--reference` dance in CLAUDE.md), and the checkout is
+wildly oversized for what builds actually consume.
+
+### Measurements (2026-07-30, data version 7.55)
+
+- `ffxiv-datamining`: builds read **31 sheets per language** (~48MB of 222MB
+  per lang; 1181 of 1212 CSVs never touched). Output: 7 × `database_{lang}.rkyv`,
+  ~4.6MB each after flate2.
+- `universalis-assets`: all 17,208 `icon2x` PNGs resized to 3 sizes (60/40/25px)
+  and encoded with the `image` crate's WebP encoder, which is **lossless-only**.
+  Output: `images.tar.zst` = **130MB** (~178MB raw webp).
+  Lossy libwebp on a 300-icon sample: **q75 = 15%, q85 = 19.6%, q90 = 23.7%**
+  of the lossless bytes → a q85 pack lands around **~30MB**.
+- `database_en.rkyv` composition (flate2-best bytes): `items` **2.88MB of
+  4.74MB (61%)** — dominated by `description`, which IS used (item_view.rs);
+  then `e_npc_bases` 0.57MB, `e_npc_residents` 0.54MB, `recipes` 0.33MB.
+  Recompressing the same payload: flate2-best 4.74MB → **zstd-19 3.11MB
+  (−34%)**. This file is downloaded by every first-time visitor
+  (`/static/data/{version}/{lang}.rkyv`), so this is page-load weight, not
+  just repo hygiene.
+- Partial clone validated: `git fetch --depth=1 --filter=blob:none origin
+  <pinned-sha>` against xivapi/ffxiv-datamining took **1.2s**; sparse-checkout
+  of 5 specific CSVs (incl. Item + ENpcBase) took **6s**, `.git` = 11MB.
+  GitHub permits arbitrary-SHA fetches, so a generator script needs neither
+  submodules nor full clones.
+
+## Phase 1 — worktree fallback (implemented in this branch)
+
+`xiv-gen/src/csv_to_rkyv.rs` and `ultros-frontend/ultros-xiv-icons/build.rs`
+resolve their data dirs through a fallback chain:
+
+1. `FFXIV_DATAMINING_DIR` / `UNIVERSALIS_ASSETS_DIR` env override
+   (`cargo:rerun-if-env-changed` wired in the consuming build scripts);
+2. the local submodule, when populated (probe: `csv/{en,cn,tc}/Item.csv` +
+   `csv/ko/csv/Item.csv`; for icons a non-empty `icon2x/`);
+3. the main git worktree's copy, discovered via `git worktree list --porcelain`
+   — with a `cargo:warning` when the fallback engages and another when the
+   worktree's pinned submodule SHA differs from what main has checked out.
+
+CI and Docker (`actions/checkout` with `submodules: recursive`) hit case 2 and
+are unaffected. The env overrides double as the seam Phase 2's generator uses.
+
+## Phase 2 — LFS data packs
+
+### Layout
+
+```
+data/
+  manifest.toml          # upstream repo URLs + pinned SHAs + pack metadata
+  xiv-db/{en,ja,de,fr,cn,ko,tc}.rkyv   # zstd-compressed, LFS-tracked
+  icons/images.tar.zst                  # LFS-tracked
+```
+
+Both artifacts are consumed today via `include_bytes!(OUT_DIR/...)`; they
+switch to including the LFS files from the repo path directly. The xiv-gen-db
+build script (CSV parse + rkyv serialize, per build) and the ultros-xiv-icons
+build script (17k-image resize, minutes of CPU on cold builds) are deleted
+from the build path entirely — they move into the generator. Dev machines and
+CI never need the data submodules again; the three submodules are removed
+(`classjob-icons`: vendor the ~1.7MB of `src/` font files the CSS actually
+references — the other 26MB of PSDs/stickers/sprites are dead weight).
+
+### Format changes bundled into the pack switch
+
+- **rkyv container: flate2 → zstd-19.** 4.74MB → 3.11MB for en. Decompression
+  lives solely in `xiv_gen_db::try_init` (the client passes raw fetched bytes),
+  so the only code change is swapping the inflater — `ruzstd` (pure Rust)
+  works on both wasm and server. IndexedDB caching of the payload is
+  format-agnostic.
+- **Icons: lossless → lossy WebP.** Default **q85** (~30MB pack vs 130MB)
+  pending visual sign-off on the comparison page generated during this
+  investigation; q90 (~37MB) is the fallback if q85 shows artifacts.
+
+### Generator: a cargo bin, not a GitHub Action
+
+`cargo run -p game-data-pack -- [--latest | --pinned]`, in-workspace so it
+reuses `xiv_gen::csv_to_rkyv::read_data` and the icon-resize code verbatim:
+
+1. Read `data/manifest.toml` (5 upstream repos: ffxiv-datamining + the cn/ko/tc
+   csv repos + universalis-assets, each with URL + SHA; ko tracks the
+   `refactor` branch upstream and nests its csvs one level deeper).
+2. `--latest`: resolve each repo's remote HEAD (`git ls-remote`) and update the
+   manifest. `--pinned`: use the recorded SHAs (reproducible rebuild).
+3. Fetch into a per-user cache (`~/.cache/ultros-game-data/<repo>/`):
+   `git fetch --depth=1 --filter=blob:none origin <sha>` + sparse-checkout of
+   exactly the 31 needed CSVs per language (seconds, ~50MB/lang). Icons need
+   the full `icon2x/` blob set (~500MB) but only re-fetch when the pinned SHA
+   moves.
+4. Point `FFXIV_DATAMINING_DIR`/`UNIVERSALIS_ASSETS_DIR` at the cache and run
+   the pack build: read_data × 7 langs → rkyv → zstd; resize + lossy-encode
+   icons → tar → zstd.
+5. Write packs + manifest; report a summary (item count delta, sheet-schema
+   drift, items whose icons are missing upstream — icons historically lag
+   name data).
+
+The generator is the only thing that ever touches upstream repos.
+
+### Automation
+
+The existing `update_game_data.yml` schedule swaps its submodule bump for
+`cargo run -p game-data-pack -- --latest` and opens a PR containing the
+manifest change + regenerated LFS packs, with the generator's summary as the
+PR body. Icon-lag detection (new items with no icon upstream) is part of that
+summary instead of tribal knowledge. Local runs are identical — the workflow
+is just a scheduler.
+
+### Git LFS: costs and mitigations
+
+Chosen storage is LFS (decision 2026-07-30). Honest numbers:
+
+- Pack set ≈ **55MB/version** after the format changes (7 × ~3.5MB rkyv +
+  ~30MB icons) — vs ~165MB without them; the format work above is what makes
+  LFS comfortable.
+- GitHub free tier: 1GB LFS storage total (history accumulates ~35–55MB per
+  game-data bump), 1GB/month bandwidth. **Every un-cached CI checkout with
+  `lfs: true` downloads the full pack set**, so bandwidth is the binding
+  constraint.
+- Mitigations, in order: (1) CI caches LFS objects keyed on the manifest hash —
+  note the repo already brushes the 10GB Actions cache quota (per-ref cargo
+  caches — the historical `not_found` Docker-cache failures), so the LFS cache
+  should be small and shared-key, not per-ref; (2) a $5/mo GitHub data pack buys
+  50GB storage + bandwidth if the free tier chafes; (3) `git lfs prune` /
+  periodic history cleanup for retired pack versions.
+
+### Migration order
+
+1. Land Phase 1 (this branch).
+2. Vendor classjob-icons `src/`, delete that submodule (independent, trivial).
+3. Add the generator bin + manifest; generate packs from the current pins;
+   `.gitattributes` LFS tracking for `data/`.
+4. Switch `xiv-gen-db` and `ultros-xiv-icons` consumption to the packs
+   (include from repo path; zstd/ruzstd swap; q85 icons). CI stops needing
+   `submodules: recursive`; Dockerfile gains `lfs`.
+5. Rewrite `update_game_data.yml` around the generator; delete the
+   `ffxiv-datamining` and `universalis-assets` submodules and the CLAUDE.md
+   submodule-init section.
+
+Each step ships independently; the fallback from Phase 1 keeps everything
+working throughout.
+
+## Open questions
+
+- **Icon quality**: q85 vs q90 — judge the generated comparison page.
+- **LFS budget**: accept the $5/mo data pack up front, or start free-tier and
+  watch the bandwidth meter?
+- Should the served `/static/data/` payloads adopt zstd in the same PR as the
+  pack switch (client + server together), or ship packs first with flate2
+  retained to keep the diff smaller?

--- a/ultros-frontend/ultros-xiv-icons/build.rs
+++ b/ultros-frontend/ultros-xiv-icons/build.rs
@@ -12,20 +12,26 @@ use tar::{Builder, Header};
 use tempfile::TempDir;
 use ultros_api_types::icon_size::IconSize;
 
+// Worktree-fallback helpers (main-worktree discovery, pin-drift detection)
+// shared with `xiv-gen/src/csv_to_rkyv.rs` — a single source of truth so the
+// two build paths can't drift. Its unit tests run through the xiv-gen side:
+// `cargo test -p xiv-gen --features csv_to_rkyv`.
+include!("../../xiv-gen/src/worktree_fallback.rs");
+
 /// Locate the `universalis-assets` checkout the icons are read from.
 ///
 /// Resolution order: `UNIVERSALIS_ASSETS_DIR` env override, then the submodule
 /// next to this crate, then the main git worktree's copy — linked worktrees
 /// rarely have submodules initialized, but the main checkout usually does.
-///
-/// The same pattern exists in `xiv-gen/src/csv_to_rkyv.rs` for the
-/// `ffxiv-datamining` submodule; keep the two in sync.
+/// Mirrors `resolve_datamining_dir` in `xiv-gen/src/csv_to_rkyv.rs`; the
+/// shared mechanics live in the include!d `worktree_fallback.rs`.
 fn universalis_assets_dir(manifest_dir: &Path) -> PathBuf {
     if let Some(dir) = env::var_os("UNIVERSALIS_ASSETS_DIR") {
         let dir = PathBuf::from(dir);
         assert!(
             assets_populated(&dir),
-            "UNIVERSALIS_ASSETS_DIR is set to {} but icon2x/ is missing or empty there",
+            "UNIVERSALIS_ASSETS_DIR is set to {} but icon2x/ is missing or incomplete there \
+             (fewer than {MIN_ICON_COUNT} files)",
             dir.display()
         );
         return dir;
@@ -40,6 +46,9 @@ fn universalis_assets_dir(manifest_dir: &Path) -> PathBuf {
             .join("ultros-xiv-icons")
             .join("universalis-assets");
         if candidate != local && assets_populated(&candidate) {
+            if let Some(drift) = pin_drift_warning(manifest_dir, "universalis-assets", &candidate) {
+                println!("cargo:warning={drift}");
+            }
             println!(
                 "cargo:warning=universalis-assets submodule not populated in this checkout; \
                  falling back to {}",
@@ -56,25 +65,21 @@ fn universalis_assets_dir(manifest_dir: &Path) -> PathBuf {
     )
 }
 
-/// A failed shallow submodule fetch can leave `universalis-assets` present but
-/// empty, so require icon2x to actually contain files.
-fn assets_populated(dir: &Path) -> bool {
-    std::fs::read_dir(dir.join("icon2x")).is_ok_and(|mut entries| entries.next().is_some())
-}
+/// Minimum number of entries `icon2x/` must contain to count as populated.
+/// The full asset set is ~17.2k PNGs (17,208 as of 2026-07, data version
+/// 7.55); an interrupted shallow fetch typically leaves the dir empty or with
+/// a small partial set. 10k leaves headroom in both directions.
+const MIN_ICON_COUNT: usize = 10_000;
 
-/// Path of the main (first) git worktree, from `git worktree list --porcelain`.
-fn main_worktree(cwd: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(cwd)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
-    String::from_utf8(output.stdout)
-        .ok()?
-        .lines()
-        .find_map(|line| line.strip_prefix("worktree "))
-        .map(PathBuf::from)
+/// A failed shallow submodule fetch can leave `universalis-assets` present
+/// but empty or partially fetched, so require icon2x to contain a plausible
+/// number of files — not just any single entry — before trusting it. An
+/// incomplete local copy then falls back instead of shipping a truncated
+/// icon tarball.
+fn assets_populated(dir: &Path) -> bool {
+    std::fs::read_dir(dir.join("icon2x"))
+        .map(|entries| entries.take(MIN_ICON_COUNT).count() >= MIN_ICON_COUNT)
+        .unwrap_or(false)
 }
 
 /// Resizes all xiv-icons and bundles them
@@ -192,6 +197,9 @@ async fn compress(path: &PathBuf) {
 #[tokio::main]
 async fn main() {
     println!("cargo:rerun-if-changed=./build.rs");
+    // build.rs textually include!s the shared worktree-fallback helpers, so
+    // watch that file too (the path is relative to this package's root).
+    println!("cargo:rerun-if-changed=../../xiv-gen/src/worktree_fallback.rs");
     println!("cargo:rerun-if-env-changed=UNIVERSALIS_ASSETS_DIR");
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let assets = universalis_assets_dir(Path::new(&manifest_dir)).join("icon2x");

--- a/ultros-frontend/ultros-xiv-icons/build.rs
+++ b/ultros-frontend/ultros-xiv-icons/build.rs
@@ -12,11 +12,75 @@ use tar::{Builder, Header};
 use tempfile::TempDir;
 use ultros_api_types::icon_size::IconSize;
 
+/// Locate the `universalis-assets` checkout the icons are read from.
+///
+/// Resolution order: `UNIVERSALIS_ASSETS_DIR` env override, then the submodule
+/// next to this crate, then the main git worktree's copy — linked worktrees
+/// rarely have submodules initialized, but the main checkout usually does.
+///
+/// The same pattern exists in `xiv-gen/src/csv_to_rkyv.rs` for the
+/// `ffxiv-datamining` submodule; keep the two in sync.
+fn universalis_assets_dir(manifest_dir: &Path) -> PathBuf {
+    if let Some(dir) = env::var_os("UNIVERSALIS_ASSETS_DIR") {
+        let dir = PathBuf::from(dir);
+        assert!(
+            assets_populated(&dir),
+            "UNIVERSALIS_ASSETS_DIR is set to {} but icon2x/ is missing or empty there",
+            dir.display()
+        );
+        return dir;
+    }
+    let local = manifest_dir.join("universalis-assets");
+    if assets_populated(&local) {
+        return local;
+    }
+    if let Some(main) = main_worktree(manifest_dir) {
+        let candidate = main
+            .join("ultros-frontend")
+            .join("ultros-xiv-icons")
+            .join("universalis-assets");
+        if candidate != local && assets_populated(&candidate) {
+            println!(
+                "cargo:warning=universalis-assets submodule not populated in this checkout; \
+                 falling back to {}",
+                candidate.display()
+            );
+            return candidate;
+        }
+    }
+    panic!(
+        "could not find a populated universalis-assets checkout. Either initialize the \
+         submodule (see CLAUDE.md), or set UNIVERSALIS_ASSETS_DIR to an existing checkout. \
+         Looked at {} and the main worktree.",
+        local.display()
+    )
+}
+
+/// A failed shallow submodule fetch can leave `universalis-assets` present but
+/// empty, so require icon2x to actually contain files.
+fn assets_populated(dir: &Path) -> bool {
+    std::fs::read_dir(dir.join("icon2x")).is_ok_and(|mut entries| entries.next().is_some())
+}
+
+/// Path of the main (first) git worktree, from `git worktree list --porcelain`.
+fn main_worktree(cwd: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    String::from_utf8(output.stdout)
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("worktree "))
+        .map(PathBuf::from)
+}
+
 /// Resizes all xiv-icons and bundles them
-async fn resize_all_images(out_dir: &Path) {
-    let dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let assets = format!("{dir}/universalis-assets/icon2x");
-    let path = std::fs::canonicalize(&assets).unwrap_or_else(|error| panic!("{error}\n{assets}"));
+async fn resize_all_images(assets: &Path, out_dir: &Path) {
+    let path = std::fs::canonicalize(assets)
+        .unwrap_or_else(|error| panic!("{error}\n{}", assets.display()));
     println!("opening {path:?}");
     let mut paths = vec![];
     for file in read_dir(&path).unwrap_or_else(|error| panic!("{error}\n{path:?}")) {
@@ -127,11 +191,17 @@ async fn compress(path: &PathBuf) {
 
 #[tokio::main]
 async fn main() {
-    println!("cargo:rerun-if-changed=./universalis-assets/icon2x");
-    println!("cargo:rerun-if-change=./build.rs");
+    println!("cargo:rerun-if-changed=./build.rs");
+    println!("cargo:rerun-if-env-changed=UNIVERSALIS_ASSETS_DIR");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let assets = universalis_assets_dir(Path::new(&manifest_dir)).join("icon2x");
+    // Register the *resolved* dir: a fixed `./universalis-assets/icon2x` would
+    // not exist in a worktree using the fallback, and cargo re-runs the build
+    // script on every build when a rerun-if-changed path is missing.
+    println!("cargo:rerun-if-changed={}", assets.display());
     let instant = Instant::now();
     let temp_dir = TempDir::new().unwrap();
-    resize_all_images(temp_dir.path()).await;
+    resize_all_images(&assets, temp_dir.path()).await;
     compress(&temp_dir.path().to_path_buf()).await;
     println!(
         "Finished resizing {}ms",

--- a/xiv-gen-db/build.rs
+++ b/xiv-gen-db/build.rs
@@ -7,6 +7,9 @@ use xiv_gen::Language;
 use xiv_gen::csv_to_rkyv::read_data;
 
 fn main() {
+    // The csv source dir is resolved by xiv_gen::csv_to_rkyv::datamining_dir —
+    // env override, then the local submodule, then the main worktree's copy.
+    println!("cargo:rerun-if-env-changed=FFXIV_DATAMINING_DIR");
     let languages = [
         Language::En,
         Language::Ja,

--- a/xiv-gen-db/build.rs
+++ b/xiv-gen-db/build.rs
@@ -4,12 +4,31 @@ use flate2::{Compression, FlushCompress};
 use std::env;
 use std::path::Path;
 use xiv_gen::Language;
-use xiv_gen::csv_to_rkyv::read_data;
+use xiv_gen::csv_to_rkyv::{read_data, resolved_datamining_dir};
 
 fn main() {
-    // The csv source dir is resolved by xiv_gen::csv_to_rkyv::datamining_dir —
-    // env override, then the local submodule, then the main worktree's copy.
+    println!("cargo:rerun-if-changed=build.rs");
+    // The csv source dir is resolved by xiv_gen::csv_to_rkyv — env override,
+    // then the local submodule, then the main worktree's copy.
     println!("cargo:rerun-if-env-changed=FFXIV_DATAMINING_DIR");
+    let datamining = match resolved_datamining_dir() {
+        Ok(resolved) => resolved,
+        Err(message) => panic!("{message}"),
+    };
+    for warning in &datamining.warnings {
+        println!("cargo:warning={warning}");
+    }
+    // Re-run when the CSVs change (i.e. a datamining submodule bump). The
+    // resolved dir may live outside this package (main-worktree fallback) or
+    // even outside the xiv-gen path dependency, so without registering it a
+    // bump would silently never rebuild the rkyv — and the pin-drift warning
+    // above only prints when this script re-runs. Deliberately the
+    // un-canonicalized path: canonicalizing on Windows yields `\\?\` paths
+    // that cargo mishandles.
+    println!(
+        "cargo:rerun-if-changed={}",
+        datamining.path.join("csv").display()
+    );
     let languages = [
         Language::En,
         Language::Ja,
@@ -45,5 +64,4 @@ fn main() {
             lang
         );
     }
-    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/xiv-gen/src/csv_to_rkyv.rs
+++ b/xiv-gen/src/csv_to_rkyv.rs
@@ -4,10 +4,22 @@
 use crate::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::OnceLock;
 
-/// Locate the `ffxiv-datamining` checkout the CSVs are read from.
+/// A resolved `ffxiv-datamining` checkout.
+pub struct ResolvedDataDir {
+    /// The resolved directory. Deliberately un-canonicalized: build scripts
+    /// register it with `cargo:rerun-if-changed`, and canonicalizing on
+    /// Windows yields `\\?\` paths that cargo mishandles.
+    pub path: PathBuf,
+    /// Messages the consuming build script should surface as `cargo:warning`
+    /// (fallback engaged, submodule pin drift). This module never prints
+    /// cargo directives itself — that's the build script's job.
+    pub warnings: Vec<String>,
+}
+
+/// Locate the `ffxiv-datamining` checkout the CSVs are read from. Resolved
+/// once and cached for the lifetime of the process.
 ///
 /// Resolution order:
 /// 1. `FFXIV_DATAMINING_DIR` — explicit override (the consuming build script
@@ -18,49 +30,77 @@ use std::sync::OnceLock;
 ///    have submodules initialized, but the main checkout usually does — this
 ///    lets worktree builds work with zero setup.
 ///
-/// The same pattern exists in `ultros-frontend/ultros-xiv-icons/build.rs` for
-/// the `universalis-assets` submodule; keep the two in sync.
-fn datamining_dir() -> &'static Path {
-    static DIR: OnceLock<PathBuf> = OnceLock::new();
-    DIR.get_or_init(|| {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        if let Some(dir) = std::env::var_os("FFXIV_DATAMINING_DIR") {
-            let dir = PathBuf::from(dir);
-            assert!(
-                datamining_populated(&dir),
+/// Build scripts should call this before [`read_data`]: emit `cargo:warning`
+/// for each entry in [`ResolvedDataDir::warnings`], register `<path>/csv`
+/// with `cargo:rerun-if-changed` (otherwise a datamining bump never re-runs
+/// the script), and panic on `Err` — see `xiv-gen-db/build.rs`. [`read_data`]
+/// panics on `Err` too, but silently drops the warnings.
+pub fn resolved_datamining_dir() -> &'static Result<ResolvedDataDir, String> {
+    static DIR: OnceLock<Result<ResolvedDataDir, String>> = OnceLock::new();
+    DIR.get_or_init(resolve_datamining_dir)
+}
+
+fn resolve_datamining_dir() -> Result<ResolvedDataDir, String> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    if let Some(dir) = std::env::var_os("FFXIV_DATAMINING_DIR") {
+        let dir = PathBuf::from(dir);
+        if !datamining_populated(&dir) {
+            return Err(format!(
                 "FFXIV_DATAMINING_DIR is set to {} but the expected csv files \
                  (csv/{{en,cn,tc}}/Item.csv, csv/ko/csv/Item.csv) are not all present there",
                 dir.display()
-            );
-            return dir;
+            ));
         }
-        let local = manifest_dir.join("ffxiv-datamining");
-        if datamining_populated(&local) {
-            return local;
-        }
-        if let Some(main) = main_worktree(manifest_dir) {
-            let candidate = main.join("xiv-gen").join("ffxiv-datamining");
-            if candidate != local && datamining_populated(&candidate) {
-                warn_on_pin_drift(manifest_dir, &candidate);
-                println!(
-                    "cargo:warning=ffxiv-datamining submodule not populated in this checkout; \
-                     falling back to {}",
-                    candidate.display()
-                );
-                return candidate;
+        return Ok(ResolvedDataDir {
+            path: dir,
+            warnings: Vec::new(),
+        });
+    }
+    let local = manifest_dir.join("ffxiv-datamining");
+    if datamining_populated(&local) {
+        return Ok(ResolvedDataDir {
+            path: local,
+            warnings: Vec::new(),
+        });
+    }
+    if let Some(main) = main_worktree(manifest_dir) {
+        let candidate = main.join("xiv-gen").join("ffxiv-datamining");
+        if candidate != local && datamining_populated(&candidate) {
+            let mut warnings = Vec::new();
+            if let Some(drift) = pin_drift_warning(manifest_dir, "ffxiv-datamining", &candidate) {
+                warnings.push(drift);
             }
+            warnings.push(format!(
+                "ffxiv-datamining submodule not populated in this checkout; \
+                 falling back to {}",
+                candidate.display()
+            ));
+            return Ok(ResolvedDataDir {
+                path: candidate,
+                warnings,
+            });
         }
-        panic!(
-            "could not find a populated ffxiv-datamining checkout. Either initialize the \
-             submodule (see CLAUDE.md), or set FFXIV_DATAMINING_DIR to an existing checkout. \
-             Looked at {} and the main worktree.",
-            local.display()
-        )
-    })
+    }
+    Err(format!(
+        "could not find a populated ffxiv-datamining checkout. Either initialize the \
+         submodule (see CLAUDE.md), or set FFXIV_DATAMINING_DIR to an existing checkout. \
+         Looked at {} and the main worktree.",
+        local.display()
+    ))
 }
 
-/// `true` when every language's data is present, including the nested cn/ko/tc
-/// submodules (a non-recursive init only populates en/ja/de/fr). `csv/ko`
+fn datamining_dir() -> &'static Path {
+    match resolved_datamining_dir() {
+        Ok(resolved) => &resolved.path,
+        Err(message) => panic!("{message}"),
+    }
+}
+
+/// `true` when every language's data is present. The probe set deliberately
+/// includes cn/tc/ko because those live in *nested* submodules — a
+/// non-recursive init only populates en/ja/de/fr, and probing the nested
+/// files catches that half-initialized state up front (falling back or
+/// failing here) instead of dying mid-build on `cn/Item.csv`. `csv/ko`
 /// genuinely nests one level deeper than its siblings — that's the ko repo's
 /// own layout.
 fn datamining_populated(dir: &Path) -> bool {
@@ -72,49 +112,6 @@ fn datamining_populated(dir: &Path) -> bool {
     ]
     .iter()
     .all(|probe| dir.join(probe).is_file())
-}
-
-/// Path of the main (first) git worktree, from `git worktree list --porcelain`.
-fn main_worktree(cwd: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(cwd)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
-    parse_main_worktree(std::str::from_utf8(&output.stdout).ok()?)
-}
-
-fn parse_main_worktree(porcelain: &str) -> Option<PathBuf> {
-    porcelain
-        .lines()
-        .find_map(|line| line.strip_prefix("worktree "))
-        .map(PathBuf::from)
-}
-
-/// Warn when this checkout pins a different submodule commit than the main
-/// worktree actually has checked out — the fallback would then build against
-/// the wrong data. Best-effort: silent on any git failure.
-fn warn_on_pin_drift(manifest_dir: &Path, fallback: &Path) {
-    let rev_parse = |dir: &Path, rev: &str| -> Option<String> {
-        let output = Command::new("git")
-            .args(["rev-parse", rev])
-            .current_dir(dir)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())?;
-        Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
-    };
-    let pinned = rev_parse(manifest_dir, "HEAD:./ffxiv-datamining");
-    let actual = rev_parse(fallback, "HEAD");
-    if let (Some(pinned), Some(actual)) = (pinned, actual)
-        && pinned != actual
-    {
-        println!(
-            "cargo:warning=ffxiv-datamining pin drift: this checkout pins {pinned} but the \
-             main worktree has {actual} checked out; building against {actual}"
-        );
-    }
 }
 
 pub fn read_data(lang: Language) -> Data {
@@ -186,7 +183,14 @@ fn read_csv_vec<T: FromCsv>(path: &str) -> Vec<T> {
     let mut reader = csv::ReaderBuilder::new()
         .has_headers(false)
         .from_path(path)
-        .unwrap_or_else(|_| panic!("Failed to open csv at {}", path));
+        .unwrap_or_else(|error| {
+            panic!(
+                "Failed to open csv at {path}: {error}. The datamining dir resolved to {}; \
+                 if that checkout is stale or partial, re-initialize the submodule (see \
+                 CLAUDE.md) or set FFXIV_DATAMINING_DIR to a populated checkout.",
+                datamining_dir().display()
+            )
+        });
     let mut records = reader.records();
 
     let first_row = records.next().expect("Missing header").unwrap();
@@ -232,27 +236,6 @@ fn split_multi_indexed_column<'a>(column: &'a str, prefix: &str) -> Option<(&'a 
     indexes.split_once("][")
 }
 
-#[cfg(test)]
-mod tests {
-    use super::parse_main_worktree;
-    use std::path::Path;
-
-    #[test]
-    fn parses_first_worktree_entry() {
-        let porcelain = "worktree C:/Users/x/code/ultros\nHEAD abc123\nbranch refs/heads/main\n\n\
-                         worktree C:/Users/x/code/ultros/.claude/worktrees/foo\nHEAD def456\n";
-        assert_eq!(
-            parse_main_worktree(porcelain).as_deref(),
-            Some(Path::new("C:/Users/x/code/ultros"))
-        );
-    }
-
-    #[test]
-    fn handles_missing_output() {
-        assert_eq!(parse_main_worktree(""), None);
-    }
-}
-
 fn read_csv_to_map<K, T>(path: &str) -> HashMap<K, T>
 where
     T: FromCsv + HasId<Id = K>,
@@ -263,3 +246,9 @@ where
         .map(|item| (item.get_id(), item))
         .collect()
 }
+
+// Worktree-fallback helpers (main-worktree discovery, pin-drift detection)
+// shared with `ultros-frontend/ultros-xiv-icons/build.rs` via `include!`.
+// Kept last because the file carries its own `#[cfg(test)]` module and
+// clippy's `items_after_test_module` wants nothing after it.
+include!("worktree_fallback.rs");

--- a/xiv-gen/src/csv_to_rkyv.rs
+++ b/xiv-gen/src/csv_to_rkyv.rs
@@ -3,18 +3,125 @@
 /// Recommended to just let xiv-gen-db handle this unless you need a different backing store.
 use crate::*;
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+/// Locate the `ffxiv-datamining` checkout the CSVs are read from.
+///
+/// Resolution order:
+/// 1. `FFXIV_DATAMINING_DIR` — explicit override (the consuming build script
+///    emits `cargo:rerun-if-env-changed` for it).
+/// 2. The submodule next to this crate, when fully populated (including the
+///    nested cn/ko/tc submodules).
+/// 3. The main git worktree's copy of the submodule. Linked worktrees rarely
+///    have submodules initialized, but the main checkout usually does — this
+///    lets worktree builds work with zero setup.
+///
+/// The same pattern exists in `ultros-frontend/ultros-xiv-icons/build.rs` for
+/// the `universalis-assets` submodule; keep the two in sync.
+fn datamining_dir() -> &'static Path {
+    static DIR: OnceLock<PathBuf> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        if let Some(dir) = std::env::var_os("FFXIV_DATAMINING_DIR") {
+            let dir = PathBuf::from(dir);
+            assert!(
+                datamining_populated(&dir),
+                "FFXIV_DATAMINING_DIR is set to {} but the expected csv files \
+                 (csv/{{en,cn,tc}}/Item.csv, csv/ko/csv/Item.csv) are not all present there",
+                dir.display()
+            );
+            return dir;
+        }
+        let local = manifest_dir.join("ffxiv-datamining");
+        if datamining_populated(&local) {
+            return local;
+        }
+        if let Some(main) = main_worktree(manifest_dir) {
+            let candidate = main.join("xiv-gen").join("ffxiv-datamining");
+            if candidate != local && datamining_populated(&candidate) {
+                warn_on_pin_drift(manifest_dir, &candidate);
+                println!(
+                    "cargo:warning=ffxiv-datamining submodule not populated in this checkout; \
+                     falling back to {}",
+                    candidate.display()
+                );
+                return candidate;
+            }
+        }
+        panic!(
+            "could not find a populated ffxiv-datamining checkout. Either initialize the \
+             submodule (see CLAUDE.md), or set FFXIV_DATAMINING_DIR to an existing checkout. \
+             Looked at {} and the main worktree.",
+            local.display()
+        )
+    })
+}
+
+/// `true` when every language's data is present, including the nested cn/ko/tc
+/// submodules (a non-recursive init only populates en/ja/de/fr). `csv/ko`
+/// genuinely nests one level deeper than its siblings — that's the ko repo's
+/// own layout.
+fn datamining_populated(dir: &Path) -> bool {
+    [
+        "csv/en/Item.csv",
+        "csv/cn/Item.csv",
+        "csv/tc/Item.csv",
+        "csv/ko/csv/Item.csv",
+    ]
+    .iter()
+    .all(|probe| dir.join(probe).is_file())
+}
+
+/// Path of the main (first) git worktree, from `git worktree list --porcelain`.
+fn main_worktree(cwd: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    parse_main_worktree(std::str::from_utf8(&output.stdout).ok()?)
+}
+
+fn parse_main_worktree(porcelain: &str) -> Option<PathBuf> {
+    porcelain
+        .lines()
+        .find_map(|line| line.strip_prefix("worktree "))
+        .map(PathBuf::from)
+}
+
+/// Warn when this checkout pins a different submodule commit than the main
+/// worktree actually has checked out — the fallback would then build against
+/// the wrong data. Best-effort: silent on any git failure.
+fn warn_on_pin_drift(manifest_dir: &Path, fallback: &Path) {
+    let rev_parse = |dir: &Path, rev: &str| -> Option<String> {
+        let output = Command::new("git")
+            .args(["rev-parse", rev])
+            .current_dir(dir)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())?;
+        Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+    };
+    let pinned = rev_parse(manifest_dir, "HEAD:./ffxiv-datamining");
+    let actual = rev_parse(fallback, "HEAD");
+    if let (Some(pinned), Some(actual)) = (pinned, actual)
+        && pinned != actual
+    {
+        println!(
+            "cargo:warning=ffxiv-datamining pin drift: this checkout pins {pinned} but the \
+             main worktree has {actual} checked out; building against {actual}"
+        );
+    }
+}
 
 pub fn read_data(lang: Language) -> Data {
+    let root = datamining_dir().display();
     let base_path = match lang {
-        Language::Ko => format!(
-            "{}/ffxiv-datamining/csv/ko/csv/",
-            env!("CARGO_MANIFEST_DIR")
-        ),
-        _ => format!(
-            "{}/ffxiv-datamining/csv/{}/",
-            env!("CARGO_MANIFEST_DIR"),
-            lang.to_path_part()
-        ),
+        Language::Ko => format!("{root}/csv/ko/csv/"),
+        _ => format!("{root}/csv/{}/", lang.to_path_part()),
     };
     Data {
         items: read_csv_to_map(&format!("{}Item.csv", base_path)),
@@ -123,6 +230,27 @@ fn read_csv_vec<T: FromCsv>(path: &str) -> Vec<T> {
 fn split_multi_indexed_column<'a>(column: &'a str, prefix: &str) -> Option<(&'a str, &'a str)> {
     let indexes = column.strip_prefix(prefix)?.strip_suffix(']')?;
     indexes.split_once("][")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_main_worktree;
+    use std::path::Path;
+
+    #[test]
+    fn parses_first_worktree_entry() {
+        let porcelain = "worktree C:/Users/x/code/ultros\nHEAD abc123\nbranch refs/heads/main\n\n\
+                         worktree C:/Users/x/code/ultros/.claude/worktrees/foo\nHEAD def456\n";
+        assert_eq!(
+            parse_main_worktree(porcelain).as_deref(),
+            Some(Path::new("C:/Users/x/code/ultros"))
+        );
+    }
+
+    #[test]
+    fn handles_missing_output() {
+        assert_eq!(parse_main_worktree(""), None);
+    }
 }
 
 fn read_csv_to_map<K, T>(path: &str) -> HashMap<K, T>

--- a/xiv-gen/src/worktree_fallback.rs
+++ b/xiv-gen/src/worktree_fallback.rs
@@ -1,0 +1,94 @@
+// Worktree-fallback helpers shared by `xiv-gen/src/csv_to_rkyv.rs` and
+// `ultros-frontend/ultros-xiv-icons/build.rs`, both via `include!`, so the
+// two build paths resolve submodule data dirs with the exact same logic and
+// a future edit can't change one without the other.
+//
+// Constraints that follow from being textually included:
+// - std-only, and everything fully qualified — no `use` statements, so this
+//   file can't collide with the includer's imports;
+// - the tests below compile (and run) only through the xiv-gen include:
+//   `cargo test -p xiv-gen --features csv_to_rkyv`. Build scripts never run
+//   unit tests, so the icons side is covered by the same tests by virtue of
+//   including the same file.
+
+/// Path of the main (first) git worktree, from `git worktree list --porcelain`.
+fn main_worktree(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    parse_main_worktree(std::str::from_utf8(&output.stdout).ok()?)
+}
+
+fn parse_main_worktree(porcelain: &str) -> Option<std::path::PathBuf> {
+    porcelain
+        .lines()
+        .find_map(|line| line.strip_prefix("worktree "))
+        .map(std::path::PathBuf::from)
+}
+
+/// `git rev-parse <rev>` in `dir`; `None` on any failure.
+fn rev_parse(dir: &std::path::Path, rev: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", rev])
+        .current_dir(dir)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    Some(String::from_utf8(output.stdout).ok()?.trim().to_string())
+}
+
+/// Warning to emit when this checkout pins a different commit of `submodule`
+/// (path relative to `member_dir`, the directory of the crate that owns it)
+/// than the main worktree's `fallback` copy actually has checked out — the
+/// fallback would then build against the wrong data. Best-effort: `None` on
+/// any git failure or when the pins match; warning-only, never fails a build.
+fn pin_drift_warning(
+    member_dir: &std::path::Path,
+    submodule: &str,
+    fallback: &std::path::Path,
+) -> Option<String> {
+    let pinned = rev_parse(member_dir, &format!("HEAD:./{submodule}"))?;
+    let actual = rev_parse(fallback, "HEAD")?;
+    (pinned != actual).then(|| drift_message(submodule, &pinned, &actual))
+}
+
+fn drift_message(submodule: &str, pinned: &str, actual: &str) -> String {
+    format!(
+        "{submodule} pin drift: this checkout pins {pinned} but the \
+         main worktree has {actual} checked out; building against {actual}"
+    )
+}
+
+#[cfg(test)]
+mod worktree_fallback_tests {
+    use super::{drift_message, parse_main_worktree};
+    use std::path::Path;
+
+    #[test]
+    fn parses_first_worktree_entry() {
+        let porcelain = "worktree C:/Users/x/code/ultros\nHEAD abc123\nbranch refs/heads/main\n\n\
+                         worktree C:/Users/x/code/ultros/.claude/worktrees/foo\nHEAD def456\n";
+        assert_eq!(
+            parse_main_worktree(porcelain).as_deref(),
+            Some(Path::new("C:/Users/x/code/ultros"))
+        );
+    }
+
+    #[test]
+    fn handles_missing_output() {
+        assert_eq!(parse_main_worktree(""), None);
+    }
+
+    #[test]
+    fn drift_message_names_submodule_and_both_shas() {
+        let message = drift_message("ffxiv-datamining", "aaa111", "bbb222");
+        assert_eq!(
+            message,
+            "ffxiv-datamining pin drift: this checkout pins aaa111 but the \
+             main worktree has bbb222 checked out; building against bbb222"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`xiv-gen-db` and `ultros-xiv-icons` no longer require submodules to be initialized in linked git worktrees. Both build paths resolve their data dir through a fallback chain:

1. `FFXIV_DATAMINING_DIR` / `UNIVERSALIS_ASSETS_DIR` env override (`cargo:rerun-if-env-changed` wired)
2. the local submodule, when populated — including the nested cn/ko/tc csv submodules (probe: `csv/{en,cn,tc}/Item.csv` + `csv/ko/csv/Item.csv`; for icons an `icon2x/` with ≥10k files — full set ~17.2k — so an interrupted fetch falls back instead of shipping a truncated tarball)
3. the **main worktree's copy**, discovered via `git worktree list --porcelain`, with a `cargo:warning` when the fallback engages and another when the worktree's pinned submodule SHA drifts from what main has checked out — on **both** paths

CI and Docker (`actions/checkout` with `submodules: recursive`) hit case 2 and are unchanged.

Also:
- **both** consuming build scripts register the **resolved** data dir for `rerun-if-changed` (un-canonicalized — Windows `\?\` paths confuse cargo): `xiv-gen-db` registers `<resolved>/csv` so a datamining bump still re-runs the rkyv generation now that the CSVs may live outside the package (and the pin-drift warning stays alive); the icons side registers the resolved `icon2x` — a fixed `./universalis-assets/icon2x` doesn't exist under the fallback, and cargo re-runs a build script on *every* build when a registered path is missing (would have re-run the ~5-minute resize each build); fixes the pre-existing `rerun-if-change` typo
- the worktree-discovery/pin-drift mechanics live once in `xiv-gen/src/worktree_fallback.rs`, `include!`d by both `csv_to_rkyv.rs` and the icons build.rs, so the two paths can't drift; resolution is a `Result`-returning, warning-collecting resolver (`csv_to_rkyv::resolved_datamining_dir()`), with panic + `cargo:warning` emission at the build-script boundary
- the feature-gated `csv_to_rkyv` tests get a real gate: `check_ci.sh` now lints `-p xiv-gen --features csv_to_rkyv`, and AGENTS.md documents the local `cargo test -p xiv-gen --features csv_to_rkyv` run (CI's test step is disabled)
- CLAUDE.md worktree instructions updated; the `--reference` init dance is now main-checkout-only guidance
- adds the phase-2 design spec (`docs/superpowers/specs/2026-07-30-game-data-packs-design.md`): LFS data packs with measured wins (icons 130MB → ~30MB at lossy q85, rkyv client payload −34% via zstd-19, pinned-SHA sparse fetch validated at seconds vs a 1.6GB clone). Follow-up PRs implement it.

## Verification

- `cargo check -p xiv-gen-db` in a worktree with **uninitialized** submodules: fell back to the main checkout's copy with the expected warning, and the build-script output registers `cargo:rerun-if-changed=<main>/xiv-gen/ffxiv-datamining/csv` (un-canonicalized)
- after initializing submodules (populated path): `cargo clippy -p ultros-xiv-icons --all-targets` re-ran the icon build against the local submodule, registering the local resolved `icon2x` + the shared helper file
- `cargo test -p xiv-gen --features csv_to_rkyv` — 3 passed (worktree parsing + drift-message tests, shared by both build paths)
- `cargo clippy -p xiv-gen -p xiv-gen-db --features xiv-gen/csv_to_rkyv --all-targets -- -D warnings` + `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)