### PR TITLE
fix(search): don't read disposed signals after the search overlay closes

### DIFF
--- a/ultros-frontend/ultros-app/src/components/list_subscribe_drawer.rs
+++ b/ultros-frontend/ultros-app/src/components/list_subscribe_drawer.rs
@@ -60,10 +60,19 @@ pub fn ListSubscribeDrawer(
             ));
             return;
         }
-        let trigger = if mode.get() == "list_updates" {
+        let list_updates = mode.get() == "list_updates";
+        let trigger = if list_updates {
             AlertTrigger::ListUpdate { list_id }
         } else {
             AlertTrigger::ListItemThreshold { list_id }
+        };
+        // Resolved before the request, not after: dismissing the drawer
+        // disposes `mode`, and reading a disposed signal panics — the same
+        // crash the search box hit in #6874.
+        let success_message = if list_updates {
+            t_string!(i18n, list_update_subscribe_success_toast).to_string()
+        } else {
+            t_string!(i18n, list_subscribe_success_toast).to_string()
         };
         let req = CreateAlertRequest {
             trigger,
@@ -91,11 +100,7 @@ pub fn ListSubscribeDrawer(
             match result {
                 Ok(_) => {
                     if let Some(t) = toasts {
-                        t.success(if mode.get() == "list_updates" {
-                            t_string!(i18n, list_update_subscribe_success_toast)
-                        } else {
-                            t_string!(i18n, list_subscribe_success_toast)
-                        });
+                        t.success(success_message);
                     }
                     set_visible.set(false);
                 }

--- a/ultros-frontend/ultros-app/src/components/search_box.rs
+++ b/ultros-frontend/ultros-app/src/components/search_box.rs
@@ -130,6 +130,34 @@ fn get_static_pages() -> &'static [SearchResult] {
     &STATIC_PAGES
 }
 
+/// What an in-flight search should do once its request comes back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchOutcome {
+    /// Still the newest search — commit its results.
+    Commit,
+    /// A newer keystroke started another search — drop these results.
+    Superseded,
+    /// The search box was unmounted while the request was in flight.
+    Cancelled,
+}
+
+/// Decide the fate of the search that started as `started_id`.
+///
+/// Reading through `try_get_untracked` rather than `get_untracked` is
+/// load-bearing. [`SearchOverlay`](crate::components::search_overlay) closes
+/// itself on every navigation, and its `<Show>` disposes this component's
+/// signals when it does — so selecting a search result routes away and drops
+/// `search_id` while the `/api/v1/search` request it started is still in
+/// flight. `get_untracked` panics on a disposed signal, which took the whole
+/// wasm bundle down on search-then-navigate (GlitchTip #6874).
+fn search_outcome(search_id: ReadSignal<usize>, started_id: usize) -> SearchOutcome {
+    match search_id.try_get_untracked() {
+        None => SearchOutcome::Cancelled,
+        Some(id) if id == started_id => SearchOutcome::Commit,
+        Some(_) => SearchOutcome::Superseded,
+    }
+}
+
 #[component]
 pub fn SearchBox(#[prop(optional)] autofocus: bool) -> impl IntoView {
     let i18n = use_i18n();
@@ -180,7 +208,7 @@ pub fn SearchBox(#[prop(optional)] autofocus: bool) -> impl IntoView {
         spawn_local(async move {
             TimeoutFuture::new(300).await;
 
-            if search_id.get_untracked() != current_id {
+            if search_outcome(search_id, current_id) != SearchOutcome::Commit {
                 return;
             }
 
@@ -206,7 +234,7 @@ pub fn SearchBox(#[prop(optional)] autofocus: bool) -> impl IntoView {
             set_loading.set(true);
             match api_search(&s).await {
                 Ok(mut results) => {
-                    if search_id.get_untracked() == current_id {
+                    if search_outcome(search_id, current_id) == SearchOutcome::Commit {
                         // Prepend static pages to the backend results
                         let mut final_results = matched_pages;
                         final_results.append(&mut results);
@@ -217,7 +245,7 @@ pub fn SearchBox(#[prop(optional)] autofocus: bool) -> impl IntoView {
                     }
                 }
                 Err(e) => {
-                    if search_id.get_untracked() == current_id {
+                    if search_outcome(search_id, current_id) == SearchOutcome::Commit {
                         log::error!("Search failed: {}", e);
                         // Even if backend fails, show matched static pages
                         let results = matched_pages.into_iter().map(Arc::new).collect();
@@ -577,4 +605,37 @@ pub fn SearchBox(#[prop(optional)] autofocus: bool) -> impl IntoView {
         </div>
     }
     .into_any()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commits_the_newest_search() {
+        let owner = Owner::new();
+        let (search_id, _set) = owner.with(|| signal(7usize));
+        assert_eq!(search_outcome(search_id, 7), SearchOutcome::Commit);
+    }
+
+    #[test]
+    fn drops_a_search_a_later_keystroke_superseded() {
+        let owner = Owner::new();
+        let (search_id, set_search_id) = owner.with(|| signal(7usize));
+        set_search_id.set(8);
+        assert_eq!(search_outcome(search_id, 7), SearchOutcome::Superseded);
+    }
+
+    /// Selecting a result navigates, `SearchOverlay`'s location effect closes
+    /// the overlay, and its `<Show>` disposes the search box — all while the
+    /// request is still in flight. Reading `search_id` here used to panic
+    /// ("Tried to access a reactive value that has already been disposed"),
+    /// killing the wasm bundle on the page just navigated to (#6874).
+    #[test]
+    fn cancels_a_search_whose_component_was_disposed_mid_flight() {
+        let owner = Owner::new();
+        let (search_id, _set) = owner.with(|| signal(7usize));
+        owner.cleanup();
+        assert_eq!(search_outcome(search_id, 7), SearchOutcome::Cancelled);
+    }
 }


### PR DESCRIPTION
Fixes the top new client-side panic in GlitchTip — [#6874](https://glitchtip.ultros.app/ultros/issues/6874), `RustWasmPanic: Tried to access a reactive value that has already been disposed.`, `environment:production`, release `ultros@9ca88ce`, Chrome 150 — plus one latent instance of the same class.

## What happens

Search for an item, click a result. The page you land on immediately dies: the wasm bundle panics, so the destination renders its SSR HTML and then stops being interactive.

The breadcrumb trail of the latest event is the whole bug in five lines:

```
23:44:29.665  fetch  /api/v1/search?q=fire      200
23:44:30.435  fetch  /api/v1/search?q=fire%20   200
23:44:30.509  navigation  /item/30394 -> /item/8
23:44:30.978  console  panicked at reactive_graph-0.2.14/src/traits.rs:361:29:
                       Tried to access a reactive value that has already been disposed.
23:44:30.982  sentry.event  Uncaught RuntimeError: unreachable
```

## Root cause

`traits.rs:361:29` is exactly the `unwrap_or_else(unwrap_signal!(self))` inside `GetUntracked::get_untracked` — so the panic is a **read** of a disposed signal, not a write. (`Set::set` and `Update::update` on a disposed signal are silent no-ops; only the read accessors panic. That's why the `set_search_results` / `set_loading` calls in the same block were never the problem.)

The disposal is by design, and it races the request:

1. `SearchBox`'s debounced effect starts `api_search(&s)` in a `spawn_local`.
2. The user clicks a result → `use_navigate` routes away.
3. `SearchOverlay` has an `Effect` on `location.pathname` that calls `state.close()` on **any** navigation — deliberately, so the sheet can't stay up over the destination.
4. That flips the `<Show>` guarding `<SearchBox>`, which **disposes every signal the search box owns**.
5. The request resolves ~470ms later and the continuation calls `search_id.get_untracked()` to check whether it's still the newest search. The signal is gone → panic.

So the crash is on the *destination* page, triggered by the *previous* page's in-flight request. Every search-then-navigate is a candidate; it needs the response to land after the navigation, which is why it's 3 events and not thousands.

## Fix

Route the "is this search still current?" decision through `try_get_untracked` and give the disposed case a name:

```rust
enum SearchOutcome { Commit, Superseded, Cancelled }

fn search_outcome(search_id: ReadSignal<usize>, started_id: usize) -> SearchOutcome {
    match search_id.try_get_untracked() {
        None => SearchOutcome::Cancelled,          // component disposed mid-flight
        Some(id) if id == started_id => SearchOutcome::Commit,
        Some(_) => SearchOutcome::Superseded,      // a later keystroke won
    }
}
```

`Cancelled` and `Superseded` both mean "drop these results", but they're distinct states worth distinguishing at the call site — and naming `Cancelled` is what documents why the `try_` accessor is load-bearing here. All three post-`await` reads in the debounce effect now go through it.

I swept the whole `ultros-app` crate for the general shape — a read accessor reached after the first `.await` inside a `spawn_local` — and it found exactly four sites: the three above, plus `list_subscribe_drawer.rs`, which read `mode.get()` after `create_alert`/`patch_alert` to pick a toast string. Dismissing that drawer mid-request would panic identically. Fixed by resolving the message before the request instead. No other instances exist in the crate.

## Verification

Genuine red→green by mutation. With `try_get_untracked()` swapped back to `get_untracked()`, the new disposal test fails at exit 101 with the **byte-identical production panic location**:

```
panicked at reactive_graph-0.2.14/src/traits.rs:361:29:
At search_box.rs:154:26, you tried to access a reactive value which was
defined at search_box.rs:637:47, but it has already been disposed.
```

The test drives the same lifecycle `<Show>` does — build the signal under an `Owner`, `owner.cleanup()`, then run the continuation.

Restored: `cargo test -p ultros-app --lib` → **442 passed / 0 failed** (base 439 + 3).

Gates, all exit 0:
- `cargo fmt --all -- --check`
- `cargo clippy -p ultros-app --all-targets -- -D warnings`
- `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown` — CI never lints the `hydrate` cfg, and this is client-only code, so it's the configuration that actually ships to the browser.

## Triage done alongside

Ignored **68** stale May-12 scraper-flood fragments (#1314→#1245, contiguous). Spot-checked #1314 first: release `c88703d8`, Chrome 112, UTC, `HTMLDocument.c` injected-script error — the established flood fingerprint. The tail continues below #1245.

**#6874 left unresolved on purpose** — this fix isn't deployed yet, so it should stay visible until it is.

One note for whoever deploys: prod is still on `9ca88ce`, which predates #1121, so the `GET /api/v1/item_stats/North-America/8 -> 400` also visible in these breadcrumbs is already-fixed-but-undeployed, not a new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
