### PR TITLE
fix(seo): OpenGraph title property, item-explorer canonicals, asset caching

### DIFF
--- a/ultros-frontend/ultros-app/src/components/meta.rs
+++ b/ultros-frontend/ultros-app/src/components/meta.rs
@@ -5,7 +5,10 @@ use leptos_meta::*;
 pub fn MetaTitle(#[prop(into)] title: TextProp) -> impl IntoView {
     view! {
         <Title text=title.clone() />
-        <Meta name="og:title" content=title.clone() />
+        // OpenGraph keys are addressed by `property`, not `name`. Emitted as
+        // `name="og:title"` this tag was invisible to every OG consumer
+        // (Discord/Slack/Facebook unfurls), which fell back to <title>.
+        <Meta property="og:title" content=title.clone() />
         <Meta name="twitter:title" content=title />
     }
 }

--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -243,7 +243,19 @@ pub fn CategoryItems() -> impl IntoView {
             })
             .unwrap_or_else(|| crate::i18n::t_string!(i18n, category_view_default).to_string())
     });
+    // Legacy name-keyed links still resolve (see `resolve_category_param`), so
+    // the same category is reachable under several URLs. Point them all at the
+    // id-keyed form so the duplicates consolidate instead of competing.
+    let canonical_href = move || {
+        let params = params();
+        let raw = params.get_str("category").unwrap_or("");
+        match resolve_category_param(data, raw) {
+            Some(category) => format!("https://ultros.app/items/category/{}", category.key_id.0),
+            None => format!("https://ultros.app/items/category/{raw}"),
+        }
+    };
     view! {
+        <MetaCanonical href=canonical_href />
         <MetaTitle title=move || crate::i18n::t_string!(i18n, item_explorer_title).to_string().replace("%name%", &category_view_name()) />
         <MetaDescription text=move || crate::i18n::t_string!(i18n, category_list_desc).to_string().replace("%category%", &category_view_name()) />
         <h3 class="text-xl">{category_view_name}</h3>
@@ -344,7 +356,15 @@ pub fn JobItems() -> impl IntoView {
             .unwrap_or_default()
     });
 
+    // `?show-non-market=` genuinely changes the item set, but the default
+    // (marketable items only) is the representative view; canonicalising to it
+    // keeps the toggled variant from being crawled as thin duplicate content.
+    // The param is already percent-encoded in the URL, so it is passed through
+    // rather than re-encoded.
+    let canonical_href = move || format!("https://ultros.app/items/jobset/{}", jobset_param.get());
+
     view! {
+        <MetaCanonical href=canonical_href />
         <MetaTitle title=move || crate::i18n::t_string!(i18n, item_explorer_title).to_string().replace("%name%", &job_set()) />
         <MetaDescription text=move || crate::i18n::t_string!(i18n, job_set_list_desc).to_string().replace("%job%", &job_set()) />
         <h3 class="text-xl">{job_set}</h3>
@@ -390,6 +410,7 @@ pub fn JobItems() -> impl IntoView {
 pub fn DefaultItems() -> impl IntoView {
     let i18n = use_i18n();
     view! {
+        <MetaCanonical href="https://ultros.app/items" />
         <MetaTitle title=t_string!(i18n, item_explorer_default_title).to_string() />
         <MetaDescription text=t_string!(i18n, item_explorer_default_desc).to_string() />
         <div class="flex flex-col">

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -192,7 +192,10 @@ pub(crate) async fn create_leptos_app(
     let cargo_leptos_service = SetResponseHeader::appending(
         cargo_leptos_service,
         header::CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=86400, immutable"),
+        // The pkg dir is namespaced by GIT_HASH above, so these URLs change on
+        // every deploy and their contents never do — a one-day max-age just
+        // forced needless revalidation. One year is the `immutable` ceiling.
+        HeaderValue::from_static("public, max-age=31536000, immutable"),
     );
     tracing::info!("Serving pkg dir: {bundle_filepath}");
     let worlds = Ok(worlds);

--- a/ultros/src/web/item_card.rs
+++ b/ultros/src/web/item_card.rs
@@ -109,5 +109,15 @@ pub(crate) async fn item_card(
     let mime_type = mime_guess::from_path("icon.png").first_or_text_plain();
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, mime_type.as_ref())
+        // Item cards are rendered per request from live prices. Half an hour
+        // keeps social-unfurl crawlers (which refetch aggressively) off the
+        // ClickHouse path without letting a card go visibly stale.
+        .header(
+            header::CACHE_CONTROL,
+            #[cfg(not(debug_assertions))]
+            header::HeaderValue::from_static("public, max-age=1800"),
+            #[cfg(debug_assertions)]
+            header::HeaderValue::from_static("no-cache, no-store, must-revalidate"),
+        )
         .body(Body::new(http_body_util::Full::from(bytes)))?)
 }

--- a/ultros/static/robots.txt
+++ b/ultros/static/robots.txt
@@ -14,5 +14,7 @@ Disallow: /logout
 Disallow: /api/
 Disallow: /invitebot
 Disallow: /redirect
+Disallow: /*?*sort=
+Disallow: /*?*per_page=
 
 Sitemap: https://ultros.app/sitemap.xml


### PR DESCRIPTION
Salvages the self-contained, verified-correct parts of #1018, which I closed — see that PR for why it can't be merged as-is.

## What's here

| Fix | Why it matters |
|---|---|
| `MetaTitle` emits `property="og:title"` instead of `name="og:title"` | OpenGraph is addressed by `property`. As `name=` the tag was invisible to every unfurl consumer (Discord, Slack, Facebook), which silently fell back to `<title>`. `MetaImage`/`MetaDescription` already set both attributes — `MetaTitle` was the odd one out. |
| `MetaCanonical` on Item Explorer category / jobset / index pages | Categories resolve under **both** the id-keyed URL and the legacy name-keyed one (`resolve_category_param` still accepts names as a fallback), so the same page competed with itself in the index. The canonical points at the id form. Jobset canonicalises away `?show-non-market=`. |
| `pkg/` `Cache-Control` `max-age` 86400 → 31536000 | `site_pkg_dir` is namespaced by `GIT_HASH`, so these URLs change every deploy and their contents never change within one. A one-day max-age just forced needless revalidation on an `immutable` response. |
| `/itemcard/*` gets a `Cache-Control` | It had none. Social crawlers refetch card images aggressively and every miss re-renders through ClickHouse. 30 min in release, `no-store` in debug. |
| robots.txt disallows `?sort=` / `?per_page=` | Facet permutations, no organic value. |

## Deliberately not salvaged

The `sitemap.rs` rework from #1018. Two reasons it needs the author rather than a reviewer:

1. It **removes** the `/sitemap/world/{s}` route and handler. Dropping a sitemap surface is a product judgement, not a mechanical fix.
2. Its currency-exchange enumeration filters with `!["Gil", "MGP"].contains(&item.name.as_str())`. Matching game data on a localized `.name` is exactly the bug class that took `/currency-exchange` down for every non-EN locale in #942. The server happens to run `Language::En` so it would work today, but it's a landmine keyed on that staying true.

## Verification

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p ultros-app -p ultros --all-targets -- -D warnings` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)