### PR TITLE
test(flip-finder): guard the mobile control bar against overflowing again

### DIFF
--- a/integration/flip-finder-mobile-bar.cjs
+++ b/integration/flip-finder-mobile-bar.cjs
@@ -1,0 +1,126 @@
+// Regression probe for the Flip Finder's sticky control bar overflowing at
+// phone widths (issues #1055 / #1057).
+//
+// The bar is height-locked to STICKY_BAR_HEIGHT (components/filter_chip.rs) so
+// the table header can stick directly beneath it, which means it cannot wrap.
+// It also must not scroll: its top row owns the saved-views and columns
+// popovers, and an `overflow-x` there computes `overflow-y: auto` too and
+// would trap them in a 32px strip. So the row has to *fit*, and when it
+// didn't the surplus went past `html { overflow-x: hidden }` — leaving
+// `Columns` and `Clear all` rendered outside the viewport with no scrollbar
+// and no wrap to reach them. At 393px that was 177px of unreachable controls.
+//
+// Anything added to that row has to keep it fitting, by any means: a
+// breakpoint, shrinking, truncation. This asserts the outcome rather than the
+// mechanism, so it stays valid across whichever the row uses. Layout is the
+// whole bug, so it can only be checked in a browser.
+//
+// Not covered: the 768-1024px band with German labels, where the side nav
+// claims 240px and the row is barely wider than it is at 768px. Switching
+// locale needs the in-app picker rather than a cookie, so it wants a separate
+// probe.
+const puppeteer = require('puppeteer');
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:8080';
+const WORLD = process.env.WORLD || 'Gilgamesh';
+const TIMEOUT_MS = Number(process.env.TIMEOUT_MS || 60000);
+const SETTLE_MS = Number(process.env.SETTLE || 9000);
+
+// Widths worth guarding. 360 is the common Android floor and 393/414 cover
+// current iPhone and Pixel classes. 320 is deliberately absent: with the
+// shell's 48px of padding it leaves 256px for the row, which the controls
+// cannot fit even icon-only, and failing there would just be noise.
+const WIDTHS = [360, 393, 414];
+
+// Enough active filters that the chip strip is populated, since it shares the
+// bar with the controls under test.
+const ROUTE = `/flip-finder/${WORLD}?profit=10000&roi=50&ppd=5000`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Measure the sticky bar against the layout viewport. */
+function measureBar() {
+  const bar = document.querySelector('.sticky-bar');
+  if (!bar) return null;
+  const row1 = bar.children[0];
+  // `innerWidth` lies under Chrome's mobile emulation; the layout viewport is
+  // what the CSS actually resolved against.
+  const viewport = document.documentElement.clientWidth;
+  const controls = [...row1.querySelectorAll('button')].map((b) => {
+    const r = b.getBoundingClientRect();
+    // A control the user cannot land a finger on is as good as absent, so
+    // check the DOM at the button's own centre rather than trusting the rect.
+    const hit = document.elementFromPoint((r.left + r.right) / 2, (r.top + r.bottom) / 2);
+    return {
+      name: (b.getAttribute('aria-label') || b.textContent || '').trim().slice(0, 24) || '<button>',
+      right: Math.round(r.right),
+      reachable: Boolean(hit) && (hit === b || b.contains(hit)),
+    };
+  });
+  return {
+    viewport,
+    barOverflow: bar.scrollWidth - bar.clientWidth,
+    rowOverflow: row1.scrollWidth - row1.clientWidth,
+    controls,
+  };
+}
+
+async function main() {
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+  const failures = [];
+
+  try {
+    const page = await browser.newPage();
+    page.setDefaultTimeout(TIMEOUT_MS);
+    const { hostname } = new URL(BASE_URL);
+    await page.setCookie({ name: 'HIDE_ADS', value: 'true', domain: hostname, path: '/' });
+    await page.setViewport({ width: WIDTHS[0], height: 852, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+    await page.goto(`${BASE_URL}${ROUTE}`, { waitUntil: 'domcontentloaded', timeout: TIMEOUT_MS });
+    await sleep(SETTLE_MS);
+
+    for (const width of WIDTHS) {
+      await page.setViewport({ width, height: 852, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+      await sleep(500);
+      const m = await page.evaluate(measureBar);
+      if (!m) throw new Error(`no .sticky-bar rendered at ${ROUTE}`);
+      if (m.viewport !== width) {
+        throw new Error(`asked for a ${width}px viewport but CSS resolved against ${m.viewport}px`);
+      }
+
+      if (m.rowOverflow > 0 || m.barOverflow > 0) {
+        failures.push(
+          `${width}px: control bar overflows its box by ${Math.max(m.rowOverflow, m.barOverflow)}px ` +
+            `— the surplus is clipped by html{overflow-x:hidden} and cannot be scrolled to`,
+        );
+      }
+      for (const c of m.controls) {
+        if (c.right > width) {
+          failures.push(`${width}px: "${c.name}" ends at x=${c.right}, past the viewport edge`);
+        } else if (!c.reachable) {
+          failures.push(`${width}px: "${c.name}" is within the viewport but not hit-testable`);
+        }
+      }
+      console.log(
+        `[info] ${width}px: ${m.controls.length} control(s), ` +
+          `row overflow ${m.rowOverflow}px, bar overflow ${m.barOverflow}px`,
+      );
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (failures.length) {
+    console.error(`[fail] the Flip Finder control bar does not fit on mobile:`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('[done] control bar fits, and every control is reachable, at every phone width tested');
+}
+
+main().catch((err) => {
+  console.error(`[fail] ${err && err.stack ? err.stack : err}`);
+  process.exit(1);
+});

--- a/integration/package.json
+++ b/integration/package.json
@@ -20,6 +20,7 @@
     "test:fc-crafting-breakdown": "node ./fc-crafting-breakdown.cjs",
     "test:dashboard": "node ./dashboard.cjs",
     "test:jobset-card-hydration": "node ./jobset-card-hydration.cjs",
+    "test:flip-finder-mobile-bar": "node ./flip-finder-mobile-bar.cjs",
     "test:group-shared-list": "node ./group-shared-list.cjs",
     "test:error-filter": "node --test ./error-filter.test.cjs",
     "diag:ooo-hydration-race": "node ./ooo-hydration-race.cjs",


### PR DESCRIPTION
Adds a regression guard for the Flip Finder's mobile control bar. **No behaviour change** — the fix itself is #1082.

## Why

The bar's first row can neither wrap (it is height-locked to `STICKY_BAR_HEIGHT`, which the table header consumes as its sticky offset) nor scroll (it is the containing block for the saved-views and columns popovers, and an `overflow-x` would clip them). So it has to *fit*, and when it didn't, the surplus went past `html { overflow-x: hidden }`: `Columns` and `Clear all` rendered outside the viewport with no scrollbar and no wrap, i.e. simply unreachable rather than merely cramped.

That is invisible to every check we run. It is pure layout, so it needs a browser.

## What it does

`npm run test:flip-finder-mobile-bar` drives 360 / 393 / 414 and asserts:

- the bar and its first row do not overflow their own box;
- every top-row control is hit-testable at its own centre via `elementFromPoint`, so a control pushed past the edge fails loudly instead of silently vanishing.

It checks the **outcome, not the mechanism**, so it stays valid whether the row is kept fitting by a breakpoint, by shrinking, or by truncation.

It also refuses to run against a viewport it did not get: `innerWidth` is misreported under Chrome's mobile emulation (537 for a 393px device), so it reads `documentElement.clientWidth` and bails if that isn't the width it asked for.

## Verified both directions

Red against production, naming both unreachable controls:

```
[info] 360px: 4 control(s), row overflow 168px, bar overflow 160px
[fail] the Flip Finder control bar does not fit on mobile:
  - 360px: control bar overflows its box by 168px — the surplus is clipped by html{overflow-x:hidden} and cannot be scrolled to
  - 360px: "Columns" ends at x=419, past the viewport edge
  - 360px: "Clear all filters" ends at x=496, past the viewport edge
```

Green against a locally built `cargo leptos serve` carrying a fix:

```
[info] 360px: 4 control(s), row overflow 0px, bar overflow 0px
[info] 393px: 4 control(s), row overflow 0px, bar overflow 0px
[info] 414px: 4 control(s), row overflow 0px, bar overflow 0px
[done] control bar fits, and every control is reachable, at every phone width tested
```

Being straight about that second run: the green build was this branch's original markup fix, which I have since dropped in favour of #1082. I could not re-run it against #1082's build — `cargo leptos serve` ignores `LEPTOS_SITE_ADDR` and always binds :8080, and other sessions on this machine were holding that port, so I could no longer tell whose server I was measuring. Both fixes make row 1 fit at phone widths, so it should pass, but **please re-run it on #1082 before relying on it**. The `SETTLE` default of 9s is also short for a cold local server; the passing run used `SETTLE=35000`.

## Not covered

The 768–1024px band with German labels, which is #1082's harder case (the side nav claims 240px at `lg`, so the row is barely wider at 1024px than at 768px). Switching locale needs the in-app picker rather than a cookie, so that wants its own probe.

## Relationship to the issues

- #1082 fixes the overflow. This guards it.
- #1057 additionally reports that the bar "doesn't show the full filter list" and that "scrolling back the other direction" brings the header into frame. Neither is closed by #1082 or by this. I left [a comment on #1057](https://github.com/akarras/ultros/issues/1057#issuecomment-5157819861) with measurements on both: the chip strip is 255px wide at 393px with `scrollbar-width: none`, so 4+ filters mostly hide with no affordance, and showing them all needs the height-lock broken; and `position: sticky` held at every scroll offset I tested, so the scroll-direction symptom did not reproduce and needs the reporter's browser to narrow down.
