### PR TITLE
feat(nav): swap home world by character from the sidebar

### DIFF
--- a/ultros-frontend/ultros-app/src/components/account_menu.rs
+++ b/ultros-frontend/ultros-app/src/components/account_menu.rs
@@ -11,6 +11,7 @@
 //!    switcher at all.
 
 use crate::api::get_login;
+use crate::components::character_switcher::CharacterSwitcher;
 use crate::components::icon::Icon;
 use crate::components::language_picker::LanguageAccordion;
 use crate::components::theme_picker::QuickThemeToggle;
@@ -99,6 +100,10 @@ pub fn AccountMenu() -> impl IntoView {
                             let signed_in = user.get().flatten().is_some();
                             if signed_in {
                                 view! {
+                                    // Switching home world is the most frequent
+                                    // thing a signed-in player does here, so it
+                                    // sits above the navigation links.
+                                    <CharacterSwitcher />
                                     <A href="/profile" attr:class="menu-item">
                                         <Icon icon=i::BsPersonCircle width="1.1em" height="1.1em" />
                                         <span class="ml-2">{t!(i18n, profile)}</span>

--- a/ultros-frontend/ultros-app/src/components/character_switcher.rs
+++ b/ultros-frontend/ultros-app/src/components/character_switcher.rs
@@ -1,0 +1,90 @@
+//! Home-world switcher driven by the user's claimed characters.
+//!
+//! Every character already carries its home world (the Lodestone tells us when
+//! the character is claimed), and most sidebar tools are world-scoped through
+//! the `HOME_WORLD` cookie. So switching characters in game gets a one-click
+//! equivalent here: pick the character you're playing and every world-aware
+//! route follows.
+//!
+//! Rendered inside the signed-in branch of the account drop-up, which is what
+//! keeps the character request from firing for anonymous visitors.
+
+use crate::api::get_characters;
+use crate::components::world_name::WorldName;
+use crate::global_state::LocalWorldData;
+use crate::global_state::home_world::use_home_world;
+use crate::i18n::{t, use_i18n};
+use leptos::prelude::*;
+use ultros_api_types::world_helper::AnySelector;
+
+#[component]
+pub fn CharacterSwitcher() -> impl IntoView {
+    let i18n = use_i18n();
+    let (homeworld, set_homeworld) = use_home_world();
+    let characters = Resource::new(|| (), |_| get_characters());
+
+    view! {
+        <Suspense fallback=|| ()>
+            {move || {
+                // A logged-out or failed request is indistinguishable from
+                // "no characters" here — both mean there is nothing to switch
+                // between, and the account menu is not the place to surface a
+                // fetch error.
+                let characters = characters.get().and_then(|c| c.ok()).unwrap_or_default();
+                (!characters.is_empty())
+                    .then(|| {
+                        view! {
+                            <div class="side-nav-section-header">{t!(i18n, characters)}</div>
+                            <div class="menu-accordion">
+                                {characters
+                                    .into_iter()
+                                    .map(|character| {
+                                        let world_id = character.world_id;
+                                        let selected = move || {
+                                            homeworld.get().is_some_and(|w| w.id == world_id)
+                                        };
+                                        view! {
+                                            <button
+                                                // The whole class string is rebuilt rather than
+                                                // toggling one name, so deselecting actually drops
+                                                // the highlight.
+                                                class=move || {
+                                                    if selected() {
+                                                        "menu-item menu-item-selected"
+                                                    } else {
+                                                        "menu-item"
+                                                    }
+                                                }
+                                                aria-pressed=move || selected().to_string()
+                                                on:click=move |_| {
+                                                    let world = use_context::<LocalWorldData>()
+                                                        .and_then(|w| w.0.ok())
+                                                        .and_then(|worlds| {
+                                                            worlds
+                                                                .lookup_selector(AnySelector::World(world_id))
+                                                                .and_then(|w| w.as_world().cloned())
+                                                        });
+                                                    if world.is_some() {
+                                                        set_homeworld(world);
+                                                    }
+                                                }
+                                            >
+                                                <span class="truncate">
+                                                    {character.first_name} " " {character.last_name}
+                                                </span>
+                                                <span class="menu-item-trailing">
+                                                    <WorldName id=AnySelector::World(world_id) />
+                                                </span>
+                                            </button>
+                                        }
+                                    })
+                                    .collect::<Vec<_>>()}
+                            </div>
+                            <div class="menu-divider"></div>
+                        }
+                    })
+            }}
+        </Suspense>
+    }
+    .into_any()
+}

--- a/ultros-frontend/ultros-app/src/components/mod.rs
+++ b/ultros-frontend/ultros-app/src/components/mod.rs
@@ -7,6 +7,7 @@ pub mod add_to_list;
 pub mod alert_config_drawer;
 pub mod alert_rules_panel;
 pub mod app_shell;
+pub mod character_switcher;
 pub mod chart_toolbar;
 pub mod cheapest_price;
 pub mod clipboard;


### PR DESCRIPTION
The second half of #1061: *"let users save the home world of the character and
surface that in the UI, that way as they change characters in game, they can
quickly swap characters in the sidebar as well."*

Independent of #1093 — it compiles and passes CI against `main` on its own, so
the two can merge in either order. **Merge #1093 first if you can**, though:
this PR carries the `Fixes`, and #1093 is what makes a character's stored world
trustworthy (see below).

No new storage was needed. `final_fantasy_character.world_id` already holds each
character's home world — the Lodestone gives it to us at claim time. The
switcher writes the selected character's world into the existing `HOME_WORLD`
cookie, the same signal `WorldOnlyPicker` in settings already drives. Every
world-scoped sidebar route (flip-finder, vendor-resale, trends, and the rest)
follows immediately, because they all build their URLs from that signal.

One caveat on `world_id` freshness: on `main` today, re-claiming a character
refreshes its name but not its world, so a character that transferred worlds
stays pinned to the old one and this switcher would send you somewhere wrong.
#1093 fixes that.

## Where it lives

Inside the account drop-up at the bottom of the sidebar, above Profile and
Settings — switching worlds is the most frequent thing a signed-in player does
there, so it goes first.

Mounting it in the signed-in branch is load-bearing, not cosmetic: the component
only exists once `get_login()` has resolved to a user, so anonymous visitors
never issue the `/api/v1/characters` request.

## Notes

- Zero new strings. It reuses the existing `characters` key and the
  `menu-item` / `menu-item-selected` / `menu-accordion` drop-up primitives, so
  there is no new CSS either.
- The active row is marked with `aria-pressed` and the selected background. The
  class is rebuilt as a whole string rather than toggled by name, so switching
  actually clears the previous highlight.
- Two characters on the same world both read as selected. That's honest rather
  than a bug: the cookie stores a world, not a character, and everything
  downstream is world-scoped.
- A user with no claimed characters sees no change at all — the section renders
  nothing rather than an empty header.

## Verification

`./check_ci.sh` passes (fmt + clippy `-D warnings`) against `main`, and
`cargo test -p ultros-app` passes locally (371 tests), since CI skips tests.

I did not exercise this in a running browser. The signed-in branch is only
reachable behind a real Discord OAuth session against a live Postgres and
ClickHouse, which isn't something I can stand up here. The component is small,
compiles, and reuses existing primitives, but the visual placement inside the
drop-up is worth a glance before merge.

Fixes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
