### PR TITLE
fix(ssr): flip-finder hydration failure — gate LocalStorage stored values out of the server build

### DIFF
--- a/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
+++ b/ultros-frontend/ultros-app/src/components/virtual_scroller.rs
@@ -1,9 +1,11 @@
 use leptos::prelude::*;
 use std::hash::Hash;
 use std::{cell::RefCell, rc::Rc};
+#[cfg(feature = "hydrate")]
+use web_sys::ResizeObserver;
 use web_sys::wasm_bindgen::JsCast;
 use web_sys::wasm_bindgen::closure::Closure;
-use web_sys::{HtmlDivElement, ResizeObserver, window};
+use web_sys::{HtmlDivElement, window};
 
 struct Fenwick {
     n: usize,
@@ -21,6 +23,9 @@ impl Fenwick {
         self.bit.clear();
         self.bit.resize(n + 1, 0.0);
     }
+    // Only called from the hydrate-gated ResizeObserver effect; the SSR
+    // build never measures rows, so the tree is only ever read there.
+    #[cfg_attr(not(feature = "hydrate"), allow(dead_code))]
     fn add(&mut self, mut idx: usize, delta: f64) {
         // fenwick tree is 1-based internally
         idx += 1;
@@ -231,6 +236,14 @@ where
     // Window-scroll mode: the container no longer scrolls, so its `on:scroll`
     // handler is inert. Drive `scroll_offset` and `window_height` from the
     // page instead.
+    //
+    // Client-only: the `LocalStorage` StoredValue below must never exist in
+    // the SSR build — Suspense re-runs/disposes the owner across `.await`
+    // points on the multithreaded runtime, so its cleanup (or drop) can land
+    // on a different worker thread than the one that created the SendWrapper,
+    // which panics and truncates the response stream (see analyzer.rs's
+    // scroll-sync block for the full story).
+    #[cfg(feature = "hydrate")]
     if is_window {
         let sticky_offset = match source {
             ScrollSource::Window { sticky_offset } => sticky_offset,
@@ -623,9 +636,14 @@ where
 
                             move |(idx, child)| {
                                 let row = NodeRef::<leptos::html::Div>::new();
-                                let height_deltas = height_deltas;
-                                let fenwick = fenwick;
+                                // Client-only for the same SendWrapper-on-SSR
+                                // reason as the window-scroll block above.
+                                #[cfg(not(feature = "hydrate"))]
+                                let _ = idx;
+                                #[cfg(feature = "hydrate")]
                                 if variable_height {
+                                    let height_deltas = height_deltas;
+                                    let fenwick = fenwick;
                                     let resize_observer = StoredValue::new_local(
                                         None::<(ResizeObserver, Closure<dyn FnMut()>)>,
                                     );

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -159,7 +159,9 @@ use ultros_api_types::{
     websocket::{FilterPredicate, SocketMessageType, is_analyzer_market_update_relevant},
     world_helper::{AnyResult, AnySelector, WorldHelper},
 };
+#[cfg(feature = "hydrate")]
 use web_sys::wasm_bindgen::JsCast;
+#[cfg(feature = "hydrate")]
 use web_sys::wasm_bindgen::closure::Closure;
 use xiv_gen::ItemId;
 
@@ -1294,44 +1296,56 @@ fn AnalyzerTable(
     // way to reach them.
     let header_scroll = NodeRef::<leptos::html::Div>::new();
     let list_scroll = NodeRef::<leptos::html::Div>::new();
-    // Parked here rather than `Closure::forget`-ed: a forgotten listener keeps
-    // firing after the component is disposed.
-    let hscroll_listeners =
-        StoredValue::new_local(Vec::<(web_sys::HtmlDivElement, Closure<dyn FnMut()>)>::new());
-    on_cleanup(move || {
-        hscroll_listeners.update_value(|listeners| {
-            for (el, cb) in listeners.drain(..) {
-                let _ =
-                    el.remove_event_listener_with_callback("scroll", cb.as_ref().unchecked_ref());
-            }
-        });
-    });
-    Effect::new(move |_| {
-        // Re-runs when the refs are populated; the guard keeps a second run
-        // from double-registering.
-        let (Some(head), Some(body)) = (header_scroll.get(), list_scroll.get()) else {
-            return;
-        };
-        if hscroll_listeners.with_value(|l| !l.is_empty()) {
-            return;
-        }
-        // Mirroring writes `scrollLeft` on the other element, which fires its
-        // scroll event in turn; the equality check is what keeps that from
-        // ping-ponging.
-        let mirror = |from: web_sys::HtmlDivElement, to: web_sys::HtmlDivElement| {
-            Closure::wrap(Box::new(move || {
-                let x = from.scroll_left();
-                if to.scroll_left() != x {
-                    to.set_scroll_left(x);
+    // Client-only: gated out of the SSR build entirely. A `LocalStorage`
+    // StoredValue created during SSR is a `SendWrapper` living on one tokio
+    // worker thread, but the Suspense rendering this component re-runs (and
+    // eventually disposes) across `.await` points, so the `on_cleanup` below
+    // can fire on a *different* worker thread — a guaranteed SendWrapper
+    // panic that aborts the response stream mid-body and leaves the client
+    // hydrating a truncated document (no `__INCOMPLETE_CHUNKS` bootstrap).
+    #[cfg(feature = "hydrate")]
+    {
+        // Parked here rather than `Closure::forget`-ed: a forgotten listener keeps
+        // firing after the component is disposed.
+        let hscroll_listeners =
+            StoredValue::new_local(Vec::<(web_sys::HtmlDivElement, Closure<dyn FnMut()>)>::new());
+        on_cleanup(move || {
+            hscroll_listeners.update_value(|listeners| {
+                for (el, cb) in listeners.drain(..) {
+                    let _ = el
+                        .remove_event_listener_with_callback("scroll", cb.as_ref().unchecked_ref());
                 }
-            }) as Box<dyn FnMut()>)
-        };
-        let head_cb = mirror(head.clone(), body.clone());
-        let body_cb = mirror(body.clone(), head.clone());
-        let _ = head.add_event_listener_with_callback("scroll", head_cb.as_ref().unchecked_ref());
-        let _ = body.add_event_listener_with_callback("scroll", body_cb.as_ref().unchecked_ref());
-        hscroll_listeners.set_value(vec![(head, head_cb), (body, body_cb)]);
-    });
+            });
+        });
+        Effect::new(move |_| {
+            // Re-runs when the refs are populated; the guard keeps a second run
+            // from double-registering.
+            let (Some(head), Some(body)) = (header_scroll.get(), list_scroll.get()) else {
+                return;
+            };
+            if hscroll_listeners.with_value(|l| !l.is_empty()) {
+                return;
+            }
+            // Mirroring writes `scrollLeft` on the other element, which fires its
+            // scroll event in turn; the equality check is what keeps that from
+            // ping-ponging.
+            let mirror = |from: web_sys::HtmlDivElement, to: web_sys::HtmlDivElement| {
+                Closure::wrap(Box::new(move || {
+                    let x = from.scroll_left();
+                    if to.scroll_left() != x {
+                        to.set_scroll_left(x);
+                    }
+                }) as Box<dyn FnMut()>)
+            };
+            let head_cb = mirror(head.clone(), body.clone());
+            let body_cb = mirror(body.clone(), head.clone());
+            let _ =
+                head.add_event_listener_with_callback("scroll", head_cb.as_ref().unchecked_ref());
+            let _ =
+                body.add_event_listener_with_callback("scroll", body_cb.as_ref().unchecked_ref());
+            hscroll_listeners.set_value(vec![(head, head_cb), (body, body_cb)]);
+        });
+    }
 
     let clear_all_filters = move || {
         set_minimum_profit(None);


### PR DESCRIPTION
## Symptom

`https://ultros.app/flip-finder/Gilgamesh?min-buy=5000&last-sold=1d&roi=30&...&confidence=high` hydration-crashes in the browser:

```
Uncaught ReferenceError: __INCOMPLETE_CHUNKS is not defined
panicked at js-sys .../singlethread.rs:142: RefCell already borrowed
Uncaught RuntimeError: unreachable executed
```

## Root cause

The SSR stream was dying mid-response. Reproduced with a curl burst: **3 of 4 fetches truncated at ~8.4MB** (mid `__RESOLVED_RESOURCES` sales JSON, no closing chunk), each truncation matching a prod panic in `docker logs`:

```
panicked at reactive_graph-0.2.14/src/owner/storage.rs:141:34:
Dereferenced SendWrapper<T> variable from a thread different to the one it has been created with.
```

leptos only emits the `__INCOMPLETE_CHUNKS=[];` bootstrap as the **final** chunk of the stream (`hydration_context/src/ssr.rs`), so a truncated stream leaves the global undefined and the client's wasm-bindgen static accessor throws during hydration — the whole cascade the user sees.

The GlitchTip backtrace (issue 6870, first seen Jul 28 — matches #991 landing) pins it: `AnalyzerTable`'s scroll-sync `on_cleanup` → `hscroll_listeners.update_value` → LocalStorage `try_with` → SendWrapper deref. `StoredValue::new_local` wraps its value in a `SendWrapper` pinned to the tokio worker thread that created it, but leptos re-runs/disposes the Suspense owner across `.await` points on the multithreaded runtime — cleanup on a different worker thread is a guaranteed panic, probabilistically (~2/3 of requests here) killing the response stream.

## Fix

The three `new_local` sites are pure client listener bookkeeping (scroll-sync closures, window scroll/resize callback, per-row ResizeObserver). Compile them out of the SSR build with `#[cfg(feature = "hydrate")]`:

- `analyzer.rs` — `hscroll_listeners` + its `on_cleanup`/`Effect`
- `virtual_scroller.rs` — the `if is_window` listener block and the per-row `resize_observer` block

They emit no markup, so SSR HTML is byte-identical and hydration is unaffected; the hydrate (client) build keeps the code unchanged. `Fenwick::add` becomes hydrate-only, hence the targeted `cfg_attr(allow(dead_code))`.

**Durable rule this encodes: no `StoredValue::new_local` / `signal_local` may be created in an SSR-compiled component path.**

## Verification

- `./check_ci.sh` → exit 0 (fmt + workspace clippy `-D warnings`, incl. the `ultros` bin)
- `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown` → 0 warnings
- `cargo test -p ultros-app` → 439 passed
- The companion `arc_memo.rs:334` unwrap-None panic seen in the same log windows looks like collateral of the aborted owner; worth re-checking prod logs after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)