### PR TITLE
test(e2e): realign /privacy, /cookie-policy and /item asserts with what the app renders

### DIFF
--- a/integration/runner.cjs
+++ b/integration/runner.cjs
@@ -53,7 +53,18 @@ const ROUTE_ASSERTS = {
   "/items": { titleIncludes: "Ultros" },
   "/item/46010": {
     titleIncludes: "Ceremonial Shamshir",
-    bodyIncludesAny: ["Fresh", "Caution", "Verify In-Game", "No Data"],
+    // The freshness verdict words ("Fresh"/"Caution"/"Verify In-Game"/"No Data")
+    // are no longer visible text — FreshnessBadge shows the data age ("Data 1h
+    // 17m old") and moved the verdict into its `title` tooltip, which innerText
+    // never sees. Assert on the sales-cadence badge sitting beside it instead:
+    // same market-data header, and its four labels cover every data state
+    // (including "no sales"), so this still proves the page rendered its data.
+    bodyIncludesAny: [
+      "Fast mover",
+      "Steady mover",
+      "Slow mover",
+      "Not enough data",
+    ],
   },
   "/items/category/Gunbreaker's Arms": { titleIncludes: "Gunbreaker" },
   "/flip-finder": { titleIncludes: "Ultros" },
@@ -64,8 +75,10 @@ const ROUTE_ASSERTS = {
   "/history": { titleIncludes: "Ultros" },
   "/settings": { titleIncludes: "Ultros" },
   "/groups": { titleIncludes: "Groups", bodyIncludesAny: ["Groups", "No groups found"] },
-  "/privacy": { titleIncludes: "Ultros", bodyIncludesAny: ["privacy", "Privacy"] },
-  "/cookie-policy": { titleIncludes: "Ultros", bodyIncludesAny: ["cookie", "Cookie"] },
+  // Both legal pages set their own <MetaTitle> now, so neither falls back to the
+  // app-default title that carries "Ultros". Assert the page's own name instead.
+  "/privacy": { titleIncludes: "Privacy Policy", bodyIncludesAny: ["privacy", "Privacy"] },
+  "/cookie-policy": { titleIncludes: "Cookie Policy", bodyIncludesAny: ["cookie", "Cookie"] },
 };
 
 // Substrings in console errors that we always ignore (third-party noise, expected hydration churn).


### PR DESCRIPTION
Two `ROUTE_ASSERTS` entries in `integration/runner.cjs` had drifted from what the app actually renders, failing identically on desktop and mobile against a live instance:

```
- /privacy: title check: expected substring "Ultros" in "Privacy Policy"
- /item/46010: body check: none of [Fresh, Caution, Verify In-Game, No Data] found
```

## `/privacy` and `/cookie-policy` — pages set their own title now

Both legal routes render their own `<MetaTitle>` (`privacy_policy.rs:10`, `cookie_policy.rs:10`) instead of falling back to the app-default title, so neither carries "Ultros" by construction.

- `privacy_policy_title` is exactly `"Privacy Policy"` → the check failed.
- `cookie_policy_title` is `"Cookie Policy for Ultros"` → the check still *passed*, but only by coincidence of wording, not because it was asserting anything about the page.

Both now assert their own page name, so `/cookie-policy` is no longer one copy-edit away from breaking.

## `/item/46010` — the freshness verdict is tooltip-only, so the check was dead

The badge was **not** renamed or removed. `freshness_verify` is still in `en.json` and `item_view.rs:644` still renders `<FreshnessBadge>`. What changed is that the verdict words moved out of the visible text: `FreshnessVerdictDisplay::format_label` (`freshness.rs:115-121`) returns `"Data {{age}} old"` whenever an age is known, and the verdict now lives in the `title` attribute. Prod SSR:

```html
<span title="Fresh: Recent enough for this item's sales rate…">Data 1h 17m old</span>
```

`document.body.innerText` never sees a `title` attribute, so none of the four strings could ever match — the assertion had been dead rather than merely wrong. The code even says so at `freshness.rs:123`: *"the visible label only shows the data age."*

Rather than delete the check, it now asserts on the `SalesCadenceBadge` sitting beside it in the same `DecisionHeader` block:

```js
bodyIncludesAny: ["Fast mover", "Steady mover", "Slow mover", "Not enough data"]
```

Those four `sales_cadence_*` strings cover every branch of `get_sales_cadence` (`analysis.rs:29`) including the no-sales case, they render behind the same listing resource the old check depended on, and none of them appear anywhere in site chrome — so the assertion still proves the page rendered its market data and can't pass vacuously.

## Verification

- Ran against `https://ultros.app` on **both** desktop and mobile — both target failures gone.
- Negative control: replacing the cadence strings with nonsense makes the check fail, confirming it has teeth.
- Full suite on both devices now reports only `/items: expected substring "Ultros" in "Items Explorer"`, which is #1073's fix and is deliberately **not** duplicated here.
- No Rust touched, so `check_ci.sh` (fmt/clippy) is unaffected; `node --check runner.cjs` passes.

## Notes for the reviewer

**Relationship to #1073** — that PR fixes the third failure (`/items`) in the same file. This branch is based on `main` and does not touch that line; I test-merged the two and they **auto-merge cleanly**. I kept it off a stacked base deliberately, since stacked PRs in this repo get no CI at all.

**Pre-existing issue found but not fixed here:** `/flip-finder/Gilgamesh` now exceeds Chrome's fullPage screenshot limit:

```
[error] ProtocolError: Protocol error (Page.captureScreenshot): Page is too large.
```

Because all workers share a single `try/catch` in `main()`, that one screenshot failure aborts the run *before* the assertion summary prints — you get exit 1 with a stack trace and zero assertion results, which reads like a harness crash. It reproduces in isolation at `CONCURRENCY=1`. My full-suite runs above excluded that route to work around it. The fix is small (wrap `page.screenshot` in its own try/catch so a screenshot problem warns instead of hiding every assertion result) but it's out of scope for this change — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
