### PR TITLE
fix(alerts): clean up push_subscription and browser registration when deleting a WebPush endpoint

### DIFF
--- a/ultros-api-types/src/alert.rs
+++ b/ultros-api-types/src/alert.rs
@@ -155,6 +155,19 @@ pub struct UpdateEndpointRequest {
     pub method: Option<EndpointMethod>,
 }
 
+/// Response for `DELETE /api/v1/endpoints/{id}`.
+///
+/// When the deleted endpoint was `WebPush`, `push_endpoint` carries the
+/// push-service URL of the subscription that was removed alongside it. The
+/// browser that owns that subscription compares it against its own
+/// `PushSubscription.endpoint` and calls `pushManager.unsubscribe()` on a
+/// match; every other browser sees a URL that isn't theirs and leaves its own
+/// subscription alone. `None` for all other endpoint methods.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteEndpointResponse {
+    pub push_endpoint: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResendResult {
     pub delivered: bool,

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -8,8 +8,8 @@ use ultros_api_types::{
     ActiveListing, CurrentlyShownItem, FfxivCharacter, FfxivCharacterVerification,
     alert::{
         Alert, AlertEvent, CreateAlertRequest, CreateEndpointRequest,
-        CreatePushSubscriptionRequest, DiscordWritableGuild, Endpoint, ResendResult,
-        UpdateAlertRequest, UpdateEndpointRequest, VapidPublicKey,
+        CreatePushSubscriptionRequest, DeleteEndpointResponse, DiscordWritableGuild, Endpoint,
+        ResendResult, UpdateAlertRequest, UpdateEndpointRequest, VapidPublicKey,
     },
     cheapest_listings::{CheapestListings, CheapestListingsMap},
     item_stats::ItemStatsResponse,
@@ -656,7 +656,7 @@ pub(crate) async fn update_endpoint(id: i32, req: UpdateEndpointRequest) -> AppR
     patch_api(&format!("/api/v1/endpoints/{id}"), req).await
 }
 
-pub(crate) async fn delete_endpoint(id: i32) -> AppResult<()> {
+pub(crate) async fn delete_endpoint(id: i32) -> AppResult<DeleteEndpointResponse> {
     delete_api(&format!("/api/v1/endpoints/{id}")).await
 }
 

--- a/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
@@ -6,7 +6,9 @@ use crate::api::{
     create_endpoint, delete_endpoint, list_discord_writable_guilds, list_endpoints, test_endpoint,
 };
 use crate::components::icon::Icon;
-use crate::components::push_subscribe::enable_browser_notifications;
+use crate::components::push_subscribe::{
+    disable_browser_notifications, enable_browser_notifications,
+};
 use crate::global_state::toasts::use_toast;
 use crate::i18n::{t, t_string, use_i18n};
 
@@ -21,9 +23,18 @@ pub fn EndpointsPanel() -> impl IntoView {
     let on_delete = move |id: i32| {
         spawn_local(async move {
             match delete_endpoint(id).await {
-                Ok(()) => {
+                Ok(resp) => {
                     if let Some(t) = toasts {
                         t.success(t_string!(i18n, endpoints_deleted_toast));
+                    }
+                    // For WebPush endpoints the server also removed the push
+                    // subscription row and told us its push-service URL; if it
+                    // was this browser's own subscription, drop the live
+                    // registration too so the push service isn't left holding
+                    // a dead one. Best-effort — the server rows are gone
+                    // either way, and other devices' URLs simply won't match.
+                    if let Some(url) = resp.push_endpoint {
+                        let _ = disable_browser_notifications(&url).await;
                     }
                     version.update(|v| *v += 1);
                 }

--- a/ultros-frontend/ultros-app/src/components/push_subscribe.rs
+++ b/ultros-frontend/ultros-app/src/components/push_subscribe.rs
@@ -108,6 +108,69 @@ pub(crate) async fn enable_browser_notifications() -> SubscribeResult {
     Err("Web Push is only available in the browser".into())
 }
 
+/// Drop this browser's live `PushSubscription` if it matches `endpoint_url` —
+/// the push-service URL of a subscription the server just deleted (returned by
+/// `DELETE /api/v1/endpoints/{id}`). The comparison is what keeps multi-device
+/// setups safe: the endpoints panel lists every browser's endpoint, and
+/// deleting another device's row from here must not kill this browser's own
+/// subscription.
+///
+/// Returns whether an unsubscribe actually happened. Best-effort — the server
+/// rows are already gone, so callers treat failure as cosmetic.
+#[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
+pub(crate) async fn disable_browser_notifications(endpoint_url: &str) -> Result<bool, String> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use web_sys::{PushSubscription, ServiceWorkerRegistration};
+
+    let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
+    let sw_container = window.navigator().service_worker();
+
+    // No registration (getRegistration() resolves undefined) means this
+    // browser never subscribed — nothing to do.
+    let reg_js = JsFuture::from(sw_container.get_registration())
+        .await
+        .map_err(|_| "service worker lookup failed".to_string())?;
+    if reg_js.is_undefined() || reg_js.is_null() {
+        return Ok(false);
+    }
+    let registration: ServiceWorkerRegistration = reg_js
+        .dyn_into()
+        .map_err(|_| "service worker lookup returned wrong type".to_string())?;
+
+    let push = registration
+        .push_manager()
+        .map_err(|_| "push manager unavailable".to_string())?;
+    let sub_promise = push
+        .get_subscription()
+        .map_err(|_| "getSubscription call failed".to_string())?;
+    let sub_js = JsFuture::from(sub_promise)
+        .await
+        .map_err(|_| "getSubscription rejected".to_string())?;
+    if sub_js.is_null() || sub_js.is_undefined() {
+        return Ok(false);
+    }
+    let subscription: PushSubscription = sub_js
+        .dyn_into()
+        .map_err(|_| "getSubscription returned wrong type".to_string())?;
+
+    if subscription.endpoint() != endpoint_url {
+        return Ok(false);
+    }
+    let unsub_promise = subscription
+        .unsubscribe()
+        .map_err(|_| "unsubscribe call failed".to_string())?;
+    JsFuture::from(unsub_promise)
+        .await
+        .map_err(|_| "unsubscribe rejected".to_string())?;
+    Ok(true)
+}
+
+#[cfg(not(all(feature = "hydrate", target_arch = "wasm32")))]
+pub(crate) async fn disable_browser_notifications(_endpoint_url: &str) -> Result<bool, String> {
+    Err("Web Push is only available in the browser".into())
+}
+
 #[cfg(all(feature = "hydrate", target_arch = "wasm32"))]
 fn subscription_key_b64url(
     sub: &web_sys::PushSubscription,

--- a/ultros/src/web/api/endpoints.rs
+++ b/ultros/src/web/api/endpoints.rs
@@ -4,8 +4,8 @@ use axum::{
 };
 use serde_json::Value as JsonValue;
 use ultros_api_types::alert::{
-    CreateEndpointRequest, DiscordWritableGuild, Endpoint, EndpointMethod, ResendResult,
-    UpdateEndpointRequest,
+    CreateEndpointRequest, DeleteEndpointResponse, DiscordWritableGuild, Endpoint, EndpointMethod,
+    ResendResult, UpdateEndpointRequest,
 };
 use ultros_db::UltrosDb;
 
@@ -232,11 +232,43 @@ pub(crate) async fn delete_endpoint(
     State(db): State<UltrosDb>,
     user: AuthDiscordUser,
     Path(id): Path<i32>,
-) -> Result<Json<()>, ApiError> {
+) -> Result<Json<DeleteEndpointResponse>, ApiError> {
+    // Look the endpoint up before deleting it: a WebPush endpoint references
+    // its push_subscription row only through the JSON config (there's no FK),
+    // so the subscription has to be cleaned up here or it's orphaned forever.
+    let endpoint = db
+        .get_endpoint_owned_by(user.id as i64, id)
+        .await
+        .map_err(ApiError::from)?;
     db.delete_endpoint(user.id as i64, id)
         .await
         .map_err(ApiError::from)?;
-    Ok(Json(()))
+
+    let mut push_endpoint = None;
+    if let Ok(EndpointMethod::WebPush { subscription_id }) =
+        db_to_method(&endpoint.method, &endpoint.config)
+    {
+        // The lookup can miss legitimately: delivery deletes the subscription
+        // row itself when the push service reports it revoked, leaving the
+        // endpoint row behind. Nothing to clean up in that case.
+        if let Ok(sub) = db.get_push_subscription_by_id(subscription_id).await
+            && sub.user_id == user.id as i64
+        {
+            match db
+                .delete_push_subscription_by_id(user.id as i64, subscription_id)
+                .await
+            {
+                Ok(()) => push_endpoint = Some(sub.endpoint),
+                Err(e) => tracing::warn!(
+                    error = ?e,
+                    endpoint_id = id,
+                    subscription_id,
+                    "endpoint deleted but linked push subscription was not"
+                ),
+            }
+        }
+    }
+    Ok(Json(DeleteEndpointResponse { push_endpoint }))
 }
 
 pub(crate) async fn test_endpoint(
@@ -422,6 +454,17 @@ mod tests {
             let back = db_to_method(method, &config).unwrap();
             assert_eq!(m, back);
         }
+    }
+
+    #[test]
+    fn method_to_db_round_trip_web_push() {
+        // delete_endpoint relies on this parse to find the push_subscription
+        // row linked through the JSON config — there is no FK.
+        let m = EndpointMethod::WebPush { subscription_id: 7 };
+        let (method, config) = method_to_db(&m);
+        assert_eq!(method, "WebPush");
+        assert_eq!(config, json!({"subscription_id": 7}));
+        assert_eq!(db_to_method(method, &config).unwrap(), m);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`POST /api/v1/push/subscribe` had no unsubscribe counterpart. Deleting a WebPush notification endpoint via `DELETE /api/v1/endpoints/{id}` removed only the `notification_endpoint` row:

- the `push_subscription` row was **orphaned forever** — no FK links the tables; the endpoint's JSON config holds `{"subscription_id": N}` and nothing on the HTTP path ever used `UltrosDb::delete_push_subscription_by_id` (previously only called from `delivery.rs` on push-service revocation)
- the browser's live `PushSubscription` stayed registered because nothing called `pushManager.unsubscribe()`

## Fix

**Server** (`ultros/src/web/api/endpoints.rs`): `delete_endpoint` fetches the endpoint before deleting it; for WebPush it parses `subscription_id` via the existing `db_to_method`, deletes the linked `push_subscription` row, and returns the subscription's push-service URL in a new `DeleteEndpointResponse`. The subscription delete is best-effort with a `tracing::warn` — a missing row is normal, since delivery already deletes it itself when the push service reports the subscription revoked.

**Client** (`push_subscribe.rs` / `endpoints_panel.rs`): new `disable_browser_notifications(endpoint_url)` gets the current registration's subscription and calls `pushManager.unsubscribe()` **only when this browser's `PushSubscription.endpoint` matches the deleted URL**. The match check is what keeps multi-device setups safe: the endpoints panel lists every browser's endpoint, and deleting another device's row must not kill this browser's own subscription (other devices' URLs simply won't match).

The test-send flow (`POST /api/v1/endpoints/{id}/test`) and `integration/push.cjs` are untouched — neither exercises DELETE.

## Verification

- `./check_ci.sh` → exit 0 (fmt + workspace clippy `--all-targets -D warnings` + xiv-gen feature clippy)
- `cargo check -p ultros-client --target wasm32-unknown-unknown` → exit 0 (the new unsubscribe code is hydrate-only, which CI clippy never compiles)
- Added a `method_to_db`/`db_to_method` WebPush round-trip unit test guarding the config parse the delete handler relies on. Note: it lives in the `ultros` bin crate, whose test binary doesn't link on Windows/MSVC and CI doesn't run tests — it's compile-checked by clippy `--all-targets` but not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)