### PR TITLE
fix(ui): let content run edge to edge on a phone

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -1726,6 +1726,34 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
     min-width: 0;
     padding: 1rem;
 }
+
+/* Phone: content runs edge to edge.
+   Two paddings stack on a phone — 1rem from the shell above, plus whatever
+   the route spells on its own `.main-content` (`p-2`, `p-6`, `px-0 sm:px-4`;
+   there are seventeen of them and they do not agree). That cost 48px of a
+   375px screen before a single character of content. Zeroing both here beats
+   editing every route, and keeps the horizontal padding decision in one
+   place.
+
+   Only the horizontal axis: vertical padding still separates the content
+   from the top bar and the fixed mobile nav. Panels keep their own inner
+   padding, so text is not flush against the glass — only the panel edges
+   move out to the screen edge.
+
+   The breakpoint is Tailwind's `sm` complement on purpose: below 640px is
+   exactly where the routes apply their tight mobile padding, so this is
+   "wherever the app already thinks it is on a phone, take it to zero".
+   `!important` is required to beat the utility classes on `.main-content`. */
+@media (max-width: 639.98px) {
+    .app-shell > .app-shell-content {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    .main-content {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+}
 .app-shell > .app-shell-ad-rail {
     display: none;
 }


### PR DESCRIPTION
Closes #1109.

## The measurement

Two horizontal paddings stack on a phone. `.app-shell-content` has `padding: 1rem`, and each route then spells its own on `.main-content` — `p-2 sm:p-6` on eight routes, `p-6` on four, `px-0 sm:px-4` on the item view, nothing at all on three more. On a 375px screen that is 48px gone before a single character of content.

Measured on prod at 375px, before → after (candidate CSS injected into the live page):

| element | before | after |
|---|---|---|
| `.main-content` (item view) | left 16, width 343 | left 0, width **375** |
| `.panel` cards | left 16, width 343 | left 0, width **375** |
| flip-finder `.analyzer-table` | width 343 | width **375** |
| flip-finder `.filter-chip-row` | width 238 | width **284** |

## The change

One media query at Tailwind's `sm` complement, zeroing the horizontal padding on both layers. Deliberately narrow:

- **Horizontal only.** Vertical padding still separates content from the top bar and the fixed mobile nav bar.
- **Panels keep their inner `p-4`.** Only the panel *edges* move out to the screen edge; text is not flush against the glass.
- **`!important` on `.main-content`** because it has to beat the per-route Tailwind utilities. This is the same escape hatch the repo already uses for the `a:not(...)` specificity trap.
- **Breakpoint is 639.98px**, the exact complement of Tailwind's `sm`. Below 640px is precisely where the routes already apply their tight mobile padding, so the rule reads "wherever the app already thinks it's on a phone, take the horizontal padding to zero" rather than inventing a new breakpoint.

One rule beats editing seventeen route files, and it keeps the horizontal padding decision in one place for whatever lands next.

## Verification

Checked six routes on prod at 375px with the rule injected — `/`, `/currency-exchange`, `/vendor-resale`, `/trends`, `/scrip-sources`, `/help`, plus `/item` and `/flip-finder`. On every one, `document.documentElement.scrollWidth` stays at **375**, so the #1101 e2e assertion that no page scrolls horizontally still holds. The elements that do extend past the viewport are all inside their own `overflow-x: auto` scrollports (the trends `min-w-[940px]` grid, the vendor-resale and scrip-sources tables) and were already like that before the change.

The stylesheet compiles: built `style/tailwind.css` with cargo-leptos' own `tailwindcss v4.1.10` binary and confirmed the rule is emitted intact. No Rust changed, so clippy and the test suite are untouched by this diff.
