### PR TITLE
fix: render character-assigned retainers, and send web push alerts to the right page

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/retainers.rs
+++ b/ultros-frontend/ultros-app/src/routes/retainers.rs
@@ -244,13 +244,15 @@ pub(crate) fn CharacterRetainerList(
         .map(|(retainer, listings)| view! { <RetainerTable retainer listings /> })
         .collect();
     view! {
-        <div>
-            {if let Some(character) = character {
-                Either::Left(view! { <span>{character.first_name} {character.last_name}</span> })
-            } else {
-                Either::Right(listings)
-            }}
-
+        <div class="flex flex-col gap-2">
+            {character
+                .map(|character| {
+                    view! {
+                        <span class="content-title font-semibold mt-2">
+                            {character.first_name} " " {character.last_name}
+                        </span>
+                    }
+                })} {listings}
         </div>
     }
     .into_any()
@@ -266,15 +268,15 @@ pub(crate) fn CharacterRetainerUndercutList(
         .map(|(retainer, listings)| view! { <RetainerUndercutTable retainer listings /> })
         .collect();
     view! {
-        <div>
-            {if let Some(character) = character {
-                Either::Left(
-                    view! { <span>{character.first_name} {character.last_name}</span> }.into_view(),
-                )
-            } else {
-                Either::Right(listings)
-            }}
-
+        <div class="flex flex-col gap-2">
+            {character
+                .map(|character| {
+                    view! {
+                        <span class="content-title font-semibold mt-2">
+                            {character.first_name} " " {character.last_name}
+                        </span>
+                    }
+                })} {listings}
         </div>
     }
     .into_any()

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -101,10 +101,16 @@ pub(crate) fn parse_endpoint_config(
 /// for endpoint test + alert-event resend. The `_db` arg is unused today but kept in the
 /// signature so future endpoint methods (e.g. ones that need to look up retainer info) can
 /// be added without rippling the call sites.
+///
+/// `click_url` is the in-app path a Web Push notification opens when clicked
+/// (e.g. `/retainers/undercuts` for undercut alerts); use `/alerts` when no
+/// more specific destination applies. Other endpoint methods ignore it — their
+/// bodies already carry full links.
 pub(crate) async fn deliver_to_endpoint(
     endpoint: &ultros_db::entity::notification_endpoint::Model,
     title: &str,
     body: &str,
+    click_url: &str,
     db: &UltrosDb,
     ctx: &serenity_prelude::Context,
 ) -> Result<()> {
@@ -118,7 +124,7 @@ pub(crate) async fn deliver_to_endpoint(
         EndpointConfig::WebPush { subscription_id } => {
             let cfg = get_web_push_config()
                 .ok_or_else(|| anyhow!("web push not configured on this deployment"))?;
-            send_webpush(subscription_id, title, body, db, cfg).await
+            send_webpush(subscription_id, title, body, click_url, db, cfg).await
         }
     }
 }
@@ -131,6 +137,7 @@ pub(crate) async fn deliver_non_discord_endpoint(
     endpoint: &ultros_db::entity::notification_endpoint::Model,
     title: &str,
     body: &str,
+    click_url: &str,
     db: &UltrosDb,
 ) -> Result<()> {
     let parsed = parse_endpoint_config(&endpoint.method, &endpoint.config)?;
@@ -142,7 +149,7 @@ pub(crate) async fn deliver_non_discord_endpoint(
         EndpointConfig::WebPush { subscription_id } => {
             let cfg = get_web_push_config()
                 .ok_or_else(|| anyhow!("web push not configured on this deployment"))?;
-            send_webpush(subscription_id, title, body, db, cfg).await
+            send_webpush(subscription_id, title, body, click_url, db, cfg).await
         }
     }
 }
@@ -153,6 +160,7 @@ pub(crate) async fn dispatch_alert(
     alert_id: i32,
     title: &str,
     body: &str,
+    click_url: &str,
     db: &UltrosDb,
     ctx: &serenity_prelude::Context,
 ) -> Result<()> {
@@ -166,7 +174,7 @@ pub(crate) async fn dispatch_alert(
     let mut any_ok = false;
 
     for endpoint in endpoints {
-        match deliver_to_endpoint(&endpoint, title, body, db, ctx).await {
+        match deliver_to_endpoint(&endpoint, title, body, click_url, db, ctx).await {
             Ok(()) => any_ok = true,
             Err(e) => {
                 error!("delivery failed for alert {alert_id}: {e}");
@@ -243,10 +251,22 @@ async fn send_dm(
 /// (b) the crate's `From<isahc::Error>` impl discards the underlying cause and
 /// surfaces every transport failure as `WebPushError::Unspecified`, leaving
 /// operators with no signal about what actually broke.
+/// Build the JSON body the service worker reads out of `event.data.json()`.
+/// `click_url` becomes `data.url`, which `notificationclick` opens — an alert
+/// that hardcodes this loses the user's actual destination.
+fn build_push_payload(title: &str, body: &str, click_url: &str) -> Result<Vec<u8>> {
+    Ok(serde_json::to_vec(&serde_json::json!({
+        "title": title,
+        "body": body,
+        "url": click_url,
+    }))?)
+}
+
 async fn send_webpush(
     subscription_id: i32,
     title: &str,
     body: &str,
+    click_url: &str,
     db: &UltrosDb,
     config: &WebPushConfig,
 ) -> Result<()> {
@@ -266,12 +286,7 @@ async fn send_webpush(
         .build()
         .map_err(|e| anyhow!("VAPID build failed: {e:?}"))?;
 
-    // Payload is the JSON the service worker will see in `event.data.json()`.
-    let payload = serde_json::to_vec(&serde_json::json!({
-        "title": title,
-        "body": body,
-        "url": "/alerts",
-    }))?;
+    let payload = build_push_payload(title, body, click_url)?;
 
     let mut builder = WebPushMessageBuilder::new(&info);
     builder.set_payload(ContentEncoding::Aes128Gcm, &payload);
@@ -360,6 +375,15 @@ async fn send_webhook(url: &str, title: &str, body: &str) -> Result<()> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn push_payload_carries_the_callers_click_url() {
+        let payload = build_push_payload("Undercut Alert", "body", "/retainers/undercuts").unwrap();
+        let decoded: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(decoded["url"], json!("/retainers/undercuts"));
+        assert_eq!(decoded["title"], json!("Undercut Alert"));
+        assert_eq!(decoded["body"], json!("body"));
+    }
 
     #[test]
     fn parses_discord_dm_from_method_plus_config() {

--- a/ultros/src/alerts/list_update_alert_tracker.rs
+++ b/ultros/src/alerts/list_update_alert_tracker.rs
@@ -169,7 +169,9 @@ async fn handle_list_event(
             "{title_hint}{body_hint}\nhttps://ultros.app/list/{}",
             rule.list_id
         );
-        let delivery_result = dispatch_alert(rule.alert_id, &title, &body, db, ctx).await;
+        let click_url = format!("/list/{}", rule.list_id);
+        let delivery_result =
+            dispatch_alert(rule.alert_id, &title, &body, &click_url, db, ctx).await;
         let delivered = delivery_result.is_ok();
         let delivery_error = delivery_result.err().map(|e| e.to_string());
 

--- a/ultros/src/alerts/price_alert_tracker.rs
+++ b/ultros/src/alerts/price_alert_tracker.rs
@@ -456,7 +456,9 @@ async fn handle_added(
             rule.price_threshold,
         );
 
-        let delivery_result = dispatch_alert(rule.alert_id, &title, &body, db, ctx).await;
+        let click_url = format!("/item/{}", rule.item_id);
+        let delivery_result =
+            dispatch_alert(rule.alert_id, &title, &body, &click_url, db, ctx).await;
         let delivered = delivery_result.is_ok();
         let delivery_error = delivery_result.err().map(|e| e.to_string());
 
@@ -495,7 +497,9 @@ async fn handle_added(
             rule.target_price,
         );
 
-        let delivery_result = dispatch_alert(rule.alert_id, &title, &body, db, ctx).await;
+        let click_url = format!("/list/{}", rule.list_id);
+        let delivery_result =
+            dispatch_alert(rule.alert_id, &title, &body, &click_url, db, ctx).await;
         let delivered = delivery_result.is_ok();
         let delivery_error = delivery_result.err().map(|e| e.to_string());
 

--- a/ultros/src/alerts/undercut_alert.rs
+++ b/ultros/src/alerts/undercut_alert.rs
@@ -354,6 +354,7 @@ impl RetainerAlertListener {
                                             alert_id,
                                             title,
                                             &undercut_msg,
+                                            "/retainers/undercuts",
                                             &ultros_db,
                                             &ctx,
                                         )

--- a/ultros/src/web/api/alerts.rs
+++ b/ultros/src/web/api/alerts.rs
@@ -591,14 +591,18 @@ pub(crate) async fn resend_alert_event(
         let result = if needs_ctx {
             match serenity_ctx.as_ref() {
                 Some(ctx) => {
-                    crate::alerts::delivery::deliver_to_endpoint(&endpoint, title, &body, &db, ctx)
-                        .await
+                    crate::alerts::delivery::deliver_to_endpoint(
+                        &endpoint, title, &body, "/alerts", &db, ctx,
+                    )
+                    .await
                 }
                 None => Err(anyhow::anyhow!("Discord client not ready")),
             }
         } else {
-            crate::alerts::delivery::deliver_non_discord_endpoint(&endpoint, title, &body, &db)
-                .await
+            crate::alerts::delivery::deliver_non_discord_endpoint(
+                &endpoint, title, &body, "/alerts", &db,
+            )
+            .await
         };
         match result {
             Ok(()) => any_ok = true,

--- a/ultros/src/web/api/endpoints.rs
+++ b/ultros/src/web/api/endpoints.rs
@@ -283,6 +283,7 @@ pub(crate) async fn test_endpoint(
             &endpoint,
             "Ultros test notification",
             "If you can read this, your endpoint is wired up correctly.",
+            "/alerts",
             &db,
             ctx,
         )
@@ -293,6 +294,7 @@ pub(crate) async fn test_endpoint(
             &endpoint,
             "Ultros test notification",
             "If you can read this, your endpoint is wired up correctly.",
+            "/alerts",
             &db,
         )
         .await


### PR DESCRIPTION
Two small confirmed bugs, one per commit.

## #1060 — retainers assigned to a character do not render

`CharacterRetainerList` and `CharacterRetainerUndercutList` in [retainers.rs](ultros-frontend/ultros-app/src/routes/retainers.rs) each branched on `Option<FfxivCharacter>` as an either/or:

```rust
if let Some(character) = character {
    Either::Left(view! { <span>{character.first_name} {character.last_name}</span> })
} else {
    Either::Right(listings)   // <-- only reachable when there is NO character
}
```

So a retainer group that *had* a character rendered the character's name and threw the listings away. Anyone who assigned their retainers to a character saw a bare name and no tables on `/retainers` and `/retainers/undercuts`.

The character isn't an alternative to the listings, it's the heading for them. Both components now render an optional header followed by the listings unconditionally. The header previously had no styling at all; it gets `content-title font-semibold` so it reads a level above the retainer names inside each panel (which already use plain `content-title`), and the wrapper became `flex flex-col gap-2` to space the groups.

The backend was already fine — `user_retainer_listings` ([web.rs:1163](ultros/src/web.rs:1163)) returns the grouping fully populated.

## #1064 — browser undercut alert just opens the alerts manager

[delivery.rs](ultros/src/alerts/delivery.rs) hardcoded the click target in the push payload for *every* alert type:

```rust
"url": "/alerts",
```

The service worker is not at fault — it opens whatever `data.url` it's handed, and falls back to `/alerts` on its own.

I took option (a) from the issue and threaded a `click_url` through `dispatch_alert` → `deliver_to_endpoint` / `deliver_non_discord_endpoint` → `send_webpush`, rather than deriving it from the alert type inside `deliver_to_endpoint`. Deriving it there would mean re-deriving state the trigger already has: the price and list trackers know the specific item and list ids, so a type-based mapping could only ever produce a generic per-type landing page, while the call sites can name the exact page.

Destinations now:

| trigger | click target |
|---|---|
| undercut alert | `/retainers/undercuts` |
| item price threshold | `/item/{item_id}` |
| list price threshold | `/list/{list_id}` |
| list updated | `/list/{list_id}` |
| endpoint test, event resend | `/alerts` |

Undercut matches the link the Discord path already sends ([undercut_alert.rs:348](ultros/src/alerts/undercut_alert.rs:348)); the price and list ones match the links already in their own message bodies. Test sends and resends keep `/alerts`, which is the right landing page for those.

Payload construction moved into a small pure `build_push_payload` so the hardcoding can't come back unnoticed.

Fixes #1060
Fixes #1064

## Verification

`./check_ci.sh` passes clean end to end (`REAL_EXIT=0`) — fmt, the `prop:` gate, workspace clippy `-D warnings` over `ultros` / `ultros-app` / `ultros-client`, and the `xiv-gen csv_to_rkyv` pass.

**One gap to flag:** I could not execute the added `push_payload_carries_the_callers_click_url` test. The `ultros` bin test binary does not link on Windows/MSVC — `LNK1120: 109 unresolved externals`, all in unrelated code (`trends`, `cookie`, `chrono`, `analyzer_service`), a pre-existing environment wall that blocks the 4 tests already in that module too. Clippy `--all-targets` does compile and lint the test, so it type-checks; it just wasn't run. Worth a `cargo test -p ultros` on Linux if you want it confirmed.

No new user-facing strings, so no locale files needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
