### PR TITLE
fix(flip-finder): stop the sticky control bar overflowing the viewport on mobile

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -106,13 +106,19 @@
 
     html {
         overflow-x: hidden;
-        width: 100vw;
+        /* Deliberately `100%`, not `100vw`. The viewport unit includes the
+           width of a classic (non-overlay) scrollbar, so on desktop the page
+           laid out ~15px wider than the space it actually had — and because
+           the x-axis is hidden, that surplus was not scrollable but simply
+           clipped off the right edge of every page. `100%` resolves against
+           the real content box, so the two agree. */
+        width: 100%;
     }
 
     body {
         background-size: 500px;
         background-position: top;
-        max-width: 100vw;
+        max-width: 100%;
         background-color: var(--color-background);
         color: var(--text-color);
         position: relative;
@@ -2331,6 +2337,28 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
 }
 .sticky-bar-button:hover {
     background-color: color-mix(in srgb, var(--brand-ring) 14%, transparent);
+}
+/* Opt-in shrink, for the control bar's own first row.
+   `.sticky-bar-button` is `flex: 0 0 auto` + `white-space: nowrap`, so a row
+   built out of them can only grow. The first row grew past a phone viewport
+   by ~210px, and since `html` is `overflow-x: hidden` that surplus was not
+   scrollable but simply unreachable — the last button sat off-screen (#1055).
+   A breakpoint alone cannot fix it: the side nav claims 240px at `lg`, so the
+   row is barely wider at 1024px than at 768px, and the German labels overflow
+   in that band. These yield instead, in a deliberate order — the row count
+   gives up space first (it is `flex-1`), then labels ellipsize, and the icon
+   never shrinks, so a control is always identifiable. */
+.sticky-bar-button-shrink {
+    flex: 0 1 auto;
+    min-width: 0;
+}
+.sticky-bar-button-shrink > svg {
+    flex: 0 0 auto;
+}
+.sticky-bar-button-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 /* Popovers hung off the bar (columns picker, + Filter menu). The bar is
    `position: sticky`, so it is already the containing block for these. */

--- a/ultros-frontend/ultros-app/src/components/realtime_status.rs
+++ b/ultros-frontend/ultros-app/src/components/realtime_status.rs
@@ -34,6 +34,14 @@ pub fn get_status_info(status: &str) -> StatusInfo {
 pub fn RealtimeStatus(
     #[prop(into)] status: Signal<String>,
     #[prop(into)] last_update: Signal<Option<DateTime<Utc>>>,
+    /// Drop the text label below `md`, leaving just the colored dot.
+    ///
+    /// For callers in a height-locked row that has no horizontal slack on a
+    /// phone — the Flip Finder's control bar, where "Reconnecting" alone is
+    /// a quarter of a 375px row. The dot already carries the state, and the
+    /// label comes back at `md`.
+    #[prop(optional)]
+    compact: bool,
 ) -> impl IntoView {
     let i18n = use_i18n();
     #[allow(unused_variables)]
@@ -82,6 +90,7 @@ pub fn RealtimeStatus(
 
         let status_key_for_view = status_key.clone();
         let status_label_clone = status_label.clone();
+        let label_class = if compact { "hidden md:inline" } else { "" };
         let tooltip_text = Signal::derive(move || {
             let updated = updated_label.get();
             if updated.is_empty() {
@@ -108,7 +117,7 @@ pub fn RealtimeStatus(
                         }}
                         <span class=format!("relative inline-flex rounded-full h-2 w-2 {}", dot_class)></span>
                     </span>
-                    <span>{status_label.clone()}</span>
+                    <span class=label_class>{status_label.clone()}</span>
                 </span>
             </Tooltip>
         }

--- a/ultros-frontend/ultros-app/src/components/saved_views.rs
+++ b/ultros-frontend/ultros-app/src/components/saved_views.rs
@@ -155,25 +155,37 @@ pub fn SavedViewsMenu(#[prop(into)] current_world: Signal<String>) -> impl IntoV
 
     view! {
         <div class="relative flex items-center gap-2">
+            // Icon-only below `md`. The Flip Finder's control bar is
+            // height-locked and its first row cannot wrap, so on a phone the
+            // labels are what pushed it past the viewport (#1055). The
+            // `aria-label` carries the name at every width.
             <button
-                class="sticky-bar-button"
+                class="sticky-bar-button sticky-bar-button-shrink"
+                aria-label=t_string!(i18n, analyzer_saved_views)
                 aria-expanded=move || list_open.get().to_string()
                 on:click=move |_| {
                     save_open.set(false);
                     list_open.update(|v| *v = !*v);
                 }
             >
-                {t!(i18n, analyzer_saved_views)}
+                <Icon icon=icondata::MdiBookmarkMultipleOutline />
+                <span class="hidden md:inline sticky-bar-button-label">
+                    {t!(i18n, analyzer_saved_views)}
+                </span>
             </button>
             <button
-                class="sticky-bar-button"
+                class="sticky-bar-button sticky-bar-button-shrink"
+                aria-label=t_string!(i18n, analyzer_save_view)
                 aria-expanded=move || save_open.get().to_string()
                 on:click=move |_| {
                     list_open.set(false);
                     save_open.update(|v| *v = !*v);
                 }
             >
-                {t!(i18n, analyzer_save_view)}
+                <Icon icon=icondata::MdiContentSaveOutline />
+                <span class="hidden md:inline sticky-bar-button-label">
+                    {t!(i18n, analyzer_save_view)}
+                </span>
             </button>
 
             <Show when=move || list_open.get()>

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1619,41 +1619,68 @@ fn AnalyzerTable(
             // grew with its content would cover its own column headers.
             <div class="sticky-bar h-[76px] px-2 py-1 flex flex-col gap-1">
                 // Row 1 — result count and view-level controls.
-                <div class="h-8 flex items-center gap-3 min-w-0">
-                    <span class="text-sm text-[color:var(--brand-fg)] font-semibold whitespace-nowrap">
+                //
+                // The row cannot wrap (the bar is height-locked) and cannot
+                // scroll (it holds the popovers, and `html` is `overflow-x:
+                // hidden`), so it has to *fit*, at every width and in every
+                // locale. It did not: every control is a `.sticky-bar-button`
+                // — `flex: 0 0 auto` — so the row could only grow, and at
+                // 375px it ran ~210px past the viewport with the last button
+                // stranded off-screen (#1055).
+                //
+                // Three things keep it inside now, in the order they give up
+                // space: the count group is `flex-1` and truncates first;
+                // labels are hidden below `md` and ellipsize above it
+                // (`.sticky-bar-button-shrink`); icons never shrink. A
+                // breakpoint alone would not do — the side nav takes 240px at
+                // `lg`, so the row is no wider at 1024px than at 768px.
+                //
+                // Anything added here needs to be able to yield too.
+                <div class="h-8 flex items-center gap-2 md:gap-3 min-w-0">
+                    // The one item allowed to give up space. `overflow-hidden`
+                    // is safe on this wrapper specifically: it holds two spans
+                    // and nothing sticky or absolutely positioned, so it does
+                    // not become a scrollport for anything that matters.
+                    <div class="flex-1 min-w-0 flex items-baseline gap-2 overflow-hidden">
+                        <span class="text-sm text-[color:var(--brand-fg)] font-semibold truncate min-w-0">
+                            {move || {
+                                t_string!(i18n, analyzer_rows_count)
+                                    .to_string()
+                                    .replace("%count%", &sorted_data.with(|d| d.len()).to_string())
+                            }}
+                        </span>
+                        // Data-transparency note: the drift / confidence / volume
+                        // floors each meet rows with no underlying data (drift
+                        // needs >= 4 buffered sales; the other two need CH
+                        // enrichment) and resolve it differently — drop, judge on
+                        // a derived band, pass. Say how many rows that was rather
+                        // than letting the row count move for invisible reasons.
+                        // Zero (and absent) whenever none of those floors is set.
                         {move || {
-                            t_string!(i18n, analyzer_rows_count)
-                                .to_string()
-                                .replace("%count%", &sorted_data.with(|d| d.len()).to_string())
+                            let n = rows_lacking_data();
+                            (n > 0)
+                                .then(|| {
+                                    view! {
+                                        <span class="text-xs text-[color:var(--color-text-muted)] truncate min-w-0">
+                                            {t_string!(i18n, analyzer_rows_lacking_data)
+                                                .to_string()
+                                                .replace("%count%", &n.to_string())}
+                                        </span>
+                                    }
+                                })
                         }}
-                    </span>
-                    // Data-transparency note: the drift / confidence / volume
-                    // floors each meet rows with no underlying data (drift
-                    // needs >= 4 buffered sales; the other two need CH
-                    // enrichment) and resolve it differently — drop, judge on
-                    // a derived band, pass. Say how many rows that was rather
-                    // than letting the row count move for invisible reasons.
-                    // Zero (and absent) whenever none of those floors is set.
-                    {move || {
-                        let n = rows_lacking_data();
-                        (n > 0)
-                            .then(|| {
-                                view! {
-                                    <span class="text-xs text-[color:var(--color-text-muted)] whitespace-nowrap">
-                                        {t_string!(i18n, analyzer_rows_lacking_data)
-                                            .to_string()
-                                            .replace("%count%", &n.to_string())}
-                                    </span>
-                                }
-                            })
-                    }}
+                    </div>
                     // Live-market indicator, carried over from the realtime work on
                     // main. It sat in the results-summary panel this bar replaced.
-                    <RealtimeStatus status=realtime_status last_update=last_update />
-                    <div class="flex-1" />
+                    <RealtimeStatus
+                        status=realtime_status
+                        last_update=last_update
+                        compact=true
+                    />
                     <SavedViewsMenu current_world=world />
                     <button
-                        class="sticky-bar-button"
+                        class="sticky-bar-button sticky-bar-button-shrink"
+                        aria-label=t_string!(i18n, analyzer_columns_button)
                         aria-expanded=move || show_columns_picker.get().to_string()
                         on:click=move |_| {
                             show_filter_menu.set(false);
@@ -1661,14 +1688,19 @@ fn AnalyzerTable(
                         }
                     >
                         <Icon icon=i::FaTableColumnsSolid />
-                        {t!(i18n, analyzer_columns_button)}
+                        <span class="hidden md:inline sticky-bar-button-label">
+                            {t!(i18n, analyzer_columns_button)}
+                        </span>
                     </button>
                     <button
-                        class="sticky-bar-button"
+                        class="sticky-bar-button sticky-bar-button-shrink"
                         aria-label=t_string!(i18n, aria_clear_all_filters)
                         on:click=move |_| clear_all_filters()
                     >
-                        {t!(i18n, analyzer_clear_all)}
+                        <Icon icon=icondata::MdiFilterRemove />
+                        <span class="hidden md:inline sticky-bar-button-label">
+                            {t!(i18n, analyzer_clear_all)}
+                        </span>
                     </button>
                 </div>
 


### PR DESCRIPTION
Fixes #1055

## What was wrong

The Flip Finder's sticky control bar has two rows. Row 2 (the filter chips) already scrolls inside itself. Row 1 could not: every control in it is a `.sticky-bar-button`, which is `flex: 0 0 auto; white-space: nowrap`, so the row had no shrinkable item and could only grow.

Measured on production at a 375px viewport, Row 1 needed **520px** in a **311px** box. Because `html` is `overflow-x: hidden`, that 209px surplus was not scrollable — it was simply unreachable, which is why "Clear all" (the last item) poked off the edge and the page felt like it over-scrolled. The document reported `scrollWidth` **552** against `clientWidth` **375**.

A second, unrelated source of over-scroll: `html { width: 100vw }`. The viewport unit includes the classic scrollbar, so on desktop every page laid out ~15px wider than the space it actually had (`scrollWidth` 1280 vs `clientWidth` 1265) and had that strip clipped off the right.

## The fix

Row 1 can neither wrap (the bar is height-locked at `STICKY_BAR_HEIGHT`) nor scroll (it is the containing block for the Saved-views / Columns / +Filter popovers), so it has to *fit*. It now yields in a deliberate order:

1. the row-count group is `flex-1 min-w-0` and truncates first;
2. control labels are hidden below `md` and ellipsize above it (`.sticky-bar-button-shrink` / `.sticky-bar-button-label`);
3. icons never shrink, so every control stays identifiable.

`RealtimeStatus` gains an opt-in `compact` prop that drops its text label below `md`, leaving the status dot. Only the Flip Finder passes it.

A breakpoint alone would not have been enough: the side nav claims 240px at `lg`, so Row 1 is no wider at 1024px (673px) than at 768px (657px), and the German labels need 681px. That band is exactly where a naive `hidden md:inline` would have re-broken it — hence the shrink behaviour underneath as the actual guarantee.

`html`/`body` move from `100vw`/`max-width: 100vw` to `100%`.

No new i18n keys: the icon-only buttons reuse their existing strings as `aria-label`s.

## Verification

Measured in Chrome against the live production DOM and stylesheet with the patch's exact CSS delta and markup applied, so the numbers come from real rendered layout rather than a local approximation.

| Case | Page overflow before | after |
|---|---|---|
| 375px (iPhone-class) | 177px | **0** |
| 1024px window, sidebar shown, **German** labels + longest status string | — | **0**, no label ellipsized |
| 1280px desktop | 15px | **0** |

Also confirmed: bar height stays exactly **76px** (`STICKY_BAR_HEIGHT` is consumed as the table header's sticky offset, so a taller bar would hide its own column headers); `.sticky-bar-popover` still opens with **zero** clipping ancestors and fully inside the viewport (no `overflow-x` was added to Row 1 — that would have clipped the popovers, the failure documented at `chart_toolbar.rs:119-121`); `position: sticky` still resolves against the viewport after the `html` width change; and no `overflow-x` was added to `body`, per the warning at `tailwind.css:119-127`.

The generated stylesheet was built with the same Tailwind v4.1.10 binary cargo-leptos uses, confirming `.sticky-bar-button-shrink`, `.sticky-bar-button-label` and `md:inline` are all emitted, and that `-shrink` sorts after `.sticky-bar-button` so it wins the cascade (both are unlayered).

`cargo fmt --all -- --check`, `cargo check -p ultros-app` and `cargo clippy -p ultros-app --all-targets -- -D warnings` all pass.

## Follow-up

The natural regression guard is a `document.scrollWidth <= clientWidth` assertion in the existing Puppeteer `DEVICE=mobile` pass. Left out of this PR because that suite needs a running instance I could not stand up here, and I did not want to add a test I had not actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
