### PR TITLE
fix(nav): hide the footer badges when the sidebar is collapsed

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -1938,8 +1938,14 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
 @media (min-width: 1024px) {
     .app-shell-collapsed .side-nav-label,
     .app-shell-collapsed .side-nav-section-header,
-    .app-shell-collapsed .side-nav-brand-text,
-    .app-shell-collapsed .side-nav-version {
+    .app-shell-collapsed .side-nav-brand-text {
+        display: none;
+    }
+    /* The whole footer goes, not just the version hash: 56px minus the row's
+       0.75rem side padding leaves 32px, which the Discord + GitHub pair
+       overflows — GitHub was clipped by the sidebar's right edge. Both links
+       are reachable again the moment the sidebar is expanded. */
+    .app-shell-collapsed .side-nav-footer {
         display: none;
     }
     .app-shell-collapsed .side-nav-item {
@@ -2067,15 +2073,16 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
            the viewport instead. `left` is unchanged in value: `.side-nav`
            is itself pinned to the viewport's left edge, so 0.35rem means
            the same thing whether measured from the sidebar or the
-           viewport. `bottom` is re-derived from the viewport instead,
-           approximating the collapsed footer row (~3.06rem: 2 x 0.75rem
-           padding + a 1.5rem icon row + border) plus the collapsed
-           trigger row (~3.1rem worst case, sized to the 32px avatar) plus
-           the same 0.35rem gap the expanded state uses above the trigger. */
+           viewport. `bottom` is re-derived from the viewport instead: the
+           account row is the bottom-most thing in the collapsed sidebar
+           (the footer is hidden at this width), so it only has to clear
+           the collapsed trigger row (~3.1rem worst case, sized to the
+           32px avatar) plus the same 0.35rem gap the expanded state uses
+           above the trigger. */
         position: fixed;
         left: 0.35rem;
         right: auto;
-        bottom: 6.5rem;
+        bottom: 3.5rem;
         width: 15rem;
     }
 }

--- a/ultros-frontend/ultros-app/src/components/side_nav.rs
+++ b/ultros-frontend/ultros-app/src/components/side_nav.rs
@@ -256,8 +256,11 @@ pub fn SideNav() -> impl IntoView {
                 </SideNavItem>
             </nav>
 
-            <AccountMenu />
-
+            // Footer sits ABOVE the account row so the account row is the
+            // bottom-most control. Collapsed, the 56px sidebar has no room for
+            // the Discord + GitHub pair (GitHub was clipped by the right edge)
+            // and the version hash is hidden anyway, so the whole footer is
+            // hidden at that width — see `.app-shell-collapsed .side-nav-footer`.
             <div class="side-nav-footer">
                 <a href=crate::DISCORD_INVITE class="side-nav-icon-link" aria-label="Discord">
                     <Icon icon=i::BsDiscord />
@@ -273,6 +276,8 @@ pub fn SideNav() -> impl IntoView {
                     {git_hash}
                 </a>
             </div>
+
+            <AccountMenu />
         </aside>
     }
     .into_any()


### PR DESCRIPTION
## What

Two changes to the sidebar's bottom stack:

1. **The account row is now the bottom-most control.** `<AccountMenu />` moved below `.side-nav-footer`.
2. **The Discord and GitHub badges only show when the sidebar is expanded.** `.app-shell-collapsed .side-nav-footer` is now `display: none`.

## Why

Collapsed, the sidebar is 56px. Minus `.side-nav-footer`'s `0.75rem` side padding, that leaves 32px of content width — which the Discord + GitHub icon pair overflows, so GitHub rendered half-clipped by the sidebar's right edge.

The row's third child, the version hash, was *already* hidden at that width (`.app-shell-collapsed .side-nav-version { display: none }`), so the footer had nothing left worth showing in the collapsed state. Hiding the whole row is a smaller rule than the alternative and removes the overflow at its source.

## Reviewer notes

- **Why hide rather than stack.** Stacking the two badges vertically would keep them reachable while collapsed, but it adds ~24px of chrome to the mode whose entire purpose is minimal width. Both links are one click away via the collapse toggle. Happy to switch to a stacked layout if you'd rather not lose them.
- **Mobile is unaffected.** `.app-shell-collapsed` stays on the shell below 1024px, but every collapse rule lives inside `@media (min-width: 1024px)` and the drawer renders at 280px — so the drawer keeps both badges. Explicitly measured (table below).
- **The drop-up's `bottom` had to move.** `.app-shell-collapsed .side-nav-account-panel` uses `position: fixed` to escape `.side-nav`'s scrollport, so its offset is measured from the viewport, not from its parent. It previously had to clear the footer row *and* the trigger row; now the account row is bottom-most and the footer is gone at that width, so it only clears the trigger. `6.5rem` → `3.5rem`. The comment above it was updated to match.
- The account panel in the expanded state is still `position: absolute` / `bottom: calc(100% + 0.35rem)` and needed no change — it grows upward, and sitting lower in the sidebar only gives it more room above.

## Verification

I built the real stylesheet with the cargo-leptos tailwind binary (`tailwindcss-v4.1.10 -i style/tailwind.css`) and measured the sidebar markup against it in a browser — rects, not eyeballing:

| | collapsed (56px) | expanded (240px) | mobile drawer (280px) |
|---|---|---|---|
| footer `display` | `none` | `flex` | `flex` |
| GitHub past nav's right edge | — | no (468 < 640) | no (68 < 280) |
| account row bottom-most | yes | yes | yes |
| drop-up overlaps trigger | no (6.4px gap) | no (5.6px gap) | — |
| drop-up off-screen top | no | no | — |

`cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` both exit 0.

## Base

Branched from `d900a040`, which was 28 commits behind `main`. Four of those commits touched these same two files (#1082, #1085, #1091, #1092), so the branch was reset onto `d5599a92` and the change re-applied before this PR. Both files applied cleanly and the browser verification above was re-run against the rebased stylesheet. The footer/account structure was unchanged by those commits, and #1091's new what's-new badge lives in `.side-nav-sections`, not the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
