### PR TITLE
feat(skeleton): table-shaped loading skeletons with a real left-to-right shimmer

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -771,6 +771,65 @@
     }
 }
 
+/* === Loading skeletons ===
+ *
+ * Two classes that compose:
+ *
+ *   `.skeleton-block`   paints a placeholder surface (the grey bar that
+ *                       stands in for a word, a number, an icon).
+ *   `.skeleton-shimmer` sweeps a highlight across whatever it is put on,
+ *                       left to right.
+ *
+ * The sweep is a translated pseudo-element rather than an animated
+ * `background-position`, so the highlight keeps a constant width and speed
+ * no matter how wide the host element is — a full-width table row and a
+ * 40px cell shimmer identically. (The previous `.background-animate`
+ * approach scaled the gradient to the element, and it lived in
+ * `style/legacy.css`, which is not part of the stylesheet build at all, so
+ * nothing was animating in the shipped bundle.)
+ *
+ * Put `.skeleton-shimmer` on a single bar for a per-bar sweep, or on a
+ * container for one highlight that travels across every bar inside it.
+ * The container form is what the table skeletons use — dozens of bars each
+ * pulsing on their own reads as noise. */
+.skeleton-block {
+    background-color: color-mix(in srgb, var(--brand-ring) 14%, transparent);
+}
+
+.skeleton-shimmer {
+    position: relative;
+    overflow: hidden;
+}
+
+.skeleton-shimmer::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    transform: translateX(-100%);
+    background-image: linear-gradient(
+        90deg,
+        transparent 0%,
+        color-mix(in srgb, var(--color-text) 9%, transparent) 50%,
+        transparent 100%
+    );
+    animation: skeleton-shimmer 1.8s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+/* Motion is decoration here — the placeholders still communicate "content
+   is loading" while completely still. */
+@media (prefers-reduced-motion: reduce) {
+    .skeleton-shimmer::after {
+        animation: none;
+    }
+}
+
 @theme {
     /* Custom violet scale tuned for dark UI */
     --color-brand-50: #f6f2ff;

--- a/ultros-frontend/ultros-app/src/components/skeleton.rs
+++ b/ultros-frontend/ultros-app/src/components/skeleton.rs
@@ -1,68 +1,346 @@
+//! Loading placeholders.
+//!
+//! Every skeleton here is built from two CSS classes defined in
+//! `style/tailwind.css`: `.skeleton-block` paints a placeholder surface and
+//! `.skeleton-shimmer` sweeps a highlight across whatever it is put on, left
+//! to right. The multi-row skeletons put the shimmer on their *container*, so
+//! one highlight travels across the whole block instead of every bar
+//! animating on its own.
+//!
+//! These render inside `<Suspense>`/`<Transition>` fallbacks, which means they
+//! are part of the SSR response and are hydrated. Their markup must therefore
+//! be a pure function of their props — no randomness, no clock. Where a
+//! skeleton wants bars of varying width (a column of identical bars reads as a
+//! bar chart, not as text) the width is picked from a fixed table by row and
+//! column index, so the server and the client always agree.
+
 use leptos::prelude::*;
 
 use crate::i18n::*;
 
+/// Bar widths cycled through to keep placeholder text from looking like a
+/// perfectly ragged-right block. Chosen by position, never at random — see
+/// the module docs.
+///
+/// These are fractions of the *column*, so they suit the narrow, mostly-full
+/// columns that hold a number or a short label.
+const BAR_WIDTHS: &[&str] = &["w-3/5", "w-4/5", "w-1/2", "w-11/12", "w-2/3", "w-3/4"];
+
+/// Widths for the name bar in an [`SkeletonCell::IconText`] cell.
+///
+/// A separate, much narrower set: the item column is the table's flexible one,
+/// so it is several times wider than the name that sits in it. Reusing
+/// [`BAR_WIDTHS`] there drew a bar three times the length of a real item name
+/// and made the loading state read as a much denser table than the one that
+/// replaced it.
+const NAME_WIDTHS: &[&str] = &["w-1/3", "w-5/12", "w-1/4", "w-2/5", "w-1/2", "w-1/6"];
+
+/// The width for the bar at `(row, column)`, picked out of `widths`.
+/// Multiplying the two indices by strides coprime with the table length keeps
+/// neighbouring rows and columns from landing on the same width.
+fn width_at(widths: &[&'static str], row: usize, column: usize) -> &'static str {
+    widths[(row * 5 + column * 3) % widths.len()]
+}
+
+fn bar_width(row: usize, column: usize) -> &'static str {
+    width_at(BAR_WIDTHS, row, column)
+}
+
+fn name_width(row: usize, column: usize) -> &'static str {
+    width_at(NAME_WIDTHS, row, column)
+}
+
+/// The silhouette drawn inside one skeleton cell. These are rough shapes, not
+/// pixel copies — enough that the loading state has the same visual rhythm as
+/// the table that replaces it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SkeletonCell {
+    /// A square icon followed by a text bar. The item column.
+    IconText,
+    /// A left-aligned text bar.
+    Text,
+    /// A shorter bar, laid out by the column's own alignment classes. Gil
+    /// amounts, counts, percentages.
+    Number,
+    /// A small pill. Confidence bands, sales-cadence badges.
+    Badge,
+    /// A wide, short bar standing in for a sparkline.
+    Spark,
+    /// Nothing at all. Columns that are blank on most rows (an HQ flag) look
+    /// wrong when the skeleton fills every one of them in.
+    Blank,
+}
+
+/// One column of a [`TableSkeleton`].
+///
+/// `class` should be copied from the real table's cell so the skeleton's
+/// columns land on the same x positions as the columns they stand in for —
+/// including the responsive `hidden md:flex` visibility, or the skeleton will
+/// show columns the table itself hides at that width.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SkeletonColumn {
+    pub class: &'static str,
+    pub cell: SkeletonCell,
+}
+
+impl SkeletonColumn {
+    pub const fn new(class: &'static str, cell: SkeletonCell) -> Self {
+        Self { class, cell }
+    }
+}
+
+fn cell_view(cell: SkeletonCell, row: usize, column: usize) -> AnyView {
+    match cell {
+        SkeletonCell::IconText => view! {
+            <div class="flex flex-row items-center gap-2 min-w-0 w-full">
+                <div class="skeleton-block size-6 rounded shrink-0"></div>
+                <div class=format!("skeleton-block h-2.5 rounded {}", name_width(row, column))></div>
+            </div>
+        }
+        .into_any(),
+        SkeletonCell::Text => view! {
+            <div class=format!("skeleton-block h-2.5 rounded {}", bar_width(row, column))></div>
+        }
+        .into_any(),
+        SkeletonCell::Number => view! {
+            <div class=format!("skeleton-block h-2.5 rounded {}", bar_width(row, column + 1))></div>
+        }
+        .into_any(),
+        SkeletonCell::Badge => {
+            view! { <div class="skeleton-block h-4 w-12 rounded-full"></div> }.into_any()
+        }
+        SkeletonCell::Spark => {
+            view! { <div class="skeleton-block h-4 w-full rounded"></div> }.into_any()
+        }
+        SkeletonCell::Blank => ().into_any(),
+    }
+}
+
+/// A skeleton shaped like a data table: a header strip over a run of striped
+/// rows, with one placeholder per column.
+///
+/// The caller supplies the columns, so the skeleton can be made to match a
+/// specific table rather than approximating all of them. `class`, `row_class`
+/// and `style` exist for the same reason — a table whose column widths come
+/// from CSS variables on its container (the Flip Finder grid) can hand those
+/// straight through and get a skeleton whose columns line up exactly with the
+/// real ones.
+#[component]
+pub fn TableSkeleton(
+    /// Columns in DOM order.
+    columns: Vec<SkeletonColumn>,
+    /// How many placeholder rows to draw.
+    #[prop(default = 12)]
+    rows: usize,
+    /// Extra classes for the container.
+    #[prop(optional, into)]
+    class: String,
+    /// Inline style for the container, for tables driven by CSS variables.
+    #[prop(optional, into)]
+    style: String,
+    /// Extra classes for every row, header included. Carries whatever layout
+    /// the real rows depend on — a min-width, a bottom border.
+    #[prop(optional, into)]
+    row_class: String,
+    /// Height class for body rows. Matching the real row height is what keeps
+    /// the page from jumping when the data arrives.
+    #[prop(default = "h-10")]
+    row_height: &'static str,
+    /// Height class for the header strip.
+    #[prop(default = "h-14")]
+    header_height: &'static str,
+    /// Draw the header strip. Off for tables whose header lives outside the
+    /// area the fallback replaces.
+    #[prop(default = true)]
+    header: bool,
+    /// Alternate the row tint. Off for tables that separate rows with a
+    /// border instead.
+    #[prop(default = true)]
+    striped: bool,
+) -> impl IntoView {
+    let i18n = use_i18n();
+    let header_row = header.then(|| {
+        let cells = columns
+            .iter()
+            .map(|column| {
+                view! {
+                    <div class=column.class>
+                        <div class="skeleton-block h-2 w-2/3 max-w-[4rem] rounded"></div>
+                    </div>
+                }
+            })
+            .collect::<Vec<_>>();
+        view! {
+            <div class=format!(
+                "flex flex-row items-center flex-nowrap {header_height} border-b border-[color:var(--color-outline)] bg-[color:color-mix(in_srgb,var(--brand-ring)_8%,transparent)] {row_class}",
+            )>{cells}</div>
+        }
+    });
+    let body = (0..rows)
+        .map(|row| {
+            // Two-tone striping matching the tables this stands in for, so the
+            // swap to real rows doesn't shift the page's texture.
+            let stripe = match (striped, row % 2 == 0) {
+                (false, _) => "",
+                (true, true) => "bg-[color:color-mix(in_srgb,var(--color-text)_6%,transparent)]",
+                (true, false) => "bg-[color:color-mix(in_srgb,var(--color-text)_8%,transparent)]",
+            };
+            let cells = columns
+                .iter()
+                .enumerate()
+                .map(|(index, column)| {
+                    view! { <div class=column.class>{cell_view(column.cell, row, index)}</div> }
+                })
+                .collect::<Vec<_>>();
+            view! {
+                <div class=format!(
+                    "flex flex-row items-center flex-nowrap {row_height} {stripe} {row_class}",
+                )>{cells}</div>
+            }
+        })
+        .collect::<Vec<_>>();
+    view! {
+        <div class="w-full" role="status">
+            <div class=format!("skeleton-shimmer {class}") style=style aria-hidden="true">
+                {header_row}
+                {body}
+            </div>
+            <div class="sr-only">{t!(i18n, loading)}</div>
+        </div>
+    }
+    .into_any()
+}
+
+/// A single placeholder bar, for standing in for one value inside an
+/// otherwise-rendered row.
+///
+/// Deliberately *not* a `role="status"` live region, unlike the block-level
+/// skeletons. This one renders per table cell — the Flip Finder puts up to
+/// three of them in every row of a list that is hundreds long — and a live
+/// region each would give a screen reader hundreds of things to announce.
+/// The `sr-only` label still describes the cell to anyone reading through it.
 #[component]
 pub fn SingleLineSkeleton() -> impl IntoView {
     let i18n = use_i18n();
     view! {
-        <div class="animate-pulse">
-            <div class="w-full h-3 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
+        <div class="w-full">
+            <div class="skeleton-block skeleton-shimmer w-full h-3 rounded-md" aria-hidden="true"></div>
             <div class="sr-only">{t!(i18n, loading)}</div>
         </div>
-    }.into_any()
+    }
+    .into_any()
 }
 
+/// A run of avatar-and-two-lines rows. The generic fallback for list-shaped
+/// content that isn't a table.
 #[component]
-pub fn BoxSkeleton() -> impl IntoView {
+pub fn BoxSkeleton(
+    /// How many placeholder rows to draw.
+    #[prop(default = 6)]
+    rows: usize,
+) -> impl IntoView {
     let i18n = use_i18n();
+    let rows = (0..rows)
+        .map(|row| {
+            view! {
+                <div class="flex items-center gap-4 p-3 rounded-lg panel">
+                    <div class="skeleton-block size-10 rounded-md"></div>
+                    <div class="flex-1 space-y-2">
+                        <div class=format!(
+                            "skeleton-block h-3 rounded-md {}",
+                            bar_width(row, 0),
+                        )></div>
+                        <div class=format!(
+                            "skeleton-block h-3 rounded-md {}",
+                            bar_width(row, 3),
+                        )></div>
+                    </div>
+                </div>
+            }
+        })
+        .collect::<Vec<_>>();
     view! {
-        <div class="w-full h-full animate-pulse">
-            <div class="space-y-2">
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
-                <div class="flex items-center gap-4 p-3 rounded-lg panel">
-                    <div class="w-10 h-10 rounded-md bg-[color:color-mix(in_srgb,_var(--brand-ring)_16%,_transparent)]"></div>
-                    <div class="flex-1 space-y-2">
-                        <div class="h-3 w-3/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                        <div class="h-3 w-2/5 bg-gradient-to-r from-[color:color-mix(in_srgb,_var(--brand-ring)_20%,_transparent)] via-[color:color-mix(in_srgb,_var(--brand-ring)_10%,_transparent)] to-transparent rounded-md background-animate"></div>
-                    </div>
-                </div>
+        <div class="w-full h-full" role="status">
+            <div class="skeleton-shimmer space-y-2 rounded-lg" aria-hidden="true">
+                {rows}
             </div>
             <div class="sr-only">{t!(i18n, loading)}</div>
         </div>
-    }.into_any()
+    }
+    .into_any()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Skeletons are rendered on the server and then hydrated, so the same
+    /// `(row, column)` has to produce the same width in both passes. Anything
+    /// derived from a clock or an RNG would diverge and take the whole page
+    /// down with a hydration panic.
+    #[test]
+    fn bar_width_is_a_pure_function_of_position() {
+        for row in 0..32 {
+            for column in 0..12 {
+                assert_eq!(bar_width(row, column), bar_width(row, column));
+            }
+        }
+    }
+
+    /// The widths are indexed modulo the table's length; every index must land
+    /// inside it for any row/column a caller can reach.
+    #[test]
+    fn width_never_panics_on_large_indices() {
+        for row in [0usize, 1, 7, 100, 10_000] {
+            for column in [0usize, 1, 5, 64, 1_000] {
+                assert!(BAR_WIDTHS.contains(&bar_width(row, column)));
+                assert!(NAME_WIDTHS.contains(&name_width(row, column)));
+            }
+        }
+    }
+
+    /// Neighbouring cells in a row shouldn't share a width, or the "ragged
+    /// text" effect collapses back into a block. Both tables are the same
+    /// length, so the stride argument holds for either.
+    #[test]
+    fn adjacent_columns_differ() {
+        for widths in [BAR_WIDTHS, NAME_WIDTHS] {
+            for row in 0..12 {
+                for column in 0..8 {
+                    assert_ne!(
+                        width_at(widths, row, column),
+                        width_at(widths, row, column + 1),
+                        "row {row}, columns {column} and {}",
+                        column + 1
+                    );
+                }
+            }
+        }
+    }
+
+    /// The item column is the table's flexible one, several times wider than
+    /// the name inside it, so its bars have to stay well under a full column.
+    /// A regression here is what made the first cut of this skeleton read as a
+    /// denser table than the real one.
+    #[test]
+    fn name_widths_are_narrower_than_bar_widths() {
+        fn fraction(class: &str) -> f64 {
+            let (num, den) = class
+                .trim_start_matches("w-")
+                .split_once('/')
+                .expect("width classes are fractions");
+            num.parse::<f64>().unwrap() / den.parse::<f64>().unwrap()
+        }
+        let widest = NAME_WIDTHS
+            .iter()
+            .copied()
+            .map(fraction)
+            .fold(0.0, f64::max);
+        assert!(
+            widest <= 0.5,
+            "widest name bar is {widest} of the column, which is too close to full"
+        );
+        let widest_bar = BAR_WIDTHS.iter().copied().map(fraction).fold(0.0, f64::max);
+        assert!(widest < widest_bar);
+    }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -22,7 +22,7 @@ use crate::{
         realtime_status::RealtimeStatus,
         sales_cadence_badge::SalesCadenceBadge,
         saved_views::SavedViewsMenu,
-        skeleton::{BoxSkeleton, SingleLineSkeleton},
+        skeleton::{SingleLineSkeleton, SkeletonCell, SkeletonColumn, TableSkeleton},
         sparkline::Sparkline,
         toggle::Toggle,
         tool_help::{ActionableEmptyState, ToolHeader},
@@ -801,6 +801,141 @@ fn extra_column_widths_px(visible: &std::collections::HashSet<&'static str>) -> 
         base: sum(ALWAYS),
         md: sum(MD),
         xl: sum(XL),
+    }
+}
+
+/// The loading skeleton's version of the grid, in DOM order.
+///
+/// Each entry's class string is the matching cell's class from the row markup
+/// below — same width, same responsive visibility, same alignment — so the
+/// placeholder columns sit exactly where the real ones will. Keep the two in
+/// step: a column added to the row markup but not here makes the table appear
+/// to gain a column when it loads.
+///
+/// Three cells differ from their real counterparts on purpose. World,
+/// datacenter and last-sold are written `hidden lg:block flex` / `hidden
+/// md:block flex` in the row markup — `block` and `flex` on the same element,
+/// where which one wins is down to stylesheet order rather than intent — so
+/// the skeleton spells them `hidden lg:flex` / `hidden md:flex`, which is what
+/// the `items-center` beside them was reaching for. The widths, which are all
+/// the alignment depends on, are identical either way.
+fn analyzer_skeleton_columns(
+    visible: &std::collections::HashSet<&'static str>,
+) -> Vec<SkeletonColumn> {
+    /// `(gate, class, cell)` in DOM order. A `None` gate is a column that
+    /// always renders; the rest follow `?cols=`.
+    const COLUMNS: &[(Option<&str>, &str, SkeletonCell)] = &[
+        // HQ. Most rows are NQ, so this one stays empty.
+        (
+            None,
+            "px-2 py-2 w-[44px] shrink-0 flex items-center justify-center",
+            SkeletonCell::Blank,
+        ),
+        (
+            None,
+            "px-4 py-2 flex flex-row flex-1 min-w-[14rem] items-center gap-2",
+            SkeletonCell::IconText,
+        ),
+        // Profit.
+        (
+            None,
+            "px-3 py-2 w-28 shrink-0 text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_PROFIT_PER_DAY),
+            "px-3 py-2 w-28 shrink-0 text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_VELOCITY),
+            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_DRIFT),
+            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_CONFIDENCE),
+            "px-3 py-2 w-[72px] shrink-0 hidden md:flex items-center justify-center",
+            SkeletonCell::Badge,
+        ),
+        (
+            Some(COL_ROI),
+            "px-3 py-2 w-28 shrink-0 text-right flex items-center justify-end",
+            SkeletonCell::Badge,
+        ),
+        // Buy price. Always on, and it sits after ROI in the row markup.
+        (
+            None,
+            "px-3 py-2 w-28 shrink-0 text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_WORLD),
+            "px-3 py-2 w-28 shrink-0 hidden lg:flex items-center",
+            SkeletonCell::Text,
+        ),
+        (
+            Some(COL_DATACENTER),
+            "px-3 py-2 w-28 shrink-0 hidden xl:flex items-center",
+            SkeletonCell::Text,
+        ),
+        (
+            Some(COL_TREND),
+            "px-3 py-2 w-[100px] shrink-0 hidden md:flex items-center justify-center",
+            SkeletonCell::Spark,
+        ),
+        (
+            Some(COL_SALES_PER_DAY),
+            "px-3 py-2 w-[140px] shrink-0 hidden md:flex items-center justify-center",
+            SkeletonCell::Badge,
+        ),
+        (
+            Some(COL_VOLUME_30D),
+            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        (
+            Some(COL_LAST_SOLD),
+            "px-3 py-2 w-28 shrink-0 hidden md:flex items-center",
+            SkeletonCell::Text,
+        ),
+    ];
+    COLUMNS
+        .iter()
+        .filter(|(gate, _, _)| gate.is_none_or(|col| visible.contains(col)))
+        .map(|(_, class, cell)| SkeletonColumn::new(class, *cell))
+        .collect()
+}
+
+/// The Flip Finder's loading state: the results grid, drawn empty.
+///
+/// Reads `?cols=` the same way the table does, so the skeleton shows the
+/// columns this particular user has switched on rather than a generic set —
+/// and reproduces the container's `--analyzer-extra-cols-*` variables, which
+/// is what makes `.analyzer-grid-row` give the placeholder rows the same
+/// min-width as the real ones.
+#[component]
+fn AnalyzerTableSkeleton() -> impl IntoView {
+    let (cols_param, _) = query_signal::<String>("cols");
+    let visible = parse_visible_cols(cols_param.get_untracked().as_deref());
+    let widths = extra_column_widths_px(&visible);
+    view! {
+        <TableSkeleton
+            columns=analyzer_skeleton_columns(&visible)
+            rows=14
+            class="analyzer-table border border-[color:var(--color-outline)]"
+            row_class="analyzer-grid-row"
+            style=format!(
+                "--analyzer-extra-cols-base: {}px; --analyzer-extra-cols-md: {}px; --analyzer-extra-cols-xl: {}px;",
+                widths.base,
+                widths.md,
+                widths.xl,
+            )
+        />
     }
 }
 
@@ -2888,7 +3023,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                     // `<Suspense>` below: `AnalyzerTable` (and the sticky bar
                     // it renders) only exists once every resource has
                     // resolved, so a control placed there vanishes behind
-                    // `BoxSkeleton` on every load — including a world change,
+                    // the skeleton on every load — including a world change,
                     // which is exactly when a user most needs to be able to
                     // change worlds again. Keeping it here means it is always
                     // on screen, load or no load.
@@ -2912,7 +3047,7 @@ pub fn AnalyzerWorldView() -> impl IntoView {
                     // the table virtualizes against the window, so the page
                     // itself is what scrolls.
                     <div>
-                        <Suspense fallback=BoxSkeleton>
+                        <Suspense fallback=AnalyzerTableSkeleton>
                             {move || {
                                 let world_cheapest = world_cheapest_listings.get();
                                 let sales = sales.get();

--- a/ultros-frontend/ultros-app/src/routes/trends.rs
+++ b/ultros-frontend/ultros-app/src/routes/trends.rs
@@ -32,7 +32,7 @@ use crate::{
         market_movers::MarketMovers,
         meta::{MetaDescription, MetaTitle},
         query_button::QueryButton,
-        skeleton::BoxSkeleton,
+        skeleton::{SkeletonCell, SkeletonColumn, TableSkeleton},
         sparkline::Sparkline,
         tool_help::*,
         toolbar::{Toolbar, ToolbarField, ToolbarPills},
@@ -71,6 +71,66 @@ fn format_volume(v: u64) -> String {
         format!("{:.1}K", v as f64 / 1_000.0)
     } else {
         v.to_string()
+    }
+}
+
+/// [`TrendsTable`]'s loading state, drawn from the same column geometry.
+///
+/// Every column here mirrors the corresponding cell class in the table below;
+/// keep them in step or the skeleton's columns will drift away from the real
+/// ones. Trends has no responsive column hiding — the whole grid sits behind
+/// one `min-w-[940px]` — so the skeleton needs no breakpoint classes either.
+#[component]
+fn TrendsTableSkeleton() -> impl IntoView {
+    let columns = vec![
+        // HQ, blank on most rows.
+        SkeletonColumn::new(
+            "px-2 py-2 w-[40px] flex items-center justify-center",
+            SkeletonCell::Blank,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 flex flex-row flex-1 min-w-[14rem] items-center gap-2",
+            SkeletonCell::IconText,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[100px] flex items-center justify-center",
+            SkeletonCell::Spark,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[110px] text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[110px] text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[90px] text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[100px] text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[110px] text-right flex items-center justify-end",
+            SkeletonCell::Number,
+        ),
+        SkeletonColumn::new(
+            "px-3 py-2 w-[110px] flex items-center justify-center",
+            SkeletonCell::Badge,
+        ),
+    ];
+    view! {
+        <TableSkeleton
+            columns
+            rows=12
+            class="rounded-lg border border-[color:var(--color-outline)]"
+            row_class="min-w-[940px] border-b border-[color:var(--line)]"
+            row_height="h-12"
+            header_height="h-12"
+            striped=false
+        />
     }
 }
 
@@ -587,7 +647,7 @@ pub fn Trends() -> impl IntoView {
 
                 // Content
                 <div class="min-h-[500px]">
-                    <Suspense fallback=BoxSkeleton>
+                    <Suspense fallback=TrendsTableSkeleton>
                         {move || match trends_for_view.get() {
                             Some(Ok(Some(_))) => {
                                 let items = displayed();
@@ -611,7 +671,7 @@ pub fn Trends() -> impl IntoView {
                                     {format!("Error loading trends: {}", e)}
                                 </div>
                             }.into_any(),
-                            None => view! { <BoxSkeleton /> }.into_any(),
+                            None => view! { <TrendsTableSkeleton /> }.into_any(),
                         }}
                     </Suspense>
                 </div>

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -743,7 +743,7 @@ pub fn VendorWorldView() -> impl IntoView {
 
                 // Main Content
                 <div class="min-h-screen">
-                    <Suspense fallback=BoxSkeleton>
+                    <Suspense fallback=move || view! { <BoxSkeleton /> }>
                         {move || {
                             let world_cheapest = world_cheapest_listings.get();
                             let sales = sales.get();


### PR DESCRIPTION
Fixes #1069

The Flip Finder's loading state was `BoxSkeleton` — six avatar-and-two-lines
rows that look nothing like the results grid, so the page visibly rearranged
itself the moment data arrived. This replaces it with a skeleton built from the
grid's own column geometry, and gives every skeleton a real left-to-right
shimmer.

## The shimmer was never running

`.background-animate`, the class the old skeletons used for their "shimmer",
is defined in `style/legacy.css` — a file nothing imports. The stylesheet build
input is `style/tailwind.css` (`Cargo.toml: tailwind-input-file`), and
`ultros/static/main.css` is empty. So the shipped bundle had no such rule and
the only animation was `animate-pulse`.

The new `.skeleton-shimmer` lives in `style/tailwind.css` and sweeps a
translated pseudo-element rather than animating `background-position`. That
keeps the highlight a constant width and speed regardless of how wide the host
is, so a full-width table row and a 40px cell shimmer identically. It pairs
with `.skeleton-block`, which paints the placeholder surface.

Put `.skeleton-shimmer` on a bar for a per-bar sweep, or on a container for one
highlight travelling across everything inside it. The table skeletons use the
container form — dozens of bars each pulsing independently reads as noise.

`prefers-reduced-motion: reduce` drops the animation; the placeholders still
say "loading" while completely still.

## `TableSkeleton`

A skeleton the caller shapes: `columns` (each a class string copied from the
real table's cell, plus a `SkeletonCell` silhouette), `rows`, row/header
heights, striping on or off, and `class`/`style` passthrough for tables whose
column widths come from CSS variables on their container.

`SkeletonCell` covers the shapes these tables actually contain: `IconText`,
`Text`, `Number`, `Badge`, `Spark`, and `Blank` for columns that are empty on
most rows (the HQ flag — filling every one of them in looks wrong).

Adopted by:

- **Flip Finder** (`AnalyzerTableSkeleton`). Reads `?cols=` exactly as the
  table does, so the skeleton shows the columns *this* user has switched on,
  and reproduces the container's `--analyzer-extra-cols-*` variables so
  `.analyzer-grid-row` gives placeholder rows the same min-width as real ones.
- **Trends** (`TrendsTableSkeleton`), which exercises the unstriped / `h-12` /
  `min-w-[940px]` path.

`listings_table.rs` and `sale_history_table.rs` are real `<table>` elements
whose cells carry no classes at all (they're styled by the global
`.main-content td` rules), and `listings_panel.rs`'s Transition wraps a header
and filter chrome as well as the table — none of them fit a div-grid column
skeleton cheaply, so they keep `BoxSkeleton`.

`BoxSkeleton` itself is no longer six copy-pasted blocks; it takes a `rows`
count (default 6, so every existing call site is unchanged) and uses the new
shimmer. One call site had to change form: `fallback=BoxSkeleton` passes the
component function itself, which stops type-checking once the component takes a
prop, so `vendor_resale.rs` now uses `fallback=move || view! { <BoxSkeleton /> }`
like every other call site already did.

## Accessibility

The block-level skeletons are `role="status"` with an `sr-only` label, and
their visual scaffolding is `aria-hidden`. `SingleLineSkeleton` deliberately is
*not* a live region: it renders per table cell — the Flip Finder puts up to
three in every row of a list hundreds long — and one live region each would
give a screen reader hundreds of things to announce. It keeps the plain
`sr-only` label it had before.

## Hydration safety

Skeletons render inside `Suspense`/`Transition` fallbacks, so they are part of
the SSR response and get hydrated. Bar widths are picked from a fixed table by
`(row, column)` — never randomised — so the server and client always agree.
There's a unit test asserting that, one asserting the modulo indexing can't
panic, and one asserting the item-name bars stay well under a full column.

## Verification

- `./check_ci.sh` clean.
- `cargo test -p ultros-app --lib skeleton` — 3 passed (CI does not run tests).
- Rendered the real markup against a Tailwind build of `style/tailwind.css` and
  compared visible column widths with a mock of the real analyzer row at three
  viewports. Identical at each: 560px `[44,228,112,112,112]`, 900px
  `[44,236,112,112,88,88,72,112,112]`, 1440px all columns — same row min-width
  too, so the responsive `hidden md:flex` hiding matches column for column.
- Confirmed via CSSOM that the shimmer animation is `running` on `::after` and
  that the reduced-motion rule resolves to `animation-name: none`.
