### PR TITLE
fix(e2e): update /items title assertion to match Items Explorer

### DIFF
--- a/integration/runner.cjs
+++ b/integration/runner.cjs
@@ -50,7 +50,7 @@ function sanitizeFileComponent(s) {
  */
 const ROUTE_ASSERTS = {
   "/": { titleIncludes: "Ultros" },
-  "/items": { titleIncludes: "Ultros" },
+  "/items": { titleIncludes: "Items Explorer" },
   "/item/46010": {
     titleIncludes: "Ceremonial Shamshir",
     bodyIncludesAny: ["Fresh", "Caution", "Verify In-Game", "No Data"],


### PR DESCRIPTION
## Summary
- The e2e route assertions in `integration/runner.cjs` still expected the `/items` page title to contain "Ultros", but since 27b35918 the item explorer sets its default meta title from the `item_explorer_default_title` locale key ("Items Explorer"). Every STRICT run failed with `/items: title check: expected substring "Ultros" in "Items Explorer"`.
- Updated the `/items` expectation to `titleIncludes: "Items Explorer"`. Harness-only change; no app strings touched.

## Verification
- Confirmed the running app serves `<title>Items Explorer</title>` for `/items`.
- `ROUTES="/items,/,/flip-finder" DEVICE=desktop node runner.cjs` — the title failure is gone; only unrelated third-party `adsbygoogle.js` page errors remained, hitting the unchanged control routes identically.
- With `STRICT_CONSOLE=0`: `[done] all routes ok, screenshots + asserts complete`.
- `cargo fmt --all -- --check` passes (JS-only change, clippy unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)