### PR TITLE
fix(lists): single header on the index, add-item search in a modal

### DIFF
--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -109,7 +109,6 @@
     "delete": "删除",
     "edit_list": "编辑清单",
     "view_items": "查看物品",
-    "my_lists": "我的清单",
     "cancel_creation": "取消创建",
     "create_new_list": "创建新清单",
     "create_list": "创建清单",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -109,7 +109,6 @@
     "delete": "Löschen",
     "edit_list": "Liste bearbeiten",
     "view_items": "Items ansehen",
-    "my_lists": "Meine Listen",
     "cancel_creation": "Erstellung abbrechen",
     "create_new_list": "Neue Liste erstellen",
     "create_list": "Liste erstellen",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -109,7 +109,6 @@
     "delete": "Delete",
     "edit_list": "Edit List",
     "view_items": "View Items",
-    "my_lists": "My Lists",
     "cancel_creation": "Cancel Creation",
     "create_new_list": "Create New List",
     "create_list": "Create List",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -109,7 +109,6 @@
     "delete": "Supprimer",
     "edit_list": "Modifier la liste",
     "view_items": "Voir les objets",
-    "my_lists": "Mes listes",
     "cancel_creation": "Annuler la création",
     "create_new_list": "Créer une nouvelle liste",
     "create_list": "Créer la liste",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -109,7 +109,6 @@
     "delete": "削除",
     "edit_list": "リストを編集",
     "view_items": "アイテムを表示",
-    "my_lists": "マイリスト",
     "cancel_creation": "作成をキャンセル",
     "create_new_list": "新しいリストを作成",
     "create_list": "リストを作成",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -109,7 +109,6 @@
     "delete": "삭제",
     "edit_list": "목록 편집",
     "view_items": "아이템 보기",
-    "my_lists": "내 목록",
     "cancel_creation": "생성 취소",
     "create_new_list": "새 목록 만들기",
     "create_list": "목록 만들기",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -109,7 +109,6 @@
     "delete": "刪除",
     "edit_list": "編輯清單",
     "view_items": "查看物品",
-    "my_lists": "我的清單",
     "cancel_creation": "取消建立",
     "create_new_list": "建立新清單",
     "create_list": "建立清單",

--- a/ultros-frontend/ultros-app/src/routes/list_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/list_view.rs
@@ -47,8 +47,7 @@ use xiv_gen::ItemId;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum MenuState {
     None,
-    Item,
-    // Recipe is now handled by a modal
+    // Recipe and item search are now handled by modals
     MakePlace,
 }
 
@@ -517,6 +516,7 @@ pub fn ListView() -> impl IntoView {
     });
 
     let (menu, set_menu) = signal(MenuState::None);
+    let (item_modal_open, set_item_modal_open) = signal(false);
     let (recipe_modal_open, set_recipe_modal_open) = signal(false);
     let (subscribe_open, set_subscribe_open) = signal(false);
     let (settings_open, set_settings_open) = signal(false);
@@ -656,13 +656,8 @@ pub fn ListView() -> impl IntoView {
                                 <Tooltip tooltip_text=t_string!(i18n, list_view_tooltip_add_item).to_string()>
                                     <button
                                         class="btn-primary"
-                                        class:active=move || menu() == MenuState::Item
-                                        on:click=move |_| set_menu(
-                                            match menu() {
-                                                MenuState::Item => MenuState::None,
-                                                _ => MenuState::Item,
-                                            },
-                                        )
+                                        class:active=move || item_modal_open()
+                                        on:click=move |_| set_item_modal_open(true)
                                     >
                                         <Icon icon=i::BiPlusRegular />
                                         <span>{t!(i18n, list_view_add_item)}</span>
@@ -879,148 +874,148 @@ pub fn ListView() -> impl IntoView {
                 }}
             </Show>
 
-            {move || match menu() {
-                MenuState::Item => {
-                    Some(
-                        Either::Left({
-                            let (search, set_search) = signal("".to_string());
-                            let items = &tracked_data().items;
-                            let item_search = move || {
-                                search
-                                    .with(|s| {
-                                        let s_lower = s.to_lowercase();
-                                        let mut score = items
-                                            .iter()
-                                            .filter(|(_, i)| i.item_search_category > 0)
-                                            .filter(|_| !s.is_empty())
-                                            .filter_map(|(id, i)| {
-                                                if i.name.to_lowercase().contains(&s_lower) {
-                                                    Some((id, i))
-                                                } else {
-                                                    None
+            <Show when=item_modal_open>
+                {move || {
+                    let (search, set_search) = signal("".to_string());
+                    let items = &tracked_data().items;
+                    let item_search = move || {
+                        search
+                            .with(|s| {
+                                let s_lower = s.to_lowercase();
+                                let mut score = items
+                                    .iter()
+                                    .filter(|(_, i)| i.item_search_category > 0)
+                                    .filter(|_| !s.is_empty())
+                                    .filter_map(|(id, i)| {
+                                        if i.name.to_lowercase().contains(&s_lower) {
+                                            Some((id, i))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
+                                // ⚡ Bolt Optimization: Replace stable sort and vector reallocation
+                                // with in-place unstable sort and truncation to avoid O(N) allocation
+                                // during hot search filter renders.
+                                score
+                                    .sort_unstable_by_key(|(_, i)| (
+                                        Reverse(i.level_item),
+                                    ));
+                                score.truncate(100);
+                                score
+                            })
+                    };
+                    let adding = add_item.pending();
+                    let add_result = add_item.value();
+                    view! {
+                        <Modal set_visible=set_item_modal_open max_width="max-w-[90vw] w-[90vw] sm:w-[640px]">
+                            <div class="flex flex-col gap-4 h-[70vh]">
+                                <div class="flex flex-col gap-2 shrink-0">
+                                    <h2 class="text-xl font-bold text-[color:var(--brand-fg)]">{t!(i18n, list_view_add_item_to_list)}</h2>
+                                    <input
+                                        class="input w-full"
+                                        placeholder=t_string!(i18n, list_view_search_items).to_string()
+                                        aria-label=t_string!(i18n, list_view_search_items).to_string()
+                                        autofocus
+                                        prop:value=search
+                                        on:input=move |input| set_search(event_target_value(&input))
+                                    />
+                                    {move || add_result.get().map(|v| {
+                                        let text = match v {
+                                            Ok(()) => t_string!(i18n, list_view_added_to_list_success).to_string(),
+                                            Err(e) => format!("{} {e}", t_string!(i18n, list_view_failed_to_add)),
+                                        };
+                                        view! { <div class="text-sm text-[color:var(--color-text-muted)]">{text}</div> }.into_view()
+                                    })}
+                                </div>
+                                <div class="grid gap-2 flex-1 min-h-0 content-start overflow-y-auto pr-1">
+                                    {move || {
+                                        item_search()
+                                            .into_iter()
+                                            .map(move |(id, item)| {
+                                                let (quantity, set_quantity) = signal(1);
+                                                let read_input_quantity = move |input| {
+                                                    if let Ok(quantity) = event_target_value(&input).parse() {
+                                                        set_quantity(quantity)
+                                                    }
+                                                };
+                                                view! {
+                                                    <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] p-2 flex flex-col gap-3 sm:flex-row sm:items-center">
+                                                        <div class="flex min-w-0 flex-1 items-center gap-3">
+                                                            <ItemIcon item_id=id.0 icon_size=IconSize::Medium />
+                                                            <span class="min-w-0 truncate font-semibold">{item.name.as_str()}</span>
+                                                        </div>
+                                                        <div class="flex items-center gap-2">
+                                                            <label class="text-sm text-[color:var(--color-text-muted)]">{t!(i18n, list_view_qty)}</label>
+                                                            <input
+                                                                type="number"
+                                                                min="1"
+                                                                class="input w-20"
+                                                                on:input=read_input_quantity
+                                                                prop:value=quantity
+                                                            />
+                                                            <button
+                                                                class="btn-primary"
+                                                                disabled=adding
+                                                                on:click=move |_| {
+                                                                    let item = ListItem {
+                                                                        item_id: id.0,
+                                                                        list_id: params
+                                                                            .with(|p| {
+                                                                                p.get("id").as_ref().and_then(|id| id.parse::<i32>().ok())
+                                                                            })
+                                                                            .unwrap_or_default(),
+                                                                        quantity: Some(quantity()),
+                                                                        ..Default::default()
+                                                                    };
+                                                                    add_item.dispatch(item);
+                                                                }
+                                                            >
+                                                                {move || if adding() {
+                                                                    Either::Left(view! { <span>{t!(i18n, list_view_adding)}</span> })
+                                                                } else {
+                                                                    Either::Right(view! {
+                                                                        <>
+                                                                            <Icon icon=i::BiPlusRegular />
+                                                                            <span>{t!(i18n, list_view_add)}</span>
+                                                                        </>
+                                                                    })
+                                                                }}
+                                                            </button>
+                                                        </div>
+                                                    </div>
                                                 }
                                             })
-                                            .collect::<Vec<_>>();
-                                        // ⚡ Bolt Optimization: Replace stable sort and vector reallocation
-                                        // with in-place unstable sort and truncation to avoid O(N) allocation
-                                        // during hot search filter renders.
-                                        score
-                                            .sort_unstable_by_key(|(_, i)| (
-                                                Reverse(i.level_item),
-                                            ));
-                                        score.truncate(100);
-                                        score
-                                    })
-                            };
-                            let adding = add_item.pending();
-                            let add_result = add_item.value();
-                            view! {
-                                <section class="panel rounded-lg p-4 space-y-4">
-                                    <div class="flex flex-col gap-2">
-                                        <label class="text-sm font-semibold text-[color:var(--brand-fg)]">{t!(i18n, list_view_add_item_to_list)}</label>
-                                        <input
-                                            class="input w-full"
-                                            placeholder=t_string!(i18n, list_view_search_items).to_string()
-                                            prop:value=search
-                                            on:input=move |input| set_search(event_target_value(&input))
-                                        />
-                                        {move || add_result.get().map(|v| {
-                                            let text = match v {
-                                                Ok(()) => t_string!(i18n, list_view_added_to_list_success).to_string(),
-                                                Err(e) => format!("{} {e}", t_string!(i18n, list_view_failed_to_add)),
-                                            };
-                                            view! { <div class="text-sm text-[color:var(--color-text-muted)]">{text}</div> }.into_view()
-                                        })}
-                                    </div>
-                                    <div class="grid gap-2 max-h-96 overflow-y-auto pr-1">
-                                        {move || {
-                                            item_search()
-                                                .into_iter()
-                                                .map(move |(id, item)| {
-                                                    let (quantity, set_quantity) = signal(1);
-                                                    let read_input_quantity = move |input| {
-                                                        if let Ok(quantity) = event_target_value(&input).parse() {
-                                                            set_quantity(quantity)
-                                                        }
-                                                    };
-                                                    view! {
-                                                        <div class="rounded-lg border border-[color:var(--color-outline)] bg-[color:var(--color-background-panel)] p-2 flex flex-col gap-3 sm:flex-row sm:items-center">
-                                                            <div class="flex min-w-0 flex-1 items-center gap-3">
-                                                                <ItemIcon item_id=id.0 icon_size=IconSize::Medium />
-                                                                <span class="min-w-0 truncate font-semibold">{item.name.as_str()}</span>
-                                                            </div>
-                                                            <div class="flex items-center gap-2">
-                                                                <label class="text-sm text-[color:var(--color-text-muted)]">{t!(i18n, list_view_qty)}</label>
-                                                                <input
-                                                                    type="number"
-                                                                    min="1"
-                                                                    class="input w-20"
-                                                                    on:input=read_input_quantity
-                                                                    prop:value=quantity
-                                                                />
-                                                                <button
-                                                                    class="btn-primary"
-                                                                    disabled=adding
-                                                                    on:click=move |_| {
-                                                                        let item = ListItem {
-                                                                            item_id: id.0,
-                                                                            list_id: params
-                                                                                .with(|p| {
-                                                                                    p.get("id").as_ref().and_then(|id| id.parse::<i32>().ok())
-                                                                                })
-                                                                                .unwrap_or_default(),
-                                                                            quantity: Some(quantity()),
-                                                                            ..Default::default()
-                                                                        };
-                                                                        add_item.dispatch(item);
-                                                                    }
-                                                                >
-                                                                    {move || if adding() {
-                                                                        Either::Left(view! { <span>{t!(i18n, list_view_adding)}</span> })
-                                                                    } else {
-                                                                        Either::Right(view! {
-                                                                            <>
-                                                                                <Icon icon=i::BiPlusRegular />
-                                                                                <span>{t!(i18n, list_view_add)}</span>
-                                                                            </>
-                                                                        })
-                                                                    }}
-                                                                </button>
-                                                            </div>
-                                                        </div>
-                                                    }
-                                                })
-                                                .collect::<Vec<_>>()
-                                        }}
+                                            .collect::<Vec<_>>()
+                                    }}
 
-                                    </div>
-                                </section>
-                            }
-                        }),
-                    )
-                }
+                                </div>
+                            </div>
+                        </Modal>
+                    }
+                }}
+            </Show>
+
+            {move || match menu() {
                 MenuState::None => None,
-                // Removed MenuState::Recipe block
                 MenuState::MakePlace => {
                     Some(
-                        Either::Right({
-                            view! {
-                                <section class="panel rounded-lg p-4">
-                                    <MakePlaceImporter
-                                        list_id=Signal::derive(move || {
-                                            params
-                                                .with(|p| {
-                                                    p.get("id").as_ref().map(|id| id.parse::<i32>().ok())
-                                                })
-                                                .flatten()
-                                                .unwrap_or_default()
-                                        })
+                        view! {
+                            <section class="panel rounded-lg p-4">
+                                <MakePlaceImporter
+                                    list_id=Signal::derive(move || {
+                                        params
+                                            .with(|p| {
+                                                p.get("id").as_ref().map(|id| id.parse::<i32>().ok())
+                                            })
+                                            .flatten()
+                                            .unwrap_or_default()
+                                    })
 
-                                        refresh=move || { list_view.refetch() }
-                                    />
-                                </section>
-                            }
-                        }),
+                                    refresh=move || { list_view.refetch() }
+                                />
+                            </section>
+                        },
                     )
                 }
             }}

--- a/ultros-frontend/ultros-app/src/routes/lists.rs
+++ b/ultros-frontend/ultros-app/src/routes/lists.rs
@@ -375,6 +375,7 @@ pub fn EditLists() -> impl IntoView {
     let (creating, set_creating) = signal(false);
     let (filter, set_filter) = signal(String::new());
     let (invite_id, set_invite_id) = signal(String::new());
+    let (redeem_open, set_redeem_open) = signal(false);
 
     let filtered_lists = Signal::derive(move || {
         let filter_text = filter.get().to_lowercase();
@@ -413,19 +414,18 @@ pub fn EditLists() -> impl IntoView {
                     }
                     Some(Some(_)) => {
                         view! {
-                            <div class="flex items-center gap-2 md:gap-3">
-                                <A exact=true attr:class="nav-link" href="/list">
-                                    <Icon height="1.25em" width="1.25em" icon=i::AiOrderedListOutlined />
-                                    <span>{t!(i18n, lists)}</span>
-                                </A>
-                            </div>
-
                             <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                                 <h1 class="text-3xl font-bold text-[color:var(--brand-fg)]">{t!(i18n, lists_page_title)}</h1>
-                                 <button class="btn-primary" on:click=move |_| set_creating(!creating())>
-                                    <Icon icon=if creating() { i::AiCloseOutlined } else { i::BiPlusRegular } />
-                                    {move || if creating() { Either::Left(t!(i18n, cancel_creation)) } else { Either::Right(t!(i18n, create_new_list)) }}
-                                </button>
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <button class="btn-secondary" on:click=move |_| set_redeem_open(true)>
+                                        <Icon icon=i::BiLinkRegular />
+                                        {t!(i18n, lists_redeem_invite_label)}
+                                    </button>
+                                    <button class="btn-primary" on:click=move |_| set_creating(!creating())>
+                                        <Icon icon=if creating() { i::AiCloseOutlined } else { i::BiPlusRegular } />
+                                        {move || if creating() { Either::Left(t!(i18n, cancel_creation)) } else { Either::Right(t!(i18n, create_new_list)) }}
+                                    </button>
+                                </div>
                             </div>
 
                             {move || {
@@ -494,31 +494,41 @@ pub fn EditLists() -> impl IntoView {
                                 />
                             </div>
 
-                            <div class="panel p-4 rounded-xl flex flex-col md:flex-row gap-3 md:items-end">
-                                <div class="flex-1">
-                                    <label for="invite-code-input" class="label text-sm font-semibold">{t!(i18n, lists_redeem_invite_label)}</label>
-                                    <input
-                                        id="invite-code-input"
-                                        class="input w-full"
-                                        placeholder=t_string!(i18n, lists_invite_code_placeholder)
-                                        prop:value=invite_id
-                                        on:input=move |ev| set_invite_id(event_target_value(&ev))
-                                    />
-                                </div>
-                                <button
-                                    class="btn-secondary"
-                                    prop:disabled=move || invite_id().trim().is_empty()
-                                    on:click=move |_| {
-                                        let id = invite_id().trim().to_string();
-                                        if !id.is_empty() {
-                                            redeem_invite.dispatch(id);
-                                            set_invite_id(String::new());
-                                        }
-                                    }
-                                >
-                                    <Icon icon=i::BiLinkRegular /> {t!(i18n, lists_redeem_button)}
-                                </button>
-                            </div>
+                            <Show when=redeem_open>
+                                <Modal set_visible=set_redeem_open>
+                                    <div class="flex flex-col gap-4">
+                                        <h2 class="text-xl font-bold text-[color:var(--brand-fg)]">
+                                            {t!(i18n, lists_redeem_invite_label)}
+                                        </h2>
+                                        <div>
+                                            <label for="invite-code-input" class="label text-sm font-semibold">{t!(i18n, lists_invite_code_placeholder)}</label>
+                                            <input
+                                                id="invite-code-input"
+                                                class="input w-full"
+                                                placeholder=t_string!(i18n, lists_invite_code_placeholder)
+                                                prop:value=invite_id
+                                                on:input=move |ev| set_invite_id(event_target_value(&ev))
+                                            />
+                                        </div>
+                                        <div class="flex justify-end">
+                                            <button
+                                                class="btn-primary"
+                                                prop:disabled=move || invite_id().trim().is_empty()
+                                                on:click=move |_| {
+                                                    let id = invite_id().trim().to_string();
+                                                    if !id.is_empty() {
+                                                        redeem_invite.dispatch(id);
+                                                        set_invite_id(String::new());
+                                                        set_redeem_open(false);
+                                                    }
+                                                }
+                                            >
+                                                <Icon icon=i::BiLinkRegular /> {t!(i18n, lists_redeem_button)}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </Modal>
+                            </Show>
 
                             <Suspense fallback=move || view! { <Loading /> }>
                                 {move || {
@@ -555,7 +565,6 @@ pub fn EditLists() -> impl IntoView {
                                                                 {if !owned.is_empty() {
                                                                     Some(view! {
                                                                         <section class="flex flex-col gap-3">
-                                                                            <h2 class="text-xl font-semibold text-[color:var(--brand-fg)]">{t!(i18n, my_lists)}</h2>
                                                                             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                                                                                 <For
                                                                                     each=move || owned.clone()


### PR DESCRIPTION
Fixes #1054
Fixes #1059

Two lists-UX cleanups, both frontend-only and confined to `ultros-app`.

## #1059 — redundant "Lists" labels on the index

The index carried three separate "Lists" labels stacked vertically: a nav chip that was an `<A exact href="/list">` pointing at the page you were already on, the page `<h1>`, and a "My Lists" `<h2>` over the owned-lists grid.

- Deleted the self-referential nav chip; the `<h1>` is now the single header.
- Dropped the `my_lists` `<h2>`. Owned lists become the unlabeled default section and "Shared with me" survives as the one heading that actually distinguishes a group. The now-unused `my_lists` key is removed from all seven locale files.
- The redeem-an-invite form was a permanently mounted panel sitting between the search box and the lists — prime real estate for a rare action. It moved behind a secondary button next to "Create new list", into the same `Modal` this file already uses for delete confirmation and `ShareListModal`. Submitting closes the modal, and the field still clears on dispatch.

**No new i18n keys.** The existing `lists_redeem_invite_label` ("Redeem invite") reads correctly as both the trigger button and the modal title, and `lists_invite_code_placeholder` serves as the field label, so all seven locales already have real translations for everything on screen.

## #1054 — add-item flow renders two panels

The toolbar's Add Item button toggled `MenuState::Item`, but the block it revealed rendered *below* the exclude-datacenters/sort panel. So one click appeared to open two unrelated panels, and the search was visually detached from the button that opened it — the "pops up inline awkwardly" in the issue.

The add-item search now lives in the existing `components/modal` `Modal`, which is exactly what the adjacent Add Recipe button already does (`AddRecipeToCurrentListModal`), so the two sibling actions in the toolbar finally behave the same way. `MenuState::Item` collapses into an `item_modal_open` bool. The search input picks up `autofocus` and an `aria-label`, and the results list becomes a flex child that scrolls inside the dialog instead of a fixed `max-h-96`.

`MenuState::MakePlace` deliberately keeps its inline panel — it is an import flow, not a search — so the enum still exists with two variants and its match arm no longer needs the `Either` wrapper.

## Notes

- Read #1029's diff first; nothing here touches the shareable view state (`filter_query_signal` params), delete confirmations, or sorting that PR introduced.
- The screenshots in both issues are mobile, where the stacked-panel and stacked-label problems are worst; the new layouts use `flex-wrap` on the button row so the header still collapses cleanly at narrow widths.

## Verification

- `cargo fmt --all -- --check` — passes.
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — passes, exit 0, no warnings. Run twice; the second run was against the exact committed tree.
- Full-workspace clippy was not run locally: this change is confined to `ultros-app`, a leaf frontend crate, and it exposes no API that other crates consume. CI runs the workspace lint.
- No tests were added (this is a pure view-layer restructure with no new logic), so the repo's "CI does not run cargo test" caveat does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)