### PR TITLE
⚡ Bolt: O(N) top items extraction in alert drawer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -58,3 +58,6 @@ When returning the top N items from a collection, first use `select_nth_unstable
 **Learning:** In `ultros-frontend/ultros-app/src/components/live_sale_ticker.rs`, a list of recent sales was fully sorted using `sorted_by_key` before taking the first 8 elements. Because sorting is an `O(N log N)` operation and the number of recent sales can be large, finding the top 8 elements in linear time `O(N)` reduces the time complexity and prevents UI jank on the main thread in WASM.
 
 **Action:** When finding the top N elements in a collection, use `select_nth_unstable_by_key` to partition the elements in linear time, followed by `truncate(N)` and `sort_unstable_by_key` on the remaining K elements.
+## 2024-11-20 - O(N) Top-K Extraction
+**Learning:** In WASM/frontend contexts, running a full `O(N log N)` sort on search results reactively as the user types can cause unnecessary main-thread blocking. Finding the top K elements can be optimized by using `select_nth_unstable_by_key(K)`, which partitions the array in `O(N)` time, followed by truncating the array to K and performing `sort_unstable_by_key` only on those K elements.
+**Action:** When extracting the top N items from a potentially large collection, avoid full sorts in hot reactive loops. Use `.select_nth_unstable_by_key(N)` followed by `.truncate(N)` and sorting only the remaining elements.

--- a/ultros-frontend/ultros-app/src/components/alert_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/alert_drawer.rs
@@ -96,10 +96,7 @@ pub fn AlertDrawer(
         }
         matches.sort_unstable_by_key(|(_, i)| Reverse(i.level_item));
 
-        matches
-            .into_iter()
-            .map(|(id, item)| (*id, item))
-            .collect()
+        matches.into_iter().map(|(id, item)| (*id, item)).collect()
     };
 
     let submit = move |_| {

--- a/ultros-frontend/ultros-app/src/components/alert_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/alert_drawer.rs
@@ -87,10 +87,17 @@ pub fn AlertDrawer(
             .filter(|(_, i)| i.item_search_category > 0)
             .filter(|(_, i)| i.name.to_lowercase().contains(&s_lower))
             .collect();
-        matches.sort_by_key(|(_, i)| Reverse(i.level_item));
+
+        // ⚡ Bolt Optimization: Use select_nth_unstable_by_key to avoid O(N log N) full sort
+        // when we only need the top 50 results. This reduces time complexity to O(N).
+        if matches.len() > 50 {
+            matches.select_nth_unstable_by_key(50, |(_, i)| Reverse(i.level_item));
+            matches.truncate(50);
+        }
+        matches.sort_unstable_by_key(|(_, i)| Reverse(i.level_item));
+
         matches
             .into_iter()
-            .take(50)
             .map(|(id, item)| (*id, item))
             .collect()
     };


### PR DESCRIPTION
### 💡 What: 
Refactored the item matches search algorithm in `alert_drawer.rs` to use `select_nth_unstable_by_key` to filter the top 50 search results before fully sorting them.

### 🎯 Why: 
Sorting the full list of `matches` before taking the top 50 requires `O(N log N)` computational time, which can trigger jank on the UI thread as the user types because this is calculated on every stroke for large matches arrays. Using `select_nth_unstable_by_key` filters down the `matches` list to the top 50 in linear `O(N)` time.

### 📊 Impact: 
Significantly reduces time complexity and execution time for the alert drawer's autocomplete search bar, mitigating UI thread freezes during typing.

### 🔬 Measurement: 
Profile the CPU usage and responsiveness when typing broad queries into the alert drawer item autocomplete input before and after.

---
*PR created automatically by Jules for task [9705930609568201001](https://jules.google.com/task/9705930609568201001) started by @akarras*