### PR TITLE
fix(best_deals): align backend profit/ROI with the Flip Finder's estimate

### DIFF
--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -326,10 +326,28 @@ struct AnalyzerState {
     cheapest_items: BTreeMap<AnySelector, CheapestListings>,
 }
 
+/// Ratio above the median at which a listing is presumed to be a "troll"
+/// price meant to game rankings rather than a real sale opportunity.
+/// Mirrors `TROLL_MULTIPLE` in
+/// ultros-frontend/ultros-app/src/routes/analyzer.rs so both surfaces treat
+/// the same rows as implausible.
+const TROLL_MULTIPLE: i64 = 50;
+
+fn is_troll_listing(price: i32, median: i32) -> bool {
+    median > 0 && (price as i64) > (median as i64).saturating_mul(TROLL_MULTIPLE)
+}
+
+/// Estimated sale price for a flip: the median recent sale price, capped by
+/// the current world floor when one exists. Mirrors the frontend Flip
+/// Finder's `estimated_sale_price` computation
+/// (ultros-frontend/ultros-app/src/routes/analyzer.rs) so the home-page
+/// "Top Opportunities" card and the Flip Finder table agree on the same
+/// flip. Callers should filter troll listings (see `is_troll_listing`) out
+/// of `current_listing_price` before calling this.
 fn calculate_valuation(median_price: i32, current_listing_price: Option<i32>) -> i32 {
     match current_listing_price {
-        Some(price) => std::cmp::min(std::cmp::max(1, price - 1), median_price),
-        None => (median_price as f32 * 1.2) as i32,
+        Some(floor) => median_price.min(floor),
+        None => median_price,
     }
 }
 
@@ -1150,8 +1168,20 @@ impl AnalyzerService {
             .iter()
             .flat_map(|(item_key, cheapest_price)| {
                 let (cheapest_history, sold_within) = *sale_history.get(item_key)?;
-                let current_cheapest_on_sale_world =
-                    sale_world_listings.item_map.get(item_key).map(|l| l.price);
+                // Troll-listing guard: if the region floor (our purchase
+                // cost) is implausibly high vs the median, the "deal" is
+                // fictional — drop the row entirely. Mirrors the frontend's
+                // row-drop in ultros-frontend/ultros-app/src/routes/analyzer.rs.
+                if is_troll_listing(cheapest_price.price, cheapest_history) {
+                    return None;
+                }
+                // Same guard on the local sale-world floor — if it's a
+                // troll, ignore it and fall through to the median estimate.
+                let current_cheapest_on_sale_world = sale_world_listings
+                    .item_map
+                    .get(item_key)
+                    .map(|l| l.price)
+                    .filter(|price| !is_troll_listing(*price, cheapest_history));
                 let est_sale_price =
                     calculate_valuation(cheapest_history, current_cheapest_on_sale_world);
                 let (profit, return_on_investment) =
@@ -1624,7 +1654,7 @@ mod test {
 
     use super::{
         SaleHistory, SaleSummary, SoldAmount, SoldWithin, calculate_profit_and_roi,
-        calculate_valuation,
+        calculate_valuation, is_troll_listing,
     };
 
     #[test]
@@ -1653,33 +1683,40 @@ mod test {
 
     #[test]
     fn test_calculate_valuation() {
-        // Case 1: Market empty (None), use 1.2 * median
-        assert_eq!(calculate_valuation(100, None), 120);
-        assert_eq!(calculate_valuation(10, None), 12);
+        // Matches the frontend Flip Finder's estimated_sale_price
+        // (ultros-frontend/ultros-app/src/routes/analyzer.rs): median capped
+        // by the current world floor, with no undercut or empty-market bump.
 
-        // Case 2: Market has listing higher than median
-        // min(listing - 1, median) -> min(200 - 1, 100) -> 100
+        // Case 1: Market empty (None) -> just the median.
+        assert_eq!(calculate_valuation(100, None), 100);
+        assert_eq!(calculate_valuation(10, None), 10);
+
+        // Case 2: Floor higher than median -> median wins.
         assert_eq!(calculate_valuation(100, Some(200)), 100);
 
-        // Case 3: Market has listing lower than median
-        // min(listing - 1, median) -> min(90 - 1, 100) -> 89
-        assert_eq!(calculate_valuation(100, Some(90)), 89);
+        // Case 3: Floor lower than median -> floor wins.
+        assert_eq!(calculate_valuation(100, Some(90)), 90);
 
-        // Case 4: Market has listing equal to median
-        // min(100 - 1, 100) -> 99
-        assert_eq!(calculate_valuation(100, Some(100)), 99);
+        // Case 4: Floor equal to median -> either, same value.
+        assert_eq!(calculate_valuation(100, Some(100)), 100);
+    }
 
-        // Case 5: Listing is 1 gil
-        // min(max(1, 1 - 1), median) -> min(1, 100) -> 1
-        assert_eq!(calculate_valuation(100, Some(1)), 1);
+    #[test]
+    fn test_is_troll_listing() {
+        // Mirrors the frontend's TROLL_MULTIPLE = 50 threshold.
 
-        // Case 6: Listing is 2 gil
-        // min(2 - 1, 100) -> 1
-        assert_eq!(calculate_valuation(100, Some(2)), 1);
+        // Price is far more than 50x the median -> troll.
+        assert!(is_troll_listing(100_000, 100));
 
-        // Case 7: Listing is 1 gil, median is 1 gil
-        // min(1, 1) -> 1
-        assert_eq!(calculate_valuation(1, Some(1)), 1);
+        // Price is within 50x the median -> not a troll.
+        assert!(!is_troll_listing(4_000, 100));
+
+        // Exactly at the boundary is not a troll (strictly greater-than).
+        assert!(!is_troll_listing(5_000, 100));
+        assert!(is_troll_listing(5_001, 100));
+
+        // Zero/negative median can't establish a ratio -> never a troll.
+        assert!(!is_troll_listing(1_000_000, 0));
     }
 
     #[test]

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -333,6 +333,28 @@ fn calculate_valuation(median_price: i32, current_listing_price: Option<i32>) ->
     }
 }
 
+/// Fraction of the sale price lost to the market board's sales tax.
+/// Matches the frontend Flip Finder's default (`tax_enabled` defaults to
+/// `true` in ultros-frontend/ultros-app/src/routes/analyzer.rs), so the
+/// home-page "Top Opportunities" card and the Flip Finder table agree on
+/// the same flip.
+const MARKET_TAX_RATE: f32 = 0.05;
+
+/// Post-tax profit and ROI for a flip. `cheapest_price` <= 0 is corrupt
+/// listing data rather than a real cost basis, so ROI is reported as `0.0`
+/// in that case — mirroring the frontend's own guard in
+/// `ultros-frontend/ultros-app/src/analysis.rs::return_on_investment`.
+fn calculate_profit_and_roi(est_sale_price: i32, cheapest_price: i32) -> (i32, f32) {
+    let post_tax_sale_price = (est_sale_price as f32 * (1.0 - MARKET_TAX_RATE)) as i32;
+    let profit = post_tax_sale_price - cheapest_price;
+    let roi = if cheapest_price <= 0 {
+        0.0
+    } else {
+        (post_tax_sale_price as f32 / cheapest_price as f32) * 100.0 - 100.0
+    };
+    (profit, roi)
+}
+
 /// Build a short list of all the items in the game that we think would sell well.
 /// Implemented as an easily cloneable Arc monster
 #[derive(Clone)]
@@ -1132,14 +1154,13 @@ impl AnalyzerService {
                     sale_world_listings.item_map.get(item_key).map(|l| l.price);
                 let est_sale_price =
                     calculate_valuation(cheapest_history, current_cheapest_on_sale_world);
-                let profit = est_sale_price - cheapest_price.price;
+                let (profit, return_on_investment) =
+                    calculate_profit_and_roi(est_sale_price, cheapest_price.price);
                 Some(ResaleStats {
                     profit,
                     item_id: item_key.item_id,
                     hq: item_key.hq,
-                    return_on_investment: ((est_sale_price as f32) / (cheapest_price.price as f32)
-                        * 100.0)
-                        - 100.0,
+                    return_on_investment,
                     world_id: cheapest_price.world_id,
                     sold_within,
                     // Pass-1 defaults; the deep-scan pass fills these in.
@@ -1601,7 +1622,34 @@ mod test {
         CheapestListingValue, CheapestListings, ItemKey, SALE_HISTORY_SIZE,
     };
 
-    use super::{SaleHistory, SaleSummary, SoldAmount, SoldWithin, calculate_valuation};
+    use super::{
+        SaleHistory, SaleSummary, SoldAmount, SoldWithin, calculate_profit_and_roi,
+        calculate_valuation,
+    };
+
+    #[test]
+    fn test_calculate_profit_and_roi_applies_market_tax() {
+        // Matches the frontend Flip Finder's default (tax_enabled defaults to
+        // true): post-tax sale price is 95% of the estimate.
+        // post-tax = 950, profit = 950 - 500 = 450, roi = 950/500*100-100 = 90
+        let (profit, roi) = calculate_profit_and_roi(1000, 500);
+        assert_eq!(profit, 450);
+        assert!((roi - 90.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_calculate_profit_and_roi_guards_nonpositive_cost() {
+        // A 0-gil or negative "cheapest price" is corrupt listing data, not a
+        // real cost basis. Dividing by it must not produce inf/NaN in the
+        // serialized response; mirror the frontend's own guard (return 0 ROI).
+        let (profit, roi) = calculate_profit_and_roi(1000, 0);
+        assert_eq!(profit, 950);
+        assert_eq!(roi, 0.0);
+
+        let (profit, roi) = calculate_profit_and_roi(1000, -5);
+        assert_eq!(profit, 955);
+        assert_eq!(roi, 0.0);
+    }
 
     #[test]
     fn test_calculate_valuation() {


### PR DESCRIPTION
## Summary

The `/api/v1/best_deals` backend (home page "Top Opportunities" card) and the Flip Finder table computed flip profit/ROI differently, so the same flip showed different numbers in each place. Two fixes:

- **Tax + zero-guard** (`ffc71efe`): `best_deals` computed profit/ROI with no market tax, while the Flip Finder applies a 5% tax by default. A `cheapest_price <= 0` could also produce inf/NaN ROI in the serialized response. Added `calculate_profit_and_roi()`, which applies the 5% tax (matching the frontend default) and returns ROI `0.0` when cost is non-positive — mirroring the frontend's own guard in `analysis.rs::return_on_investment`.
- **Valuation formula alignment** (`ea7712bc`): `calculate_valuation` undercut the current floor by 1 gil and bumped empty-market estimates by 1.2x, while the frontend's `estimated_sale_price` is just the median capped by the world floor, guarded against "troll" listings (implausible prices >50x the median). Dropped the undercut/bump and ported the frontend's `is_troll_listing` guard into `get_best_resale` so both surfaces drop/ignore the same rows. Confirmed via grep that `calculate_valuation` has no other callers (e.g. undercut alerts don't use it), so this was safe to change.

Retainer-city tax variation is intentionally not modeled anywhere — out of scope.

## Test plan

- [x] Added unit tests for the tax + zero-guard behavior (`test_calculate_profit_and_roi_applies_market_tax`, `test_calculate_profit_and_roi_guards_nonpositive_cost`)
- [x] Rewrote `test_calculate_valuation` for the new median/floor semantics and added `test_is_troll_listing`
- [x] All tests written test-first (RED confirmed before implementation, GREEN after)
- [x] `./check_ci.sh` (fmt + clippy `-D warnings`) passes clean
- [ ] Not verified: actual home-card vs. Flip-Finder rendering in a running app — no dev environment was set up for this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)