### PR TITLE
fix(charts): stop the open-ended price window dropping the newest month of sales

### DIFF
--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -437,6 +437,43 @@ fn resolve_bucket_seconds(bucket: Option<i64>, span_secs: i64) -> i64 {
     }
 }
 
+/// How long a cached response stays servable, and — for an open-ended window
+/// — the grain [`open_window_cache_stamp`] quantizes its cache key onto.
+/// Deriving both from one place means exactly one entry per item/scope is live
+/// at a time: the key rolls over on the same schedule the entry expires on.
+///
+/// Capped at an hour so an open window is never served staler than that, and
+/// floored at a minute so a hypothetical sub-minute bucket couldn't turn the
+/// cache into a no-op. A closed window is immutable, so it just takes the cap.
+fn cache_ttl_secs(closed: bool, bucket_seconds: i64) -> u64 {
+    if closed {
+        3_600
+    } else {
+        (bucket_seconds as u64).clamp(60, 3_600)
+    }
+}
+
+/// Quantize an open-ended window's end onto a `grain`-second grid, for use in
+/// the **cache key only** — never for the window actually queried.
+///
+/// An open-ended request ends at "now", so feeding that raw timestamp into the
+/// cache key mints a fresh entry every second and the cache never hits.
+/// Rounding it onto the same grid as the entry's TTL keeps one live entry per
+/// item/scope, which is all the quantization was ever for.
+///
+/// This deliberately moves the *key* and not the queried window. Flooring the
+/// window itself — which both handlers used to do, at `bucket_seconds`
+/// granularity — drags the query's exclusive upper bound backwards, excluding
+/// every sale after the boundary. An open-ended "full history" request
+/// resolves to a 12-year span, the ladder duly picks its widest step (30
+/// days), and so the newest 0–30 days of sales silently vanished from every
+/// chart. Serving a slightly stale snapshot is the cache's job and is bounded
+/// by the TTL; narrowing the window is data loss and is not.
+fn open_window_cache_stamp(to_ts: i64, grain: i64) -> i64 {
+    let grain = grain.max(1);
+    to_ts - to_ts.rem_euclid(grain)
+}
+
 /// Uniform bin height covering `[lo, hi]` inclusive in `bins` steps, floored
 /// at 1 gil so degenerate windows (every sale at one price) still bin sanely.
 fn density_bin_width(lo: u32, hi: u32, bins: u16) -> f64 {
@@ -666,13 +703,18 @@ async fn price_series(
     let span_secs = (to - from).num_seconds().max(1);
     let bucket_seconds = resolve_bucket_seconds(query.bucket, span_secs);
 
-    // Snap an open-ended `to` down to the current bucket boundary so live
-    // views share a cache entry instead of minting a unique key per second.
-    let to = if query.to.is_none() {
-        let secs = to.timestamp() - to.timestamp().rem_euclid(bucket_seconds);
-        chrono::DateTime::from_timestamp(secs, 0).unwrap_or(to)
+    // A closed window is immutable; an open one is a snapshot of "now" and
+    // stays servable until its TTL expires.
+    let ttl_secs = cache_ttl_secs(query.to.is_some(), bucket_seconds);
+    let ttl = std::time::Duration::from_secs(ttl_secs);
+
+    // `to` itself is left at `now`: only the cache key is quantized, so live
+    // views still share an entry without the query window losing its newest
+    // sales. See [`open_window_cache_stamp`] for why flooring `to` is a bug.
+    let cache_to = if query.to.is_none() {
+        open_window_cache_stamp(to.timestamp(), ttl_secs as i64)
     } else {
-        to
+        to.timestamp()
     };
 
     // The cache key is built from the *pre-widening* `bucket_seconds` — the
@@ -698,18 +740,11 @@ async fn price_series(
         item_id,
         scope: world.clone(),
         from: from.timestamp(),
-        to: to.timestamp(),
+        to: cache_to,
         bucket: bucket_seconds,
         group: group.as_str(),
         hq: hq.as_str(),
         bins: 0,
-    };
-    // A closed window is immutable; an open one only changes when the current
-    // bucket rolls over.
-    let ttl = if query.to.is_some() {
-        std::time::Duration::from_secs(3_600)
-    } else {
-        std::time::Duration::from_secs((bucket_seconds as u64).clamp(60, 3_600))
     };
     if let Some(hit) = cache.get(&cache_key) {
         return Ok(cached_json(hit, ttl));
@@ -830,29 +865,25 @@ async fn price_density(
         }
     }
 
-    // Snap an open-ended `to` to the bucket boundary — same cache-sharing
-    // rationale as price_series.
-    let to = if query.to.is_none() {
-        let secs = to.timestamp() - to.timestamp().rem_euclid(bucket_seconds);
-        chrono::DateTime::from_timestamp(secs, 0).unwrap_or(to)
+    // Quantize an open-ended `to` for the cache key only — same rationale, and
+    // same data-loss trap, as price_series.
+    let ttl_secs = cache_ttl_secs(query.to.is_some(), bucket_seconds);
+    let ttl = std::time::Duration::from_secs(ttl_secs);
+    let cache_to = if query.to.is_none() {
+        open_window_cache_stamp(to.timestamp(), ttl_secs as i64)
     } else {
-        to
+        to.timestamp()
     };
 
     let cache_key = crate::web::price_series_cache::CacheKey {
         item_id,
         scope: world.clone(),
         from: from.timestamp(),
-        to: to.timestamp(),
+        to: cache_to,
         bucket: bucket_seconds,
         group: "density",
         hq: hq.as_str(),
         bins,
-    };
-    let ttl = if query.to.is_some() {
-        std::time::Duration::from_secs(3_600)
-    } else {
-        std::time::Duration::from_secs((bucket_seconds as u64).clamp(60, 3_600))
     };
     if let Some(hit) = cache.get(&cache_key) {
         return Ok(cached_json(hit, ttl));
@@ -933,6 +964,75 @@ mod price_series_tests {
         assert_eq!(density_bin_width(100, 400, 4), 301.0 / 4.0);
         // Degenerate flat price: floor at 1.0 so floor((p-lo)/w) stays 0.
         assert_eq!(density_bin_width(100, 100, 32), 1.0);
+    }
+
+    /// 2026-08-01T12:00:00Z — an arbitrary but fixed "now" so these tests
+    /// don't depend on when they run.
+    const NOW: i64 = 1_785_585_600;
+
+    /// The whole point of quantizing: requests seconds apart must land on one
+    /// cache entry rather than minting a key each.
+    #[test]
+    fn cache_stamp_is_stable_across_the_grain() {
+        let grain = cache_ttl_secs(false, 30 * 86_400) as i64;
+        let base = open_window_cache_stamp(NOW, grain);
+        for offset in [0, 1, 59, 600, grain - 1] {
+            assert_eq!(
+                open_window_cache_stamp(NOW + offset, grain),
+                base,
+                "+{offset}s should still hit the same cache entry"
+            );
+        }
+        assert_ne!(
+            open_window_cache_stamp(NOW + grain, grain),
+            base,
+            "the key must roll over once the entry expires"
+        );
+    }
+
+    /// Regression, and the reason this function exists at all.
+    ///
+    /// An open-ended "full history" request (the item page's default — no
+    /// `from`, no `to`) resolves `from` to 12 years back, which puts the
+    /// bucket ladder at its widest step. Both handlers used to floor the
+    /// *queried* window's exclusive upper bound onto that step, so every sale
+    /// in the current bucket — up to a month of the newest data — was
+    /// excluded from the response. Pin that the quantization applied now is
+    /// bounded by the TTL instead of the bucket width, at every ladder step.
+    #[test]
+    fn cache_stamp_never_discards_more_than_the_ttl() {
+        let span_secs = 365 * 12 * 86_400;
+        assert_eq!(
+            resolve_bucket_seconds(None, span_secs),
+            30 * 86_400,
+            "full history sits on the widest rung — the old floor's grain"
+        );
+
+        // What the old code did to the window itself, at that rung.
+        let floored = NOW - NOW.rem_euclid(30 * 86_400);
+        assert!(
+            NOW - floored > 26 * 86_400,
+            "the old floor dropped {} days of the newest sales",
+            (NOW - floored) / 86_400
+        );
+
+        // What the fix does: bounded by the TTL, whatever the bucket width.
+        for step in ultros_charts::data::buckets::BUCKET_LADDER {
+            let grain = cache_ttl_secs(false, step) as i64;
+            let stamp = open_window_cache_stamp(NOW, grain);
+            assert!(
+                grain <= 3_600 && NOW - stamp < 3_600,
+                "at a {step}s bucket the stamp discarded {}s",
+                NOW - stamp
+            );
+        }
+    }
+
+    /// A grain of zero (or negative) must not panic on `rem_euclid`.
+    #[test]
+    fn cache_stamp_tolerates_a_degenerate_grain() {
+        assert_eq!(open_window_cache_stamp(NOW, 0), NOW);
+        assert_eq!(open_window_cache_stamp(NOW, -5), NOW);
     }
 
     // `world_group_map` at `SeriesGroup::World` is intentionally not tested


### PR DESCRIPTION
## The bug

An open-ended `/api/v1/price_series` request — no `from`, no `to` — resolves `from` to 12 years back. The bucket ladder duly picks its widest rung, **30 days**. Both `price_series` and `price_density` then floored the **queried window's exclusive upper bound** onto that rung:

```rust
let to = if query.to.is_none() {
    let secs = to.timestamp() - to.timestamp().rem_euclid(bucket_seconds);
    chrono::DateTime::from_timestamp(secs, 0).unwrap_or(to)
} else { to };
```

The ClickHouse predicate is `sold_date < to` (half-open), so **every sale in the current 30-day bucket was excluded from the response**.

This is the default path for every item page — `selected_range` starts at `None` (`item_view.rs:1270`), so `range = None` goes out until the user drags the timeline slicer.

## Reproduced against production

Same endpoint, open-ended vs. an explicit `from`/`to` covering the same span (the explicit path was never floored). Gilgamesh, fetched 2026-08-01:

| item | shown | actual | hidden |
|---|---:|---:|---:|
| 5 | 113 | 155 | 42 (27.1%) |
| 5057 | 342 | 509 | 167 (32.8%) |
| 5106 | 188 | 277 | 89 (32.1%) |
| 5111 | 495 | 743 | 248 (33.4%) |
| 7010 | 83 | 112 | 29 (25.9%) |
| 12538 | 171 | 266 | 95 (35.7%) |
| 19938 | 394 | 565 | 171 (30.3%) |
| 27722 | 47 | 51 | 4 (7.8%) |
| **total** | **1,833** | **2,678** | **845 (31.6%)** |

Every chart's right edge sat at **2026-07-05/06** — the 30-day epoch boundary — roughly 27 days stale.

## The fix

The floor existed only so a live view would share a cache entry instead of minting a unique key every second. That is a **cache-key** concern, so it belongs on the key:

- `cache_ttl_secs(closed, bucket_seconds)` — one place deriving both the TTL and the key's grain, so the key rolls over exactly when the entry expires (one live entry per item/scope, as before).
- `open_window_cache_stamp(to_ts, grain)` — quantizes **`CacheKey.to` only**. The queried window keeps running to `now`.

Staleness is now bounded by the TTL, which already capped it at an hour. Cache cardinality is unchanged. No data is dropped.

Applied to both `price_series` and `price_density`, which had the identical floor.

`item_card.rs` (the OG PNG) was never affected — it calls `build_price_series` directly with an unfloored `to`, which is why cards stayed current while charts did not.

## Notes for review

- **This predates #1050.** Before it the chart drew 1–2 month-wide buckets, so the missing tail was invisible; #1050 made *resolution* follow the data and exposed it. Not a #1050 regression.
- The response's `from`/`to` are the *actual data span* (`build_price_series`), so the visible symptom was the chart's right edge, not an obviously-wrong axis bound.

## Verification

- `./check_ci.sh` → **exit 0** (fmt + clippy, workspace-wide).
- `cargo clippy -p ultros --all-targets -- -D warnings` → exit 0 on a *forced* re-check, so the new tests compile under test cfg.
- Three regression tests added to `price_series_tests`: key stability across the grain, the grain never exceeding the TTL at any ladder rung, and a degenerate-grain guard.
- ⚠️ **The tests could not be executed in-crate.** `cargo test -p ultros` fails to *link* on Windows/MSVC with `LNK2001/LNK2019 unresolved external symbol … ultros_app`, and this is pre-existing and unrelated — the unresolved symbols come from long-standing tests (`auth_failures_keep_their_structured_body`, `test_persistence`, `method_to_db_round_trip_webhook`). To prove the logic rather than just the compile, the two pure helpers and their tests were mirrored into a standalone file and run with `rustc --edition 2024 --test`: **4/4 pass**. Worth a run on Linux to confirm in-crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
