### PR TITLE
⚡ Bolt: Optimize top N item extraction with select_nth_unstable

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,8 @@ When returning the top N items from a collection, first use `select_nth_unstable
 ## 2024-11-20 - O(N) Top-K Extraction
 **Learning:** In WASM/frontend contexts, running a full `O(N log N)` sort on search results reactively as the user types can cause unnecessary main-thread blocking. Finding the top K elements can be optimized by using `select_nth_unstable_by_key(K)`, which partitions the array in `O(N)` time, followed by truncating the array to K and performing `sort_unstable_by_key` only on those K elements.
 **Action:** When extracting the top N items from a potentially large collection, avoid full sorts in hot reactive loops. Use `.select_nth_unstable_by_key(N)` followed by `.truncate(N)` and sorting only the remaining elements.
+## 2024-08-04 - Optimize top N item extraction with select_nth_unstable
+**Learning:**
+In `ultros-db/src/sales.rs` and `ultros/src/discord/ffxiv/analyze.rs`, taking the top N elements of a slice using a full sort (`sort_by_key`/`sort_unstable_by_key` followed by `.truncate()` or `.take()`) takes $O(M \log M)$ time. When returning the top N items from a potentially large collection, avoid full sorts.
+**Action:**
+Use `select_nth_unstable_by_key(N)` followed by `.truncate(N)` and sorting only the remaining $N$ elements to partition the array in $O(M)$ time and do the $O(N \log N)$ sort only on the truncated array. Guard it with `if slice.len() > limit`.

--- a/ultros-db/src/sales.rs
+++ b/ultros-db/src/sales.rs
@@ -127,8 +127,14 @@ impl UltrosDb {
         .await;
 
         let mut sales: Vec<_> = all?.into_iter().flat_map(|w| w.into_iter()).collect();
-        sales.sort_by_key(|sale| std::cmp::Reverse(sale.sold_date));
-        sales.truncate(limit as usize);
+
+        // ⚡ Bolt: Optimization: Extract top N elements in O(N) time with select_nth_unstable_by_key before sorting
+        let limit_usize = limit as usize;
+        if sales.len() > limit_usize {
+            sales.select_nth_unstable_by_key(limit_usize, |sale| std::cmp::Reverse(sale.sold_date));
+            sales.truncate(limit_usize);
+        }
+        sales.sort_unstable_by_key(|sale| std::cmp::Reverse(sale.sold_date));
 
         let buyers = unknown_final_fantasy_character::Entity::find()
             .filter(
@@ -221,8 +227,14 @@ impl UltrosDb {
         )
         .await?;
         let mut sales: Vec<sale_history::Model> = per_world.into_iter().flatten().collect();
-        sales.sort_by_key(|s| std::cmp::Reverse(s.sold_date));
-        sales.truncate(limit as usize);
+
+        // ⚡ Bolt: Optimization: Extract top N elements in O(N) time with select_nth_unstable_by_key before sorting
+        let limit_usize = limit as usize;
+        if limit_usize > 0 && sales.len() > limit_usize {
+            sales.select_nth_unstable_by_key(limit_usize, |s| std::cmp::Reverse(s.sold_date));
+            sales.truncate(limit_usize);
+        }
+        sales.sort_unstable_by_key(|s| std::cmp::Reverse(s.sold_date));
         Ok(sales)
     }
 

--- a/ultros/src/discord/ffxiv/analyze.rs
+++ b/ultros/src/discord/ffxiv/analyze.rs
@@ -66,9 +66,14 @@ pub(crate) async fn profit(
         .get_best_resale(world_id, region_id, resale, &ctx.data().world_cache)
         .await
         .ok_or(anyhow::anyhow!("Unable to get resale results"))?;
-    sales.sort_by_key(|s| std::cmp::Reverse(s.profit));
     let total_results = sales.len();
-    let sales = sales.into_iter().take(15);
+    // ⚡ Bolt: Optimization: Extract top N elements in O(N) time with select_nth_unstable_by_key before sorting
+    if sales.len() > 15 {
+        sales.select_nth_unstable_by_key(15, |s| std::cmp::Reverse(s.profit));
+        sales.truncate(15);
+    }
+    sales.sort_unstable_by_key(|s| std::cmp::Reverse(s.profit));
+    let sales = sales.into_iter();
     ctx.send(poise::CreateReply::default().embed(
         poise::serenity_prelude::CreateEmbed::new()
             .title("Flip Finder")


### PR DESCRIPTION
💡 **What:** Optimized top K element extraction by utilizing `select_nth_unstable_by_key` before sorting the final elements.
🎯 **Why:** Previously, the application was using `sort_by_key` or `sort_unstable_by_key` to fully sort the slice of size $M$ before performing `.truncate(N)` or `.take(N)`, taking $O(M \log M)$ time. `select_nth_unstable_by_key` allows finding the top $N$ elements in linear $O(M)$ time, reducing unnecessary sorting work. 
📊 **Impact:** Provides significant CPU time improvements whenever the limit is significantly smaller than the total results.
🔬 **Measurement:** Verify CPU profile to confirm `sort_by_key` time drops during heavy DB sales history access patterns.

---
*PR created automatically by Jules for task [5315684271983234542](https://jules.google.com/task/5315684271983234542) started by @akarras*