### PR TITLE
fix(flip-finder): render every enabled column at every width

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -2373,41 +2373,15 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
    rows, so the two scrollports scroll through the same range and the row
    striping covers it.
 
-   The base value tracks the columns each breakpoint actually reveals (several
-   are `hidden md:flex` / `lg:flex`). The `--analyzer-extra-cols-*` variables
-   are set inline by the route and carry the optional columns the user has
-   switched on beyond the default set — the stylesheet cannot know those. They
-   are bucketed by the breakpoint at which the column first renders (`base` =
-   always, `md` = `hidden md:flex` columns, `xl` = `hidden xl:flex` columns) so
-   a viewport only reserves width for columns it actually shows; adding a
-   hidden column's width would extend the scroll range into blank space. */
+   No breakpoint enters into it: every column the user switched on renders at
+   every viewport width, and a narrow screen scrolls to reach them. The 30.75rem
+   here is the four always-on columns (HQ 44px + Item 14rem + Profit 7rem + Buy
+   Price 7rem); `--analyzer-optional-cols` is set inline by the route and carries
+   whatever `?cols=` turned on, which the stylesheet cannot know. */
 .analyzer-table {
-    --analyzer-row-min-width: calc(38rem + var(--analyzer-extra-cols-base, 0px));
-}
-@media (min-width: 768px) {
-    .analyzer-table {
-        --analyzer-row-min-width: calc(
-            61rem + var(--analyzer-extra-cols-base, 0px) +
-                var(--analyzer-extra-cols-md, 0px)
-        );
-    }
-}
-@media (min-width: 1024px) {
-    .analyzer-table {
-        --analyzer-row-min-width: calc(
-            68rem + var(--analyzer-extra-cols-base, 0px) +
-                var(--analyzer-extra-cols-md, 0px)
-        );
-    }
-}
-@media (min-width: 1280px) {
-    .analyzer-table {
-        --analyzer-row-min-width: calc(
-            68rem + var(--analyzer-extra-cols-base, 0px) +
-                var(--analyzer-extra-cols-md, 0px) +
-                var(--analyzer-extra-cols-xl, 0px)
-        );
-    }
+    --analyzer-row-min-width: calc(
+        30.75rem + var(--analyzer-optional-cols, 0px)
+    );
 }
 .analyzer-grid-row {
     min-width: var(--analyzer-row-min-width, 0px);

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "7 天价格趋势",
     "analyzer_tooltip_sales_per_day": "30 天销售速度（每日销量）",
     "analyzer_tooltip_volume_30d": "30 天总销售量（销售次数）",
-    "analyzer_columns_picker_desktop_only": "仅限桌面端",
     "analyzer_last_sold_days_ago": "%count%天前",
     "analyzer_last_sold_hours_ago": "%count%小时前",
     "analyzer_last_sold_just_now": "刚刚",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "7-Tage-Preistrend",
     "analyzer_tooltip_sales_per_day": "30-Tage-Verkaufsgeschwindigkeit (Verkäufe pro Tag)",
     "analyzer_tooltip_volume_30d": "30-Tage-Gesamtverkaufsvolumen (Anzahl der Verkäufe)",
-    "analyzer_columns_picker_desktop_only": "nur Desktop",
     "analyzer_last_sold_days_ago": "vor %count% T.",
     "analyzer_last_sold_hours_ago": "vor %count% Std.",
     "analyzer_last_sold_just_now": "gerade eben",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -1297,7 +1297,6 @@
     "analyzer_tooltip_trend": "7-day price trend",
     "analyzer_tooltip_sales_per_day": "30-day sales velocity (sales per day)",
     "analyzer_tooltip_volume_30d": "30-day total sales volume (number of sales)",
-    "analyzer_columns_picker_desktop_only": "desktop only",
     "analyzer_last_sold_days_ago": "%count%d ago",
     "analyzer_last_sold_hours_ago": "%count%h ago",
     "analyzer_last_sold_just_now": "just now",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "Tendance des prix sur 7 jours",
     "analyzer_tooltip_sales_per_day": "Vitesse de vente sur 30 jours (ventes par jour)",
     "analyzer_tooltip_volume_30d": "Volume total des ventes sur 30 jours (nombre de ventes)",
-    "analyzer_columns_picker_desktop_only": "sur PC uniquement",
     "analyzer_last_sold_days_ago": "il y a %count%j",
     "analyzer_last_sold_hours_ago": "il y a %count%h",
     "analyzer_last_sold_just_now": "à l'instant",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "7日間の価格推移",
     "analyzer_tooltip_sales_per_day": "30日間の販売速度（1日あたりの販売数）",
     "analyzer_tooltip_volume_30d": "30日間の合計販売量（販売回数）",
-    "analyzer_columns_picker_desktop_only": "PCのみ",
     "analyzer_last_sold_days_ago": "%count%日前",
     "analyzer_last_sold_hours_ago": "%count%時間前",
     "analyzer_last_sold_just_now": "たった今",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "7일 가격 추세",
     "analyzer_tooltip_sales_per_day": "30일 기준 판매 속도 (일일 판매량)",
     "analyzer_tooltip_volume_30d": "30일간 총 판매량 (판매 횟수)",
-    "analyzer_columns_picker_desktop_only": "데스크톱 전용",
     "analyzer_last_sold_days_ago": "%count%일 전",
     "analyzer_last_sold_hours_ago": "%count%시간 전",
     "analyzer_last_sold_just_now": "방금 전",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -1294,7 +1294,6 @@
     "analyzer_tooltip_trend": "7 天價格趨勢",
     "analyzer_tooltip_sales_per_day": "30 天銷售速度（每日銷量）",
     "analyzer_tooltip_volume_30d": "30 天總銷售量（銷售次數）",
-    "analyzer_columns_picker_desktop_only": "僅限桌面端",
     "analyzer_last_sold_days_ago": "%count%天前",
     "analyzer_last_sold_hours_ago": "%count%小時前",
     "analyzer_last_sold_just_now": "剛剛",

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -760,72 +760,47 @@ fn format_velocity_floor(v: f32) -> String {
     }
 }
 
-/// Rendered width of the optional columns that are *not* in the default set,
-/// in px, bucketed by the breakpoint at which each column actually renders.
+/// Rendered width, in px, of every optional column the user has switched on.
 ///
-/// The grid's base width lives in the stylesheet, which is the only place that
-/// can know which columns a breakpoint hides. What it cannot know is which
-/// optional columns the user switched on, so that part is measured here and
-/// handed over as `--analyzer-extra-cols-{base,md,xl}`. Under-reserving is the
-/// failure that matters: the two scrollports would stop short of the last
-/// column and it would be unreachable.
+/// Every column renders at every viewport width — the table is a horizontal
+/// scrollport, so a narrow screen scrolls to the columns instead of hiding
+/// them. That makes the reservation one number: the stylesheet holds the width
+/// of the four always-on columns and this adds whatever `?cols=` turned on,
+/// handed over as `--analyzer-optional-cols`. Under-reserving is the failure
+/// that matters: the two scrollports would stop short of the last column and it
+/// would be unreachable.
 ///
-/// The bucketing exists for the opposite failure: several opt-in columns are
-/// `hidden md:flex` / `hidden xl:flex`, and reserving their width below the
-/// breakpoint that reveals them gives a phone a horizontal scroll range whose
-/// far end is empty space. Each bucket is only added by the stylesheet's media
-/// query for that breakpoint (see `style/tailwind.css`), which keeps the whole
-/// mechanism CSS-driven — no `matchMedia` read, so SSR and the first client
-/// render stay identical.
-#[derive(Debug, Default, PartialEq, Eq)]
-struct ExtraColumnWidths {
-    /// Columns visible at every viewport width.
-    base: u32,
-    /// Columns hidden below `md` (768px).
-    md: u32,
-    /// Columns hidden below `xl` (1280px).
-    xl: u32,
-}
-
-fn extra_column_widths_px(visible: &std::collections::HashSet<&'static str>) -> ExtraColumnWidths {
-    // Width AND breakpoint here must match the column's header/cell markup
-    // (`w-[..]` + `hidden md:flex` etc.) in the view below.
-    const ALWAYS: &[(&str, u32)] = &[(COL_ROI, 112)];
-    const MD: &[(&str, u32)] = &[
+/// No `matchMedia` read is involved, so SSR and the first client render stay
+/// identical.
+fn optional_column_width_px(visible: &std::collections::HashSet<&'static str>) -> u32 {
+    // Widths here must match the `w-[..]` on the column's header/cell markup
+    // in the view below.
+    const WIDTHS: &[(&str, u32)] = &[
+        (COL_PROFIT_PER_DAY, 112),
+        (COL_VELOCITY, 88),
+        (COL_DRIFT, 88),
+        (COL_CONFIDENCE, 72),
+        (COL_ROI, 112),
+        (COL_WORLD, 112),
+        (COL_DATACENTER, 112),
         (COL_TREND, 100),
         (COL_SALES_PER_DAY, 140),
         (COL_VOLUME_30D, 88),
+        (COL_LAST_SOLD, 112),
     ];
-    const XL: &[(&str, u32)] = &[(COL_DATACENTER, 112)];
-    let sum = |widths: &[(&str, u32)]| {
-        widths
-            .iter()
-            .filter(|(col, _)| visible.contains(col))
-            .map(|(_, w)| w)
-            .sum()
-    };
-    ExtraColumnWidths {
-        base: sum(ALWAYS),
-        md: sum(MD),
-        xl: sum(XL),
-    }
+    WIDTHS
+        .iter()
+        .filter(|(col, _)| visible.contains(col))
+        .map(|(_, w)| w)
+        .sum()
 }
 
 /// The loading skeleton's version of the grid, in DOM order.
 ///
 /// Each entry's class string is the matching cell's class from the row markup
-/// below — same width, same responsive visibility, same alignment — so the
-/// placeholder columns sit exactly where the real ones will. Keep the two in
-/// step: a column added to the row markup but not here makes the table appear
-/// to gain a column when it loads.
-///
-/// Three cells differ from their real counterparts on purpose. World,
-/// datacenter and last-sold are written `hidden lg:block flex` / `hidden
-/// md:block flex` in the row markup — `block` and `flex` on the same element,
-/// where which one wins is down to stylesheet order rather than intent — so
-/// the skeleton spells them `hidden lg:flex` / `hidden md:flex`, which is what
-/// the `items-center` beside them was reaching for. The widths, which are all
-/// the alignment depends on, are identical either way.
+/// below — same width, same alignment — so the placeholder columns sit exactly
+/// where the real ones will. Keep the two in step: a column added to the row
+/// markup but not here makes the table appear to gain a column when it loads.
 fn analyzer_skeleton_columns(
     visible: &std::collections::HashSet<&'static str>,
 ) -> Vec<SkeletonColumn> {
@@ -856,17 +831,17 @@ fn analyzer_skeleton_columns(
         ),
         (
             Some(COL_VELOCITY),
-            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            "px-3 py-2 w-[88px] shrink-0 flex items-center justify-end",
             SkeletonCell::Number,
         ),
         (
             Some(COL_DRIFT),
-            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            "px-3 py-2 w-[88px] shrink-0 flex items-center justify-end",
             SkeletonCell::Number,
         ),
         (
             Some(COL_CONFIDENCE),
-            "px-3 py-2 w-[72px] shrink-0 hidden md:flex items-center justify-center",
+            "px-3 py-2 w-[72px] shrink-0 flex items-center justify-center",
             SkeletonCell::Badge,
         ),
         (
@@ -882,32 +857,32 @@ fn analyzer_skeleton_columns(
         ),
         (
             Some(COL_WORLD),
-            "px-3 py-2 w-28 shrink-0 hidden lg:flex items-center",
+            "px-3 py-2 w-28 shrink-0 flex items-center",
             SkeletonCell::Text,
         ),
         (
             Some(COL_DATACENTER),
-            "px-3 py-2 w-28 shrink-0 hidden xl:flex items-center",
+            "px-3 py-2 w-28 shrink-0 flex items-center",
             SkeletonCell::Text,
         ),
         (
             Some(COL_TREND),
-            "px-3 py-2 w-[100px] shrink-0 hidden md:flex items-center justify-center",
+            "px-3 py-2 w-[100px] shrink-0 flex items-center justify-center",
             SkeletonCell::Spark,
         ),
         (
             Some(COL_SALES_PER_DAY),
-            "px-3 py-2 w-[140px] shrink-0 hidden md:flex items-center justify-center",
+            "px-3 py-2 w-[140px] shrink-0 flex items-center justify-center",
             SkeletonCell::Badge,
         ),
         (
             Some(COL_VOLUME_30D),
-            "px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end",
+            "px-3 py-2 w-[88px] shrink-0 flex items-center justify-end",
             SkeletonCell::Number,
         ),
         (
             Some(COL_LAST_SOLD),
-            "px-3 py-2 w-28 shrink-0 hidden md:flex items-center",
+            "px-3 py-2 w-28 shrink-0 flex items-center",
             SkeletonCell::Text,
         ),
     ];
@@ -922,14 +897,13 @@ fn analyzer_skeleton_columns(
 ///
 /// Reads `?cols=` the same way the table does, so the skeleton shows the
 /// columns this particular user has switched on rather than a generic set —
-/// and reproduces the container's `--analyzer-extra-cols-*` variables, which
+/// and reproduces the container's `--analyzer-optional-cols` variable, which
 /// is what makes `.analyzer-grid-row` give the placeholder rows the same
 /// min-width as the real ones.
 #[component]
 fn AnalyzerTableSkeleton() -> impl IntoView {
     let (cols_param, _) = query_signal::<String>("cols");
     let visible = parse_visible_cols(cols_param.get_untracked().as_deref());
-    let widths = extra_column_widths_px(&visible);
     view! {
         <TableSkeleton
             columns=analyzer_skeleton_columns(&visible)
@@ -937,38 +911,10 @@ fn AnalyzerTableSkeleton() -> impl IntoView {
             class="analyzer-table border border-[color:var(--color-outline)]"
             row_class="analyzer-grid-row"
             style=format!(
-                "--analyzer-extra-cols-base: {}px; --analyzer-extra-cols-md: {}px; --analyzer-extra-cols-xl: {}px;",
-                widths.base,
-                widths.md,
-                widths.xl,
+                "--analyzer-optional-cols: {}px;",
+                optional_column_width_px(&visible),
             )
         />
-    }
-}
-
-/// Tailwind class that hides a column's "desktop only" note in the Columns
-/// picker once the viewport is wide enough to actually render the column.
-/// `None` for columns visible at every width. Must mirror the `hidden
-/// md:flex` / `lg:flex` / `xl:flex` classes on the column's own markup.
-///
-/// Ticking a hidden column on a phone changes nothing on screen, which reads
-/// as a broken checkbox; the note explains it. The gating is pure CSS so SSR
-/// and the first client render agree.
-fn col_hidden_note_class(col: &str) -> Option<&'static str> {
-    match col {
-        c if c == COL_VELOCITY
-            || c == COL_DRIFT
-            || c == COL_CONFIDENCE
-            || c == COL_TREND
-            || c == COL_SALES_PER_DAY
-            || c == COL_VOLUME_30D
-            || c == COL_LAST_SOLD =>
-        {
-            Some("md:hidden")
-        }
-        c if c == COL_WORLD => Some("lg:hidden"),
-        c if c == COL_DATACENTER => Some("xl:hidden"),
-        _ => None,
     }
 }
 
@@ -2389,14 +2335,6 @@ fn AnalyzerTable(
                                                         on:change=on_change
                                                     />
                                                     <span>{label}</span>
-                                                    {col_hidden_note_class(col)
-                                                        .map(|hide_at| view! {
-                                                            <span class=format!(
-                                                                "text-xs text-[color:var(--color-text-muted)] {hide_at}",
-                                                            )>
-                                                                {t!(i18n, analyzer_columns_picker_desktop_only)}
-                                                            </span>
-                                                        })}
                                                 </label>
                                             }
                                         })
@@ -2475,12 +2413,9 @@ fn AnalyzerTable(
             <div
                 class="analyzer-table border border-[color:var(--color-outline)]"
                 style=move || {
-                    let widths = extra_column_widths_px(&visible_cols());
                     format!(
-                        "--analyzer-extra-cols-base: {}px; --analyzer-extra-cols-md: {}px; --analyzer-extra-cols-xl: {}px;",
-                        widths.base,
-                        widths.md,
-                        widths.xl,
+                        "--analyzer-optional-cols: {}px;",
+                        optional_column_width_px(&visible_cols()),
                     )
                 }
             >
@@ -2531,17 +2466,17 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_VELOCITY).then(|| view! {
-                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 hidden md:flex items-center justify-end" title=t_string!(i18n, analyzer_tooltip_velocity)>
+                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 flex items-center justify-end" title=t_string!(i18n, analyzer_tooltip_velocity)>
                                         {t!(i18n, analyzer_col_velocity)}
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_DRIFT).then(|| view! {
-                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 hidden md:flex items-center justify-end" title=t_string!(i18n, analyzer_tooltip_drift)>
+                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 flex items-center justify-end" title=t_string!(i18n, analyzer_tooltip_drift)>
                                         {t!(i18n, analyzer_col_drift)}
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_CONFIDENCE).then(|| view! {
-                                    <div role="columnheader" class="w-[72px] shrink-0 px-3 py-2 hidden md:flex items-center justify-center" title=t_string!(i18n, analyzer_tooltip_confidence)>
+                                    <div role="columnheader" class="w-[72px] shrink-0 px-3 py-2 flex items-center justify-center" title=t_string!(i18n, analyzer_tooltip_confidence)>
                                         {t!(i18n, analyzer_col_confidence)}
                                     </div>
                                 })}
@@ -2559,7 +2494,7 @@ fn AnalyzerTable(
                                     {t!(i18n, analyzer_col_buy_price)}
                                 </div>
                                 {move || visible_cols().contains(COL_WORLD).then(|| view! {
-                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 flex flex-row gap-2 hidden lg:flex">
+                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 flex flex-row gap-2">
                                         {t!(i18n, analyzer_col_world)}
                                         <div>
                                             {move || {
@@ -2581,7 +2516,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_DATACENTER).then(|| view! {
-                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 flex flex-row gap-2 hidden xl:flex">
+                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 flex flex-row gap-2">
                                         {t!(i18n, analyzer_col_datacenter)}
                                         <div>
                                             {move || {
@@ -2603,7 +2538,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_TREND).then(|| view! {
-                                    <div role="columnheader" class="w-[100px] shrink-0 px-3 py-2 hidden md:flex flex-col items-center text-center leading-tight" title=t_string!(i18n, analyzer_tooltip_trend)>
+                                    <div role="columnheader" class="w-[100px] shrink-0 px-3 py-2 flex flex-col items-center text-center leading-tight" title=t_string!(i18n, analyzer_tooltip_trend)>
                                         <span>{t!(i18n, analyzer_col_spark)}</span>
                                         <span class="text-[10px] font-normal normal-case text-[color:var(--color-text-muted)] truncate max-w-full">
                                             {move || world()}
@@ -2611,7 +2546,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_SALES_PER_DAY).then(|| view! {
-                                    <div role="columnheader" class="w-[140px] shrink-0 px-3 py-2 hidden md:flex flex-col items-center text-center leading-tight" title=t_string!(i18n, analyzer_tooltip_sales_per_day)>
+                                    <div role="columnheader" class="w-[140px] shrink-0 px-3 py-2 flex flex-col items-center text-center leading-tight" title=t_string!(i18n, analyzer_tooltip_sales_per_day)>
 
                                         <span>{t!(i18n, analyzer_col_sales_per_day)}</span>
                                         <span class="text-[10px] font-normal normal-case text-[color:var(--color-text-muted)] truncate max-w-full">
@@ -2620,7 +2555,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_VOLUME_30D).then(|| view! {
-                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 hidden md:flex flex-col items-end text-right leading-tight" title=t_string!(i18n, analyzer_tooltip_volume_30d)>
+                                    <div role="columnheader" class="w-[88px] shrink-0 px-3 py-2 flex flex-col items-end text-right leading-tight" title=t_string!(i18n, analyzer_tooltip_volume_30d)>
                                         <span>{t!(i18n, analyzer_col_volume_30d)}</span>
                                         <span class="text-[10px] font-normal normal-case text-[color:var(--color-text-muted)] truncate max-w-full">
                                             {move || world()}
@@ -2628,7 +2563,7 @@ fn AnalyzerTable(
                                     </div>
                                 })}
                                 {move || visible_cols().contains(COL_LAST_SOLD).then(|| view! {
-                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 hidden md:flex flex-col leading-tight">
+                                    <div role="columnheader" class="w-28 shrink-0 px-3 py-2 flex flex-col leading-tight">
                                         <span>{t!(i18n, analyzer_col_last_sold)}</span>
                                         <span class="text-[10px] font-normal normal-case text-[color:var(--color-text-muted)] truncate max-w-full">
                                             {move || world()}
@@ -2745,7 +2680,7 @@ fn AnalyzerTable(
                                             None => "—".to_string(),
                                         };
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end font-mono tabular-nums">
+                                            <div role="cell" class="px-3 py-2 w-[88px] shrink-0 flex items-center justify-end font-mono tabular-nums">
                                                 {text}
                                             </div>
                                         }
@@ -2767,7 +2702,7 @@ fn AnalyzerTable(
                                             <div
                                                 role="cell"
                                                 title=title
-                                                class=format!("px-3 py-2 w-[88px] shrink-0 hidden md:flex items-center justify-end font-mono tabular-nums {class}")
+                                                class=format!("px-3 py-2 w-[88px] shrink-0 flex items-center justify-end font-mono tabular-nums {class}")
                                             >
                                                 {text}
                                             </div>
@@ -2788,7 +2723,7 @@ fn AnalyzerTable(
                                             },
                                         };
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-[72px] shrink-0 hidden md:flex items-center justify-center">
+                                            <div role="cell" class="px-3 py-2 w-[72px] shrink-0 flex items-center justify-center">
                                                 <span class=format!("text-xs font-semibold {class}")>{label}</span>
                                             </div>
                                         }
@@ -2804,7 +2739,7 @@ fn AnalyzerTable(
                                         <Gil amount=data.inner.cheapest_price />
                                     </div>
                                     {move || visible_cols().contains(COL_WORLD).then(|| view! {
-                                        <div role="cell" class="px-3 py-2 w-28 shrink-0 hidden lg:block flex items-center">
+                                        <div role="cell" class="px-3 py-2 w-28 shrink-0 flex items-center">
                                             <Tooltip tooltip_text=Signal::derive(move || {
                                                 t_string!(i18n, analyzer_only_show_world).to_string().replace("%world%", &world())
                                             })>
@@ -2821,7 +2756,7 @@ fn AnalyzerTable(
                                         </div>
                                     })}
                                     {move || visible_cols().contains(COL_DATACENTER).then(|| view! {
-                                        <div role="cell" class="px-3 py-2 w-28 shrink-0 hidden xl:block flex items-center">
+                                        <div role="cell" class="px-3 py-2 w-28 shrink-0 flex items-center">
                                             <Tooltip tooltip_text=Signal::derive(move || {
                                                 t_string!(i18n, analyzer_only_show_world).to_string().replace("%world%", &datacenter())
                                             })>
@@ -2858,7 +2793,7 @@ fn AnalyzerTable(
                                             view! { <SingleLineSkeleton /> }.into_any()
                                         };
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-[100px] hidden md:flex items-center justify-center">
+                                            <div role="cell" class="px-3 py-2 w-[100px] shrink-0 flex items-center justify-center">
                                                 {inner}
                                             </div>
                                         }
@@ -2884,7 +2819,7 @@ fn AnalyzerTable(
                                             (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
                                         };
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-[140px] shrink-0 hidden md:flex items-center justify-center">
+                                            <div role="cell" class="px-3 py-2 w-[140px] shrink-0 flex items-center justify-center">
                                                 {inner}
                                             </div>
                                         }
@@ -2897,7 +2832,7 @@ fn AnalyzerTable(
                                             (None, false) => view! { <SingleLineSkeleton /> }.into_any(),
                                         };
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-[88px] hidden md:flex items-center justify-end font-mono tabular-nums">
+                                            <div role="cell" class="px-3 py-2 w-[88px] shrink-0 flex items-center justify-end font-mono tabular-nums">
                                                 {inner}
                                             </div>
                                         }
@@ -2921,7 +2856,7 @@ fn AnalyzerTable(
                                             })
                                             .unwrap_or_else(|| t_string!(i18n, analyzer_last_sold_never).to_string());
                                         view! {
-                                            <div role="cell" class="px-3 py-2 w-28 truncate hidden md:block flex items-center">
+                                            <div role="cell" class="px-3 py-2 w-28 shrink-0 truncate flex items-center">
                                                 {last}
                                             </div>
                                         }
@@ -3682,82 +3617,43 @@ mod tests {
     }
 
     #[test]
-    fn the_default_column_set_adds_no_extra_width() {
-        // The stylesheet's per-breakpoint baseline already covers these, so
-        // counting them here would reserve the width twice and leave the grid
-        // scrolling into empty space.
-        let defaults: std::collections::HashSet<&'static str> =
-            DEFAULT_VISIBLE_COLS.iter().copied().collect();
+    fn no_optional_columns_reserves_no_extra_width() {
+        // The stylesheet's 30.75rem baseline is exactly the four always-on
+        // columns, so an empty set must add nothing on top of it.
         assert_eq!(
-            extra_column_widths_px(&defaults),
-            ExtraColumnWidths::default()
-        );
-        assert_eq!(
-            extra_column_widths_px(&std::collections::HashSet::new()),
-            ExtraColumnWidths::default()
+            optional_column_width_px(&std::collections::HashSet::new()),
+            0
         );
     }
 
     #[test]
-    fn every_opt_in_column_reserves_width() {
-        // A column that neither the CSS baseline nor this function accounts
-        // for is one the scrollports stop short of — the column renders and
-        // cannot be reached, which is the bug this whole mechanism exists to
-        // prevent.
+    fn every_optional_column_reserves_width() {
+        // A column this function does not account for is one the scrollports
+        // stop short of — it renders and cannot be reached, which is the bug
+        // this whole mechanism exists to prevent.
         for col in ALL_OPTIONAL_COLS {
-            if DEFAULT_VISIBLE_COLS.contains(col) {
-                continue;
-            }
             let set: std::collections::HashSet<&'static str> = [*col].into_iter().collect();
-            let widths = extra_column_widths_px(&set);
             assert!(
-                widths.base + widths.md + widths.xl > 0,
+                optional_column_width_px(&set) > 0,
                 "{col} reserves no width, so the grid would stop short of it"
             );
         }
     }
 
     #[test]
-    fn breakpoint_hidden_columns_reserve_no_width_below_their_breakpoint() {
-        // The other half of the reservation contract: a `hidden md:flex` /
-        // `hidden xl:flex` column must not widen the scroll range of a
-        // viewport that never renders it, or a phone scrolls into blank
-        // space. `base` is the only bucket a phone-width stylesheet applies,
-        // and `md` is the widest bucket applied below `xl`.
-        let md_gated: std::collections::HashSet<&'static str> =
-            [COL_TREND, COL_SALES_PER_DAY, COL_VOLUME_30D]
-                .into_iter()
-                .collect();
-        let widths = extra_column_widths_px(&md_gated);
-        assert_eq!(widths.base, 0);
-        assert!(widths.md > 0);
-        assert_eq!(widths.xl, 0);
-
-        let xl_gated: std::collections::HashSet<&'static str> =
-            [COL_DATACENTER].into_iter().collect();
-        let widths = extra_column_widths_px(&xl_gated);
-        assert_eq!(widths.base, 0);
-        assert_eq!(widths.md, 0);
-        assert!(widths.xl > 0);
-
-        // ROI renders at every width, so its reservation must too.
-        let always: std::collections::HashSet<&'static str> = [COL_ROI].into_iter().collect();
-        assert!(extra_column_widths_px(&always).base > 0);
-    }
-
-    #[test]
-    fn hidden_note_matches_the_width_buckets() {
-        // Every optional column that is breakpoint-hidden gets a "desktop
-        // only" note in the Columns picker; the two always-visible ones must
-        // not, or the note would be a lie.
-        for col in ALL_OPTIONAL_COLS {
-            let note = col_hidden_note_class(col);
-            if *col == COL_PROFIT_PER_DAY || *col == COL_ROI {
-                assert!(note.is_none(), "{col} is always visible");
-            } else {
-                assert!(note.is_some(), "{col} is breakpoint-hidden");
-            }
-        }
+    fn column_reservations_add_up() {
+        // The reservation is a plain sum now that no column is breakpoint
+        // hidden — nothing is bucketed away from a narrow viewport.
+        let all: std::collections::HashSet<&'static str> =
+            ALL_OPTIONAL_COLS.iter().copied().collect();
+        let summed: u32 = ALL_OPTIONAL_COLS
+            .iter()
+            .map(|col| {
+                let one: std::collections::HashSet<&'static str> = [*col].into_iter().collect();
+                optional_column_width_px(&one)
+            })
+            .sum();
+        assert_eq!(optional_column_width_px(&all), summed);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1111.

## The bug

The Flip Finder's columns picker offers eleven optional columns. Nine of them carried a breakpoint gate (`hidden md:flex`, `hidden lg:block`, `hidden xl:flex`), so on a phone ticking them changed nothing — the checkbox toggled, the URL changed, and the column stayed `display: none`. The picker even shipped a "desktop only" note next to those nine, which explained the dead checkbox rather than fixing it.

Measured on prod at narrow width with **every** column enabled (`?cols=profit_per_day,velocity,drift,confidence,world,last_sold,roi,datacenter,trend,sales_per_day,volume_30d`):

| column | rendered width |
|---|---|
| HQ, Item, Profit, Profit/day, ROI, Buy Price | 44 / 228 / 112 / 112 / 112 / 112 |
| Velocity, Drift, Confidence, World, Datacenter, Trend, Sales/day, 30d Volume, Last Sold | **0 — `display: none`** |

## The fix

The results grid is already a pair of synchronized horizontal scrollports (`.analyzer-hscroll`), so a narrow viewport can *scroll* to a column rather than hide it. Every optional header, cell and skeleton column loses its breakpoint gate; `?cols=` becomes the only thing that decides what renders.

## What that simplifies

The width reservation existed in three breakpoint buckets (`--analyzer-extra-cols-{base,md,xl}`) for exactly one reason: reserving a hidden column's width would have given a phone a scroll range whose far end was blank. With nothing hidden that concern disappears and the reservation is one number.

- `ExtraColumnWidths` + `extra_column_widths_px` → `optional_column_width_px`, a plain sum over all eleven columns.
- Four `@media` blocks in `style/tailwind.css` → one rule. The baseline is now just the four always-on columns: `30.75rem` = HQ 44px + Item 14rem + Profit 7rem + Buy Price 7rem, exact rather than the old rounded-up 38/61/68rem tiers.
- `col_hidden_note_class` and the picker's "desktop only" note are gone, along with `analyzer_columns_picker_desktop_only` in all seven locale files.

Also picked up: Trend, 30d Volume and Last Sold were missing `shrink-0` on their body cells. That never showed because those cells were `display: none` at precisely the widths where the row is tightest.

## Tests

`the_default_column_set_adds_no_extra_width`, `every_opt_in_column_reserves_width`, `breakpoint_hidden_columns_reserve_no_width_below_their_breakpoint` and `hidden_note_matches_the_width_buckets` all encoded the bucketing contract that no longer exists. Replaced with `no_optional_columns_reserves_no_extra_width`, `every_optional_column_reserves_width` (now covers all eleven, not just the non-default ones) and `column_reservations_add_up`, which pins that the reservation is a plain sum.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean
- `cargo test -p ultros-app --lib analyzer::` — **68 passed, 0 failed**

Note this widens the default mobile scroll range: with the default six optional columns the row min-width goes from 604px to 1076px on a phone. That is the point of the issue — the columns are reachable now instead of silently dropped — but it is a visible change to the default phone view, so flagging it.

Heads-up on overlap: #1136 is open against `analyzer.rs` too. It touches the realtime/sort paths and the table wrapper; this touches column class strings, the width helper and the picker. They should merge cleanly but whichever lands second is worth a look.
