### PR TITLE
fix(search): drop the modal X on mobile, tap the sheet to dismiss

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -2128,6 +2128,12 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
            on-screen keyboard open it can outgrow 100dvh, so the sheet
            itself has to scroll or the tail becomes unreachable. */
         overflow-y: auto;
+        /* Tapping the sheet's empty space closes it (#1067). iOS Safari only
+           bubbles taps on non-interactive elements up to the document — where
+           Leptos's delegated click listener lives — when they look clickable,
+           and `cursor: pointer` is what satisfies that heuristic. No visual
+           cost: this rule is phone-only and phones have no cursor. */
+        cursor: pointer;
     }
     /* Keep the close button reachable even when the sheet above has
        scrolled the input out of view. */
@@ -2137,6 +2143,28 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
         z-index: 2;
         background-color: var(--color-background);
         padding-bottom: 0.5rem;
+        /* The header is a normal control row — don't inherit the sheet's
+           tap-to-close pointer cursor. */
+        cursor: auto;
+    }
+    /* On a phone the explicit close button crowded the input row and put a
+       second X right next to the input's own clear-X (#1067). Tapping the
+       sheet's empty space closes the overlay instead, so collapse the button
+       to a screen-reader-only control: still in the accessibility tree and
+       keyboard-focusable (tap-off is a bare div and Escape needs a hardware
+       keyboard), and it pops back into the row when keyboard-focused so
+       sighted keyboard users at narrow widths aren't tabbed onto an
+       invisible control. */
+    .search-overlay-close:not(:focus-visible) {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        overflow: hidden;
+        clip-path: inset(50%);
+        border: 0;
+        white-space: nowrap;
     }
 }
 

--- a/ultros-frontend/ultros-app/src/components/search_overlay.rs
+++ b/ultros-frontend/ultros-app/src/components/search_overlay.rs
@@ -14,6 +14,7 @@ use crate::components::search_box::SearchBox;
 use crate::global_state::search_overlay::use_search_overlay_state;
 use crate::i18n::{t_string, use_i18n};
 use icondata as i;
+use leptos::html::Div;
 use leptos::prelude::*;
 use leptos_hotkeys::use_hotkeys;
 use leptos_router::hooks::use_location;
@@ -23,6 +24,7 @@ pub fn SearchOverlay() -> impl IntoView {
     let i18n = use_i18n();
     let state = use_search_overlay_state();
     let open = state.open;
+    let panel = NodeRef::<Div>::new();
 
     use_hotkeys!(("MetaLeft+KeyK,ControlLeft+KeyK", "*") => move |_| {
         state.toggle();
@@ -59,18 +61,45 @@ pub fn SearchOverlay() -> impl IntoView {
                     class="search-overlay-backdrop"
                     on:click=move |_| state.close()
                 />
-                <div class="search-overlay-panel">
+                // On mobile the panel is an opaque full-viewport sheet, so
+                // the backdrop underneath can never be tapped — instead a tap
+                // on the sheet's own empty space dismisses it (#1067).
+                // Matching on the event target rather than stopping
+                // propagation in the header keeps this independent of how
+                // Leptos's delegated click handling bubbles: only a hit on
+                // the panel's own box counts, so the input, its clear button
+                // and the absolutely-positioned result/hint dropdowns are all
+                // untouched.
+                <div
+                    node_ref=panel
+                    class="search-overlay-panel"
+                    on:click=move |ev: leptos::ev::MouseEvent| {
+                        let hit_panel = ev
+                            .target()
+                            .zip(panel.get_untracked())
+                            .is_some_and(|(target, panel)| {
+                                let panel: &web_sys::EventTarget = &panel;
+                                &target == panel
+                            });
+                        if hit_panel {
+                            state.close();
+                        }
+                    }
+                >
                     <div class="search-overlay-header">
                         <div class="search-overlay-searchbox">
                             <SearchBox autofocus=true />
                         </div>
-                        // The backdrop click target and Escape key are both
-                        // unreachable on mobile once the panel goes opaque
-                        // full-viewport (see the CSS below), so this is the
-                        // only way out of the sheet on a phone. Always
-                        // rendered — not just below 1024px — so keyboard and
-                        // mouse users on desktop get an explicit close
-                        // affordance too.
+                        // Explicit close affordance. Visible on desktop only:
+                        // at 375px it sat 20px from the input's own clear-X —
+                        // two adjacent X's meaning different things (#1067) —
+                        // and cost 52px of a 351px row. Below 1024px the CSS
+                        // collapses it to a visually-hidden control (it comes
+                        // back at full size on :focus-visible) and tap-off
+                        // takes over as the pointer path. It stays in the DOM
+                        // at every width so keyboard and assistive-tech users
+                        // always have a reachable, labelled exit — tap-off is
+                        // a plain div and Escape needs a hardware keyboard.
                         <button
                             type="button"
                             class="search-overlay-close"


### PR DESCRIPTION
Fixes #1067

On a phone the search sheet showed two X's about 20px apart that meant different
things: the input's own clear-X (wipe the query) and the modal's close-X (leave
the sheet). This drops the modal X on small viewports and makes a tap on the
sheet's empty space dismiss instead — the option the issue itself suggested.

## What changed

- **Tap-off to dismiss.** `.search-overlay-panel` now closes the overlay when
  the click lands on the panel's own box. This is the mobile counterpart of the
  backdrop, which already worked but is unreachable on a phone because the panel
  goes opaque and full-viewport below 1024px.
- **The modal X is visually hidden below 1024px.** It stays in the DOM at every
  width and returns to its full 44x44 tap target on `:focus-visible`, so keyboard
  and screen-reader users keep a labelled exit. Escape, close-on-navigation and
  the desktop backdrop are untouched.

No new user-facing strings — the button keeps its existing `close` i18n key.

## Why this shape

The dismissal check matches on the **event target** rather than stopping
propagation in the header. That keeps it independent of how Leptos's delegated
click handling bubbles, and it means the input, its clear-X and the
absolutely-positioned result/hint dropdowns are all naturally excluded — they
are never the panel itself. `cursor: pointer` on the mobile panel is not
cosmetic: iOS Safari only bubbles taps on non-interactive elements up to the
document (where Leptos's delegated listener lives) when they look clickable.

I considered replacing the X with a "Cancel" text button, which is the usual
mobile idiom, and measured it against the real stylesheet: it costs 63px in
English but **93-96px in German and Japanese**, versus 44px for the X. It would
have taken *more* space from the input than the button it replaced, which is the
opposite of what the issue asks for. Rejected.

## Verified at 375x812

Measured against the production stylesheet in Chrome device emulation, rendering
the component's exact markup:

| | before | after |
| --- | --- | --- |
| input width | 299px | **351px** (full row) |
| gap between the two X's | 20px | n/a — only one X |
| close button, keyboard-focused | 44x44 | 44x44 (`:focus-visible` restores it) |
| close button, not focused | 44x44 | 1x1, clipped, not hit-testable |

Hit-testing confirms the split: a tap on the sheet's empty space resolves to the
panel (closes), while taps on the input and on the clear-X resolve to those
elements (no close). The hidden 1px button cannot steal a tap — `elementFromPoint`
at its box returns the searchbox wrapper, since `clip-path` removes it from hit
testing.

## Known tradeoff

With the on-screen keyboard **and** a full results list up, the results cover the
visible viewport and leave no panel gutter to tap (250px of tap-off space with the
keyboard closed, 0px with it open). In that state the exits are the clear-X — one
tap, right there, which collapses the results and frees the whole sheet —
selecting a result, or Escape. I went with the issue's stated preference rather
than keeping a visible control, since every always-visible alternative costs
input width in exactly the way #1067 objects to. Happy to add a Cancel button
back if you'd rather have the guaranteed single-tap exit.

## Checks

`cargo fmt --all -- --check` and `cargo clippy -p ultros-app --all-targets -- -D warnings` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
