### PR TITLE
fix(seo): return real 404 status codes for unknown routes and bad item ids

### DIFF
--- a/ultros-frontend/ultros-app/src/global_state/xiv_data.rs
+++ b/ultros-frontend/ultros-app/src/global_state/xiv_data.rs
@@ -38,3 +38,42 @@ pub async fn reload_xiv_data(locale: &str) -> anyhow::Result<()> {
     xiv_gen_db::try_init(&bytes)?;
     Ok(())
 }
+
+/// Whether an item with this id exists in the currently loaded xiv_gen data.
+pub fn item_exists(id: i32) -> bool {
+    tracked_data().items.contains_key(&xiv_gen::ItemId(id))
+}
+
+/// Parses a route path param as an item id, returning `None` if it doesn't
+/// parse as an integer or doesn't name a real item — the two ways a garbage
+/// `/item/<id>` URL currently falls through to a fake "item 0" page.
+pub fn resolve_item_id(raw: Option<&str>) -> Option<i32> {
+    let id: i32 = raw?.parse().ok()?;
+    item_exists(id).then_some(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_item_id_accepts_a_real_item() {
+        let real_id = tracked_data().items.keys().next().expect("data loaded").0;
+        assert_eq!(resolve_item_id(Some(&real_id.to_string())), Some(real_id));
+    }
+
+    #[test]
+    fn resolve_item_id_rejects_unparseable_ids() {
+        assert_eq!(resolve_item_id(Some("notanumber")), None);
+    }
+
+    #[test]
+    fn resolve_item_id_rejects_nonexistent_ids() {
+        assert_eq!(resolve_item_id(Some("999999999")), None);
+    }
+
+    #[test]
+    fn resolve_item_id_rejects_missing_param() {
+        assert_eq!(resolve_item_id(None), None);
+    }
+}

--- a/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
+++ b/ultros-frontend/ultros-app/src/routes/currency_exchange.rs
@@ -20,8 +20,9 @@ use crate::components::number_input::ParseableInputBox;
 use crate::components::query_button::QueryButton;
 use crate::error::AppError;
 use crate::global_state::home_world::use_home_world;
-use crate::global_state::xiv_data::tracked_data;
+use crate::global_state::xiv_data::{resolve_item_id, tracked_data};
 use crate::i18n::*;
+use crate::routes::not_found::NotFound;
 use chrono::TimeDelta;
 use chrono::Utc;
 use field_iterator::FieldLabels;
@@ -248,8 +249,24 @@ fn is_in_range(value: i32, field_label: &str, query_map: &ParamsMap) -> bool {
     }
 }
 
+/// Gates the exchange-item page on the `:id` route param naming a real item —
+/// same "fake item 0 page at 200" bug as `ItemView`, see
+/// `crate::routes::item_view::ItemView`.
 #[component]
 pub fn ExchangeItem() -> impl IntoView {
+    let params = use_params_map();
+    let item_id_valid =
+        Memo::new(move |_| params.with(|p| resolve_item_id(p.get_str("id"))).is_some());
+
+    view! {
+        <Show when=move || item_id_valid.get() fallback=|| view! { <NotFound /> }.into_any()>
+            <ExchangeItemContent />
+        </Show>
+    }
+}
+
+#[component]
+fn ExchangeItemContent() -> impl IntoView {
     let i18n = use_i18n();
     let params = use_params_map();
     let query = use_query_map();

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -17,9 +17,10 @@ use crate::error::AppError;
 use crate::global_state::LocalWorldData;
 use crate::global_state::cheapest_prices::CheapestPrices;
 use crate::global_state::home_world::{get_price_zone, locale_preferred_region, use_home_world};
-use crate::global_state::xiv_data::tracked_data;
+use crate::global_state::xiv_data::{resolve_item_id, tracked_data};
 use crate::i18n::{t, t_string};
 use crate::routes::item_view_scope::item_href;
+use crate::routes::not_found::NotFound;
 use crate::ws::realtime::{RealtimeSubscription, use_realtime};
 use leptos::prelude::*;
 use leptos_meta::Meta;
@@ -1670,8 +1671,27 @@ fn DiscordCommandChip(
     }
 }
 
+/// Gates the item page on the `:id` route param actually naming a real item.
+/// A param that fails to parse, or parses to an id with no matching item,
+/// previously fell through to `unwrap_or_default()` and silently rendered an
+/// empty "item 0" page with a 200 status — an indexable junk page for every
+/// garbage `/item/<id>` URL. Render `NotFound` (which sets the 404 status)
+/// instead.
 #[component]
 pub fn ItemView() -> impl IntoView {
+    let params = use_params_map();
+    let item_id_valid =
+        Memo::new(move |_| params.with(|p| resolve_item_id(p.get_str("id"))).is_some());
+
+    view! {
+        <Show when=move || item_id_valid.get() fallback=|| view! { <NotFound /> }.into_any()>
+            <ItemViewContent />
+        </Show>
+    }
+}
+
+#[component]
+fn ItemViewContent() -> impl IntoView {
     let i18n = crate::i18n::use_i18n();
     let params = use_params_map();
     let query = use_query_map();

--- a/ultros-frontend/ultros-app/src/routes/not_found.rs
+++ b/ultros-frontend/ultros-app/src/routes/not_found.rs
@@ -1,13 +1,21 @@
-use crate::components::meta::MetaTitle;
+use crate::components::meta::{MetaRobotsNoIndex, MetaTitle};
 use crate::i18n::*;
 use leptos::prelude::*;
 use leptos_router::components::A;
 
 #[component]
 pub fn NotFound() -> impl IntoView {
+    #[cfg(feature = "ssr")]
+    {
+        if let Some(response) = use_context::<leptos_axum::ResponseOptions>() {
+            response.set_status(axum::http::StatusCode::NOT_FOUND);
+        }
+    }
+
     let i18n = use_i18n();
     view! {
         <MetaTitle title=move || t_string!(i18n, not_found_meta_title).to_string() />
+        <MetaRobotsNoIndex />
         <div class="flex flex-col items-center justify-center min-h-[80vh] text-center space-y-12 p-4 overflow-hidden relative select-none">
 
             // Background effect


### PR DESCRIPTION
## Summary
- `NotFound` never touched leptos_axum's `ResponseOptions`, so unknown routes rendered the 404 page with HTTP 200. Sets `StatusCode::NOT_FOUND` (ssr-gated) and adds a `robots: noindex` meta tag.
- `ItemView` parsed `:id` with `.unwrap_or_default()`, so `/item/<world>/notanumber` (or any nonexistent id) silently became "item 0" — an empty, indexable junk page at 200. It's now a thin gate that validates the id (parses **and** exists in `xiv_gen_db`) before rendering the real page; invalid ids render `NotFound` instead. Same fix applied to `ExchangeItem` (`currency-exchange/:id`), which had the identical bug.
- Added `global_state::xiv_data::{item_exists, resolve_item_id}` with unit tests (real item, unparseable id, nonexistent id, missing param) — all pass against the embedded xiv_gen dataset.
- Left `job_set_detail.rs` and `item_explorer.rs`'s category/jobset routes alone: their `None`/empty-result branches already render a distinct "no results" state at 200, which is legitimate (a valid job/ilvl combo can have zero matching gear), unlike the item-id bug where a nonexistent id silently impersonated a real item.

## Verification
- `cargo test -p ultros-app`: 217 passed, 0 failed (includes the 4 new `resolve_item_id` tests, TDD'd red→green).
- `./check_ci.sh` (fmt + `clippy --all-targets -- -D warnings`): clean.
- **Not verified**: live `curl -sI` against a running server. This sandbox has no working Postgres (local homebrew install has a broken `icu4c` dylib link) and no Docker daemon, so the full app (DB + Universalis world data + OAuth) couldn't be started. The fix's mechanism was instead verified by reading the `leptos_axum` 0.8.10 source directly — `ResponseOptions` is provided into Leptos context by both render paths this app uses (`render_app_to_stream_in_order_with_context` for the in-order item routes, `render_app_to_stream_with_context_and_replace_blocks` for the rest), and `NotFound`'s `set_status` call propagates correctly. Please do a manual smoke test before merging:
  ```
  curl -sI https://<host>/this-does-not-exist
  curl -sI https://<host>/item/Gilgamesh/notanumber
  curl -sI https://<host>/item/Gilgamesh/999999999
  curl -sI https://<host>/item/Gilgamesh/<a-real-item-id>   # must stay 200
  ```

## Test plan
- [ ] Manual curl smoke test above once a server with DB access is available
- [x] `cargo test -p ultros-app`
- [x] `./check_ci.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)