### PR TITLE
fix(flip-finder): don't print the confidence twice on one row

### DIFF
--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -2729,7 +2729,15 @@ fn AnalyzerTable(
                                                 <ItemIcon item_id icon_size=IconSize::Small loading=icon_loading />
                                             </div>
                                             {item}
+                                            // Inline confidence, for when the Confidence
+                                            // column is switched off. With the column on
+                                            // the row would otherwise say "Low" twice —
+                                            // once beside the name and once in its own
+                                            // column (#1106).
                                             {move || {
+                                                if visible_cols().contains(COL_CONFIDENCE) {
+                                                    return None;
+                                                }
                                                 let maps = enrichment.get();
                                                 maps.quality_for(&row_key).map(|q| {
                                                     view! {


### PR DESCRIPTION
Closes #1106.

Stacked on #1137 — base is `fix/flip-finder-drop-desktop-only-columns`, so review that first. The diff here is 8 lines.

## The bug

The item cell renders a `ConfidenceBadge` next to the name *and* the Confidence column prints the same band a few columns over, so with the column on a row reads:

> Flagstone Loft **(Low)** 📋 ☰ … 568,355 −2% **Low** 355,045

Both read from the same `enrichment.quality_for(row_key).confidence_band`, so they can never disagree — it is pure duplication, and it costs width in the one column that is `flex-1`.

## The fix

Keep the inline badge only when the Confidence column is switched off, where it is the row's only confidence signal. `visible_cols()` comes from `?cols=`, which is identical on the server and the first client render, so this does not introduce a hydration mismatch.

## Why it is stacked

On `main` the Confidence column is `hidden md:flex`. Gating the badge on the column being *enabled* would therefore blank the confidence entirely on a phone — enabled column, hidden by CSS, badge suppressed. #1137 removes that breakpoint gate, which is what makes "column on ⇒ badge off" safe at every width.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean
- `cargo test -p ultros-app --lib analyzer::` — 68 passed, 0 failed
