### PR TITLE
perf(analyzer): batch the cheapest-listing refill and drop the locks around it

### DIFF
--- a/ultros-db/src/lib.rs
+++ b/ultros-db/src/lib.rs
@@ -218,30 +218,6 @@ impl UltrosDb {
             .ok_or_else(|| anyhow::Error::msg("Region not found"))
     }
 
-    #[instrument(skip(self, world_id, item))]
-    pub async fn get_multiple_listings_for_worlds_hq_sensitive(
-        &self,
-        world_id: impl Iterator<Item = WorldId>,
-        item: impl Iterator<Item = ItemId> + Clone,
-        hq: bool,
-        limit: u64,
-    ) -> Result<Vec<active_listing::Model>> {
-        use active_listing::*;
-        let join = futures::future::try_join_all(world_id.flat_map(|world| {
-            item.clone().map(move |i| {
-                Entity::find()
-                    .filter(Column::ItemId.eq(i.0))
-                    .filter(Column::WorldId.eq(world.0))
-                    .filter(Column::Hq.eq(hq))
-                    .order_by_asc(Column::PricePerUnit)
-                    .limit(limit)
-                    .all(&self.db)
-            })
-        }))
-        .await?;
-        Ok(join.into_iter().flat_map(|l| l.into_iter()).collect())
-    }
-
     #[instrument(skip(self))]
     pub async fn get_listings_for_world_hq(
         &self,

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -4,7 +4,8 @@ use itertools::Itertools;
 use metrics::{counter, histogram};
 use migration::DbErr;
 use sea_orm::{
-    ColumnTrait, DbBackend, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, Statement,
+    ColumnTrait, DbBackend, EntityTrait, ExprTrait, FromQueryResult, QueryFilter, QuerySelect,
+    Statement,
 };
 use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
@@ -504,6 +505,47 @@ impl UltrosDb {
             .increment(removed.len() as u64);
         histogram!("ultros_db_update_listings_duration_seconds").record(instant.elapsed());
         Ok((added, removed))
+    }
+
+    /// Cheapest price per (item, hq, world) for a specific set of items — the
+    /// query behind the analyzer's cheapest-listing refill.
+    ///
+    /// This replaces `get_multiple_listings_for_worlds_hq_sensitive`, which built
+    /// its result with `worlds.flat_map(|w| items.map(|i| ...))` — **one query per
+    /// (world × item) pair**. Refilling 18 items across Aether's 8 worlds meant
+    /// 144 round-trips, and the analyzer issued them per removed listing while
+    /// holding a write lock. One grouped query answers the same question.
+    ///
+    /// Both qualities come back in a single call: [`ListingSummary`] carries `hq`
+    /// and the analyzer keys on it, so there is no reason to split into two
+    /// round-trips the way the hq-sensitive variant did.
+    pub async fn cheapest_listings_for_items(
+        &self,
+        worlds: &[i32],
+        items: &[i32],
+    ) -> Result<Vec<ListingSummary>> {
+        use active_listing::*;
+        if worlds.is_empty() || items.is_empty() {
+            return Ok(vec![]);
+        }
+        let instant = Instant::now();
+        let summaries = Entity::find()
+            .select_only()
+            .column(Column::ItemId)
+            .column(Column::Hq)
+            .column(Column::WorldId)
+            .column_as(Column::PricePerUnit.min(), "price_per_unit")
+            .filter(Column::ItemId.is_in(items.to_vec()))
+            .filter(Column::WorldId.is_in(worlds.to_vec()))
+            .group_by(Column::ItemId)
+            .group_by(Column::Hq)
+            .group_by(Column::WorldId)
+            .into_model::<ListingSummary>()
+            .all(&self.db)
+            .await?;
+        histogram!("ultros_db_cheapest_listings_for_items_duration_seconds")
+            .record(instant.elapsed());
+        Ok(summaries)
     }
 
     pub async fn cheapest_listings(

--- a/ultros/src/analyzer_service.rs
+++ b/ultros/src/analyzer_service.rs
@@ -3,7 +3,7 @@ use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, btree_map::Entry},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     fmt::Display,
     io::{Read, Write},
     sync::{
@@ -24,7 +24,6 @@ use ultros_db::{
     UltrosDb,
     entity::{active_listing, sale_history},
 };
-use universalis::{ItemId, WorldId};
 
 use crate::event::{BusRecv, EventReceivers, handle_bus_recv};
 use crate::trend_candidates::{TrendCandidate, select_trend_candidates};
@@ -278,51 +277,25 @@ impl CheapestListings {
         *entry = cheapest_listing.min(*entry);
     }
 
-    async fn remove_listing(
-        &mut self,
-        listing: &ActiveListing,
-        id: AnySelector,
-        world_cache: &WorldCache,
-        ultros_db: &UltrosDb,
-    ) {
-        // if this was the cheapest listing we need to ask the database for the new cheapest item
-        let key = listing.into();
+    /// Drops `listing` if it is at or below the stored cheapest price, returning
+    /// the key whose price now has to be re-read from the database.
+    ///
+    /// Deliberately synchronous and DB-free. This used to run the refill query
+    /// itself, which meant the caller held a write lock across a Postgres
+    /// round-trip — for the region selector, one lock covering every item in the
+    /// region, held across one query per removed listing. Splitting the decision
+    /// from the refill lets the caller batch the queries and issue them with no
+    /// lock held.
+    fn remove_if_cheapest(&mut self, listing: &ActiveListing) -> Option<ItemKey> {
+        let key = ItemKey::from(listing);
         match self.item_map.entry(key) {
-            Entry::Occupied(entry) => {
-                // only remove a listing if we see a lower price
-                if listing.price_per_unit <= entry.get().price {
-                    entry.remove();
-                    let Some(worlds) = world_cache
-                        .lookup_selector(&id)
-                        .map(|r| world_cache.get_all_worlds_in(&r))
-                        .ok()
-                        .flatten()
-                    else {
-                        // Same outcome as the DB query below failing: the entry
-                        // stays removed and the next listing event for this item
-                        // refills it.
-                        warn!(selector = ?id, "no worlds for selector, skipping cheapest-listing refill");
-                        skipped_event("remove_listing", "unknown_selector");
-                        return;
-                    };
-                    if let Ok(listings) = ultros_db
-                        .get_multiple_listings_for_worlds_hq_sensitive(
-                            worlds.iter().map(|w| WorldId(*w)),
-                            [ItemId(listing.item_id)].into_iter(),
-                            key.hq,
-                            1,
-                        )
-                        .await
-                    {
-                        for db_listing in &listings {
-                            if key == ItemKey::from(db_listing) {
-                                self.add_listing(db_listing);
-                            }
-                        }
-                    }
-                }
+            // Only drop the entry when the removed listing is the one the price
+            // came from; a dearer listing disappearing changes nothing.
+            Entry::Occupied(entry) if listing.price_per_unit <= entry.get().price => {
+                entry.remove();
+                Some(key)
             }
-            Entry::Vacant(_) => {}
+            _ => None,
         }
     }
 }
@@ -1581,6 +1554,12 @@ impl AnalyzerService {
     }
 
     /// remove listings in bulk. can handle multiple item types, but must have only one region.
+    ///
+    /// Every listing touches three levels of the map — its world, each datacenter
+    /// containing that world, and the region — so the work is grouped by selector
+    /// first and each selector is then handled in one pass. Previously each
+    /// (listing, level) pair was handled individually, and each one could issue
+    /// its own refill query while holding that level's write lock.
     async fn remove_listings(
         &self,
         region_id: i32,
@@ -1588,73 +1567,120 @@ impl AnalyzerService {
         world_cache: &WorldCache,
         ultros_db: &UltrosDb,
     ) {
-        // A missing region only costs us the region-level removal — keep going so
-        // the datacenter and world maps still drop the listing. Leaving a sold
-        // listing in place is what makes prices read as stale.
-        if let Some(entry) = self.cheapest_items.get(&AnySelector::Region(region_id)) {
-            let mut entry = entry.write().await;
-            for (listing, _) in listings.listings.iter() {
-                entry
-                    .remove_listing(
-                        listing,
-                        AnySelector::Region(region_id),
-                        world_cache,
-                        ultros_db,
-                    )
-                    .await;
-            }
-        } else {
-            warn!(
-                region_id,
-                "no cheapest-listing entry for region, skipping region-level removal"
-            );
-            skipped_event("remove_listings", "unknown_region");
-        }
+        let mut by_selector: BTreeMap<AnySelector, Vec<&ActiveListing>> = BTreeMap::new();
         for (listing, _) in listings.listings.iter() {
-            let world_result = world_cache.lookup_selector(&AnySelector::World(listing.world_id));
-            if let Ok(w) = world_result {
-                #[allow(clippy::collapsible_if)]
-                if let Some(dcs) = world_cache.get_datacenters(&w) {
-                    for dc in dcs {
-                        if let Some(entry) =
-                            self.cheapest_items.get(&AnySelector::Datacenter(dc.id))
-                        {
-                            entry
-                                .write()
-                                .await
-                                .remove_listing(
-                                    listing,
-                                    AnySelector::Datacenter(dc.id),
-                                    world_cache,
-                                    ultros_db,
-                                )
-                                .await;
-                        }
+            // A missing region only costs us the region-level removal — keep going
+            // so the datacenter and world maps still drop the listing. Leaving a
+            // sold listing in place is what makes prices read as stale.
+            by_selector
+                .entry(AnySelector::Region(region_id))
+                .or_default()
+                .push(listing);
+            by_selector
+                .entry(AnySelector::World(listing.world_id))
+                .or_default()
+                .push(listing);
+            match world_cache.lookup_selector(&AnySelector::World(listing.world_id)) {
+                Ok(world) => {
+                    for dc in world_cache.get_datacenters(&world).unwrap_or_default() {
+                        by_selector
+                            .entry(AnySelector::Datacenter(dc.id))
+                            .or_default()
+                            .push(listing);
                     }
                 }
+                Err(_) => {
+                    warn!(
+                        world_id = listing.world_id,
+                        item_id = listing.item_id,
+                        "unknown world, skipping datacenter-level removal"
+                    );
+                    skipped_event("remove_listings", "unknown_world");
+                }
             }
-            let Some(world) = self
-                .cheapest_items
-                .get(&AnySelector::World(listing.world_id))
-            else {
-                warn!(
-                    world_id = listing.world_id,
-                    item_id = listing.item_id,
-                    "no cheapest-listing entry for world, skipping world-level removal"
-                );
-                skipped_event("remove_listings", "unknown_world");
-                continue;
-            };
-            world
-                .write()
-                .await
-                .remove_listing(
-                    listing,
-                    AnySelector::World(listing.world_id),
-                    world_cache,
-                    ultros_db,
-                )
+        }
+
+        for (selector, listings) in by_selector {
+            self.remove_from_selector(selector, &listings, world_cache, ultros_db)
                 .await;
+        }
+    }
+
+    /// Drops the given listings from one selector's map and refills any price
+    /// they were the source of.
+    ///
+    /// Structured in three phases so that **no lock is ever held across a
+    /// database round-trip**:
+    ///
+    /// 1. under the write lock, purely in memory, work out which keys went stale;
+    /// 2. with the lock released, fetch their real cheapest prices in one query;
+    /// 3. re-acquire and apply.
+    ///
+    /// The old shape held the region's write lock — one lock covering every item
+    /// in the region — across a sequence of queries, one per removed listing, and
+    /// each of those was itself a (world × item) fan-out. An 18-listing removal on
+    /// an 8-world region meant ~144 sequential round-trips under that lock, which
+    /// is what let the consumer fall behind the listings bus.
+    async fn remove_from_selector(
+        &self,
+        selector: AnySelector,
+        listings: &[&ActiveListing],
+        world_cache: &WorldCache,
+        ultros_db: &UltrosDb,
+    ) {
+        let Some(lock) = self.cheapest_items.get(&selector) else {
+            warn!(
+                ?selector,
+                "no cheapest-listing entry for selector, skipping removal"
+            );
+            skipped_event("remove_listings", "unknown_selector");
+            return;
+        };
+
+        // Phase 1: in-memory only. The lock is held for microseconds.
+        let stale: BTreeSet<i32> = {
+            let mut map = lock.write().await;
+            listings
+                .iter()
+                .filter_map(|listing| map.remove_if_cheapest(listing))
+                .map(|key| key.item_id)
+                .collect()
+        };
+        if stale.is_empty() {
+            return;
+        }
+
+        // Phase 2: the refill, with no lock held.
+        let Some(worlds) = world_cache
+            .lookup_selector(&selector)
+            .map(|r| world_cache.get_all_worlds_in(&r))
+            .ok()
+            .flatten()
+        else {
+            // Same outcome as the query failing: the entries stay removed and the
+            // next listing event for those items refills them.
+            warn!(
+                ?selector,
+                "no worlds for selector, skipping cheapest-listing refill"
+            );
+            skipped_event("remove_listing", "unknown_selector");
+            return;
+        };
+        let items: Vec<i32> = stale.into_iter().collect();
+        let refill = match ultros_db.cheapest_listings_for_items(&worlds, &items).await {
+            Ok(refill) => refill,
+            Err(e) => {
+                error!(error = ?e, ?selector, "cheapest-listing refill query failed");
+                skipped_event("remove_listing", "refill_query_failed");
+                return;
+            }
+        };
+
+        // Phase 3: apply. `add_listing` keys on (item, hq), so both qualities from
+        // the one query land on the right entries.
+        let mut map = lock.write().await;
+        for summary in &refill {
+            map.add_listing(summary);
         }
     }
 
@@ -1938,6 +1964,73 @@ mod test {
     use super::{
         SaleHistory, SaleSummary, SoldAmount, SoldWithin, estimate_sale_price, flip_profit_and_roi,
     };
+    use ultros_api_types::ActiveListing;
+
+    fn active_listing(item_id: i32, price: i32, hq: bool) -> ActiveListing {
+        ActiveListing {
+            id: 1,
+            world_id: 54,
+            item_id,
+            retainer_id: 1,
+            price_per_unit: price,
+            quantity: 1,
+            hq,
+            timestamp: chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc(),
+        }
+    }
+
+    /// `remove_if_cheapest` decides, without touching the database, whether a
+    /// removed listing invalidates the stored price. The caller batches the refill
+    /// for whatever it reports, so this gate has to stay exact: reporting too
+    /// little strands a sold-out price, reporting too much costs a query.
+    #[test]
+    fn remove_if_cheapest_only_reports_keys_whose_price_actually_went_stale() {
+        let mut map = CheapestListings::default();
+        map.add_listing(&active_listing(1, 100, false));
+        map.add_listing(&active_listing(2, 500, false));
+        // Same item, different quality — a distinct key.
+        map.add_listing(&active_listing(1, 900, true));
+
+        // A dearer listing disappearing leaves the stored price alone.
+        assert_eq!(map.remove_if_cheapest(&active_listing(1, 250, false)), None);
+        assert_eq!(
+            map.item_map
+                .get(&ItemKey {
+                    item_id: 1,
+                    hq: false
+                })
+                .unwrap()
+                .price,
+            100
+        );
+
+        // Removing the listing the price came from invalidates that key only.
+        assert_eq!(
+            map.remove_if_cheapest(&active_listing(1, 100, false)),
+            Some(ItemKey {
+                item_id: 1,
+                hq: false
+            })
+        );
+        assert!(!map.item_map.contains_key(&ItemKey {
+            item_id: 1,
+            hq: false
+        }));
+        // The HQ entry for the same item is untouched.
+        assert_eq!(
+            map.item_map
+                .get(&ItemKey {
+                    item_id: 1,
+                    hq: true
+                })
+                .unwrap()
+                .price,
+            900
+        );
+
+        // An item we never stored reports nothing rather than a spurious refill.
+        assert_eq!(map.remove_if_cheapest(&active_listing(99, 1, false)), None);
+    }
 
     /// The formula here must stay identical to the Flip Finder's
     /// `estimated_sale_price` in `ultros-app/src/routes/analyzer.rs`, which is

--- a/ultros/src/event.rs
+++ b/ultros/src/event.rs
@@ -54,14 +54,21 @@ impl<T> EventType<Arc<T>> {
 /// and drives each chunk through `buffer_unordered(50)`, and every item emits
 /// *two* listing events (Add + Remove). So a single chunk can put ~200 events on
 /// the bus as fast as Postgres finishes writing, while the analyzer's listings
-/// loop drains them one at a time — and its `remove_listing` path does a DB
-/// round-trip per removed listing. The old value of 100 was smaller than one
+/// loop drains them one at a time. The original value of 100 was smaller than one
 /// chunk's burst, i.e. guaranteed to lag during any full sweep.
 ///
-/// 1024 gives ~5 chunks of headroom. Slots hold `Arc<ListingEventData>`, and a
-/// typical event carries only a handful of listings (~1-2 KiB), so the ring
-/// costs single-digit MiB even when completely full.
-const LISTINGS_BUS_SIZE: usize = 1024;
+/// 1024 still wasn't enough: `ultros_analyzer_bus_lagged_total` recorded ~99k
+/// dropped listing events in a week, in bursts. Dropped events are not merely
+/// delayed — a lost `listings/remove` strands a cheapest price that no later
+/// event can correct — so headroom is worth real memory here.
+///
+/// 8192 is ~40 chunks. Slots hold `Arc<ListingEventData>`, so the ring costs one
+/// pointer per slot plus the events still referenced by it; a typical event
+/// carries a handful of listings (~1-2 KiB), keeping a full ring in the tens of
+/// MiB. Buffer size is a mitigation, not a fix — a consumer that is persistently
+/// slower than the producer lags at any size, which is why the refill path no
+/// longer holds a lock across its database round-trips.
+const LISTINGS_BUS_SIZE: usize = 8192;
 
 /// Ring size for the sale-history bus.
 ///


### PR DESCRIPTION
## Why

The analyzer's listings consumer can't keep up with ingest bursts — `ultros_analyzer_bus_lagged_total` recorded **~99k dropped listing events in a week**. Dropped events aren't merely delayed: a lost `listings/remove` strands a cheapest price that no later event can correct, because `add_listing` only ever lowers a stored price. (#1123 handles the recovery side; this PR attacks why the consumer falls behind in the first place.)

## Two compounding causes

**1. The refill query was a cartesian fan-out.** `get_multiple_listings_for_worlds_hq_sensitive` built its result with `worlds.flat_map(|w| items.map(|i| ...))` — **one query per (world × item) pair**.

**2. It ran inside the write lock.** `remove_listing` called that query per removed listing, from inside the write lock for that level of the map. For the region selector that's a *single lock covering every item in the region*, held across a sequence of queries.

An 18-listing removal on an 8-world region meant roughly **144 sequential round-trips under one write lock** — then repeated for the datacenter and world maps.

## Changes

- **Replace the fan-out** with `cheapest_listings_for_items`: one grouped query, built with sea-orm's query builder so the `IN` lists stay parameterized. It returns both qualities at once, since `ListingSummary` carries `hq` and the analyzer keys on it — the hq-sensitive split was two round-trips for no reason. The old method had exactly one caller, so it's deleted rather than left as a trap.
- **Split `remove_listing`** into `remove_if_cheapest` (synchronous, DB-free, reports which keys went stale) and a three-phase caller: decide under the lock → query with **no lock held** → re-acquire and apply.
- **Group removals by selector first**, so each selector is one pass and one query instead of one per (listing, level) pair.

Net: that same 18-listing removal goes from ~144 sequential round-trips under a write lock to **3 queries, none under a lock**.

- Bus raised 1024 → 8192. Explicitly a mitigation, not a fix — a consumer persistently slower than the producer lags at any size — which is why the lock and fan-out changes are the substance.

## Verification

- `cargo clippy -p ultros-db -p ultros --all-targets -- -D warnings` — clean
- `cargo fmt --all` — clean
- `cargo test -p ultros-db --lib` — 30 passed

⚠️ The new `remove_if_cheapest_only_reports_keys_whose_price_actually_went_stale` test **compiles but has not been executed**: the `ultros` bin test binary doesn't link on Windows/MSVC (74 unresolved `ultros_app` externals), and CI runs fmt + clippy only, not `cargo test`. It should run on Linux.

## Merge order

Based on `main`, not stacked, so it gets its own CI. It overlaps #1123 in `analyzer_service.rs`, so whichever lands second needs a small conflict resolution — **#1123 first is cleaner**, since its covering index on `(item_id, hq, world_id, price_per_unit)` is exactly what this PR's grouped query is shaped to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
