### PR TITLE
test(e2e): assert no page scrolls horizontally

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -111,6 +111,24 @@ const routes = ['/', '/items', '/flip-finder', '/flip-finder/Gilgamesh', '/analy
 
 Edit that array to add/remove pages you care about. Re-run `npm run test:desktop` or `npm run test:mobile` to generate fresh screenshots.
 
+## Horizontal-overflow guard
+
+Every route in both passes asserts that the page itself does not scroll sideways:
+
+```js
+document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1
+```
+
+`html` is `overflow-x: hidden`, so a document wider than the viewport is not merely ugly — the surplus is clipped with no scrollbar and no wrap, i.e. unreachable. That is how [#1055](https://github.com/akarras/ultros/issues/1055) presented: the Flip Finder's `Columns` and `Clear all` controls rendered outside the viewport.
+
+The assertion is on `documentElement`, never on descendants. Several surfaces are legitimately wider than the viewport and scroll inside their own scrollport — `.analyzer-hscroll` (the Flip Finder grid), `.filter-chip-row`, `.item-explorer-chip-row` — and measuring descendants would flag all of them. On failure the runner also lists the widest elements that are *not* inside a horizontal scrollport, so the message names the culprit rather than just a pixel count.
+
+**Known exceptions** live in `KNOWN_OVERFLOW` in `runner.cjs`, keyed by route, each naming the `devices` it applies to and a `reason`. They are not silent: a listed route that has *stopped* overflowing fails the run, so a fix cannot land without also deleting its exception. Scope `devices` as narrowly as the bug is — exempting a width where the route already fits would mask a future regression there.
+
+Set `SKIP_OVERFLOW=1` to disable the check.
+
+**What it does not cover:** headless Chrome uses overlay scrollbars, so `100vw === clientWidth` here. A page laid out against `100vw` while a real browser reserves a classic scrollbar gutter (the second half of PR #1082, which clipped ~15px off every desktop page) is invisible to this check. It guards content overflow, not viewport-unit mistakes.
+
 ## Changing viewport/device
 
 - Desktop: 1280×800

--- a/integration/runner.cjs
+++ b/integration/runner.cjs
@@ -14,6 +14,7 @@
  *  - STRICT_CONSOLE: "1" to fail on console errors / page errors (default "1")
  *  - CONSOLE_ALLOW: comma-separated substrings to ignore in console errors
  *  - SKIP_ASSERTS: "1" to skip per-route content assertions (default "0")
+ *  - SKIP_OVERFLOW: "1" to skip the horizontal-overflow assertion (default "0")
  */
 
 "use strict";
@@ -66,6 +67,33 @@ const ROUTE_ASSERTS = {
   "/groups": { titleIncludes: "Groups", bodyIncludesAny: ["Groups", "No groups found"] },
   "/privacy": { titleIncludes: "Ultros", bodyIncludesAny: ["privacy", "Privacy"] },
   "/cookie-policy": { titleIncludes: "Ultros", bodyIncludesAny: ["cookie", "Cookie"] },
+};
+
+/**
+ * Routes known to overflow horizontally right now. Each entry names the
+ * `devices` it applies to and the `reason`.
+ *
+ * These are *not* silently tolerated: a listed route that has stopped
+ * overflowing fails the run, so a fix cannot land without also deleting its
+ * exception. Scope `devices` as narrowly as the bug actually is — a route
+ * exempted at a width where it already fits would mask a future regression
+ * there. Keep this empty.
+ */
+const KNOWN_OVERFLOW = {
+  // github.com/akarras/ultros/issues/1055 — the Flip Finder's sticky control
+  // bar has no shrinkable item in its first row, so at phone widths the row
+  // grows past the viewport (~159px at 390px) instead of fitting. The row can
+  // neither wrap (the bar is height-locked; the table header consumes
+  // STICKY_BAR_HEIGHT as its sticky offset) nor scroll (it is the containing
+  // block for the saved-views/columns popovers), so the fix is to make it
+  // shrink — PR #1082. Delete this entry when that merges.
+  //
+  // Desktop is deliberately not listed: the same row already fits at 1280px,
+  // and this check is what proves it stays that way.
+  "/flip-finder/Gilgamesh": {
+    devices: ["mobile"],
+    reason: "#1055, fixed by PR #1082 (sticky control bar row 1 cannot shrink)",
+  },
 };
 
 // Substrings in console errors that we always ignore (third-party noise, expected hydration churn).
@@ -142,6 +170,101 @@ async function runAsserts(page, route, asserts) {
   return failures;
 }
 
+/**
+ * Assert the page itself does not scroll horizontally.
+ *
+ * `html` is `overflow-x: hidden`, so a document wider than the viewport is not
+ * merely ugly — the surplus is clipped with no scrollbar and no wrap, i.e.
+ * simply unreachable. That is how #1055 presented: the Flip Finder's "Columns"
+ * and "Clear all" controls rendered outside the viewport.
+ *
+ * The assertion is on `documentElement` deliberately. Several surfaces are
+ * legitimately wider than the viewport and scroll inside their own scrollport
+ * (`.analyzer-hscroll` for the Flip Finder grid, `.filter-chip-row`,
+ * `.item-explorer-chip-row`); measuring descendants would flag all of them.
+ *
+ * Caveat for whoever extends this: headless Chrome uses overlay scrollbars, so
+ * `100vw === clientWidth` here. A page laid out against `100vw` while the real
+ * browser reserves a classic scrollbar gutter — the other half of #1082 — is
+ * invisible to this check. It guards content overflow, not viewport-unit
+ * mistakes.
+ */
+async function checkHorizontalOverflow(page, route, device) {
+  const result = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const limit = doc.clientWidth + 1;
+    const offenders = [];
+
+    for (const el of document.querySelectorAll("body *")) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+      if (rect.right <= limit) continue;
+
+      const style = getComputedStyle(el);
+      // Viewport-anchored elements (toasts, full-bleed background layers) get
+      // stretched *by* an overflowing document rather than causing it.
+      if (style.position === "fixed") continue;
+
+      // Anything inside a horizontal scrollport is scrollable-to, not clipped.
+      let parent = el.parentElement;
+      let contained = false;
+      while (parent && parent !== document.body) {
+        const overflowX = getComputedStyle(parent).overflowX;
+        if (overflowX !== "visible") {
+          contained = true;
+          break;
+        }
+        parent = parent.parentElement;
+      }
+      if (contained) continue;
+
+      const cls = typeof el.className === "string" ? el.className : "";
+      offenders.push({
+        desc: (el.tagName.toLowerCase() + (cls ? `.${cls}` : "")).slice(0, 90),
+        right: Math.round(rect.right),
+      });
+    }
+
+    offenders.sort((a, b) => b.right - a.right);
+    return {
+      scrollWidth: doc.scrollWidth,
+      clientWidth: doc.clientWidth,
+      offenders: offenders.slice(0, 5),
+    };
+  });
+
+  const surplus = result.scrollWidth - result.clientWidth;
+  const overflows = surplus > 1;
+  const entry = KNOWN_OVERFLOW[route];
+  const known = entry && entry.devices.includes(device) ? entry : null;
+
+  if (known) {
+    if (overflows) {
+      console.warn(
+        `[warn] ${route} [${device}]: known horizontal overflow (${surplus}px) — ${known.reason}`,
+      );
+      return [];
+    }
+    return [
+      `horizontal overflow check: no longer overflows on ${device} — drop "${device}" from ` +
+        `the KNOWN_OVERFLOW entry for "${route}" (was: ${known.reason})`,
+    ];
+  }
+
+  if (!overflows) return [];
+
+  const blame = result.offenders.length
+    ? `; widest offenders: ${result.offenders
+        .map((o) => `${o.desc} (right=${o.right})`)
+        .join(", ")}`
+    : "";
+  return [
+    `horizontal overflow: document is ${surplus}px wider than the viewport ` +
+      `(scrollWidth ${result.scrollWidth} vs clientWidth ${result.clientWidth}) — ` +
+      `html{overflow-x:hidden} clips the surplus, so it cannot be scrolled to${blame}`,
+  ];
+}
+
 async function main() {
   const puppeteer = require("puppeteer");
 
@@ -151,6 +274,10 @@ async function main() {
   const TIMEOUT_MS = Number(process.env.TIMEOUT_MS || 60000);
   const STRICT_CONSOLE = envFlag("STRICT_CONSOLE", true);
   const SKIP_ASSERTS = envFlag("SKIP_ASSERTS", false);
+  const SKIP_OVERFLOW = envFlag("SKIP_OVERFLOW", false);
+  // Both device passes share this runner, and the same route can fit at one
+  // width and not the other, so failures name the width they were seen at.
+  const DEVICE_LABEL = isMobile ? "mobile" : "desktop";
   const userAllow = (process.env.CONSOLE_ALLOW || "")
     .split(",")
     .map((s) => s.trim())
@@ -173,7 +300,9 @@ async function main() {
   console.log(`[info] DEVICE=${isMobile ? "mobile" : "desktop"}`);
   console.log(`[info] OUTPUT_DIR=${outdir}`);
   console.log(`[info] HEADLESS=${headless}`);
-  console.log(`[info] STRICT_CONSOLE=${STRICT_CONSOLE} SKIP_ASSERTS=${SKIP_ASSERTS}`);
+  console.log(
+    `[info] STRICT_CONSOLE=${STRICT_CONSOLE} SKIP_ASSERTS=${SKIP_ASSERTS} SKIP_OVERFLOW=${SKIP_OVERFLOW}`,
+  );
   if (executablePath) console.log(`[info] USING_EXECUTABLE=${executablePath}`);
   console.log(`[info] CONCURRENCY=${CONCURRENCY}`);
 
@@ -241,6 +370,12 @@ async function main() {
           for (const f of fails) failures.push(`${r}: ${f}`);
         }
 
+        // Applies to every route, not just the ones with content assertions.
+        if (!SKIP_OVERFLOW) {
+          const fails = await checkHorizontalOverflow(page, r, DEVICE_LABEL);
+          for (const f of fails) failures.push(`${r} [${DEVICE_LABEL}]: ${f}`);
+        }
+
         if (STRICT_CONSOLE) {
           const newConsole = consoleErrors.slice(beforeConsole);
           const newPage = pageErrors.slice(beforePage);
@@ -252,8 +387,25 @@ async function main() {
         const filename = `${safe}-${isMobile ? "mobile" : "desktop"}.png`;
         const file = path.join(outdir, filename);
 
-        await page.screenshot({ path: file, fullPage: true });
-        console.log(`[ok] ${url} -> ${file}`);
+        // Chrome refuses to capture past an internal bitmap limit, and a route
+        // whose list is long enough (the Flip Finder grid against a data-rich
+        // instance) trips it. That used to reject out of the worker and take
+        // Promise.all — i.e. every remaining route's assertions — down with it.
+        // A screenshot is a diagnostic; it must not decide whether the suite runs.
+        try {
+          await page.screenshot({ path: file, fullPage: true });
+          console.log(`[ok] ${url} -> ${file}`);
+        } catch (e) {
+          console.warn(
+            `[warn] ${r}: full-page screenshot failed (${e && e.message}); capturing viewport only`,
+          );
+          try {
+            await page.screenshot({ path: file });
+            console.log(`[ok] ${url} -> ${file} (viewport only)`);
+          } catch (e2) {
+            console.warn(`[warn] ${r}: viewport screenshot also failed (${e2 && e2.message})`);
+          }
+        }
       }
       await page.close();
     };


### PR DESCRIPTION
Adds the regression guard PR #1082 names as its follow-up. **Harness-only — no app code, no strings, no behaviour change.**

## Why

`html` is `overflow-x: hidden`, so a document wider than the viewport is not merely ugly — the surplus is clipped with no scrollbar and no wrap, i.e. simply unreachable. That is how #1055 presented: the Flip Finder's `Columns` and `Clear all` rendered outside the viewport with no way to reach them.

It is pure layout, so nothing we run today can see it. It needs a browser.

## What it does

Every route in **both** device passes now asserts:

```js
document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1
```

On `documentElement` deliberately. `.analyzer-hscroll` (the Flip Finder grid), `.filter-chip-row` and `.item-explorer-chip-row` are all legitimately wider than the viewport and scroll inside their own scrollport — I confirmed empirically that a descendant-based check flags every one of them. Failures list the widest elements that are *not* inside a horizontal scrollport, so the message names a culprit rather than a pixel count.

Desktop is included as well as mobile: it costs nothing, passes today, and 1280px is exactly the width where #1082 argues the row is barely wider than at 768px.

`SKIP_OVERFLOW=1` disables it.

### Known exceptions do not rot

`KNOWN_OVERFLOW` is keyed by route, each entry naming the `devices` it applies to and a reason. It is **inverted**: a listed route that has *stopped* overflowing fails the run, so a fix cannot land without deleting its exception.

One entry today — `/flip-finder/Gilgamesh`, **mobile only**. That is #1055 itself, still open as #1082. Desktop is deliberately not listed because the row already fits at 1280px, and this check is what holds that.

## Heads up: #1082 has not merged, so this is red-by-design until it does

The brief I was given described #1082 as landed. It isn't — `style/tailwind.css:109` is still `html { width: 100vw }` and `.sticky-bar-button-shrink` does not exist on main. Hence the exception rather than a green guard. **When #1082 merges, the mobile pass will fail with a message telling you to delete the entry.** That is the intended nag; it is a one-line fix.

## Also: a failed screenshot no longer aborts the run

`/flip-finder/Gilgamesh` fails `Page.captureScreenshot` with *"Page is too large"* against a data-rich instance — Chrome refuses to capture past an internal bitmap limit. That rejection propagated out of the worker and took `Promise.all` down with it, so **every remaining route's assertions were skipped**. Only 15 of 16 screenshots were ever written and the run exited before reporting.

Confirmed pre-existing by reproducing it with the new check fully disabled (`SKIP_OVERFLOW=1`), i.e. behaviour identical to today's runner. It now falls back to a viewport screenshot and warns. A screenshot is a diagnostic; it must not decide whether the suite runs.

## Verification

Run against a live instance at both viewports, all 16 routes. **Zero overflow failures.**

Red direction, with the exception temporarily removed:

```
[fail] 1 assertion failure(s):
  - /flip-finder/Gilgamesh [mobile]: horizontal overflow: document is 159px wider than the
    viewport (scrollWidth 549 vs clientWidth 390) — html{overflow-x:hidden} clips the surplus,
    so it cannot be scrolled to; widest offenders: div.absolute inset-0 (right=549),
    button.sticky-bar-button (right=548), a.mobile-bar-slot (right=546),
    button.sticky-bar-button (right=471), svg (right=467)
```

`/` in the same run passed, so it is not a blanket failure. The offenders it names are the `.sticky-bar-button` controls #1082 makes shrinkable.

The device-scoping was not my first design — the desktop run caught it. My initial exception was device-blind, and desktop correctly reported it as stale because the route already fits at 1280px.

Three assertion failures remain, identical on both passes and untouched here — pre-existing `ROUTE_ASSERTS` drift, not overflow:

```
- /items:      title check: expected "Ultros" in "Items Explorer"     <- fixed by #1073
- /privacy:    title check: expected "Ultros" in "Privacy Policy"
- /item/46010: body check: none of [Fresh, Caution, Verify In-Game, No Data] found
```

`cargo fmt --all -- --check` passes. Clippy is unaffected (no Rust touched); `node --check` passes on the runner.

## What this does not cover

Headless Chrome uses overlay scrollbars, so `100vw === clientWidth` and desktop measures clean at 1280px **even with `html { width: 100vw }` live**. The second half of #1082 — every desktop page laid out ~15px wider than its space and clipped — is invisible to this check. It guards content overflow, not viewport-unit mistakes. Documented in the code and the README rather than left to imply coverage it doesn't have.

## Relationship to #1083

#1083 adds a narrower guard for the same bug: per-control `elementFromPoint` hit-testing on the Flip Finder bar at 360/393/414. This is the document-level one across all routes. Complementary — the only file both touch is `integration/package.json`, which this PR does not need to modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
