### PR TITLE
feat(item-explorer): let gear-set icons fill their tile

### DIFF
--- a/ultros-frontend/ultros-app/src/components/item_icon.rs
+++ b/ultros-frontend/ultros-app/src/components/item_icon.rs
@@ -8,6 +8,13 @@ pub fn ItemIcon(
     #[prop(into)] item_id: Signal<i32>,
     icon_size: IconSize,
     #[prop(optional)] loading: &'static str,
+    /// Stretch the icon to fill its parent instead of pinning it to
+    /// `icon_size`'s fixed pixel box. `icon_size` still selects which
+    /// source variant is fetched, so pass the smallest one that stays
+    /// sharp at the rendered size. Used by tile layouts (gear set
+    /// cards) where the container, not the icon, decides the size.
+    #[prop(optional)]
+    fill: bool,
 ) -> impl IntoView {
     // ⚡ Bolt Optimization: Replace Memo::new with Signal::derive
     // `valid_search_category` and `item_name` are simple map lookups.
@@ -31,15 +38,26 @@ pub fn ItemIcon(
 
     let (failed, set_failed) = signal(0);
     let failed_item = move || failed() == item_id();
+    // Keep the element/attribute shape identical in both modes so the SSR
+    // and CSR view trees agree for tachys hydration — only the values differ.
+    let box_size = if fill {
+        "100%"
+    } else {
+        icon_size.get_size_px()
+    };
+    let img_class = if fill {
+        "w-full h-full object-contain".to_string()
+    } else {
+        format!(
+            "{} max-w-full max-h-full object-contain",
+            icon_size.get_class()
+        )
+    };
     view! {
-        <div
-            class="overflow-hidden"
-            style:width=icon_size.get_size_px()
-            style:height=icon_size.get_size_px()
-        >
+        <div class="overflow-hidden" style:width=box_size style:height=box_size>
             <img
                 alt=item_name
-                class=format!("{} max-w-full max-h-full object-contain", icon_size.get_class())
+                class=img_class
                 src=move || {
                     if !failed_item() && valid_search_category.get() {
                         format!("/static/itemicon/{}?size={}", item_id(), icon_size)

--- a/ultros-frontend/ultros-app/src/components/job_set_card.rs
+++ b/ultros-frontend/ultros-app/src/components/job_set_card.rs
@@ -313,6 +313,9 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
                 </div>
             </div>
 
+            // The icon art already reads as a framed tile, so the swatch
+            // gets no card of its own — the image fills the square and the
+            // hover state is a ring rather than a background swap.
             <div class="grid grid-cols-6 sm:grid-cols-5 gap-1.5 mb-3">
                 {group_for_view.items.iter().map(|item| {
                     let id = item.id.0;
@@ -320,12 +323,12 @@ pub fn JobSetCard(group: JobSetGroup, jobset: String) -> impl IntoView {
                     view! {
                         <A
                             href=format!("/item/{}", id)
-                            attr:class="flex items-center justify-center aspect-square rounded bg-white/5 hover:bg-white/10 \
-                                       border border-white/5 hover:border-brand-500/30 \
-                                       transition-colors p-0.5"
+                            attr:class="block aspect-square rounded-md overflow-hidden \
+                                       ring-1 ring-white/5 hover:ring-brand-500/50 \
+                                       transition-all hover:scale-105"
                             attr:title=title
                         >
-                            <ItemIcon item_id=id icon_size=IconSize::Small />
+                            <ItemIcon item_id=id icon_size=IconSize::Large fill=true />
                         </A>
                     }
                 }).collect::<Vec<_>>()}


### PR DESCRIPTION
## What

The gear-set cards on the item explorer rendered each piece as a 25px `IconSize::Small` icon centered in a much larger square tile. Most of each tile was padding and card chrome wrapped around a tiny image.

Two changes:

**`ItemIcon` gains an optional `fill` prop.** When set, the wrapper sizes to `100%` of its parent instead of `icon_size`'s fixed `25px`/`40px`/`60px` box, and the `<img>` stretches with `w-full h-full object-contain`. `icon_size` still selects which source variant is fetched, so resolution and rendered size are chosen independently.

**`JobSetCard` uses it.** Pieces now request the 60px `Large` source and fill their square. The tile drops `bg-white/5`, its border, and `p-0.5` in favor of `rounded-md overflow-hidden` with a hairline ring that brightens to brand on hover, plus a slight scale. At the ~50px the 6/5-column grid produces, the Large source downscales cleanly rather than upscaling.

## Why

Reported visually: the icons were small enough that the surrounding card read as unnecessary decoration rather than as a frame for the art.

## Notes for review

- Both `fill` modes emit the same element and attribute shape — only the values differ — so the SSR and CSR view trees still agree for tachys hydration. This matters here; `job_set_card.rs` has prior hydration-mismatch history (see the `GilOrDash` module docs in that file).
- Scope is the set-piece grid only. The material rows on the set detail page still use `Small`, since those are genuine inline icon-beside-text rows where a fixed small box is correct.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both pass. I did **not** run the app to eyeball the result — the icon art has its own baked-in background, so with the card chrome gone the tiles read as a tighter mosaic of colored squares. If that ends up too dense, `gap-1.5` on the grid is the knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)