### PR TITLE
fix(world-picker): stop the collapsed value clipping the field, mark kinds with icons

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -42,6 +42,7 @@
     "currency_exchange": "通货兑换",
     "currency_exchange_desc": "消耗神典石，换取金币",
     "datacenter": "大区",
+    "region": "区域",
     "worlds": "服务器",
     "vendor_available": "NPC 可购买",
     "exchange_available": "可兑换",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -42,6 +42,7 @@
     "currency_exchange": "Währungstausch",
     "currency_exchange_desc": "Tomesteine ausgeben, Gil bekommen",
     "datacenter": "Rechenzentrum",
+    "region": "Region",
     "worlds": "Welten",
     "vendor_available": "Beim Händler erhältlich",
     "exchange_available": "Tausch möglich",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -42,6 +42,7 @@
     "currency_exchange": "Currency Exchange",
     "currency_exchange_desc": "Spend tomestones, get gil",
     "datacenter": "Datacenter",
+    "region": "Region",
     "worlds": "Worlds",
     "vendor_available": "Vendor Available",
     "exchange_available": "Exchange Available",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -42,6 +42,7 @@
     "currency_exchange": "Échange de devises",
     "currency_exchange_desc": "Dépensez vos mémoquartz, gagnez des gils",
     "datacenter": "Centre serveur",
+    "region": "Région",
     "worlds": "Mondes",
     "vendor_available": "Disponible chez un PNJ",
     "exchange_available": "Échange possible",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -42,6 +42,7 @@
     "currency_exchange": "通貨交換",
     "currency_exchange_desc": "トームストーンを使ってギルを稼ぐ",
     "datacenter": "データセンター",
+    "region": "地域",
     "worlds": "ワールド",
     "vendor_available": "NPCで入手可",
     "exchange_available": "交換可",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -42,6 +42,7 @@
     "currency_exchange": "재화 교환",
     "currency_exchange_desc": "전승석을 쓰고 길을 얻기",
     "datacenter": "데이터 센터",
+    "region": "지역",
     "worlds": "월드",
     "vendor_available": "NPC 구매 가능",
     "exchange_available": "교환 가능",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -42,6 +42,7 @@
     "currency_exchange": "通貨兌換",
     "currency_exchange_desc": "消耗神典石，換取金幣",
     "datacenter": "大區",
+    "region": "區域",
     "worlds": "伺服器",
     "vendor_available": "NPC 可購買",
     "exchange_available": "可兌換",

--- a/ultros-frontend/ultros-app/src/components/select.rs
+++ b/ultros-frontend/ultros-app/src/components/select.rs
@@ -1,3 +1,4 @@
+use icondata as i;
 use leptos::{
     html::{Div, Input},
     portal::Portal,
@@ -7,6 +8,8 @@ use leptos::{
 use web_sys::KeyboardEvent;
 use web_sys::wasm_bindgen::JsCast;
 
+use crate::components::icon::Icon;
+
 #[component]
 pub fn Select<T, EF, L, ViewOut>(
     items: Signal<Vec<T>>,
@@ -14,6 +17,11 @@ pub fn Select<T, EF, L, ViewOut>(
     choice: Signal<Option<T>>,
     set_choice: SignalSetter<Option<T>>,
     children: EF,
+    /// Optional leading adornment (icon, swatch, ...) rendered beside the
+    /// collapsed value. Kept separate from `children` so the field can carry a
+    /// compact marker without inheriting the dropdown row's decoration.
+    #[prop(into, optional)]
+    selected_prefix: Option<Callback<T, AnyView>>,
     #[prop(optional)] class: Option<&'static str>,
     #[prop(optional)] dropdown_class: Option<&'static str>,
 ) -> impl IntoView
@@ -97,10 +105,41 @@ where
     });
 
     Effect::new(move |_| {
-        // Reset highlighted index when results change
-        final_result.track();
+        // Typing re-filters the list, so start again from the top of the new
+        // results. Deliberately keyed on the query rather than on
+        // `final_result` - the latter also fires when the item list itself
+        // arrives, which would yank the highlight away from the open selection.
+        current_input.track();
         set_highlighted_index(0);
     });
+
+    // Keep the highlighted row inside the scroll viewport. Only the dropdown's
+    // own scroll offset is touched (rather than `scroll_into_view`, which can
+    // pull the whole page around a `fixed` panel).
+    let scroll_highlight_into_view = move |render_idx: usize| {
+        #[cfg(feature = "hydrate")]
+        {
+            let Some(panel) = dropdown.get_untracked() else {
+                return;
+            };
+            let Some(item) = document()
+                .get_element_by_id(&format!("select-item-{}", render_idx))
+                .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+            else {
+                return;
+            };
+            // `offset_*` / `client_height` are i32, `scroll_top` is f64.
+            let (top, height) = (item.offset_top() as f64, item.offset_height() as f64);
+            let (view_top, view_height) = (panel.scroll_top(), panel.client_height() as f64);
+            if top < view_top {
+                panel.set_scroll_top(top);
+            } else if top + height > view_top + view_height {
+                panel.set_scroll_top(top + height - view_height);
+            }
+        }
+        #[cfg(not(feature = "hydrate"))]
+        let _ = render_idx;
+    };
 
     let keydown = move |e: KeyboardEvent| {
         let key = e.key();
@@ -110,9 +149,9 @@ where
                 let len = final_result.with(|r| r.len());
                 if len > 0 {
                     *i = (*i + 1) % len;
-                    // Scroll into view logic could be added here if needed
                 }
             });
+            scroll_highlight_into_view(highlighted_index.get_untracked());
         } else if key == "ArrowUp" {
             e.prevent_default();
             set_highlighted_index.update(|i| {
@@ -121,6 +160,7 @@ where
                     *i = (*i + len - 1) % len;
                 }
             });
+            scroll_highlight_into_view(highlighted_index.get_untracked());
         } else if key == "Enter" {
             e.prevent_default();
             let idx = highlighted_index.get_untracked();
@@ -153,7 +193,8 @@ where
         }
     };
 
-    let default_input_class = "input w-full";
+    // `pr-9` reserves the trailing gutter for the chevron.
+    let default_input_class = "input w-full pr-9";
     let default_dropdown_class =
         "fixed max-h-96 overflow-y-auto panel rounded-lg shadow-lg z-[100]";
     let combined_input_class = format!("{} {}", default_input_class, class.unwrap_or(""));
@@ -163,10 +204,14 @@ where
         dropdown_class.unwrap_or("")
     );
 
-    let current_choice_view = move || {
-        choice()
-            .map(|c| children(c.clone(), as_label(&c).into_any()))
-            .into_any()
+    // The collapsed value is rendered as plain text sized to match the input's
+    // own padding. It deliberately does *not* reuse `children` - the dropdown
+    // row decoration (hover fill, row padding, per-item badges) is taller than
+    // the input's content box and spills over the field's border.
+    let current_choice_view = move || choice().map(|c| as_label(&c));
+    let current_prefix_view = move || {
+        let prefix = selected_prefix?;
+        choice().map(|c| prefix.run(c))
     };
 
     let selected_index_memo = Memo::new(move |_| {
@@ -179,6 +224,21 @@ where
         })
     });
     let is_selected_selector = Selector::new(move || selected_index_memo.get());
+
+    // Opening the list should highlight what is already chosen, so that an
+    // immediate Enter re-confirms the current value instead of silently
+    // swapping it for whichever entry happens to sort first.
+    let highlight_current_choice = move || {
+        let render_idx = selected_index_memo
+            .get_untracked()
+            .and_then(|selected| {
+                final_result
+                    .with_untracked(|r| r.iter().position(|(original, _)| *original == selected))
+            })
+            .unwrap_or(0);
+        set_highlighted_index(render_idx);
+        render_idx
+    };
 
     let dropdown_panel = {
         let is_selected_selector = is_selected_selector.clone();
@@ -266,7 +326,9 @@ where
                     // zero when the node ref was already set before the
                     // watcher's first run (hydration).
                     update_dropdown_position();
-                    set_focused(true)
+                    set_focused(true);
+                    let render_idx = highlight_current_choice();
+                    scroll_highlight_into_view(render_idx);
                 }
                 on:focusout=move |_| set_focused(false)
                 on:input=move |e| {
@@ -275,13 +337,34 @@ where
                 }
                 on:keydown=keydown
                 prop:value=current_input
+                // While the field is open the overlay is hidden, so the current
+                // value is echoed as a placeholder - you can still see what you
+                // are replacing as you type over it.
+                prop:placeholder=move || {
+                    if has_focus() { current_choice_view().unwrap_or_default() } else { String::new() }
+                }
                 role="combobox"
                 aria-autocomplete="list"
                 aria-expanded=move || (has_focus() || hovered()).to_string()
                 aria-activedescendant=move || format!("select-item-{}", highlighted_index())
             />
             <div
-                class="absolute top-1 left-1 select-none cursor flex items-center"
+                class="absolute inset-y-0 right-0 flex items-center pr-3 text-[color:var(--color-text-muted)] pointer-events-none"
+                aria-hidden="true"
+            >
+                <Icon
+                    icon=i::BsChevronDown
+                    attr:class=move || {
+                        if has_focus() || hovered() {
+                            "transition-transform duration-200 rotate-180"
+                        } else {
+                            "transition-transform duration-200"
+                        }
+                    }
+                />
+            </div>
+            <div
+                class="absolute inset-0 flex items-center gap-2 pl-3 pr-9 py-2 border border-transparent select-none cursor overflow-hidden"
                 class:invisible=move || has_focus() || !current_input().is_empty()
                 on:click=move |_| {
                     if let Some(input) = input.get() {
@@ -289,7 +372,8 @@ where
                     }
                 }
             >
-                {current_choice_view}
+                {current_prefix_view}
+                <span class="truncate">{current_choice_view}</span>
             </div>
             <Portal>{dropdown_panel.clone()}</Portal>
         </div>

--- a/ultros-frontend/ultros-app/src/components/world_picker.rs
+++ b/ultros-frontend/ultros-app/src/components/world_picker.rs
@@ -1,3 +1,4 @@
+use icondata as i;
 use leptos::{
     either::Either,
     prelude::*,
@@ -5,10 +6,41 @@ use leptos::{
 };
 
 use crate::{
-    components::select::Select,
+    components::{icon::Icon, select::Select},
     global_state::{LocalWorldData, home_world::locale_preferred_region},
 };
 use ultros_api_types::{world::World, world_helper::AnySelector};
+
+/// Marks whether an entry is a world, datacenter or region.
+///
+/// The icons zoom out as the scope widens - a pin on the map for a single
+/// world, the server rack that hosts a datacenter's worlds, the globe for a
+/// region - so the three tiers stay distinguishable at a glance without a text
+/// badge crowding the name. The kind is still exposed as text via `title` and
+/// an `sr-only` label, so nothing is icon-only.
+#[component]
+fn SelectorKind(selector: AnySelector) -> impl IntoView {
+    let i18n = crate::i18n::use_i18n();
+    let icon = match selector {
+        AnySelector::World(_) => i::BsGeoAltFill,
+        AnySelector::Datacenter(_) => i::FaServerSolid,
+        AnySelector::Region(_) => i::FaEarthAmericasSolid,
+    };
+    let label = move || match selector {
+        AnySelector::World(_) => crate::i18n::t_string!(i18n, world).to_string(),
+        AnySelector::Datacenter(_) => crate::i18n::t_string!(i18n, datacenter).to_string(),
+        AnySelector::Region(_) => crate::i18n::t_string!(i18n, region).to_string(),
+    };
+    view! {
+        <span
+            class="shrink-0 flex items-center text-[color:var(--color-text-muted)]"
+            title=label
+        >
+            <Icon icon=icon aria_hidden=true />
+            <span class="sr-only">{label}</span>
+        </span>
+    }
+}
 
 #[component]
 pub fn WorldOnlyPicker(
@@ -37,11 +69,7 @@ pub fn WorldOnlyPicker(
                         choice=current_world
                         set_choice=set_current_world
                         children=move |_w, label| {
-                            view! {
-                                <div class="flex items-center px-4 py-2 rounded-lg transition-colors hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)]">
-                                    {label}
-                                </div>
-                            }
+                            view! { <div class="flex items-center min-w-0 truncate">{label}</div> }
                         }
                     />
                 </div>
@@ -98,19 +126,14 @@ pub fn WorldPicker(
                         choice=choice
                         set_choice=set_choice
                         as_label=move |(d, _)| d.clone()
+                        selected_prefix=move |(_, s)| {
+                            view! { <SelectorKind selector=s /> }.into_any()
+                        }
                         children=move |(_, s), view| {
                             view! {
-                                <div class="flex justify-between px-4 py-2
-                                hover:bg-[color:color-mix(in_srgb,var(--brand-ring)_12%,transparent)] rounded-lg transition-colors
-                                items-end gap-2">
-                                    <div>{view}</div>
-                                    <div class="text-sm text-[color:var(--color-text-muted)]">
-                                        {match s {
-                                            AnySelector::World(_) => "world",
-                                            AnySelector::Region(_) => "region",
-                                            AnySelector::Datacenter(_) => "datacenter",
-                                        }}
-                                    </div>
+                                <div class="flex w-full min-w-0 items-center gap-2.5">
+                                    <SelectorKind selector=s />
+                                    <div class="truncate">{view}</div>
                                 </div>
                             }
                         }


### PR DESCRIPTION
## What

The world picker's selected value rendered as a chip that overhung the bottom of its own input, and the "region" / "world" / "datacenter" badge sat inside the box as trailing muted text.

| Before | After |
|---|---|
| chip overhangs the field by 2px; badge text crowds the value | value sits on the input's own text baseline; kind shown as a leading icon |

## Why

`Select` rendered the collapsed value with the same closure it uses for dropdown rows, so the selected value inherited the row's `px-4 py-2`, `rounded-lg` and `hover:bg-…`. That box is 40px tall inside a 42px input and was positioned at `top-1 left-1` — overhanging the bottom border by exactly 2px, which the hover fill made visible as a chip clipping the field.

The collapsed value is now plain text laid out to the input's own metrics (`inset-0`, `px-3 py-2`, transparent border matching `.input`), so it lands in exactly the position the input's real text would.

## Icons

Rendering the value as plain text would have lost the ability to tell whether `North-America` is a region or a similarly-named world, so the kind is now a leading icon on both the dropdown rows and the collapsed field:

| | | |
|---|---|---|
| World | `BsGeoAltFill` | map pin |
| Datacenter | `FaServerSolid` | server rack |
| Region | `FaEarthAmericasSolid` | globe |

The metaphor zooms out as scope widens. `Select` gained an optional `selected_prefix` callback to carry it — existing callers are unaffected since it's `#[prop(optional)]`.

**The icon isn't the only carrier of the semantics.** It also renders `title` plus an `sr-only` label. Those were hardcoded English literals in the view before (against the no-hardcoded-strings rule in CLAUDE.md); they're now wired to i18n. `world` and `datacenter` keys already existed, and `region` is added to all seven locales with real translations.

`WorldOnlyPicker` deliberately gets no icons — everything in it is a world, so a marker would be noise.

## Defects fixed in the same component

- **Enter immediately after opening changed your selection.** The highlight started at 0 and was reset to 0 whenever the result list changed, so confirming the current value instead selected whichever entry sorted first. The highlight is now seeded from the current choice on open. The reset effect is also re-keyed from `final_result` to `current_input` — the former fires when the *async item list* arrives too, which would have yanked the highlight back to 0 underneath an already-open dropdown.
- **The keyboard highlight scrolled out of sight.** There was a `// Scroll into view logic could be added here if needed` and the rows already carried `scroll-mt-2` in anticipation. With ~90 worlds in a `max-h-96` panel, arrowing past the eighth row moved the highlight out of view permanently.

## Affordances

- A chevron on the trailing edge that rotates when open — nothing previously signalled this was a dropdown rather than a plain text field. Input and overlay both take `pr-9` so long names can't run underneath it.
- The current value is echoed as a placeholder while focused, so you can see what you're replacing as you type over it.

## Reviewer notes

- **Why not `scrollIntoView`:** the panel is `fixed` inside a portal, and the browser method drags the whole page around to satisfy it. The fix adjusts only the dropdown's own `scrollTop`. It uses `offsetTop`/`clientHeight` rather than `ScrollIntoViewOptions` specifically to avoid adding `web-sys` features.
- **Why the placeholder is conditional on focus:** set unconditionally it would double-render beneath the overlay text, since the overlay has no background.
- **Deliberately not addressed** (happy to take in a follow-up): an empty search silently falls back to showing the *entire* list, so typing `zzz` looks identical to typing nothing; the dropdown only ever opens downward and runs off-screen near the bottom of a short viewport; and the input has no accessible name, no `aria-controls`, and keeps `aria-activedescendant` set while closed.

## Testing

`./check_ci.sh` passes — fmt and workspace clippy, exit 0, no warnings.

**Not exercised in a running app.** No dev server was available and a full `cargo-leptos` build plus Postgres was disproportionate for a CSS-level change, so the geometry was verified against a markup-faithful reproduction instead: it confirmed the old overlay overhangs by exactly 2px and the new one renders at the same position as the input's own text. Worth a quick manual look at the picker before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)