### PR TITLE
fix(trends): stop the world picker from wiping filters out of the URL

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -34,6 +34,7 @@ use crate::{
     global_state::LocalWorldData,
     math::filter_outliers_iqr_in_place,
     query_defaults::{DEFAULT_MAX_SALE_TIME, filter_query_signal, seed_query_default},
+    routes::world_nav::world_nav_url,
 };
 use ultros_api_types::{
     resale_quality::ResaleQualityRow, sparklines::SparklinesRequest, trends::ConfidenceBand,
@@ -2987,23 +2988,25 @@ fn AnalyzerWorldNavigator() -> impl IntoView {
 
     let (current_world, set_current_world) = signal(initial_world);
     let query = use_query_map();
+    let location = use_location();
 
     Effect::new(move |_| {
         if let Some(world) = current_world() {
-            let world = world.name;
-            let query_map = query.get_untracked();
-            // `to_query_string()` already includes the leading `?` when the map
-            // is non-empty (and is "" when empty) — don't add another, or the
-            // URL becomes `/flip-finder/World??cols=…`, which parses the query
-            // key as `?cols` and silently drops the column selection on reload.
-            let query = query_map.to_query_string();
-            nav(
-                &format!("/flip-finder/{world}{query}"),
-                NavigateOptions {
-                    scroll: false,
-                    ..Default::default()
-                },
+            let url = world_nav_url(
+                "/flip-finder",
+                &world.name,
+                &location.pathname.get_untracked(),
+                &query.get_untracked(),
             );
+            if let Some(url) = url {
+                nav(
+                    &url,
+                    NavigateOptions {
+                        scroll: false,
+                        ..Default::default()
+                    },
+                );
+            }
         }
     });
 

--- a/ultros-frontend/ultros-app/src/routes/mod.rs
+++ b/ultros-frontend/ultros-app/src/routes/mod.rs
@@ -29,6 +29,7 @@ pub mod trends;
 pub mod vendor_resale;
 pub mod venture_analyzer;
 pub mod welcome;
+pub mod world_nav;
 
 pub mod legal {
     pub mod cookie_policy;

--- a/ultros-frontend/ultros-app/src/routes/trends.rs
+++ b/ultros-frontend/ultros-app/src/routes/trends.rs
@@ -16,7 +16,7 @@ use leptos::either::Either;
 use leptos::prelude::*;
 use leptos_router::{
     NavigateOptions,
-    hooks::{query_signal, use_navigate, use_params_map},
+    hooks::{query_signal, use_location, use_navigate, use_params_map, use_query_map},
 };
 use ultros_api_types::{icon_size::IconSize, trends::TrendItem};
 
@@ -39,6 +39,7 @@ use crate::{
         world_picker::WorldOnlyPicker,
     },
     global_state::LocalWorldData,
+    routes::world_nav::world_nav_url,
 };
 
 const DEFAULT_WINDOW: u16 = 30;
@@ -268,17 +269,29 @@ fn TrendsWorldNavigator() -> impl IntoView {
     });
 
     let (current_world, set_current_world) = signal(initial_world);
+    let query = use_query_map();
+    let location = use_location();
 
     Effect::new(move |_| {
         if let Some(world) = current_world() {
-            let world = world.name;
-            nav(
-                &format!("/trends/{world}"),
-                NavigateOptions {
-                    scroll: false,
-                    ..Default::default()
-                },
+            // This effect also runs on mount, where the world already matches
+            // the path. Navigating anyway — and without the query — wiped every
+            // filter out of a shared link as it hydrated (issue #1053).
+            let url = world_nav_url(
+                "/trends",
+                &world.name,
+                &location.pathname.get_untracked(),
+                &query.get_untracked(),
             );
+            if let Some(url) = url {
+                nav(
+                    &url,
+                    NavigateOptions {
+                        scroll: false,
+                        ..Default::default()
+                    },
+                );
+            }
         }
     });
 

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -21,6 +21,7 @@ use crate::{
     global_state::LocalWorldData,
     i18n::*,
     query_defaults::{DEFAULT_MAX_SALE_TIME, filter_query_signal, seed_query_default},
+    routes::world_nav::world_nav_url,
     ws::realtime::use_realtime,
 };
 use chrono::{Duration, Utc};
@@ -29,7 +30,7 @@ use icondata as i;
 use leptos::{either::Either, prelude::*};
 use leptos_router::{
     NavigateOptions,
-    hooks::{query_signal, use_navigate, use_params_map, use_query_map},
+    hooks::{query_signal, use_location, use_navigate, use_params_map, use_query_map},
 };
 use std::{cmp::Reverse, collections::HashMap, str::FromStr, sync::Arc};
 use ultros_api_types::{
@@ -809,19 +810,25 @@ fn VendorWorldNavigator() -> impl IntoView {
 
     let (current_world, set_current_world) = signal(initial_world);
     let query = use_query_map();
+    let location = use_location();
 
     Effect::new(move |_| {
         if let Some(world) = current_world() {
-            let world = world.name;
-            let query_map = query.get_untracked();
-            let query = query_map.to_query_string();
-            nav(
-                &format!("/vendor-resale/{world}?{query}"),
-                NavigateOptions {
-                    scroll: false,
-                    ..Default::default()
-                },
+            let url = world_nav_url(
+                "/vendor-resale",
+                &world.name,
+                &location.pathname.get_untracked(),
+                &query.get_untracked(),
             );
+            if let Some(url) = url {
+                nav(
+                    &url,
+                    NavigateOptions {
+                        scroll: false,
+                        ..Default::default()
+                    },
+                );
+            }
         }
     });
 

--- a/ultros-frontend/ultros-app/src/routes/world_nav.rs
+++ b/ultros-frontend/ultros-app/src/routes/world_nav.rs
@@ -1,0 +1,108 @@
+//! Shared URL builder for the tools that put the selected world in the path.
+//!
+//! Flip Finder, Vendor Resale and Market Trends all render a world picker
+//! whose `Effect` navigates to `/<tool>/<world>` when the pick changes. That
+//! effect also runs once on mount, so a navigation that forgets the query
+//! string doesn't just lose filters on a world switch — it wipes them out of
+//! a shared or bookmarked link the moment the page hydrates.
+//! `leptos_router`'s navigate builds the next URL purely from the path it is
+//! handed, so the query has to be carried across explicitly.
+
+use leptos_router::params::ParamsMap;
+
+/// Where a world picker should navigate, or `None` if it is already there.
+///
+/// Returning `None` for the no-op case matters as much as building the URL
+/// correctly: the effect runs on mount, and `query_signal`'s navigation is
+/// deferred to an animation frame. A redundant navigate on mount pushes a
+/// duplicate history entry (so Back appears dead) and re-sets the router's
+/// URL underneath any filter write that is still in flight.
+///
+/// `ParamsMap::to_query_string` already emits the leading `?` for a non-empty
+/// map (and `""` when empty), so this must not add one — `/trends/World??cat=8`
+/// parses the key as `?cat` and silently drops the filter on reload.
+pub fn world_nav_url(
+    base: &str,
+    world: &str,
+    current_path: &str,
+    query: &ParamsMap,
+) -> Option<String> {
+    let path = format!("{base}/{world}");
+    if path == current_path {
+        return None;
+    }
+    Some(format!("{path}{}", query.to_query_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn switching_world_keeps_a_bare_path_when_there_are_no_filters() {
+        let query = ParamsMap::new();
+        assert_eq!(
+            world_nav_url("/trends", "Gilgamesh", "/trends/Adamantoise", &query).as_deref(),
+            Some("/trends/Gilgamesh")
+        );
+    }
+
+    /// The regression behind issue #1053: filters live in the query string and
+    /// the trends navigator dropped them, so a shared link lost its filters and
+    /// a world switch reset them.
+    #[test]
+    fn filters_survive_a_world_switch() {
+        let mut query = ParamsMap::new();
+        query.insert("category", "10".to_string());
+        assert_eq!(
+            world_nav_url("/trends", "Gilgamesh", "/trends/Adamantoise", &query).as_deref(),
+            Some("/trends/Gilgamesh?category=10")
+        );
+    }
+
+    /// The other half of #1053: this effect also runs on mount, where the world
+    /// is already the one in the path. Navigating there again wiped the query.
+    #[test]
+    fn already_on_the_world_is_not_a_navigation() {
+        let mut query = ParamsMap::new();
+        query.insert("category", "10".to_string());
+        assert_eq!(
+            world_nav_url("/trends", "Gilgamesh", "/trends/Gilgamesh", &query),
+            None
+        );
+    }
+
+    /// A path that differs only in case is still a navigation — it canonicalizes
+    /// the world name the user typed.
+    #[test]
+    fn differing_case_still_navigates() {
+        let query = ParamsMap::new();
+        assert!(world_nav_url("/trends", "Gilgamesh", "/trends/gilgamesh", &query).is_some());
+    }
+
+    /// A doubled `?` is the failure mode a hand-written `format!("…?{query}")`
+    /// falls into once `to_query_string` supplies its own.
+    ///
+    /// Keys here are deliberately alphanumeric: `Url::escape` percent-encodes
+    /// with `NON_ALPHANUMERIC` under `ssr` but uses `encodeURIComponent` on
+    /// wasm, so a key like `min_price` is spelled `min%5Fprice` in this test
+    /// binary and `min_price` in the browser. Asserting on either spelling
+    /// would be asserting on which half of that `cfg` got compiled.
+    #[test]
+    fn never_emits_a_double_question_mark() {
+        let mut query = ParamsMap::new();
+        query.insert("category", "10".to_string());
+        query.insert("sort", "vwap".to_string());
+        let url = world_nav_url(
+            "/vendor-resale",
+            "Adamantoise",
+            "/vendor-resale/Cerberus",
+            &query,
+        )
+        .expect("a different world is a navigation");
+        assert_eq!(url.matches('?').count(), 1);
+        assert!(url.starts_with("/vendor-resale/Adamantoise?"));
+        assert!(url.contains("category=10"), "{url}");
+        assert!(url.contains("sort=vwap"), "{url}");
+    }
+}


### PR DESCRIPTION
Fixes #1053

## What was wrong

`TrendsWorldNavigator` ran an `Effect` that navigated to `/trends/{world}` with **no query string**. Two things go wrong there, and both were confirmed against prod before writing any code:

1. `leptos_router`'s navigate builds the next URL purely from the path it is handed — it does not carry the current query over. So the navigation drops `category`, `min_sales`, `min_price`, `sort`, `window` and `show_suspicious`, all of which live in the URL.
2. `Effect::new` always runs once on mount, so this fired with no user action at all.

Measured on prod by polling `location.href` every 300ms in a real browser:

```
load  /trends/Gilgamesh?category=10&min_price=500&min_sales=3
t+301ms  /trends/Gilgamesh          <- all three filters gone, select back to "All categories"
```

Filtered links were impossible to share or bookmark, and every world switch silently reset the filters.

`vendor_resale.rs` had a second, latent form of the same bug: `format!("/vendor-resale/{world}?{query}")` while `ParamsMap::to_query_string()` already emits its own leading `?`, producing `//vendor-resale/World??filter=…`, which parses the first key as `?filter`. `analyzer.rs` already had the correct form, with a comment warning about exactly this trap.

## The fix

One tested helper, `routes/world_nav.rs::world_nav_url`, used by all three world navigators (Market Trends, Flip Finder, Vendor Resale):

- carries the existing query string across the navigation, using `to_query_string()`'s own `?`;
- returns `None` when the path already points at the selected world — the mount case — so the redundant navigation doesn't happen at all.

That second half matters beyond this bug: `query_signal`'s write is deferred to an animation frame and applies its pending mutation inside whichever `navigate()` runs next, so a stray navigate can silently revert a filter write that is still in flight. It was also pushing a duplicate history entry on every mount, which made Back appear dead.

Five unit tests cover the helper: world switch with and without filters, the mount no-op, case-only path differences (still canonicalizes), and the doubled-`?` regression.

## Verification

- Root cause reproduced live on prod, as above.
- `cargo test -p ultros-app --lib world_nav` — 5 passed (CI does not run `cargo test`, so this was run locally).
- `./check_ci.sh` — clean (`cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings`).
- No new user-facing strings, so no locale changes.

## Not fixed here

Two things surfaced while investigating and are deliberately out of scope:

- **#1081** — `get_trends_v2` selects items with `.take(1500)` over a `BTreeMap` keyed by item id, so Market Trends only ever considers the **1500 lowest item ids**. Prod returns 63 items spanning ids 2–4650, all early-ARR. Whole categories — including the reporter's Pugilist's Arms — are legitimately empty for that reason, and will stay empty until that is fixed. Filed separately with a proposed ranking-based selection.
- The trends endpoint intermittently returns `{}` in prod (repeated identical requests alternate between a 28KB payload and 2 bytes; SSR alternates between 63 rendered rows and 0), which looks like one replica answering before `analyzer_service` warms. Noted in #1081.

I also checked the suspicion that `TrendsTable` taking rows as a by-value prop frozen in a dependency-free `Memo` breaks reactivity. It does not — the table re-rendered correctly on a category pick in prod (63 rows to 0), so I left that structure alone rather than refactor it on spec.
