### PR TITLE
fix(item-page): base freshness badge on real ingest time and honest velocity

### DIFF
--- a/ultros-api-types/src/freshness.rs
+++ b/ultros-api-types/src/freshness.rs
@@ -1,3 +1,4 @@
+use crate::SaleHistory;
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,33 @@ const BASE_CAUTION_HOURS: f64 = 72.0;
 /// - 100 sales/day: ~14m Fresh / ~42m Caution
 const VELOCITY_FACTOR: f64 = 1.0;
 
+/// Estimates sales velocity (sales per day) from a window of recent sales.
+///
+/// Returns `None` whenever a rate cannot honestly be derived, so callers feed
+/// [`calculate_freshness_verdict`] a `None` and get a [`FreshnessVerdict::NoData`]
+/// instead of a fabricated number:
+/// - no sales at all: `None` — an absence of data is *not* a confident zero
+///   (a zero would select the most permissive freshness thresholds);
+/// - exactly one sale: `None` — a single point has no time window;
+/// - all sales share one timestamp: `None` — a zero-length window has no
+///   finite rate (previously this produced a magic `100.0`).
+///
+/// The estimate is `(count - 1) / window_days`, i.e. the number of intervals
+/// between the oldest and newest sale in the window. Sale order does not matter.
+pub fn sales_per_day(sales: &[SaleHistory]) -> Option<f32> {
+    if sales.len() < 2 {
+        return None;
+    }
+    let newest = sales.iter().map(|sale| sale.sold_date).max()?;
+    let oldest = sales.iter().map(|sale| sale.sold_date).min()?;
+    let seconds = (newest - oldest).num_seconds();
+    if seconds <= 0 {
+        return None;
+    }
+    let intervals = (sales.len() - 1) as f32;
+    Some(intervals / (seconds as f32 / 86_400.0))
+}
+
 /// Calculates a freshness verdict based on the age of a listing and its sales velocity.
 ///
 /// If either `age` or `sales_per_day` is missing, returns [`FreshnessVerdict::NoData`].
@@ -69,7 +97,65 @@ pub fn calculate_freshness_verdict(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Duration;
+    use chrono::{DateTime, Duration};
+
+    fn sale_at(seconds: i64) -> SaleHistory {
+        SaleHistory {
+            id: seconds as i32,
+            quantity: 1,
+            price_per_item: 100,
+            buying_character_id: 1,
+            hq: false,
+            sold_item_id: 1,
+            sold_date: DateTime::from_timestamp(seconds, 0).unwrap().naive_utc(),
+            world_id: 1,
+            buyer_name: None,
+        }
+    }
+
+    #[test]
+    fn test_sales_per_day_empty_is_none() {
+        // No sales is unknown velocity, NOT a confident zero: a zero would
+        // select the most permissive thresholds and paint no-data items green.
+        assert_eq!(sales_per_day(&[]), None);
+        assert_eq!(
+            calculate_freshness_verdict(Some(Duration::hours(1)), sales_per_day(&[])),
+            FreshnessVerdict::NoData
+        );
+    }
+
+    #[test]
+    fn test_sales_per_day_single_sale_is_none() {
+        // One sale has no window; consistent with the empty case.
+        assert_eq!(sales_per_day(&[sale_at(0)]), None);
+        assert_eq!(
+            calculate_freshness_verdict(Some(Duration::hours(1)), sales_per_day(&[sale_at(0)])),
+            FreshnessVerdict::NoData
+        );
+    }
+
+    #[test]
+    fn test_sales_per_day_zero_window_is_none() {
+        // All sales at the same instant: no finite rate can be derived.
+        let sales = vec![sale_at(1000), sale_at(1000), sale_at(1000)];
+        assert_eq!(sales_per_day(&sales), None);
+    }
+
+    #[test]
+    fn test_sales_per_day_simple_rates() {
+        let day = 86_400;
+        // 2 sales one day apart -> 1 sale/day.
+        let sales = vec![sale_at(0), sale_at(day)];
+        assert_eq!(sales_per_day(&sales), Some(1.0));
+
+        // 5 sales spread over one day -> 4 intervals/day.
+        let sales: Vec<_> = (0..5).map(|i| sale_at(i * day / 4)).collect();
+        assert_eq!(sales_per_day(&sales), Some(4.0));
+
+        // Order does not matter (min/max scan, not first/last).
+        let sales = vec![sale_at(day), sale_at(0)];
+        assert_eq!(sales_per_day(&sales), Some(1.0));
+    }
 
     #[test]
     fn test_no_data() {

--- a/ultros-api-types/src/lib.rs
+++ b/ultros-api-types/src/lib.rs
@@ -30,12 +30,29 @@ pub use retainer::Retainer;
 pub use sale_history::{CompactSale, ExtendedSaleHistory, SaleHistory};
 
 use crate::websocket::{EventType, ListingEventData, SaleEventData};
+use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// When Ultros last ingested market-board data for an item on a specific world.
+///
+/// This is the real ingest time (the `listing_last_updated` marker written when
+/// listings/sales for the item are stored), *not* Universalis' `last_review_time`
+/// which [`ActiveListing::timestamp`] carries (when the seller last touched the
+/// listing in-game).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorldItemLastUpdated {
+    pub world_id: i32,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CurrentlyShownItem {
     pub listings: Vec<(ActiveListing, Retainer)>,
     pub sales: Vec<SaleHistory>,
+    /// Per-world ingest timestamps for the queried scope. Additive field:
+    /// defaults to empty when deserializing payloads from older servers.
+    #[serde(default)]
+    pub last_updated: Vec<WorldItemLastUpdated>,
 }
 
 impl CurrentlyShownItem {
@@ -163,6 +180,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![],
+            last_updated: vec![],
         };
         let event = EventType::Added(ListingEventData {
             item_id: 1,
@@ -180,6 +198,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![test_listing(1, 1, 100)],
             sales: vec![],
+            last_updated: vec![],
         };
         let event = EventType::Updated(ListingEventData {
             item_id: 1,
@@ -197,6 +216,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![test_listing(1, 1, 100)],
             sales: vec![],
+            last_updated: vec![],
         };
         let event = EventType::Removed(ListingEventData {
             item_id: 1,
@@ -213,6 +233,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![test_listing(1, 1, 100)],
             sales: vec![],
+            last_updated: vec![],
         };
         let event = EventType::Updated(ListingEventData {
             item_id: 2,
@@ -232,6 +253,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![],
+            last_updated: vec![],
         };
         let event = EventType::Added(SaleEventData {
             sales: vec![test_sale(1, 1, 100, NaiveDateTime::default())],
@@ -248,6 +270,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![sale],
+            last_updated: vec![],
         };
         let event = EventType::Updated(SaleEventData {
             sales: vec![test_sale(1, 1, 150, NaiveDateTime::default())],
@@ -264,6 +287,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![sale],
+            last_updated: vec![],
         };
         let event = EventType::Removed(SaleEventData {
             sales: vec![test_sale(1, 1, 100, NaiveDateTime::default())],
@@ -279,6 +303,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![sale],
+            last_updated: vec![],
         };
         // Add event for wrong item
         let event = EventType::Added(SaleEventData {
@@ -301,6 +326,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![],
+            last_updated: vec![],
         };
         let date_early = DateTime::from_timestamp(1000, 0).unwrap().naive_utc();
         let date_late = DateTime::from_timestamp(2000, 0).unwrap().naive_utc();
@@ -323,6 +349,7 @@ mod tests {
         let mut data = CurrentlyShownItem {
             listings: vec![],
             sales: vec![],
+            last_updated: vec![],
         };
         let mut sales = vec![];
         for i in 0..205 {

--- a/ultros-db/src/recently_updated.rs
+++ b/ultros-db/src/recently_updated.rs
@@ -49,6 +49,24 @@ impl UltrosDb {
             .await?)
     }
 
+    /// Returns the ingest markers for one item across the given worlds — i.e.
+    /// when Ultros last stored market data for the item on each world. Worlds
+    /// that have never been ingested simply have no row.
+    pub async fn get_listing_last_updated_for_worlds(
+        &self,
+        item_id: ItemId,
+        world_ids: &[i32],
+    ) -> Result<Vec<listing_last_updated::Model>, anyhow::Error> {
+        if world_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        Ok(listing_last_updated::Entity::find()
+            .filter(listing_last_updated::Column::ItemId.eq(item_id.0))
+            .filter(listing_last_updated::Column::WorldId.is_in(world_ids.iter().copied()))
+            .all(&self.db)
+            .await?)
+    }
+
     pub async fn get_recently_updated_listings_for_world(
         &self,
         world_id: i32,

--- a/ultros-frontend/ultros-app/src/freshness.rs
+++ b/ultros-frontend/ultros-app/src/freshness.rs
@@ -1,8 +1,57 @@
 use crate::analysis::format_duration_short;
 use crate::i18n::{I18nKeys, Locale, t_string};
-use chrono::Duration;
+use chrono::{Duration, NaiveDateTime};
 use leptos_i18n::I18nContext;
 use ultros_api_types::freshness::FreshnessVerdict;
+use ultros_api_types::{SaleHistory, WorldItemLastUpdated};
+
+/// Inputs for the freshness/cadence badges, derived from the listings payload.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FreshnessInputs {
+    /// Time since Ultros last ingested market data for this item anywhere in
+    /// the page's scope. `None` when nothing has ever been ingested.
+    pub age: Option<Duration>,
+    /// Sales velocity across the whole page scope (world, DC, or region).
+    /// This is what the cadence badge shows: "how fast does it sell *here*".
+    pub scope_sales_per_day: Option<f32>,
+    /// Scope velocity normalized to a single market board. Freshness is a
+    /// per-board judgement, so this is what the verdict thresholds consume.
+    pub per_world_sales_per_day: Option<f32>,
+}
+
+/// Derives the freshness-badge inputs from the item page's listings payload.
+///
+/// Age basis: the newest `last_updated` ingest marker in scope — when Ultros
+/// actually last heard about this item's boards — NOT `ActiveListing::timestamp`,
+/// which is Universalis' `last_review_time` (when the seller last touched the
+/// listing in-game). A board unrefreshed for days must not look "Fresh" just
+/// because a retainer re-listed right before the last ingest.
+///
+/// Velocity scoping: `sales` are merged across every world in the page scope
+/// (capped at the newest 200), so on a DC/region view the raw rate is roughly
+/// `world_count`× a single board's rate. The per-200-cap window makes per-world
+/// subsets sparse and biased, so instead of filtering by world we divide the
+/// scope rate by `world_count` to approximate the average board's velocity.
+/// On a single-world page (`world_count == 1`) this is a no-op.
+pub fn derive_freshness_inputs(
+    last_updated: &[WorldItemLastUpdated],
+    sales: &[SaleHistory],
+    world_count: usize,
+    now: NaiveDateTime,
+) -> FreshnessInputs {
+    let age = last_updated
+        .iter()
+        .map(|updated| updated.updated_at)
+        .max()
+        .map(|updated_at| now - updated_at);
+    let scope_sales_per_day = ultros_api_types::freshness::sales_per_day(sales);
+    FreshnessInputs {
+        age,
+        scope_sales_per_day,
+        per_world_sales_per_day: scope_sales_per_day
+            .map(|velocity| velocity / world_count.max(1) as f32),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(dead_code)]
@@ -110,8 +159,149 @@ pub fn get_freshness_verdict_display(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Duration;
-    use ultros_api_types::freshness::FreshnessVerdict;
+    use chrono::{DateTime, Duration};
+    use ultros_api_types::freshness::{FreshnessVerdict, calculate_freshness_verdict};
+
+    fn sale_at(seconds: i64) -> SaleHistory {
+        SaleHistory {
+            id: seconds as i32,
+            quantity: 1,
+            price_per_item: 100,
+            buying_character_id: 1,
+            hq: false,
+            sold_item_id: 1,
+            sold_date: DateTime::from_timestamp(seconds, 0).unwrap().naive_utc(),
+            world_id: 1,
+            buyer_name: None,
+        }
+    }
+
+    fn ingest_at(world_id: i32, seconds: i64) -> WorldItemLastUpdated {
+        WorldItemLastUpdated {
+            world_id,
+            updated_at: DateTime::from_timestamp(seconds, 0).unwrap().naive_utc(),
+        }
+    }
+
+    fn ts(seconds: i64) -> NaiveDateTime {
+        DateTime::from_timestamp(seconds, 0).unwrap().naive_utc()
+    }
+
+    #[test]
+    fn test_age_comes_from_ingest_time_not_listings() {
+        // The seller last touched their listings days ago (which is what
+        // ActiveListing::timestamp would say), but Ultros ingested the board
+        // 30 seconds ago: the badge must judge the 30-second ingest age.
+        let now = ts(1_000_000);
+        let inputs = derive_freshness_inputs(
+            &[ingest_at(1, 1_000_000 - 30)],
+            &[sale_at(0), sale_at(86_400)],
+            1,
+            now,
+        );
+        assert_eq!(inputs.age, Some(Duration::seconds(30)));
+        assert_eq!(
+            calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+            FreshnessVerdict::Fresh
+        );
+
+        // Conversely, a stale ingest is stale even if a seller re-listed just
+        // before it: 4 days since the last ingest at 1 sale/day => VerifyInGame.
+        let inputs = derive_freshness_inputs(
+            &[ingest_at(1, 1_000_000 - 4 * 86_400)],
+            &[sale_at(0), sale_at(86_400)],
+            1,
+            now,
+        );
+        assert_eq!(inputs.age, Some(Duration::days(4)));
+        assert_eq!(
+            calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+            FreshnessVerdict::VerifyInGame
+        );
+    }
+
+    #[test]
+    fn test_no_ingest_marker_means_no_data() {
+        let inputs = derive_freshness_inputs(&[], &[sale_at(0), sale_at(86_400)], 1, ts(1_000));
+        assert_eq!(inputs.age, None);
+        assert_eq!(
+            calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+            FreshnessVerdict::NoData
+        );
+    }
+
+    #[test]
+    fn test_newest_ingest_in_scope_wins() {
+        let now = ts(10_000);
+        let inputs = derive_freshness_inputs(
+            &[
+                ingest_at(1, 1_000),
+                ingest_at(2, 9_000),
+                ingest_at(3, 5_000),
+            ],
+            &[],
+            3,
+            now,
+        );
+        assert_eq!(inputs.age, Some(Duration::seconds(1_000)));
+    }
+
+    #[test]
+    fn test_empty_and_single_sale_are_no_data() {
+        let now = ts(10_000);
+        // Empty sales: unknown velocity, not a confident zero.
+        let inputs = derive_freshness_inputs(&[ingest_at(1, 9_990)], &[], 1, now);
+        assert_eq!(inputs.scope_sales_per_day, None);
+        assert_eq!(inputs.per_world_sales_per_day, None);
+        assert_eq!(
+            calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+            FreshnessVerdict::NoData
+        );
+
+        // One sale: consistent with the empty case.
+        let inputs = derive_freshness_inputs(&[ingest_at(1, 9_990)], &[sale_at(0)], 1, now);
+        assert_eq!(inputs.per_world_sales_per_day, None);
+        assert_eq!(
+            calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+            FreshnessVerdict::NoData
+        );
+    }
+
+    #[test]
+    fn test_velocity_normalized_by_world_count() {
+        let now = ts(2 * 86_400);
+        // 9 sales over one day across an 8-world DC: scope rate 8/day,
+        // per-board rate 1/day.
+        let sales: Vec<_> = (0..9).map(|i| sale_at(i * 86_400 / 8)).collect();
+        let inputs = derive_freshness_inputs(&[ingest_at(1, 2 * 86_400 - 60)], &sales, 8, now);
+        assert_eq!(inputs.scope_sales_per_day, Some(8.0));
+        assert_eq!(inputs.per_world_sales_per_day, Some(1.0));
+
+        // A world count of 0 (unknown scope) must not divide by zero.
+        let inputs = derive_freshness_inputs(&[], &sales, 0, now);
+        assert_eq!(inputs.per_world_sales_per_day, Some(8.0));
+    }
+
+    #[test]
+    fn test_threshold_selection_at_normalized_boundaries() {
+        // 1 sale/day per board => 12h Fresh / 36h Caution boundaries.
+        let sales: Vec<_> = (0..9).map(|i| sale_at(i * 86_400 / 8)).collect();
+        let base = 10 * 86_400;
+        for (age_hours, expected) in [
+            (12, FreshnessVerdict::Fresh),
+            (13, FreshnessVerdict::Caution),
+            (36, FreshnessVerdict::Caution),
+            (37, FreshnessVerdict::VerifyInGame),
+        ] {
+            let now = ts(base + age_hours * 3_600);
+            let inputs = derive_freshness_inputs(&[ingest_at(1, base)], &sales, 8, now);
+            assert_eq!(
+                calculate_freshness_verdict(inputs.age, inputs.per_world_sales_per_day),
+                expected,
+                "expected {expected:?} at {age_hours}h"
+            );
+        }
+    }
 
     #[test]
     fn test_get_freshness_verdict_display() {

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -594,45 +594,45 @@ fn DecisionHeader(
                     .with(|data_ref| {
                         if let Some(Ok(data)) = data_ref.as_ref() {
                             let listings = get_or_default(&filtered_listings);
-                            let current_world_id = {
+                            let scope = {
                                 let world_name = Url::unescape(&world());
-                                world_data
-                                    .lookup_world_by_name(&world_name)
-                                    .and_then(|result| result.as_world().map(|world| world.id))
+                                world_data.lookup_world_by_name(&world_name)
                             };
+                            let current_world_id = scope
+                                .as_ref()
+                                .and_then(|result| result.as_world().map(|world| world.id));
+                            // Number of worlds the page selector covers (1 on a
+                            // world page, ~8 on a DC, more on a region).
+                            let world_count = scope
+                                .as_ref()
+                                .map(|result| result.all_worlds().count())
+                                .unwrap_or(1);
                             let savings_verdict = current_world_id
                                 .and_then(|world_id| cheapest_savings_verdict(&listings, world_id));
                             let recent_sales = &data.sales;
 
-                            let sales_per_day = if recent_sales.len() > 1 {
-                                let newest = recent_sales.first().unwrap().sold_date;
-                                let oldest = recent_sales.last().unwrap().sold_date;
-                                let seconds = (newest - oldest).num_seconds().abs();
-                                let count = recent_sales.len() - 1;
-                                if seconds > 0 {
-                                    Some((count as f32) / (seconds as f32 / 86400.0))
-                                } else {
-                                    Some(100.0) // high velocity
-                                }
-                            } else if recent_sales.is_empty() {
-                                Some(0.0)
-                            } else {
-                                None
-                            };
-
-                            let latest_timestamp = listings
-                                .iter()
-                                .map(|(listing, _)| listing.timestamp)
-                                .max();
-
-                            let age = latest_timestamp.map(|t| chrono::Utc::now().naive_utc() - t);
+                            // Freshness is judged on when Ultros last ingested the
+                            // board (`last_updated`), not on the sellers' re-list
+                            // times carried by `ActiveListing::timestamp`.
+                            let freshness_inputs = crate::freshness::derive_freshness_inputs(
+                                &data.last_updated,
+                                recent_sales,
+                                world_count,
+                                chrono::Utc::now().naive_utc(),
+                            );
+                            let age = freshness_inputs.age;
 
                             let freshness_verdict = ultros_api_types::freshness::calculate_freshness_verdict(
                                 age,
-                                sales_per_day,
+                                freshness_inputs.per_world_sales_per_day,
                             );
+                            // The cadence badge describes the whole scope, so it
+                            // keeps the unnormalized velocity.
+                            let scope_sales_per_day = freshness_inputs
+                                .scope_sales_per_day
+                                .unwrap_or_default();
                             let cadence_verdict = crate::analysis::get_sales_cadence(
-                                sales_per_day.unwrap_or_default(),
+                                scope_sales_per_day,
                                 recent_sales.len(),
                             );
 
@@ -642,7 +642,7 @@ fn DecisionHeader(
                                         <FreshnessBadge verdict=freshness_verdict age=age />
                                         <SalesCadenceBadge
                                             cadence=cadence_verdict
-                                            sales_per_day=sales_per_day.unwrap_or_default()
+                                            sales_per_day=scope_sales_per_day
                                         />
                                     </div>
                                     {savings_verdict

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -20,7 +20,7 @@ use axum::{Json, Router, middleware};
 use axum_extra::extract::CookieJar;
 use axum_extra::extract::cookie::Cookie;
 use axum_extra::headers::{CacheControl, HeaderMapExt};
-use futures::future::{try_join, try_join_all};
+use futures::future::{try_join_all, try_join3};
 use hyper::header;
 use itertools::Itertools;
 use leptos::prelude::provide_context;
@@ -54,7 +54,7 @@ use ultros_api_types::websocket::{ListEventData, ListingEventData};
 use ultros_api_types::world::WorldData;
 use ultros_api_types::{
     ActiveListing, CompactSale, CurrentlyShownItem, ExtendedSaleHistory, FfxivCharacter,
-    FfxivCharacterVerification, Retainer,
+    FfxivCharacterVerification, Retainer, WorldItemLastUpdated,
 };
 use ultros_app::{LocalWorldData, shell};
 use ultros_charts::data::buckets::{bucket_seconds_for_span, snap_bucket_seconds, widen_bucket};
@@ -239,10 +239,12 @@ async fn world_item_listings(
         .get_all_worlds_in(&selected_value)
         .ok_or_else(|| Error::msg("Unable to get worlds"))?;
     let db_clone = db.clone();
+    let db_clone_2 = db.clone();
     let world_iter = worlds.iter().copied();
-    let (listings, sales) = try_join(
+    let (listings, sales, last_updated) = try_join3(
         db_clone.get_all_listings_in_worlds_with_retainers(&worlds, ItemId(item_id)),
         db.get_sale_history_from_multiple_worlds(world_iter, item_id, 200),
+        db_clone_2.get_listing_last_updated_for_worlds(ItemId(item_id), &worlds),
     )
     .await
     .inspect_err(|e| tracing::error!(error = ?e, "Error getting listings"))?;
@@ -252,6 +254,13 @@ async fn world_item_listings(
             .flat_map(|(l, r)| r.map(|r| (l.into(), r.into())))
             .collect(),
         sales: sales.into_iter().map(|s| s.into()).collect(),
+        last_updated: last_updated
+            .into_iter()
+            .map(|updated| WorldItemLastUpdated {
+                world_id: updated.world_id,
+                updated_at: updated.date_time,
+            })
+            .collect(),
     };
     Ok(axum::Json(currently_shown))
 }


### PR DESCRIPTION
Implements #1002: the item-page freshness badge judged the board by the sellers' re-list times and treated missing sales data as a confident zero. Both inputs are fixed; the threshold curve in `freshness.rs` is untouched.

## Age basis: real ingest time, not seller re-list time

- `ultros-db`: new `get_listing_last_updated_for_worlds(item_id, &[world_id])` reads the `listing_last_updated` ingest markers (the ones written by `listings.rs`/`sales.rs` on every store).
- `ultros/src/web.rs` `world_item_listings`: joins that query into the existing listings response — no new endpoint.
- `ultros-api-types`: `CurrentlyShownItem` gains an **additive** `last_updated: Vec<WorldItemLastUpdated>` (`{world_id, updated_at}`) with `#[serde(default)]`, so payloads from older servers (and any external consumer of the JSON) keep deserializing. The Discord bot / alerts / websocket paths all live in the `ultros` crate, which compiles clean against the change (websocket listing/sale events never touch the new field).
- `item_view.rs`: the badge's age is now `now - max(last_updated in scope)`. If no ingest marker exists, the verdict is honestly `NoData` instead of borrowing the sellers' timestamps. `ActiveListing::timestamp` (Universalis `last_review_time`) is untouched and still drives the "listed X ago" column in the listings table.

## Velocity: no data is not a confident zero

New `ultros_api_types::freshness::sales_per_day(&[SaleHistory]) -> Option<f32>`:

- empty sales → `None` (was `Some(0.0)`, which selected the *most permissive* thresholds — no-data items got the greenest badge)
- exactly one sale → `None` (was already `None`; now consistent by construction with the empty case)
- all sales at one instant → `None` (was a `Some(100.0)` magic constant; a zero-length window has no finite rate)
- otherwise `(count − 1) / window_days`, order-agnostic (min/max scan instead of trusting first/last)

## Scope: per-board judgement gets a per-board rate

`recent_sales` is fetched for the whole page selector, so a DC view merged ~8 worlds' sales into one board's freshness judgement. `derive_freshness_inputs` (new, `ultros-app/src/freshness.rs`) now divides the scope rate by the number of worlds under the selector. **Choice documented in the code**: the response is capped at the 200 newest sales across the scope, so per-world subsets are sparse and biased (slow worlds contribute few of the 200); dividing the scope rate by world count is the average-board estimate the data actually supports. Single-world pages are a no-op (`world_count == 1`). The *cadence* badge intentionally keeps the unnormalized scope rate — it describes how fast the item sells in the whole selected scope.

## UI

No visual changes: the badge already renders a `NoData` state (neutral tone, `freshness_no_data`/tooltip keys present in all seven locales), so no new user-facing strings were needed.

## Gates (all foreground, real exit codes)

- `cargo test -p ultros-api-types -p ultros-app --lib` — **474 passed, 0 failed** (138 + 336), including new tests: empty-sales→NoData, one-sale consistency, zero-window→NoData, ingest-age-beats-listing-age, newest-ingest-in-scope, world-count normalization, and threshold selection at the normalized 12h/36h boundaries.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p ultros -p ultros-api-types -p ultros-app --all-targets -- -D warnings` — clean; also `cargo clippy -p ultros-db --all-targets -- -D warnings` — clean.
- Windows caveat: the `ultros` bin's *test binary* does not link on MSVC, so clippy is the compile gate for the backend change (per repo convention); the unit tests above run in `ultros-api-types`/`ultros-app`, where they do link and run.

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)