### PR TITLE
fix: retire the flip-finder overflow exception, restore send_webpush docs

### DIFF
--- a/integration/runner.cjs
+++ b/integration/runner.cjs
@@ -79,22 +79,7 @@ const ROUTE_ASSERTS = {
  * exempted at a width where it already fits would mask a future regression
  * there. Keep this empty.
  */
-const KNOWN_OVERFLOW = {
-  // github.com/akarras/ultros/issues/1055 — the Flip Finder's sticky control
-  // bar has no shrinkable item in its first row, so at phone widths the row
-  // grows past the viewport (~159px at 390px) instead of fitting. The row can
-  // neither wrap (the bar is height-locked; the table header consumes
-  // STICKY_BAR_HEIGHT as its sticky offset) nor scroll (it is the containing
-  // block for the saved-views/columns popovers), so the fix is to make it
-  // shrink — PR #1082. Delete this entry when that merges.
-  //
-  // Desktop is deliberately not listed: the same row already fits at 1280px,
-  // and this check is what proves it stays that way.
-  "/flip-finder/Gilgamesh": {
-    devices: ["mobile"],
-    reason: "#1055, fixed by PR #1082 (sticky control bar row 1 cannot shrink)",
-  },
-};
+const KNOWN_OVERFLOW = {};
 
 // Substrings in console errors that we always ignore (third-party noise, expected hydration churn).
 const DEFAULT_CONSOLE_ALLOW = [

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -236,6 +236,17 @@ async fn send_dm(
     Ok(())
 }
 
+/// Build the JSON body the service worker reads out of `event.data.json()`.
+/// `click_url` becomes `data.url`, which `notificationclick` opens — an alert
+/// that hardcodes this loses the user's actual destination.
+fn build_push_payload(title: &str, body: &str, click_url: &str) -> Result<Vec<u8>> {
+    Ok(serde_json::to_vec(&serde_json::json!({
+        "title": title,
+        "body": body,
+        "url": click_url,
+    }))?)
+}
+
 /// Send a Web Push notification to a single subscription. Body is JSON-encoded
 /// `{title, body, url}` — the service worker decodes that in its `push` handler.
 ///
@@ -251,17 +262,6 @@ async fn send_dm(
 /// (b) the crate's `From<isahc::Error>` impl discards the underlying cause and
 /// surfaces every transport failure as `WebPushError::Unspecified`, leaving
 /// operators with no signal about what actually broke.
-/// Build the JSON body the service worker reads out of `event.data.json()`.
-/// `click_url` becomes `data.url`, which `notificationclick` opens — an alert
-/// that hardcodes this loses the user's actual destination.
-fn build_push_payload(title: &str, body: &str, click_url: &str) -> Result<Vec<u8>> {
-    Ok(serde_json::to_vec(&serde_json::json!({
-        "title": title,
-        "body": body,
-        "url": click_url,
-    }))?)
-}
-
 async fn send_webpush(
     subscription_id: i32,
     title: &str,


### PR DESCRIPTION
Two follow-ups to today's merge batch of 20 PRs.

**1. Stale `KNOWN_OVERFLOW` exception (would have turned e2e red).**
#1101 landed the horizontal-overflow guard with an exception for `/flip-finder/Gilgamesh` on mobile, annotated "Delete this entry when [#1082] merges." #1082 has since merged. The guard is deliberately two-sided — a listed route that has *stopped* overflowing fails the run, so a fix cannot land without also retiring its exception — which means leaving this in place fails `npm run test:e2e` rather than passing quietly. `KNOWN_OVERFLOW` is now empty, which is the documented goal state.

**2. Misplaced doc comment from #1088.**
#1088 inserted `build_push_payload` *between* `send_webpush` and its doc comment. The result: an 15-line block about the libcurl/isahc client tradeoff and revoked-subscription soft-delete was documenting a three-line JSON helper, and `send_webpush` itself had no docs at all. Moved the helper above the block. No behaviour change.

## Verification
- `cargo fmt --all -- --check` — exit 0.
- `node --check integration/runner.cjs` — OK.
- Doc-comment move is a pure reordering; `git diff -M` shows no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)