### PR TITLE
fix(trends): rank the ClickHouse candidate set by recent sales, not item id

### DIFF
--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -27,6 +27,7 @@ use ultros_db::{
 use universalis::{ItemId, WorldId};
 
 use crate::event::{BusRecv, EventReceivers, handle_bus_recv};
+use crate::trend_candidates::{TrendCandidate, select_trend_candidates};
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -1101,21 +1102,47 @@ impl AnalyzerService {
         if !self.initiated.load(Ordering::Relaxed) {
             return None;
         }
+        // Acquired in the same order as `get_trends` (sale history, then
+        // cheapest) so the two paths cannot deadlock against each other.
+        let sale_history = self.recent_sale_history.get(&world_id)?.read().await;
         let cheapest = self
             .cheapest_items
             .get(&AnySelector::World(world_id))?
             .read()
             .await;
 
-        // Build the request tuple list from every item the cheapest map
-        // knows about on this world. Cap to a sane upper bound so a fresh
-        // world with thousands of listings doesn't blow up the SQL.
+        // Build the request tuple list from the items the cheapest map
+        // knows about on this world, capped to a sane upper bound so a
+        // world with tens of thousands of listings doesn't blow up the
+        // SQL. Which items make the cut is a real decision rather than a
+        // truncation: the map is keyed on item id, so taking the first N
+        // would ask only about the N lowest ids in the game.
         const MAX_TUPLES: usize = 1500;
-        let mut requests: Vec<(i32, u8, i32)> = cheapest
-            .item_map
-            .iter()
-            .take(MAX_TUPLES)
-            .map(|(key, _)| (key.item_id, key.hq as u8, world_id))
+        let candidates = select_trend_candidates(
+            cheapest
+                .item_map
+                .keys()
+                .map(|key| {
+                    let buffered = sale_history.item_map.get(key);
+                    TrendCandidate {
+                        item_id: key.item_id,
+                        hq: key.hq,
+                        // `SaleHistory::add_sale` keeps the buffer sorted
+                        // newest-first, so the head is the latest sale.
+                        last_sale: buffered.and_then(|s| s.first()).map(|s| s.sale_date),
+                        buffered_sales: buffered.map_or(0, |s| s.len() as u8),
+                    }
+                })
+                .collect(),
+            MAX_TUPLES,
+        );
+        // Dropped before the ClickHouse round-trips below — live sale
+        // ingestion needs this lock to write, and a deep scan is slow.
+        drop(sale_history);
+
+        let mut requests: Vec<(i32, u8, i32)> = candidates
+            .into_iter()
+            .map(|c| (c.item_id, c.hq as u8, world_id))
             .collect();
         requests.sort_unstable();
         requests.dedup();

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -12,6 +12,7 @@ pub mod leptos;
 pub mod profiling;
 pub(crate) mod resale_eligibility;
 pub(crate) mod search_service;
+pub(crate) mod trend_candidates;
 pub(crate) mod utils;
 mod web;
 mod web_metrics;

--- a/ultros/src/trend_candidates.rs
+++ b/ultros/src/trend_candidates.rs
@@ -1,0 +1,207 @@
+//! Pure "which items should Market Trends ask ClickHouse about?" policy.
+//!
+//! Split out of `analyzer_service` for the same reason as
+//! `resale_eligibility`: so the choice is unit-testable without standing up
+//! an `AnalyzerService` (whose test binary does not link on Windows).
+//!
+//! Trends can only afford a bounded number of item tuples per request, so
+//! something has to pick. The obvious pick — iterate the cheapest-listings
+//! map and take the first N — is silently catastrophic, because that map is
+//! a `BTreeMap` keyed on item id: taking the first N takes the N *lowest
+//! item ids in the game*. Everything above that id boundary can never
+//! appear on the page no matter how briskly it trades, which is why whole
+//! categories render empty.
+//!
+//! The signal used instead is the one the page is actually about: has this
+//! item sold recently. That is the same driver the v1 `get_trends` path
+//! uses (it iterates the sale history and looks the cheapest price up),
+//! and it is available in-process from the analyzer's per-world sale
+//! buffer — no extra query.
+
+use std::cmp::Reverse;
+
+use chrono::NaiveDateTime;
+
+/// A listed item on one world, plus whatever recent-sale signal the
+/// analyzer has buffered for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TrendCandidate {
+    pub(crate) item_id: i32,
+    pub(crate) hq: bool,
+    /// When this item most recently sold on this world, if the analyzer's
+    /// bounded buffer has seen it sell at all.
+    pub(crate) last_sale: Option<NaiveDateTime>,
+    /// How many sales are currently buffered for it (saturates at the
+    /// buffer size, so it separates "trades constantly" from "sold once").
+    pub(crate) buffered_sales: u8,
+}
+
+/// Total order on "how much does this item belong on the Trends page",
+/// most relevant first.
+///
+/// Sorting by a tuple that ends in the item id keeps this a *total* order,
+/// so the selection is deterministic — two replicas answering the same
+/// request pick the same items.
+fn relevance(
+    candidate: &TrendCandidate,
+) -> (Reverse<Option<NaiveDateTime>>, Reverse<u8>, i32, bool) {
+    // `None` sorts below every `Some`, so reversing puts the most recently
+    // traded items first and the never-seen-selling ones last.
+    (
+        Reverse(candidate.last_sale),
+        Reverse(candidate.buffered_sales),
+        candidate.item_id,
+        candidate.hq,
+    )
+}
+
+/// Keep the `max` most relevant candidates, most relevant first.
+///
+/// Items the analyzer has never seen sell keep their old relative order
+/// (ascending item id) at the back of the list, so a world whose sale
+/// buffer is still cold behaves exactly as it did before this existed.
+pub(crate) fn select_trend_candidates(
+    mut candidates: Vec<TrendCandidate>,
+    max: usize,
+) -> Vec<TrendCandidate> {
+    if max == 0 {
+        return Vec::new();
+    }
+    // Partition before sorting so a board of tens of thousands of listed
+    // items costs O(n) rather than O(n log n); `relevance` is a total
+    // order, so the unstable variants are safe here.
+    if candidates.len() > max {
+        candidates.select_nth_unstable_by_key(max, relevance);
+        candidates.truncate(max);
+    }
+    candidates.sort_unstable_by_key(relevance);
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn at(day: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 8, day)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap()
+    }
+
+    /// A listed item the sale buffer has never seen sell.
+    fn dormant(item_id: i32) -> TrendCandidate {
+        TrendCandidate {
+            item_id,
+            hq: false,
+            last_sale: None,
+            buffered_sales: 0,
+        }
+    }
+
+    /// A listed item that sold on `day`, with `count` sales buffered.
+    fn traded(item_id: i32, day: u32, count: u8) -> TrendCandidate {
+        TrendCandidate {
+            item_id,
+            hq: false,
+            last_sale: Some(at(day)),
+            buffered_sales: count,
+        }
+    }
+
+    fn ids(picked: &[TrendCandidate]) -> Vec<i32> {
+        picked.iter().map(|c| c.item_id).collect()
+    }
+
+    /// The regression. Candidates arrive in ascending item-id order because
+    /// the cheapest-listings map is a `BTreeMap`, so a budget spent in
+    /// arrival order buys nothing but the oldest items in the game.
+    #[test]
+    fn an_actively_traded_high_id_item_beats_dormant_low_id_items() {
+        // Ids 2 and 3 are early-ARR junk sitting on the board; 44242 is a
+        // current-expansion item that sold twice today.
+        let candidates = vec![dormant(2), dormant(3), traded(44242, 10, 6)];
+
+        let picked = select_trend_candidates(candidates, 2);
+
+        assert!(
+            ids(&picked).contains(&44242),
+            "the only item that actually traded was dropped in favour of \
+             two dormant low-id items; picked {:?}",
+            ids(&picked)
+        );
+    }
+
+    #[test]
+    fn more_recently_traded_items_rank_first() {
+        let candidates = vec![traded(100, 1, 6), traded(200, 20, 6), traded(300, 10, 6)];
+
+        let picked = select_trend_candidates(candidates, 3);
+
+        assert_eq!(ids(&picked), vec![200, 300, 100]);
+    }
+
+    #[test]
+    fn ties_on_recency_break_on_how_much_is_buffered() {
+        let candidates = vec![traded(100, 5, 1), traded(200, 5, 6), traded(300, 5, 3)];
+
+        let picked = select_trend_candidates(candidates, 3);
+
+        assert_eq!(ids(&picked), vec![200, 300, 100]);
+    }
+
+    /// A world whose sale buffer is still cold must behave exactly as it
+    /// did before relevance ranking existed: ascending item id.
+    #[test]
+    fn a_cold_sale_buffer_falls_back_to_ascending_item_id() {
+        let candidates = vec![dormant(2), dormant(3), dormant(44242)];
+
+        let picked = select_trend_candidates(candidates, 2);
+
+        assert_eq!(ids(&picked), vec![2, 3]);
+    }
+
+    #[test]
+    fn every_traded_item_outranks_every_dormant_one() {
+        let candidates = vec![
+            dormant(1),
+            traded(50_000, 1, 1),
+            dormant(2),
+            traded(40_000, 2, 1),
+        ];
+
+        let picked = select_trend_candidates(candidates, 4);
+
+        assert_eq!(ids(&picked), vec![40_000, 50_000, 1, 2]);
+    }
+
+    #[test]
+    fn hq_and_lq_of_one_item_are_separate_candidates_in_a_stable_order() {
+        let lq = TrendCandidate {
+            item_id: 5,
+            hq: false,
+            last_sale: Some(at(3)),
+            buffered_sales: 2,
+        };
+        let hq = TrendCandidate { hq: true, ..lq };
+
+        let picked = select_trend_candidates(vec![hq, lq], 2);
+
+        assert_eq!(picked, vec![lq, hq], "lq must sort ahead of hq on ties");
+    }
+
+    #[test]
+    fn a_budget_larger_than_the_board_keeps_everything() {
+        let candidates = vec![traded(100, 1, 1), dormant(2)];
+
+        let picked = select_trend_candidates(candidates, 500);
+
+        assert_eq!(ids(&picked), vec![100, 2]);
+    }
+
+    #[test]
+    fn a_zero_budget_selects_nothing() {
+        assert!(select_trend_candidates(vec![traded(100, 1, 1)], 0).is_empty());
+    }
+}


### PR DESCRIPTION
Fixes #1081.

## The bug

`get_trends_v2` built its ClickHouse request set like this:

```rust
let mut requests: Vec<(i32, u8, i32)> = cheapest
    .item_map
    .iter()
    .take(MAX_TUPLES)   // 1500
```

`item_map` is a `BTreeMap<ItemKey, _>` and `ItemKey` orders on `item_id` first, so
"take the first 1500" means **take the 1500 lowest item ids in the game**. Everything
above that id boundary can never appear on Market Trends no matter how briskly it
trades. That is not a truncation of a ranked list — the cap *is* the ranking, and it
ranks by "how early in FFXIV's history was this item added".

## Measured on prod, just now

Same world, same instant. `/api/v1/movers/{world}` is a clean control: it queries
ClickHouse **directly** and never goes through the analyzer's candidate selection.

| endpoint | rows | max item id | ids > 10000 |
| --- | --- | --- | --- |
| `/api/v1/trends/Gilgamesh?window=30` | 500 | **4661** | **0** |
| `/api/v1/movers/Gilgamesh` | 10 | **51958** | 8 |

Trends is returning a *full* 500-row page — it just cannot see past item id ~4700.
Sargatanas is the same shape (500 rows, max id 4700, zero above 10000).

The sharpest version: of the true **top 50 items by unit volume** on Gilgamesh
(`/api/v1/movers/Gilgamesh?direction=volume&limit=50`, straight out of ClickHouse),
**35 have ids above 4700** — so 70% of the highest-volume items on the world are
structurally invisible to a page whose default sort is *"units traded, descending"*.

Because `movers` reads the same rollup, this also confirms the rollup **does** have
coverage for those high-id items. Trends simply never asked about them.

## The fix

Rank the candidates by the signal the page is actually about — has this item sold
recently — and *then* apply the cap. That signal is already in-process: the analyzer's
per-world sale buffer (`recent_sale_history`). No extra query, no schema change.

This is also what the v1 `get_trends` path has always done — it drives off the sale
history and looks the cheapest price up, rather than the other way round. v2 regressed
the driver when it moved to ClickHouse aggregates.

The policy lives in a new `ultros/src/trend_candidates.rs`, split out for the same
reason `resale_eligibility.rs` was: so it is unit-testable without standing up an
`AnalyzerService`. Ordering is `(last_sale desc, buffered_sales desc, item_id, hq)` —
a **total** order, so two replicas answering the same request pick the same items.

Two properties worth calling out:

- **It cannot regress a cold world.** Items the sale buffer has never seen sell sort
  last, among themselves by ascending item id — exactly today's behaviour. A world
  whose buffer is still cold behaves identically to before. There is a test for this.
- **It stays O(n).** `select_nth_unstable_by` partitions before sorting, so a board of
  tens of thousands of listed items doesn't pay a full sort.

`MAX_TUPLES` stays at 1500. The cap was never the problem; what it selected was.

Also in this diff: the sale-history lock is taken in the **same order** as `get_trends`
(sale history, then cheapest) so the two paths can't deadlock against each other, and
it is explicitly dropped before the ClickHouse round-trips — live sale ingestion needs
that lock to write and a deep scan is slow.

## Verification

⚠️ Read this bit rather than assuming the tests in the diff ran in CI — they did not.

`ultros` is a bin-only crate (`main.rs`, no `lib.rs`), so its test binary does not link
on Windows/MSVC (the pre-existing `LNK1120 ... _10ultros_app` wall), and CI has the
test step commented out in `rust.yml`. So I made the new module **dependency-free**
(`chrono` + std only) and ran its tests through a standalone harness crate that
`#[path]`-includes the real shipped file — meaning the tests below are literally the
tests in this diff, executed against the file as committed, not a copy.

Genuine red → green, one behaviour at a time:

- **RED** (module implemented with today's `take(max)` semantics): `REAL_EXIT=101`,
  **5 failed / 3 passed**. The headline test failed with the exact prod symptom —
  `the only item that actually traded was dropped in favour of two dormant low-id
  items; picked [2, 3]`. The 3 that passed are the preserved-behaviour tests, which
  should pass on both sides of the fix.
- **GREEN** (after the ranking fix): `REAL_EXIT=0`, **8 passed / 0 failed**.

Gates:

- `cargo fmt --all -- --check` → exit 0
- `cargo clippy -p ultros --all-targets -- -D warnings` → exit 0 (this pulls in
  `ultros-app`, `ultros-db` and `ultros-clickhouse`, so the whole `ssr` path
  type-checks). Full-workspace clippy not run; the diff is confined to the `ultros`
  crate.

## What this does not do

It does not touch the **second** half of #1081 — prod flapping between a populated
payload and `{}` (one replica answering before `analyzer_service` warms). That is a
separate fix and the issue should stay open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
