### PR TITLE
fix(seo): remove dead per-world sitemap endpoint, eager-load hero item icon (closes out #1003)

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1908,7 +1908,9 @@ fn ItemViewContent() -> impl IntoView {
                 <div class="flex flex-col gap-4 p-3 sm:p-4 border-b border-[color:var(--color-outline)] pb-6">
                     <div class="flex flex-col md:flex-row items-start gap-4">
                         <div class="flex items-center gap-4 flex-1">
-                            <ItemIcon item_id icon_size=IconSize::Large />
+                            // The hero icon is the LCP candidate on the item page —
+                            // eager-load it; every other icon stays lazy.
+                            <ItemIcon item_id icon_size=IconSize::Large loading="eager" />
                             <div class="flex flex-col min-w-0">
                                 <h1 class="text-3xl sm:text-4xl font-bold text-[color:var(--color-text)] flex items-center gap-2 leading-tight">
                                     {item_name}

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -87,7 +87,7 @@ use crate::web::api::{
     cheapest_per_world, get_best_deals, get_item_stats, get_market_heat, get_market_pulse,
     get_movers, get_trends, post_resale_quality, post_sparklines, recent_sales,
 };
-use crate::web::sitemap::{generic_pages_sitemap, item_sitemap, sitemap_index, world_sitemap};
+use crate::web::sitemap::{generic_pages_sitemap, item_sitemap, sitemap_index};
 use crate::web::{
     alerts_websocket::connect_websocket,
     item_card::item_card,
@@ -2437,7 +2437,6 @@ pub(crate) async fn start_web(
         .route("/robots.txt", get(robots))
         .route("/service-worker.js", get(service_worker_js))
         .route("/itemcard/{world}/{id}", get(item_card))
-        .route("/sitemap/world/{s}", get(world_sitemap))
         .route("/sitemap/items.xml", get(item_sitemap))
         .route("/sitemap.xml", get(sitemap_index))
         .route("/sitemap/pages.xml", get(generic_pages_sitemap))

--- a/ultros/src/web/sitemap.rs
+++ b/ultros/src/web/sitemap.rs
@@ -2,7 +2,7 @@ use super::error::WebError;
 use crate::analyzer_service::AnalyzerService;
 use anyhow::anyhow;
 use axum::{
-    extract::{Path, State},
+    extract::State,
     http::HeaderValue,
     response::{IntoResponse, Response},
 };
@@ -18,12 +18,9 @@ use sitemap_rs::{
     url::{ChangeFrequency, Url},
     url_set::UrlSet,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use ultros_api_types::world_helper::WorldHelper;
-use ultros_db::world_data::world_cache::{AnySelector, WorldCache};
+use ultros_db::world_data::world_cache::AnySelector;
 
 pub(crate) struct Xml(Vec<u8>);
 
@@ -42,29 +39,7 @@ impl IntoResponse for Xml {
     }
 }
 
-// State(world_cache): State<Arc<WorldCache>>,)
 pub(crate) async fn sitemap_index() -> Result<Xml, WebError> {
-    // Get all the worlds from the world cache and then populate the listings sitemap to point to all the world subsitemaps
-    // let mut sitemap_list: Vec<_> = world_cache
-    //     .get_inner_data()
-    //     .iter()
-    //     .flat_map(|(r, dcs)| {
-    //         [AnyResult::Region(r)]
-    //             .into_iter()
-    //             .chain(dcs.iter().flat_map(|(dc, worlds)| {
-    //                 [AnyResult::Datacenter(dc)]
-    //                     .into_iter()
-    //                     .chain(worlds.iter().map(|w| AnyResult::World(w)))
-    //             }))
-    //     })
-    //     .map(|name| {
-    //         Sitemap::new(
-    //             format!("https://ultros.app/sitemap/world/{}.xml", name.get_name()),
-    //             None,
-    //         )
-    //     })
-    //     .collect();
-    // add general page sitemap
     let sitemap_list = vec![
         Sitemap::new("https://ultros.app/sitemap/pages.xml".to_string(), None),
         Sitemap::new("https://ultros.app/sitemap/items.xml".to_string(), None),
@@ -213,44 +188,6 @@ pub(crate) async fn generic_pages_sitemap() -> Result<Xml, WebError> {
     }
 
     let url_set = UrlSet::new(urls)?;
-    let mut url_xml = Vec::new();
-    url_set
-        .write(&mut url_xml)
-        .map_err(|_| anyhow!("Error creating sitemap"))?;
-    Ok(Xml(url_xml))
-}
-
-pub(crate) async fn world_sitemap(
-    State(db): State<AnalyzerService>,
-    State(world_cache): State<Arc<WorldCache>>,
-    Path(world_name): Path<String>,
-) -> Result<Xml, WebError> {
-    // validate that this is a valid world name, then repeat back a sitemap using all the item ids
-
-    // handle .xml being in the path potentially
-    let world_name = match world_name.split_once('.') {
-        Some((left, _)) => left,
-        None => &world_name,
-    };
-
-    let result = world_cache.lookup_value_by_name(world_name)?;
-    // Create a unique list of item ids
-    let items: HashSet<_> = db
-        .read_cheapest_items(&AnySelector::from(&result), |items| {
-            items.item_map.keys().map(|k| k.item_id).collect()
-        })
-        .await?;
-    // format those item ids into urls based on the world name and generate a url set
-    let url_set = UrlSet::new(
-        items
-            .iter()
-            .map(|i| {
-                Url::builder(format!("https://ultros.app/item/{world_name}/{i}"))
-                    .build()
-                    .unwrap()
-            })
-            .collect(),
-    )?;
     let mut url_xml = Vec::new();
     url_set
         .write(&mut url_xml)


### PR DESCRIPTION
Fixes #1003

Closes out the SEO mechanical batch. Five of the seven items were already done or moot on main; this PR does the remaining two.

## What this PR changes

**1. Delete the dead `/sitemap/world/{s}` endpoint** (`ultros/src/web.rs`, `ultros/src/web/sitemap.rs`)

The route was registered but nothing ever linked to it: the sitemap-index code that would list per-world sitemaps has been commented out for years, so no crawler could discover the URL. Decision: **delete** rather than wire it in — per-world item sitemaps would multiply crawl surface for item pages already reachable from the item sitemap (which covers every marketable item id), and the endpoint has been dead this long without anyone missing it. Removed the route, the `world_sitemap` handler, the commented-out index block, and the imports that became unused.

**2. Eager-load the hero ItemIcon on the item page** (`ultros-frontend/ultros-app/src/routes/item_view.rs`)

The above-the-fold hero icon inherited `ItemIcon`'s default `loading="lazy"`, deprioritizing the LCP candidate image on the highest-traffic page type. It now passes `loading="eager"`. Only the hero icon changes — list/related-item icons stay lazy.

## Status of the other five items (why the issue can close)

| Item | Status |
|---|---|
| `og:title` uses `property` attribute | Done — landed via #1036 |
| Explorer facet canonicals | Done — landed via #1036 |
| robots.txt `Disallow` lines | Done — landed via #1036 |
| `/pkg` asset caching | Done — landed via #1036; itemcard `Cache-Control` also present (`ultros/src/web/item_card.rs:116`) |
| Sitemap category URL percent-encoding | Moot — category URLs are id-keyed since #1001 (`sitemap.rs`), no names to encode; `/currency-exchange` is in the pages sitemap |

Jules' earlier attempt at this issue (#1018) was closed unmerged and is superseded by this PR.

## Verification

- `./check_ci.sh` clean (fmt + clippy `-D warnings`).
- Local server: `GET /sitemap.xml` returns the index listing `pages.xml` + `items.xml`; `GET /sitemap/world/Cerberus.xml` now 404s.
- Local server: item page SSR HTML contains `loading="eager"` on the hero icon `<img>` and `loading="lazy"` on the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
