### PR TITLE
fix(analyzer): rebuild the cheapest-listing map instead of trusting the event stream

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -32,6 +32,7 @@ mod m20260514_000002_alert_list_update;
 mod m20260514_000003_list_activity;
 mod m20260802_000001_authless_character_claims;
 mod m20260802_000002_user_group_discord_guild;
+mod m20260804_000001_active_listing_cheapest_index;
 
 pub struct Migrator;
 
@@ -73,6 +74,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260514_000003_list_activity::Migration),
             Box::new(m20260802_000001_authless_character_claims::Migration),
             Box::new(m20260802_000002_user_group_discord_guild::Migration),
+            Box::new(m20260804_000001_active_listing_cheapest_index::Migration),
         ]
     }
 }

--- a/migration/src/m20260804_000001_active_listing_cheapest_index.rs
+++ b/migration/src/m20260804_000001_active_listing_cheapest_index.rs
@@ -1,0 +1,47 @@
+use sea_orm_migration::prelude::*;
+
+/// Covering index for `UltrosDb::cheapest_listings`, which the analyzer runs on
+/// boot and on bus-lag recovery:
+///
+/// ```sql
+/// SELECT item_id, hq, world_id, MIN(price_per_unit)
+/// FROM active_listing GROUP BY item_id, hq, world_id
+/// ```
+///
+/// The only pre-existing index on this table is `WorldItemIndex` on
+/// (item_id, world_id) — it carries neither `hq` nor `price_per_unit`, so that
+/// query had to go to the heap for every row. Ordering the columns
+/// group-keys-then-value lets Postgres serve it as an index-only scan.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    /// `CREATE INDEX CONCURRENTLY` is rejected inside a transaction block, and
+    /// sea-orm wraps migrations in one by default on Postgres. `active_listing`
+    /// is written continuously by ingest, so a plain `CREATE INDEX` would hold an
+    /// exclusive write lock for the whole build — opting out of the transaction
+    /// is what keeps this migration online.
+    fn use_transaction(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_listing_cheapest
+                   ON active_listing (item_id, hq, world_id, price_per_unit)"#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(r#"DROP INDEX CONCURRENTLY IF EXISTS idx_active_listing_cheapest"#)
+            .await?;
+        Ok(())
+    }
+}

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -506,17 +506,32 @@ impl UltrosDb {
         Ok((added, removed))
     }
 
+    /// The cheapest price for every (item, hq, world) currently on the market.
+    ///
+    /// This runs on analyzer boot and on bus-lag recovery, so it wants to be as
+    /// cheap as the shape of the question allows. It used to compute
+    /// `RANK() OVER (PARTITION BY item_id, hq, world_id ORDER BY price_per_unit)`
+    /// over the whole table and then keep only rank 1 — Postgres cannot push that
+    /// filter into the window, so it sorted every row in `active_listing` just to
+    /// discard nearly all of them. `RANK()` also emits ties, so price-matched
+    /// listings came back as duplicate rows.
+    ///
+    /// [`ListingSummary`] is a pure aggregate, so a plain `GROUP BY` answers it
+    /// exactly: one row per group, no global sort, no per-row window state. With
+    /// `idx_active_listing_cheapest` on (item_id, hq, world_id, price_per_unit)
+    /// it can be served by an index-only scan.
     pub async fn cheapest_listings(
         &self,
     ) -> Result<impl Stream<Item = Result<ListingSummary, DbErr>> + '_, DbErr> {
         ListingSummary::find_by_statement(Statement::from_sql_and_values(
             DbBackend::Postgres,
-            r#"SELECT ranks.* FROM (SELECT l.item_id, l.hq, l.price_per_unit, l.world_id,
-                RANK() OVER (PARTITION BY l.item_id, l.hq, l.world_id ORDER BY l.price_per_unit ASC) listing_rank
-                FROM active_listing l) ranks
-                WHERE ranks.listing_rank = 1"#,
+            r#"SELECT item_id, hq, world_id, MIN(price_per_unit) AS price_per_unit
+                FROM active_listing
+                GROUP BY item_id, hq, world_id"#,
             vec![],
-        )).stream(&self.db).await
+        ))
+        .stream(&self.db)
+        .await
     }
 }
 

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -446,6 +446,12 @@ pub(crate) struct AnalyzerService {
     /// Cheapest items get stored as any anyselector. Currently exists for WorldID/RegionID, but not datacenter.
     cheapest_items: Arc<BTreeMap<AnySelector, RwLock<CheapestListings>>>,
     initiated: Arc<AtomicBool>,
+    /// Set while a bus-lag rebuild of [`Self::cheapest_items`] is running.
+    ///
+    /// Lag arrives in bursts — one overloaded moment yields many consecutive
+    /// `Lagged` results — and every one of them wants the same full rebuild. This
+    /// collapses a burst into a single pass instead of queueing one per drop.
+    cheapest_resync_in_flight: Arc<AtomicBool>,
     /// Dual-writes every observed sale into the ClickHouse `sales` table.
     /// Non-blocking, fire-and-forget — Postgres remains the source of truth so
     /// dropped rows are recoverable via the backfill binary.
@@ -508,6 +514,7 @@ impl AnalyzerService {
             recent_sale_history,
             cheapest_items,
             initiated: Arc::default(),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer,
             ch_client,
         };
@@ -682,6 +689,17 @@ impl AnalyzerService {
                     continue;
                 }
             };
+            // Restoring the cheapest map no longer decides what the analyzer
+            // serves: `run_worker` now rebuilds it from Postgres on every boot and
+            // *replaces* each selector, so whatever is read back here is
+            // overwritten moments later. It is kept as a fallback for when that
+            // rebuild query fails — stale prices beat an empty map — and so the
+            // snapshot round-trip stays self-contained.
+            //
+            // What changed is that the restore is no longer the *only* source.
+            // The DB reload used to run only when no snapshot restored, so a
+            // phantom minimum was written into the snapshot every 15 minutes and
+            // read back on every restart, outliving the lag that created it.
             for (key, value) in state.cheapest_items {
                 if let Some(lock) = self.cheapest_items.get(&key) {
                     let mut write = lock.write().await;
@@ -705,6 +723,97 @@ impl AnalyzerService {
         false
     }
 
+    /// Rebuilds [`Self::cheapest_items`] from Postgres, replacing whatever is
+    /// there.
+    ///
+    /// **Replacing rather than merging is the whole point.** `add_listing` keeps
+    /// the `min` of the old and new price, so merging fresh data into a map
+    /// holding a phantom minimum leaves the phantom in place — the stored price
+    /// can only ever move down. Overwriting each selector wholesale is the only
+    /// thing that clears one.
+    ///
+    /// Phantoms arise because a dropped `listings/remove` event is unrecoverable:
+    /// `remove_listing` is the sole path that can raise a stored price, and it is
+    /// gated on the removed listing being at-or-below the stored minimum. Once a
+    /// too-low price is in the map, every later remove fails that gate. Bus lag
+    /// dropped ~99k listing events in one week, so this is routine, not exotic.
+    ///
+    /// The map is built into plain (unlocked) maps first, so no lock is held
+    /// across the DB stream and readers never observe a half-filled map.
+    async fn rebuild_cheapest_from_db(
+        &self,
+        ultros_db: &UltrosDb,
+        world_cache: &WorldCache,
+    ) -> Result<(), anyhow::Error> {
+        // Pre-seed every selector so one that has lost all of its listings is
+        // reset to empty rather than keeping stale entries.
+        let mut fresh: BTreeMap<AnySelector, CheapestListings> = self
+            .cheapest_items
+            .keys()
+            .map(|key| (*key, CheapestListings::default()))
+            .collect();
+
+        let mut listings = ultros_db.cheapest_listings().await?;
+        while let Some(Ok(value)) = listings.next().await {
+            // The database can hold listings for worlds this process'
+            // `WorldCache` never saw — skip them rather than fail the rebuild.
+            let Ok(world) = world_cache.lookup_selector(&AnySelector::World(value.world_id)) else {
+                skipped_event("db_reload_listing", "unknown_world");
+                continue;
+            };
+            let Some(region) = world_cache.get_region(&world) else {
+                skipped_event("db_reload_listing", "unknown_region");
+                continue;
+            };
+            if let Some(entry) = fresh.get_mut(&AnySelector::Region(region.id)) {
+                entry.add_listing(&value);
+            }
+            for dc in world_cache.get_datacenters(&world).unwrap_or_default() {
+                if let Some(entry) = fresh.get_mut(&AnySelector::Datacenter(dc.id)) {
+                    entry.add_listing(&value);
+                }
+            }
+            if let Some(entry) = fresh.get_mut(&AnySelector::World(value.world_id)) {
+                entry.add_listing(&value);
+            }
+        }
+
+        for (selector, listings) in fresh {
+            if let Some(lock) = self.cheapest_items.get(&selector) {
+                *lock.write().await = listings;
+            }
+        }
+        Ok(())
+    }
+
+    /// Kicks off a background [`Self::rebuild_cheapest_from_db`] after the bus
+    /// dropped events, unless one is already running.
+    ///
+    /// Recovery has to be asynchronous: the caller is the listings consumer, and
+    /// blocking it on a full rebuild would starve the very bus that just
+    /// overflowed.
+    fn schedule_cheapest_resync(&self, ultros_db: &UltrosDb, world_cache: &Arc<WorldCache>) {
+        if self.cheapest_resync_in_flight.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let this = self.clone();
+        let ultros_db = ultros_db.clone();
+        let world_cache = world_cache.clone();
+        tokio::spawn(async move {
+            warn!("listings bus lagged; rebuilding cheapest-listing map from the database");
+            metrics::counter!("ultros_analyzer_cheapest_resync_total", "trigger" => "bus_lag")
+                .increment(1);
+            if let Err(e) = this
+                .rebuild_cheapest_from_db(&ultros_db, &world_cache)
+                .await
+            {
+                error!(error = ?e, "cheapest-listing resync failed");
+            }
+            this.cheapest_resync_in_flight
+                .store(false, Ordering::Release);
+        });
+    }
+
     async fn run_worker(
         &self,
         ultros_db: UltrosDb,
@@ -713,55 +822,9 @@ impl AnalyzerService {
         token: CancellationToken,
     ) {
         if !self.try_restore_from_snapshot().await {
-            // on startup we should try to read through the database to get the spiciest of item listings
             info!("worker starting");
-            let (listings, sale_data) = futures::future::join(
-                ultros_db.cheapest_listings(),
-                ultros_db.last_n_sales(SALE_HISTORY_SIZE as i32),
-            )
-            .await;
-            info!("starting item listings");
-            match listings {
-                Ok(mut listings) => {
-                    let writer = &self.cheapest_items;
-                    while let Some(Ok(value)) = listings.next().await {
-                        // The database can hold listings for worlds this process'
-                        // `WorldCache` never saw. Panicking here aborts the whole
-                        // worker before `initiated` is ever set, so the analyzer
-                        // both serves nothing and ingests nothing — forever.
-                        let Ok(world) =
-                            world_cache.lookup_selector(&AnySelector::World(value.world_id))
-                        else {
-                            skipped_event("db_reload_listing", "unknown_world");
-                            continue;
-                        };
-                        let Some(region) = world_cache.get_region(&world) else {
-                            skipped_event("db_reload_listing", "unknown_region");
-                            continue;
-                        };
-                        let datacenters = world_cache.get_datacenters(&world).unwrap_or_default();
-                        let (Some(region_listings), Some(world_listings)) = (
-                            writer.get(&AnySelector::Region(region.id)),
-                            writer.get(&AnySelector::World(value.world_id)),
-                        ) else {
-                            skipped_event("db_reload_listing", "unknown_selector");
-                            continue;
-                        };
-                        region_listings.write().await.add_listing(&value);
-                        for dc in datacenters {
-                            if let Some(dc_listings) = writer.get(&AnySelector::Datacenter(dc.id)) {
-                                dc_listings.write().await.add_listing(&value);
-                            }
-                        }
-                        world_listings.write().await.add_listing(&value);
-                    }
-                }
-                Err(e) => {
-                    error!("Streaming item listings failed {e:?}");
-                }
-            }
             info!("starting sale data");
-            match sale_data {
+            match ultros_db.last_n_sales(SALE_HISTORY_SIZE as i32).await {
                 Ok(mut history_stream) => {
                     while let Some(Ok(value)) = history_stream.next().await {
                         let Some(history) = self.recent_sale_history.get(&value.world_id) else {
@@ -772,9 +835,24 @@ impl AnalyzerService {
                     }
                 }
                 Err(e) => {
-                    error!("Streaming item listings failed {e:?}");
+                    error!("Streaming sale history failed {e:?}");
                 }
             }
+        }
+        // The cheapest map is rebuilt from Postgres on every boot, snapshot or
+        // not. The snapshot exists for `recent_sale_history`, which can only be
+        // reassembled by replaying sales; the cheapest map is one aggregate query.
+        // Restoring it instead used to make phantom minimums immortal — they were
+        // serialized every 15 minutes and read back on each deploy, so a price
+        // stranded by a lag burst days earlier survived indefinitely.
+        info!("rebuilding cheapest listings from the database");
+        metrics::counter!("ultros_analyzer_cheapest_resync_total", "trigger" => "boot")
+            .increment(1);
+        if let Err(e) = self
+            .rebuild_cheapest_from_db(&ultros_db, &world_cache)
+            .await
+        {
+            error!(error = ?e, "Streaming item listings failed");
         }
         self.initiated.store(true, Ordering::Relaxed);
         info!("worker primed, now using live data");
@@ -846,10 +924,19 @@ impl AnalyzerService {
                             crate::event::EventType::Add(add) => {
                                 self.add_listings(&add.listings, &world_cache).await;
                             }
-                            crate::event::EventType::Update(_) => todo!(),
+                            // Nothing publishes `Update` on the listings bus; the
+                            // sales arm treats it as a no-op and this used to be
+                            // `todo!()`, i.e. a panic that would take the whole
+                            // analyzer down if anything ever started to.
+                            crate::event::EventType::Update(_) => {}
                         },
-                        // Still live, positioned at the oldest survivor.
-                        BusRecv::Lagged => {}
+                        // Still live, positioned at the oldest survivor — but the
+                        // skipped events are gone for good. A dropped remove
+                        // strands a phantom minimum that no later event can clear,
+                        // so recover by rebuilding the map from Postgres.
+                        BusRecv::Lagged => {
+                            self.schedule_cheapest_resync(&ultros_db, &world_cache)
+                        }
                         // recv() on a closed bus returns instantly forever;
                         // looping here would hot-spin and emit one warn per
                         // iteration. Only happens at shutdown, when the
@@ -1938,6 +2025,52 @@ mod test {
     use super::{
         SaleHistory, SaleSummary, SoldAmount, SoldWithin, estimate_sale_price, flip_profit_and_roi,
     };
+    use ultros_db::listings::ListingSummary;
+
+    /// `add_listing` stores the `min` of the existing and incoming price, so a
+    /// stranded low price survives any amount of fresh data merged on top of it.
+    ///
+    /// That asymmetry is why `rebuild_cheapest_from_db` overwrites each selector
+    /// wholesale instead of merging, and why the cheapest map is no longer
+    /// restored from the snapshot: a phantom written into the snapshot would be
+    /// read back on every restart and no later event could ever raise it, because
+    /// `remove_listing` — the only path that can — is itself gated on the removed
+    /// listing being at-or-below the stored price.
+    #[test]
+    fn merging_fresh_data_cannot_clear_a_phantom_minimum_but_replacing_does() {
+        let summary = |price| ListingSummary {
+            item_id: 52267,
+            hq: false,
+            price_per_unit: price,
+            world_id: 54,
+        };
+        let key = ItemKey {
+            item_id: 52267,
+            hq: false,
+        };
+
+        // A price left behind by a dropped `listings/remove`: the listing is long
+        // gone from the board, but the map still believes in it.
+        let mut stranded = CheapestListings::default();
+        stranded.add_listing(&summary(6_769));
+
+        // Merging in what the database actually holds changes nothing.
+        stranded.add_listing(&summary(379_996));
+        assert_eq!(
+            stranded.item_map.get(&key).unwrap().price,
+            6_769,
+            "merging cannot raise a stored price, so the phantom survives"
+        );
+
+        // Rebuilding the selector from scratch is what clears it.
+        let mut rebuilt = CheapestListings::default();
+        rebuilt.add_listing(&summary(379_996));
+        assert_eq!(
+            rebuilt.item_map.get(&key).unwrap().price,
+            379_996,
+            "a wholesale replace reflects the real cheapest listing"
+        );
+    }
 
     /// The formula here must stay identical to the Flip Finder's
     /// `estimated_sale_price` in `ultros-app/src/routes/analyzer.rs`, which is
@@ -2468,6 +2601,7 @@ mod tests {
             recent_sale_history: Arc::new(recent_sale_history),
             cheapest_items: Arc::new(cheapest_items),
             initiated: Arc::new(AtomicBool::new(false)),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
@@ -2514,6 +2648,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: new_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(false)),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
@@ -2545,6 +2680,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: dc_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(true)),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
@@ -2561,6 +2697,7 @@ mod tests {
             recent_sale_history: new_recent_sale_history.clone(),
             cheapest_items: restore_dc_cheapest_items.clone(),
             initiated: Arc::new(AtomicBool::new(false)),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };
@@ -2612,6 +2749,7 @@ mod tests {
                 .collect(),
             ),
             initiated: Arc::new(AtomicBool::new(false)),
+            cheapest_resync_in_flight: Arc::default(),
             ch_writer: ultros_clickhouse::writer::Writer::disabled(),
             ch_client: ultros_clickhouse::ClickHouseClient::from_env(),
         };


### PR DESCRIPTION
## The bug

The analyzer served buy prices for listings that no longer exist. On Faerie, item 52267 read **6,769 gil** while Postgres and Universalis both agreed the real cheapest was **379,996**.

A 400-item sample on Faerie, analyzer vs. the database's true cheapest:

| | count | |
|---|---|---|
| exact match | 294 | 77.2% |
| **stuck below DB** | **76** | **19.9%** |
| above DB (ordinary lag) | 11 | 2.9% |

That asymmetry is the signature. Worst cases ran 630x, several pinned at literally **1 gil**.

## Why it sticks

`add_listing` keeps the `min` of stored and incoming price, so a stored price can only ever move **down**. The one path that can raise it is `remove_listing`, gated on `listing.price_per_unit <= entry.get().price`. Once a too-low price is in the map, every later remove fails that gate — `379996 <= 6769` is false — and the entry is pinned forever.

**Recovery was the missing piece, not injection.** `ultros_analyzer_bus_lagged_total` shows **~99k listings-bus events dropped in 7 days** (bursty — zero in the last 5 hours), and `BusRecv::Lagged` acknowledged the loss and did nothing.

Worth recording: `ultros_analyzer_skipped_events_total` has **never been incremented** in production, so the retainer-filter drop paths in `update_listings`/`remove_listings` are latent, not a cause.

Snapshots then made each burst permanent. `run_worker` reseeded from Postgres only when no snapshot restored — but one is written every 15 minutes, so a price stranded days earlier was serialized and read back on every deploy.

## Changes

- **Rebuild `cheapest_items` from Postgres on every boot**, snapshot or not, and again after any bus lag (collapsed to one pass per burst so a burst doesn't queue N rebuilds).
- **Rebuilds replace rather than merge.** Merging cannot clear a phantom, since the stored price only moves down. There's a test for exactly this.
- Snapshot restore is **kept as a fallback** for a failed rebuild — stale prices beat an empty map — it's just no longer the only source. (The existing snapshot round-trip test asserts DC-keyed restore; dropping it would have broken that for no gain.)
- Build into unlocked maps first, so no lock is held across the DB stream and readers never see a half-filled map.
- **`cheapest_listings`: full-table `RANK()` window → `GROUP BY MIN`.** The `rank = 1` filter can't be pushed into the window, so Postgres sorted every row in `active_listing` to keep one per group; `RANK()` also returned ties as duplicate rows. Adds a covering index on `(item_id, hq, world_id, price_per_unit)` — the only existing index (`WorldItemIndex`) carries neither `hq` nor price. Created `CONCURRENTLY` via `use_transaction() -> Some(false)`, since `active_listing` is written continuously by ingest.
- **`EventType::Update` on the listings bus was `todo!()`** — a panic that would take the analyzer down if anything ever published one. Now a no-op, matching the sales arm.

## Verification

- `cargo clippy -p ultros --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean
- `cargo test -p ultros-db --lib` — 30 passed

⚠️ The new `merging_fresh_data_cannot_clear_a_phantom_minimum_but_replacing_does` test **compiles but has not been executed**: the `ultros` bin test binary doesn't link on Windows/MSVC (74 unresolved `ultros_app` externals), and this repo's CI runs fmt + clippy only, not `cargo test`. It should run on Linux — worth a check before merge if you have one handy.

## Merge order

Independent of #1122. If the analyzer perf PR follows, this one should land first — its index is what that PR's new query is designed to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
