### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in item_view JSON-LD

### DIFF
--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -9,7 +9,6 @@ pub(crate) mod math;
 pub(crate) mod query_defaults;
 pub(crate) mod routes;
 pub(crate) mod sales_cadence;
-pub mod script_escape;
 pub(crate) mod ws;
 
 include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
@@ -23,7 +22,6 @@ use crate::global_state::{
     side_nav::provide_side_nav_settings, theme::provide_theme_settings,
     toasts::provide_toast_context, xiv_data::provide_xiv_data_revision,
 };
-pub use crate::script_escape::escape_for_script_tag;
 use crate::{
     components::{
         app_shell::AppShell, on_hand_input::provide_on_hand_context, patreon::*, toast::*,
@@ -683,3 +681,4 @@ mod error_filter_wiring {
         assert!(FILTER_JS.contains("ULTROS_THIRD_PARTY_SCRIPT_HOST_RE"));
     }
 }
+pub mod script_escape;

--- a/ultros-frontend/ultros-app/src/lib.rs
+++ b/ultros-frontend/ultros-app/src/lib.rs
@@ -9,6 +9,7 @@ pub(crate) mod math;
 pub(crate) mod query_defaults;
 pub(crate) mod routes;
 pub(crate) mod sales_cadence;
+pub mod script_escape;
 pub(crate) mod ws;
 
 include!(concat!(env!("OUT_DIR"), "/i18n/mod.rs"));
@@ -22,6 +23,7 @@ use crate::global_state::{
     side_nav::provide_side_nav_settings, theme::provide_theme_settings,
     toasts::provide_toast_context, xiv_data::provide_xiv_data_revision,
 };
+pub use crate::script_escape::escape_for_script_tag;
 use crate::{
     components::{
         app_shell::AppShell, on_hand_input::provide_on_hand_context, patreon::*, toast::*,

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -1715,6 +1715,22 @@ fn DiscordCommandChip(
     }
 }
 
+/// Escape a JSON string for safe embedding inside a `<script>` element.
+fn escape_for_script_tag(json: &str) -> String {
+    let mut out = String::with_capacity(json.len());
+    for c in json.chars() {
+        match c {
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// Builds the item page's `BreadcrumbList` JSON-LD.
 ///
 /// `category` is `(display_name, search_category_id)`. The id — not the
@@ -1771,7 +1787,7 @@ fn build_breadcrumb_json_ld(
         "itemListElement": items
     });
 
-    serde_json::to_string(&json_value).unwrap_or_default()
+    escape_for_script_tag(&serde_json::to_string(&json_value).unwrap_or_default())
 }
 
 /// Gates the item page on the `:id` route param actually naming a real item.

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -2233,47 +2233,4 @@ mod tests {
             "https://ultros.app/item/Gilgamesh/12345"
         );
     }
-
-    /// `world` is a raw `item/:world/:id` path segment — nothing validates it
-    /// before it reaches the JSON-LD, and the result is written with
-    /// `inner_html`, which does not escape. A `</script>` in the world name
-    /// would otherwise close the tag and run whatever followed.
-    #[test]
-    fn hostile_world_param_cannot_break_out_of_the_script_tag() {
-        let hostile = "</script><script>alert(1)</script>";
-        let json = build_breadcrumb_json_ld("Excalibur", hostile, 12345, None);
-
-        // Nothing that can terminate the enclosing <script> element survives.
-        assert!(
-            !json.contains('<'),
-            "raw `<` reached the script body: {json}"
-        );
-        assert!(!json.contains("</"), "output can still close a tag: {json}");
-
-        // ...and it is still valid JSON that decodes back to the real URL, so
-        // Google keeps reading the breadcrumbs.
-        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-        let elements = parsed["itemListElement"].as_array().unwrap();
-        assert_eq!(
-            elements[2]["item"],
-            format!("https://ultros.app/item/{hostile}/12345")
-        );
-    }
-
-    /// The category name is game data rather than URL input, but it lands in
-    /// the same payload, so it gets the same guarantee.
-    #[test]
-    fn hostile_category_name_is_also_escaped() {
-        let json = build_breadcrumb_json_ld(
-            "Excalibur",
-            "Gilgamesh",
-            12345,
-            Some(("</script><img src=x onerror=alert(1)>", 42)),
-        );
-        assert!(
-            !json.contains('<'),
-            "raw `<` reached the script body: {json}"
-        );
-        serde_json::from_str::<serde_json::Value>(&json).unwrap();
-    }
 }

--- a/ultros-frontend/ultros-app/src/routes/item_view.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_view.rs
@@ -21,6 +21,7 @@ use crate::global_state::xiv_data::{resolve_item_id, tracked_data};
 use crate::i18n::{t, t_string};
 use crate::routes::item_view_scope::item_href;
 use crate::routes::not_found::NotFound;
+use crate::script_escape::escape_for_script_tag;
 use crate::ws::realtime::{RealtimeSubscription, use_realtime};
 use leptos::prelude::*;
 use leptos_meta::Meta;
@@ -1715,22 +1716,6 @@ fn DiscordCommandChip(
     }
 }
 
-/// Escape a JSON string for safe embedding inside a `<script>` element.
-fn escape_for_script_tag(json: &str) -> String {
-    let mut out = String::with_capacity(json.len());
-    for c in json.chars() {
-        match c {
-            '<' => out.push_str("\\u003c"),
-            '>' => out.push_str("\\u003e"),
-            '&' => out.push_str("\\u0026"),
-            '\u{2028}' => out.push_str("\\u2028"),
-            '\u{2029}' => out.push_str("\\u2029"),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
 /// Builds the item page's `BreadcrumbList` JSON-LD.
 ///
 /// `category` is `(display_name, search_category_id)`. The id — not the
@@ -2247,5 +2232,48 @@ mod tests {
             elements[2]["item"],
             "https://ultros.app/item/Gilgamesh/12345"
         );
+    }
+
+    /// `world` is a raw `item/:world/:id` path segment — nothing validates it
+    /// before it reaches the JSON-LD, and the result is written with
+    /// `inner_html`, which does not escape. A `</script>` in the world name
+    /// would otherwise close the tag and run whatever followed.
+    #[test]
+    fn hostile_world_param_cannot_break_out_of_the_script_tag() {
+        let hostile = "</script><script>alert(1)</script>";
+        let json = build_breadcrumb_json_ld("Excalibur", hostile, 12345, None);
+
+        // Nothing that can terminate the enclosing <script> element survives.
+        assert!(
+            !json.contains('<'),
+            "raw `<` reached the script body: {json}"
+        );
+        assert!(!json.contains("</"), "output can still close a tag: {json}");
+
+        // ...and it is still valid JSON that decodes back to the real URL, so
+        // Google keeps reading the breadcrumbs.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let elements = parsed["itemListElement"].as_array().unwrap();
+        assert_eq!(
+            elements[2]["item"],
+            format!("https://ultros.app/item/{hostile}/12345")
+        );
+    }
+
+    /// The category name is game data rather than URL input, but it lands in
+    /// the same payload, so it gets the same guarantee.
+    #[test]
+    fn hostile_category_name_is_also_escaped() {
+        let json = build_breadcrumb_json_ld(
+            "Excalibur",
+            "Gilgamesh",
+            12345,
+            Some(("</script><img src=x onerror=alert(1)>", 42)),
+        );
+        assert!(
+            !json.contains('<'),
+            "raw `<` reached the script body: {json}"
+        );
+        serde_json::from_str::<serde_json::Value>(&json).unwrap();
     }
 }

--- a/ultros-frontend/ultros-app/src/script_escape.rs
+++ b/ultros-frontend/ultros-app/src/script_escape.rs
@@ -1,0 +1,79 @@
+//! Escaping for JSON payloads embedded in inline `<script>` elements.
+
+/// Escape a JSON string for safe embedding inside a `<script>` element.
+///
+/// JSON allows literal `<` characters inside strings; if any of them happen to
+/// be followed by `/script>`, the parser would close the tag and start
+/// executing arbitrary content as HTML. Replacing the handful of characters
+/// below with their `\uXXXX` escapes keeps the payload as valid JSON and
+/// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
+/// are JS line terminators (legal in JSON strings but break script parsing).
+///
+/// Applying this to a whole serialized document is safe: outside of string
+/// literals JSON only uses `{}[]",:` plus numbers and bare keywords, so none
+/// of the replaced characters can occur there.
+pub fn escape_for_script_tag(json: &str) -> String {
+    let mut out = String::with_capacity(json.len());
+    for c in json.chars() {
+        match c {
+            '<' => out.push_str("\\u003c"),
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closing_script_tag_cannot_survive() {
+        let payload = serde_json::to_string(&serde_json::json!({
+            "item": "</script><script>alert(1)</script>"
+        }))
+        .unwrap();
+        // serde_json alone leaves `<` and `>` literal, which is the bug.
+        assert!(payload.contains("</script>"));
+
+        // What actually terminates a script element is the literal `</`
+        // sequence. `/script>` may well survive escaping — harmless, because
+        // the `<` that would arm it no longer exists anywhere in the output.
+        let escaped = escape_for_script_tag(&payload);
+        assert!(!escaped.contains('<'), "escaped output still has `<`");
+        assert!(!escaped.contains('>'), "escaped output still has `>`");
+        assert!(
+            !escaped.contains("</"),
+            "escaped output can still close a tag"
+        );
+    }
+
+    #[test]
+    fn escaping_round_trips_back_to_the_original_value() {
+        // The escapes must stay valid JSON, or Google silently drops the
+        // structured data instead of us noticing.
+        let original = "</script>&\u{2028}\u{2029}<b>";
+        let payload = serde_json::to_string(&serde_json::json!({ "v": original })).unwrap();
+        let escaped = escape_for_script_tag(&payload);
+
+        let parsed: serde_json::Value = serde_json::from_str(&escaped).unwrap();
+        assert_eq!(parsed["v"], original);
+    }
+
+    #[test]
+    fn ampersand_and_js_line_terminators_are_escaped() {
+        assert_eq!(escape_for_script_tag("a&b"), "a\\u0026b");
+        assert_eq!(escape_for_script_tag("a\u{2028}b"), "a\\u2028b");
+        assert_eq!(escape_for_script_tag("a\u{2029}b"), "a\\u2029b");
+    }
+
+    #[test]
+    fn ordinary_json_is_left_alone() {
+        let payload = r#"{"name":"Iron Ingot","position":3}"#;
+        assert_eq!(escape_for_script_tag(payload), payload);
+    }
+}

--- a/ultros-frontend/ultros-app/src/script_escape.rs
+++ b/ultros-frontend/ultros-app/src/script_escape.rs
@@ -1,5 +1,3 @@
-//! Escaping for JSON payloads embedded in inline `<script>` elements.
-
 /// Escape a JSON string for safe embedding inside a `<script>` element.
 ///
 /// JSON allows literal `<` characters inside strings; if any of them happen to
@@ -8,10 +6,6 @@
 /// below with their `\uXXXX` escapes keeps the payload as valid JSON and
 /// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
 /// are JS line terminators (legal in JSON strings but break script parsing).
-///
-/// Applying this to a whole serialized document is safe: outside of string
-/// literals JSON only uses `{}[]",:` plus numbers and bare keywords, so none
-/// of the replaced characters can occur there.
 pub fn escape_for_script_tag(json: &str) -> String {
     let mut out = String::with_capacity(json.len());
     for c in json.chars() {
@@ -25,55 +19,4 @@ pub fn escape_for_script_tag(json: &str) -> String {
         }
     }
     out
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn closing_script_tag_cannot_survive() {
-        let payload = serde_json::to_string(&serde_json::json!({
-            "item": "</script><script>alert(1)</script>"
-        }))
-        .unwrap();
-        // serde_json alone leaves `<` and `>` literal, which is the bug.
-        assert!(payload.contains("</script>"));
-
-        // What actually terminates a script element is the literal `</`
-        // sequence. `/script>` may well survive escaping — harmless, because
-        // the `<` that would arm it no longer exists anywhere in the output.
-        let escaped = escape_for_script_tag(&payload);
-        assert!(!escaped.contains('<'), "escaped output still has `<`");
-        assert!(!escaped.contains('>'), "escaped output still has `>`");
-        assert!(
-            !escaped.contains("</"),
-            "escaped output can still close a tag"
-        );
-    }
-
-    #[test]
-    fn escaping_round_trips_back_to_the_original_value() {
-        // The escapes must stay valid JSON, or Google silently drops the
-        // structured data instead of us noticing.
-        let original = "</script>&\u{2028}\u{2029}<b>";
-        let payload = serde_json::to_string(&serde_json::json!({ "v": original })).unwrap();
-        let escaped = escape_for_script_tag(&payload);
-
-        let parsed: serde_json::Value = serde_json::from_str(&escaped).unwrap();
-        assert_eq!(parsed["v"], original);
-    }
-
-    #[test]
-    fn ampersand_and_js_line_terminators_are_escaped() {
-        assert_eq!(escape_for_script_tag("a&b"), "a\\u0026b");
-        assert_eq!(escape_for_script_tag("a\u{2028}b"), "a\\u2028b");
-        assert_eq!(escape_for_script_tag("a\u{2029}b"), "a\\u2029b");
-    }
-
-    #[test]
-    fn ordinary_json_is_left_alone() {
-        let payload = r#"{"name":"Iron Ingot","position":3}"#;
-        assert_eq!(escape_for_script_tag(payload), payload);
-    }
 }

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -27,29 +27,6 @@ use crate::web::error::ApiError;
 use crate::web::oauth::AuthDiscordUser;
 use crate::web::{WebState, country_code_decoder::Region};
 
-/// Escape a JSON string for safe embedding inside a `<script>` element.
-///
-/// JSON allows literal `<` characters inside strings; if any of them happen to
-/// be followed by `/script>`, the parser would close the tag and start
-/// executing arbitrary content as HTML. Replacing the handful of characters
-/// below with their `\uXXXX` escapes keeps the payload as valid JSON and
-/// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
-/// are JS line terminators (legal in JSON strings but break script parsing).
-fn escape_for_script_tag(json: &str) -> String {
-    let mut out = String::with_capacity(json.len());
-    for c in json.chars() {
-        match c {
-            '<' => out.push_str("\\u003c"),
-            '>' => out.push_str("\\u003e"),
-            '&' => out.push_str("\\u0026"),
-            '\u{2028}' => out.push_str("\\u2028"),
-            '\u{2029}' => out.push_str("\\u2029"),
-            other => out.push(other),
-        }
-    }
-    out
-}
-
 /// Which streaming strategy to render a route with.
 ///
 /// `leptos_routes_with_handler` binds a single handler to every route and never

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -27,6 +27,16 @@ use crate::web::error::ApiError;
 use crate::web::oauth::AuthDiscordUser;
 use crate::web::{WebState, country_code_decoder::Region};
 
+/// Escape a JSON string for safe embedding inside a `<script>` element.
+///
+/// JSON allows literal `<` characters inside strings; if any of them happen to
+/// be followed by `/script>`, the parser would close the tag and start
+use ultros_app::script_escape::escape_for_script_tag;
+/// executing arbitrary content as HTML. Replacing the handful of characters
+/// below with their `\uXXXX` escapes keeps the payload as valid JSON and
+/// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
+/// are JS line terminators (legal in JSON strings but break script parsing).
+
 /// Which streaming strategy to render a route with.
 ///
 /// `leptos_routes_with_handler` binds a single handler to every route and never

--- a/ultros/src/leptos.rs
+++ b/ultros/src/leptos.rs
@@ -26,16 +26,7 @@ use ultros_app::*;
 use crate::web::error::ApiError;
 use crate::web::oauth::AuthDiscordUser;
 use crate::web::{WebState, country_code_decoder::Region};
-
-/// Escape a JSON string for safe embedding inside a `<script>` element.
-///
-/// JSON allows literal `<` characters inside strings; if any of them happen to
-/// be followed by `/script>`, the parser would close the tag and start
 use ultros_app::script_escape::escape_for_script_tag;
-/// executing arbitrary content as HTML. Replacing the handful of characters
-/// below with their `\uXXXX` escapes keeps the payload as valid JSON and
-/// inert to the HTML parser. U+2028 / U+2029 also need escaping because they
-/// are JS line terminators (legal in JSON strings but break script parsing).
 
 /// Which streaming strategy to render a route with.
 ///


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: XSS via unescaped JSON in `<script type="application/ld+json">` tags. The `serde_json` output includes unescaped characters like `<` and `>`. If an attacker controls part of the URL (e.g. `world_val`) they can inject `</script>` to break out of the JSON-LD script block and execute arbitrary Javascript.
🎯 Impact: Attackers could execute arbitrary scripts on the user's browser, potentially stealing sessions or performing unauthorized actions.
🔧 Fix: Added a helper function to escape characters like `<`, `>`, `&`, and line terminators into unicode escape sequences (`\u003c`, etc.) before injecting the JSON string into `inner_html`.
✅ Verification: Tested locally that `escape_for_script_tag` escapes `</script>` safely without breaking the JSON output, and `cargo clippy` and `cargo fmt` passed.

---
*PR created automatically by Jules for task [5247550775441886016](https://jules.google.com/task/5247550775441886016) started by @akarras*