### PR TITLE
fix(item-explorer): key job routes on a locale-independent acronym

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -15,6 +15,7 @@ use crate::components::{add_to_list::*, cheapest_price::*, item_icon::*, meta::*
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
 use crate::routes::item_explorer_scope::{ExplorerPriceScope, use_explorer_price_scope};
+use crate::routes::item_explorer_toolbar::jobset_display_label;
 use icondata as i;
 use itertools::Itertools;
 use leptos::prelude::*;
@@ -27,8 +28,89 @@ use paginate::Pages;
 use percent_encoding::percent_decode_str;
 use ultros_api_types::world_helper::AnySelector;
 use xiv_gen::{
-    ClassJobCategory, ClassJobCategoryId, Item, ItemId, ItemSearchCategory, ItemSearchCategoryId,
+    ClassJobCategory, ClassJobCategoryId, ClassJobId, Item, ItemId, ItemSearchCategory,
+    ItemSearchCategoryId,
 };
+
+/// Canonical, locale-independent acronym for a `ClassJob`, keyed on its id.
+///
+/// `ClassJob::abbreviation` is a *localized display string*: German calls
+/// Pugilist "FST" (Faustkämpfer) and French "PUG", while `ClassJobCategory`'s
+/// columns — the flags [`job_category_lookup`] matches on — are English
+/// acronyms baked into the sheet schema and therefore identical in every
+/// locale. Anything that uses an abbreviation as a *key* (a route param, a
+/// role bucket, an href) must go through this table instead of reading
+/// `abbreviation`, or it resolves on English data and nowhere else.
+///
+/// The ids are the `ClassJob` sheet's row ids and the order matches
+/// [`job_category_lookup`]'s destructure exactly, because the
+/// `ClassJobCategory` sheet's per-job columns are laid out in `ClassJob` id
+/// order. `canonical_acronym_matches_english_abbreviation` pins the table
+/// against the shipped English pack, so a game-data bump that renumbers or
+/// adds a job fails the test rather than silently emptying a route.
+pub(crate) fn canonical_job_acronym(id: ClassJobId) -> Option<&'static str> {
+    // Ids 0..=42 line up with `ClassJobCategory`'s columns. "BST" (43) has a
+    // `ClassJob` row but no category column in the shipped pack — it still
+    // belongs here so role grouping and display resolve, even though nothing
+    // can select its gear (see `only_beastmaster_lacks_a_category_column`).
+    const ACRONYMS: [&str; 44] = [
+        "ADV", "GLA", "PGL", "MRD", "LNC", "ARC", "CNJ", "THM", "CRP", "BSM", "ARM", "GSM", "LTW",
+        "WVR", "ALC", "CUL", "MIN", "BTN", "FSH", "PLD", "MNK", "WAR", "DRG", "BRD", "WHM", "BLM",
+        "ACN", "SMN", "SCH", "ROG", "NIN", "MCH", "DRK", "AST", "SAM", "RDM", "BLU", "GNB", "DNC",
+        "RPR", "SGE", "VPR", "PCT", "BST",
+    ];
+    usize::try_from(id.0)
+        .ok()
+        .and_then(|i| ACRONYMS.get(i))
+        .copied()
+}
+
+/// Resolve the `/items/jobset/:jobset` route param to a canonical,
+/// locale-independent job acronym suitable for [`job_category_lookup`].
+///
+/// The canonical param is the **English acronym**, for the same reason
+/// `/items/category/:category` is keyed on a numeric id (see
+/// [`resolve_category_param`]): the server initializes `xiv_gen_db` to
+/// `Language::En` and never swaps it, while the client `try_init`s the
+/// visitor's locale *before* hydrating. A param keyed on the localized
+/// `abbreviation` resolves on at most one of the two sides.
+///
+/// Matching the acronym table first means the canonical form resolves
+/// identically in both processes regardless of which locale each loaded. The
+/// localized `abbreviation`/`name` match is kept as a fallback so links minted
+/// before this change (and the English full names in the search index) keep
+/// resolving; it carries exactly the locale caveat it always had, the same
+/// tradeoff `resolve_category_param` makes for legacy name-keyed category
+/// links.
+pub(crate) fn resolve_jobset_param(data: &xiv_gen::Data, raw_param: &str) -> Option<String> {
+    let decoded = percent_decode_str(raw_param)
+        .decode_utf8()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|_| raw_param.to_string());
+
+    // Locale-independent path: the param already is a canonical acronym.
+    if let Some(canonical) = data
+        .class_jobs
+        .keys()
+        .filter_map(|id| canonical_job_acronym(*id))
+        .find(|acronym| acronym.eq_ignore_ascii_case(&decoded))
+    {
+        return Some(canonical.to_string());
+    }
+
+    // Legacy fallback: a localized abbreviation or a full job name. Resolves
+    // against whichever locale *this* process loaded, so it is inherently
+    // one-sided for non-English visitors — but it only ever fires for
+    // non-canonical URLs, which today resolve to nothing at all.
+    data.class_jobs
+        .iter()
+        .find(|(_id, job)| {
+            job.abbreviation.eq_ignore_ascii_case(&decoded)
+                || job.name.eq_ignore_ascii_case(&decoded)
+        })
+        .and_then(|(id, _job)| canonical_job_acronym(*id))
+        .map(|acronym| acronym.to_string())
+}
 
 /// Return true if the given acronym is in the given class job category
 pub(crate) fn job_category_lookup(
@@ -274,40 +356,36 @@ pub fn JobItems() -> impl IntoView {
     let set_market_only =
         SignalSetter::map(move |market: bool| set_non_market((!market).then_some(true)));
     let items = Memo::new(move |_| {
-        // decode, normalize, and map to a known job abbreviation if possible
+        // Resolve to the canonical English acronym. Reading `abbreviation`
+        // straight off the matched job would hand `job_category_lookup` a
+        // localized string it cannot match — see `resolve_jobset_param`.
         let raw = match params().get("jobset") {
             Some(p) => p.clone(),
             None => return vec![],
         };
-        let decoded = percent_encoding::percent_decode_str(&raw)
-            .decode_utf8()
-            .map(|s| s.to_string())
-            .unwrap_or(raw.clone());
-        let lower = decoded.to_lowercase();
-
-        // try to resolve to a canonical abbreviation (fallback: decoded input)
-        let canonical_abbr = data
-            .class_jobs
-            .iter()
-            .find_map(|(_id, job)| {
-                let abbr = job.abbreviation.as_str();
-                let name = job.name.as_str();
-                if abbr.eq_ignore_ascii_case(&lower) || name.eq_ignore_ascii_case(&lower) {
-                    Some(abbr.to_string())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or(decoded.clone());
+        let canonical_abbr = match resolve_jobset_param(data, &raw) {
+            Some(abbr) => abbr,
+            None => return vec![],
+        };
 
         collect_job_items_sorted(data, &canonical_abbr, market_only())
     });
+    // Heading/meta text: the param is a canonical English acronym, so resolve
+    // it back to the visitor's localized label the way `CategoryItems` does
+    // with its numeric category id. Falls through to the raw param so an
+    // unrecognised jobset still names itself.
     let job_set = Memo::new(move |_| {
         params()
             .get("jobset")
             .as_ref()
-            .and_then(|s| percent_encoding::percent_decode_str(s).decode_utf8().ok())
-            .map(|s| s.to_string())
+            .and_then(|raw| {
+                jobset_display_label(data, raw).or_else(|| {
+                    percent_decode_str(raw)
+                        .decode_utf8()
+                        .ok()
+                        .map(|s| s.to_string())
+                })
+            })
             .unwrap_or_else(|| crate::i18n::t_string!(i18n, job_set_default).to_string())
     });
 
@@ -359,9 +437,17 @@ pub fn JobItems() -> impl IntoView {
     // `?show-non-market=` genuinely changes the item set, but the default
     // (marketable items only) is the representative view; canonicalising to it
     // keeps the toggled variant from being crawled as thin duplicate content.
-    // The param is already percent-encoded in the URL, so it is passed through
-    // rather than re-encoded.
-    let canonical_href = move || format!("https://ultros.app/items/jobset/{}", jobset_param.get());
+    // Legacy name-keyed and localized-abbreviation links still resolve (see
+    // `resolve_jobset_param`), so one job is reachable under several URLs —
+    // point them all at the canonical acronym so the duplicates consolidate
+    // instead of competing, exactly as `CategoryItems` does with its id.
+    let canonical_href = move || {
+        let raw = jobset_param.get();
+        match resolve_jobset_param(data, &raw) {
+            Some(acronym) => format!("https://ultros.app/items/jobset/{acronym}"),
+            None => format!("https://ultros.app/items/jobset/{raw}"),
+        }
+    };
 
     view! {
         <MetaCanonical href=canonical_href />
@@ -1067,9 +1153,152 @@ pub fn ItemExplorer() -> impl IntoView {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_job_items_sorted, resolve_category_param};
+    use super::{
+        canonical_job_acronym, collect_job_items_sorted, resolve_category_param,
+        resolve_jobset_param,
+    };
+    use crate::routes::item_explorer_toolbar::{job_chip_slug, job_chips_sorted_in};
     use paginate::Pages;
     use xiv_gen::Language;
+
+    const ALL_LOCALES: [Language; 7] = [
+        Language::En,
+        Language::Ja,
+        Language::De,
+        Language::Fr,
+        Language::Cn,
+        Language::Ko,
+        Language::Tc,
+    ];
+
+    /// Pins the hardcoded acronym table against the shipped English pack. A
+    /// game-data bump that renumbers, adds, or removes a job fails here
+    /// instead of silently emptying `/items/jobset/*`.
+    #[test]
+    fn canonical_acronym_matches_english_abbreviation() {
+        let en = xiv_gen_db::data_for(Language::En);
+        for job in job_chips_sorted_in(en) {
+            assert_eq!(
+                canonical_job_acronym(job.key_id),
+                Some(job.abbreviation.as_str()),
+                "job id {} ({}) is missing or wrong in the acronym table",
+                job.key_id.0,
+                job.name,
+            );
+        }
+    }
+
+    /// The bug. `ClassJobCategory`'s columns are English acronyms baked into
+    /// the sheet schema, but `ClassJob::abbreviation` is a localized display
+    /// string — so a German client's own "FST" chip is a key that
+    /// `job_category_lookup` matches nothing against, on *either* side of the
+    /// SSR/CSR split. The result was a nav link to a permanently empty page.
+    #[test]
+    fn a_localized_job_abbreviation_is_not_a_usable_category_key() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let de = xiv_gen_db::data_for(Language::De);
+
+        // Find a job German actually renames, so the assertion is not vacuous.
+        let (localized, canonical) = job_chips_sorted_in(de)
+            .into_iter()
+            .find_map(|job| {
+                let canonical = canonical_job_acronym(job.key_id)?;
+                (job.abbreviation != canonical)
+                    .then(|| (job.abbreviation.clone(), canonical.to_string()))
+            })
+            .expect("German renames at least one job abbreviation");
+
+        assert!(
+            collect_job_items_sorted(de, &localized, false).is_empty(),
+            "the localized abbreviation {localized:?} must not resolve — it is \
+             the dead-link bug, and if it ever does the acronym table is moot",
+        );
+        assert!(
+            !collect_job_items_sorted(de, &canonical, false).is_empty(),
+            "the canonical acronym {canonical:?} resolves against German data",
+        );
+        // Same key, same items, either side of the SSR/CSR locale split.
+        assert_eq!(
+            collect_job_items_sorted(de, &canonical, false)
+                .iter()
+                .map(|(id, _)| id.0)
+                .collect::<Vec<_>>(),
+            collect_job_items_sorted(en, &canonical, false)
+                .iter()
+                .map(|(id, _)| id.0)
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    /// Jobs that no `ClassJobCategory` row can select, because the sheet has
+    /// no column for them. These render an empty `/items/jobset/*` page in
+    /// *every* locale, English included — a gap in the shipped game-data pack
+    /// (`ClassJobCategory` predates Beastmaster), not something the acronym
+    /// table can repair. Pinned so a data bump that widens or closes the gap
+    /// surfaces in review instead of quietly changing which pages are dead.
+    #[test]
+    fn only_beastmaster_lacks_a_category_column() {
+        let en = xiv_gen_db::data_for(Language::En);
+        let unselectable: Vec<&str> = job_chips_sorted_in(en)
+            .into_iter()
+            .filter_map(|job| canonical_job_acronym(job.key_id))
+            .filter(|acronym| {
+                !en.class_job_categorys
+                    .values()
+                    .any(|c| super::job_category_lookup(c, acronym))
+            })
+            .collect();
+        assert_eq!(unselectable, vec!["BST"]);
+    }
+
+    /// The fix, end to end: the href the job nav actually mints resolves to a
+    /// non-empty item list in every locale. Pre-fix this minted the localized
+    /// abbreviation and failed for German and French.
+    #[test]
+    fn every_job_chip_link_resolves_to_items_in_every_locale() {
+        let en = xiv_gen_db::data_for(Language::En);
+        for lang in ALL_LOCALES {
+            let data = xiv_gen_db::data_for(lang);
+            for job in job_chips_sorted_in(data) {
+                // Dead for everyone regardless of locale keying — covered by
+                // `only_beastmaster_lacks_a_category_column`. Keyed on the id
+                // so the exclusion is itself locale-independent.
+                if canonical_job_acronym(job.key_id) == Some("BST") {
+                    continue;
+                }
+                let slug = job_chip_slug(job);
+                let resolved = resolve_jobset_param(data, &slug).unwrap_or_else(|| {
+                    panic!("{lang:?}: chip link /items/jobset/{slug} resolves to no job")
+                });
+                // The URL is a key, so every locale must read it as the same
+                // job. Item *sets* are deliberately not compared across
+                // locales: the CN/KO/TC packs track an older game version and
+                // genuinely hold different items — a separate and far broader
+                // SSR-locale issue that a route key cannot address.
+                assert_eq!(
+                    Some(resolved.as_str()),
+                    canonical_job_acronym(job.key_id),
+                    "{lang:?}: /items/jobset/{slug} resolves to the wrong job",
+                );
+                assert!(
+                    !collect_job_items_sorted(data, &resolved, false).is_empty(),
+                    "{lang:?}: /items/jobset/{slug} ({}) renders zero items",
+                    job.name,
+                );
+            }
+        }
+        // English is the SSR locale, so it must resolve every slug a client of
+        // any locale can mint — that is the pairing that actually hydrates.
+        for lang in ALL_LOCALES {
+            for job in job_chips_sorted_in(xiv_gen_db::data_for(lang)) {
+                let slug = job_chip_slug(job);
+                assert!(
+                    resolve_jobset_param(en, &slug).is_some(),
+                    "English SSR cannot resolve {slug}, minted by a {lang:?} client",
+                );
+            }
+        }
+    }
 
     /// Lowest-id category that the toolbar actually links to (`category`
     /// 1..=4), so the locale tests below key off a real navigable page

--- a/ultros-frontend/ultros-app/src/routes/item_explorer_roles.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer_roles.rs
@@ -8,7 +8,8 @@
 //! categories added by future expansions group automatically as long as
 //! their job's abbreviation is in the table.
 
-use xiv_gen::{ClassJobId, ItemSearchCategory};
+use crate::routes::item_explorer::canonical_job_acronym;
+use xiv_gen::{ClassJob, ClassJobId, ItemSearchCategory};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub(crate) enum RoleGroup {
@@ -55,6 +56,23 @@ pub(crate) fn role_for_job_abbr(abbr: &str) -> RoleGroup {
     }
 }
 
+/// Map a [`ClassJob`] to its role.
+///
+/// Keyed on the job's **id**, not its `abbreviation`: that field is a
+/// localized display string ("FST" in German for the job English calls "PGL"),
+/// so matching it against the English table below buckets 23 of 36 German and
+/// 22 of 36 French jobs into [`RoleGroup::Other`]. Ids are locale-independent,
+/// so this resolves identically for every visitor.
+pub(crate) fn role_for_job(job: &ClassJob) -> RoleGroup {
+    match canonical_job_acronym(job.key_id) {
+        Some(acronym) => role_for_job_abbr(acronym),
+        None => {
+            tracing::warn!(id = job.key_id.0, "Class job id outside the acronym table");
+            RoleGroup::Other
+        }
+    }
+}
+
 /// Map a weapon search category (group 1) to a role via its `class_job`.
 pub(crate) fn role_for_weapon_category(
     cat: &ItemSearchCategory,
@@ -62,19 +80,22 @@ pub(crate) fn role_for_weapon_category(
 ) -> RoleGroup {
     data.class_jobs
         .get(&ClassJobId(cat.class_job as i32))
-        .map(|job| role_for_job_abbr(&job.abbreviation))
+        .map(role_for_job)
         .unwrap_or(RoleGroup::Other)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routes::item_explorer_toolbar::{category_chips_for_group, job_chips_sorted};
+    use crate::routes::item_explorer_toolbar::{
+        category_chips_for_group, job_chips_sorted, job_chips_sorted_in,
+    };
+    use xiv_gen::Language;
 
     #[test]
     fn every_visible_job_maps_to_a_role() {
         for job in job_chips_sorted() {
-            let role = role_for_job_abbr(&job.abbreviation);
+            let role = role_for_job(job);
             assert_ne!(
                 role,
                 RoleGroup::Other,
@@ -82,6 +103,47 @@ mod tests {
                 job.abbreviation,
                 job.name,
             );
+        }
+    }
+
+    /// `every_visible_job_maps_to_a_role` passed even while the grouping was
+    /// broken, because the test process loads English data. Keying the lookup
+    /// on the localized `abbreviation` dropped 23 of 36 German and 22 of 36
+    /// French jobs into `Other`, collapsing the role sections of the Job Sets
+    /// popover into one undifferentiated list.
+    #[test]
+    fn role_grouping_is_identical_in_every_locale() {
+        let en = xiv_gen_db::data_for(Language::En);
+        for lang in [
+            Language::En,
+            Language::Ja,
+            Language::De,
+            Language::Fr,
+            Language::Cn,
+            Language::Ko,
+            Language::Tc,
+        ] {
+            let data = xiv_gen_db::data_for(lang);
+            for job in job_chips_sorted_in(data) {
+                let role = role_for_job(job);
+                assert_ne!(
+                    role,
+                    RoleGroup::Other,
+                    "{lang:?}: job {:?} ({}) has no role mapping",
+                    job.abbreviation,
+                    job.name,
+                );
+                let en_role = en
+                    .class_jobs
+                    .get(&job.key_id)
+                    .map(role_for_job)
+                    .expect("the same job id exists in every locale");
+                assert_eq!(
+                    role, en_role,
+                    "{lang:?}: job id {} buckets differently than under English data",
+                    job.key_id.0,
+                );
+            }
         }
     }
 

--- a/ultros-frontend/ultros-app/src/routes/item_explorer_toolbar.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer_toolbar.rs
@@ -7,8 +7,10 @@ use crate::components::toolbar::{Toolbar, ToolbarField, ToolbarPills, ToolbarSpa
 use crate::components::world_picker::WorldPicker;
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::{t, t_string, use_i18n};
-use crate::routes::item_explorer::resolve_category_param;
-use crate::routes::item_explorer_roles::{RoleGroup, role_for_job_abbr, role_for_weapon_category};
+use crate::routes::item_explorer::{
+    canonical_job_acronym, resolve_category_param, resolve_jobset_param,
+};
+use crate::routes::item_explorer_roles::{RoleGroup, role_for_job, role_for_weapon_category};
 use crate::routes::item_explorer_scope::{ExplorerPriceScope, href_with_world};
 use leptos::prelude::*;
 use leptos_router::components::A;
@@ -51,7 +53,13 @@ pub(crate) fn category_chips_for_group(group: u8) -> Vec<(&'static str, ItemSear
 /// `test_job_filtering` test: only jobs with `job_index > 0` or
 /// `doh_dol_job_index >= 0`, and with a non-empty abbreviation or name.
 pub(crate) fn job_chips_sorted() -> Vec<&'static ClassJob> {
-    let data = xiv_gen_db::data();
+    job_chips_sorted_in(xiv_gen_db::data())
+}
+
+/// `job_chips_sorted` against an explicit dataset, so the locale-independence
+/// tests can run the real filter over each shipped locale pack rather than a
+/// reimplementation of it.
+pub(crate) fn job_chips_sorted_in(data: &'static xiv_gen::Data) -> Vec<&'static ClassJob> {
     let mut jobs: Vec<&'static ClassJob> = data
         .class_jobs
         .iter()
@@ -79,6 +87,34 @@ pub(crate) fn job_chip_label(job: &ClassJob) -> &str {
     } else {
         job.abbreviation.as_str()
     }
+}
+
+/// Path segment for a job's `/items/jobset/:jobset` link.
+///
+/// The canonical English acronym, *not* `job_chip_label`: the label is
+/// localized, and a localized slug is a link that resolves under no locale at
+/// all — `job_category_lookup` only knows the English acronyms, so a German
+/// client's own "FST" chip navigates to an empty page. Falls back to the
+/// (escaped) label only for a job id outside the acronym table.
+pub(crate) fn job_chip_slug(job: &ClassJob) -> String {
+    canonical_job_acronym(job.key_id)
+        .map(|acronym| acronym.to_string())
+        .unwrap_or_else(|| job_chip_label(job).replace('/', "%2F"))
+}
+
+/// Localized display label for a `/items/jobset/:jobset` param.
+///
+/// The param is the canonical English acronym, so showing it verbatim would
+/// label a German player's active chip "PGL" where every other chip reads
+/// "FST". Resolve it back through the job the same way `CategoryItems` turns
+/// its numeric category id back into a localized name; falls through to the
+/// raw param when it names no known job.
+pub(crate) fn jobset_display_label(data: &xiv_gen::Data, raw_param: &str) -> Option<String> {
+    let canonical = resolve_jobset_param(data, raw_param)?;
+    data.class_jobs
+        .iter()
+        .find(|(id, _)| canonical_job_acronym(**id) == Some(canonical.as_str()))
+        .map(|(_, job)| job_chip_label(job).to_string())
 }
 
 #[component]
@@ -170,10 +206,15 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                     let button_label = if active_group.get() == Some(group) {
                         let p = params.get();
                         match p.get("jobset") {
-                            Some(jobset) => percent_encoding::percent_decode_str(&jobset)
-                                .decode_utf8()
-                                .ok()
-                                .map(|s| s.to_string()),
+                            // The jobset param is a canonical English acronym,
+                            // so resolve it back to the localized label rather
+                            // than labelling a German player's trigger "PGL".
+                            Some(jobset) => jobset_display_label(data, &jobset).or_else(|| {
+                                percent_encoding::percent_decode_str(&jobset)
+                                    .decode_utf8()
+                                    .ok()
+                                    .map(|s| s.to_string())
+                            }),
                             // The category param is an id, so resolve it back
                             // to the localized name instead of labelling the
                             // trigger with a bare number.
@@ -196,12 +237,16 @@ pub fn ItemExplorerToolbar() -> impl IntoView {
                             .map(|role| (*role, Vec::new()))
                             .collect();
                         for job in job_chips_sorted() {
+                            // Label stays localized (a German player expects
+                            // "FST"); the href uses the canonical English
+                            // acronym so the route resolves on both the
+                            // English SSR pass and the client's locale.
                             let label = job_chip_label(job).to_string();
                             let href = href_with_world(
-                                format!("/items/jobset/{}", label.replace('/', "%2F")),
+                                format!("/items/jobset/{}", job_chip_slug(job)),
                                 world.as_deref(),
                             );
-                            let role = role_for_job_abbr(&job.abbreviation);
+                            let role = role_for_job(job);
                             if let Some((_, links)) =
                                 buckets.iter_mut().find(|(r, _)| *r == role)
                             {

--- a/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
+++ b/ultros-frontend/ultros-app/src/routes/job_set_detail.rs
@@ -24,7 +24,8 @@ use crate::components::meta::{MetaDescription, MetaTitle};
 use crate::global_state::home_world::use_home_world;
 use crate::global_state::xiv_data::tracked_data;
 use crate::i18n::*;
-use crate::routes::item_explorer::job_category_lookup;
+use crate::routes::item_explorer::{job_category_lookup, resolve_jobset_param};
+use crate::routes::item_explorer_toolbar::jobset_display_label;
 
 /// Sum the cheapest-of-(NQ,HQ) price across every item in the set
 /// using the given listings map. Mirrors the helper in `JobSetCard`
@@ -370,25 +371,7 @@ pub fn JobSetDetail() -> impl IntoView {
     // Resolve the job acronym from the route, same as `JobItems` does.
     let canonical_abbr = Memo::new(move |_| {
         let raw = params().get("jobset").map(|s| s.to_string())?;
-        let decoded = percent_encoding::percent_decode_str(&raw)
-            .decode_utf8()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|_| raw.clone());
-        let lower = decoded.to_lowercase();
-        Some(
-            data.class_jobs
-                .iter()
-                .find_map(|(_id, job)| {
-                    let abbr = job.abbreviation.as_str();
-                    let name = job.name.as_str();
-                    if abbr.eq_ignore_ascii_case(&lower) || name.eq_ignore_ascii_case(&lower) {
-                        Some(abbr.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(decoded),
-        )
+        resolve_jobset_param(data, &raw)
     });
 
     let target_ilvl = Memo::new(move |_| {
@@ -441,9 +424,15 @@ pub fn JobSetDetail() -> impl IntoView {
     let default_zone_listings = cheapest_prices.map(|p| p.read_listings);
 
     let set_stem = Signal::derive(move || group.get().map(|g| g.stem).unwrap_or_default());
+    // Show the visitor's localized abbreviation, not the canonical English
+    // acronym the route is keyed on — a German player browsing Krieger gear
+    // should not see the heading read "WAR".
     let job_name = Memo::new(move |_| {
-        canonical_abbr
-            .get()
+        params()
+            .get("jobset")
+            .as_ref()
+            .and_then(|raw| jobset_display_label(data, raw))
+            .or_else(|| canonical_abbr.get())
             .unwrap_or_else(|| t_string!(i18n, job_set_default).to_string())
     });
     let back_href = Memo::new(move |_| {


### PR DESCRIPTION
## The bug

`ClassJob::abbreviation` is a **localized display string**. `ClassJobCategory`'s columns — the flags `job_category_lookup` matches on — are **English acronyms baked into the sheet schema**, identical in every locale. Four call sites used the former as a key for the latter.

German renames 23 of 36 visible jobs, French 22. For those visitors:

1. **The Job Sets nav minted dead links.** A German client's Warrior chip pointed at `/items/jobset/KRG`. `job_category_lookup` rejects `"KRG"`, and English SSR can't resolve it either — so the page rendered zero items on *both* sides of hydration. Every renamed job's own nav link was a dead page.
2. **Role grouping collapsed.** `role_for_job_abbr(&job.abbreviation)` bucketed those same jobs into `RoleGroup::Other`, flattening the popover's role sections. The existing `every_visible_job_maps_to_a_role` test passed only because the test process loads English data.

This is the sibling of #1001, which fixed `/items/category/:category` the same way. The mechanism is documented in the `resolve_jobset_param` doc comment.

## The fix

`canonical_job_acronym(ClassJobId) -> Option<&'static str>` — a locale-independent id→acronym table. Routes, hrefs, and role buckets key on it; **display labels stay localized** (a German player still sees "KRG" on the chip and in the heading, the link just goes to `/items/jobset/WAR`).

The legacy localized-abbreviation / full-name fallback is kept, carrying the identical documented locale caveat that `resolve_category_param` already accepts for legacy category links. Canonical hrefs now consolidate duplicates the way `CategoryItems` does.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --all-targets -- -D warnings` (full workspace) | exit 0, 18m33s |
| `cargo test -p ultros-app --lib` | **368 passed / 0 failed** (base 363 + 5 added, 0 removed) |

**Genuine red→green.** With the pre-fix behaviour temporarily restored, exactly the two new locale tests fail, at exit 101:

```
De: job "KRG" (Krieger) has no role mapping
English SSR cannot resolve KRG, minted by a De client
```

Both pass with the fix. The tests drive the **real `data/xiv-db` locale packs** via `data_for(Language::De)` etc., not a mock — the LFS packs ship all seven locales, so this class of bug is now testable without a browser.

The other three added tests are pins/characterization rather than regression proofs, and are labelled as such: `canonical_acronym_matches_english_abbreviation` (table vs. shipped data), `only_beastmaster_lacks_a_category_column`, `a_localized_job_abbreviation_is_not_a_usable_category_key` (documents the mechanism; `collect_job_items_sorted` is unchanged, so it is green either way).

## Incidental finding — not fixed here

**`/items/jobset/BST` renders empty in every locale, English included.** Beastmaster (job id 43) ships in `ClassJob`, but `ClassJobCategory` in the current pack has only 43 bool columns ending at `PCT` — there is no BST column, so no category row can select its gear. That is a gap in the game-data pack, not a keying bug, and closing it means a pack regeneration plus an `xiv-gen` schema change (its own PR per `CLAUDE.md`). Pinned by `only_beastmaster_lacks_a_category_column` so it stays visible instead of being silently absorbed.

Also left alone deliberately: item *sets* are not compared across locales in the tests, because the CN/KO/TC packs track an older game version and genuinely hold different items. That is a separate and much broader SSR-locale issue a route key can't address.

## GlitchTip triage: none

**The GlitchTip MCP server is still unregistered** — no `glitchtip_*` tools are exposed and there is no `.mcp.json` at the worktree root or the main clone root. That is the fourth consecutive run with the backlog unreachable, so zero issues were triaged, ignored, or resolved. Re-adding the server config (with the token as an env var, per the #991 sanitization) is needed before triage can resume. This fix came from the code-hunt fallback instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
