### PR TITLE
refactor(ui): extract a shared SortHeader, fix vendor resale's stuck sort

### DIFF
--- a/ultros-frontend/ultros-app/src/components/mod.rs
+++ b/ultros-frontend/ultros-app/src/components/mod.rs
@@ -70,6 +70,7 @@ pub mod select;
 pub mod side_nav;
 pub mod skeleton;
 pub mod small_item_display;
+pub mod sort_header;
 pub mod sparkline;
 pub mod stats_display;
 pub mod theme_picker;

--- a/ultros-frontend/ultros-app/src/components/sort_header.rs
+++ b/ultros-frontend/ultros-app/src/components/sort_header.rs
@@ -1,0 +1,303 @@
+//! Sortable column header, shared by every tool table.
+//!
+//! Four routes had grown their own copy of this — the Flip Finder's (the
+//! reference), Scrip Sources' near-identical fork, the Item Explorer's
+//! string-keyed variant, and Vendor Resale's inline `QueryButton` with a
+//! hardcoded down arrow. They disagreed on the details that matter: which
+//! direction a fresh click applies, whether the arrow reflects the direction
+//! actually in effect, and whether `?dir=` is written when it is redundant.
+//!
+//! The contract here:
+//!
+//! * clicking an inactive column sorts by it in that column's
+//!   [`SortColumn::default_dir`]; clicking the active column flips it,
+//! * the arrow always reflects the direction actually applied,
+//! * `dir` is omitted from the href when it matches the column's default, so
+//!   the common case stays a clean `?sort=…` and bookmarks don't accumulate a
+//!   redundant param,
+//! * every other query param survives — that's the part each copy got subtly
+//!   different.
+
+use leptos::prelude::*;
+use leptos_router::hooks::use_location;
+use leptos_router::location::Location;
+use leptos_router::params::ParamsMap;
+
+use crate::components::icon::Icon;
+use icondata as i;
+
+/// `?dir=` — sort direction. Absent means the active column's
+/// [`SortColumn::default_dir`].
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub enum SortDir {
+    Asc,
+    #[default]
+    Desc,
+}
+
+impl SortDir {
+    /// The direction a click on the already-active column moves to.
+    pub fn flipped(self) -> Self {
+        match self {
+            SortDir::Asc => SortDir::Desc,
+            SortDir::Desc => SortDir::Asc,
+        }
+    }
+}
+
+impl std::str::FromStr for SortDir {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "asc" => Ok(SortDir::Asc),
+            "desc" => Ok(SortDir::Desc),
+            _ => Err(()),
+        }
+    }
+}
+
+impl std::fmt::Display for SortDir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SortDir::Asc => "asc",
+            SortDir::Desc => "desc",
+        })
+    }
+}
+
+/// A route's sort-mode enum, as far as [`SortHeader`] needs to know it.
+///
+/// [`Display`](std::fmt::Display) has to produce exactly the token the route's
+/// `FromStr` parses back out of `?sort=`, since that round trip is the whole
+/// mechanism.
+pub trait SortColumn: Copy + PartialEq + std::fmt::Display + Send + Sync + 'static {
+    /// The column in effect when `?sort=` is absent or unparseable. Must match
+    /// whatever the route's sort itself falls back to, or the highlighted
+    /// header lies about which column the rows are ordered by.
+    fn fallback() -> Self;
+
+    /// Direction applied when this column is first clicked, and when `?dir=`
+    /// is absent. Defaults to descending — override where a column reads
+    /// best-first ascending (a cost, a time-to-sell).
+    fn default_dir(self) -> SortDir {
+        SortDir::Desc
+    }
+}
+
+/// Direction a click on `mode` applies.
+///
+/// Clicking the column already in effect flips it; clicking any other column
+/// starts from that column's own default, because arriving at a new column in
+/// the wrong direction buries exactly the rows it was clicked for.
+pub(crate) fn next_dir<M: SortColumn>(mode: M, is_active: bool, current: SortDir) -> SortDir {
+    if is_active {
+        current.flipped()
+    } else {
+        mode.default_dir()
+    }
+}
+
+/// The href a header links to: the current query with `sort`/`dir` rewritten
+/// and everything else left alone.
+///
+/// `dir` is written only when it differs from the column's default, so the
+/// common case stays a clean `?sort=…`.
+pub(crate) fn sort_href<M: SortColumn>(
+    pathname: &str,
+    mut q: ParamsMap,
+    mode: M,
+    is_active: bool,
+    current: SortDir,
+    reset_keys: &[&str],
+) -> String {
+    for key in reset_keys {
+        q.remove(key);
+    }
+    q.remove("sort");
+    q.remove("dir");
+    q.insert("sort".to_string(), mode.to_string());
+    let next = next_dir(mode, is_active, current);
+    if next != mode.default_dir() {
+        q.insert("dir".to_string(), next.to_string());
+    }
+    format!("{}{}", pathname, q.to_query_string())
+}
+
+/// One sortable column header link.
+///
+/// Renders the `<a>` only; callers keep their own `role="columnheader"` cell
+/// so column widths and responsive visibility stay with the table that owns
+/// them.
+#[component]
+pub fn SortHeader<M>(
+    /// Column this header sorts by.
+    mode: M,
+    #[prop(into)] label: String,
+    /// Current `?sort=`, as parsed by the route.
+    #[prop(into)]
+    sort_mode: Signal<Option<M>>,
+    /// Current `?dir=`, as parsed by the route.
+    #[prop(into)]
+    sort_dir: Signal<Option<SortDir>>,
+    /// Query keys dropped when the sort changes. The Item Explorer resets
+    /// `page` this way — re-sorting a paginated list otherwise lands you on
+    /// page 7 of a completely different ordering.
+    #[prop(optional)]
+    reset_keys: &'static [&'static str],
+) -> impl IntoView
+where
+    M: SortColumn,
+{
+    let Location {
+        pathname, query, ..
+    } = use_location();
+    let is_active = Signal::derive(move || sort_mode.get().unwrap_or_else(M::fallback) == mode);
+    let dir = Signal::derive(move || {
+        sort_dir
+            .get()
+            .unwrap_or_else(|| sort_mode.get().unwrap_or_else(M::fallback).default_dir())
+    });
+    view! {
+        <a
+            class=move || {
+                if is_active() {
+                    "!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
+                } else {
+                    "!text-brand-300 hover:text-brand-200"
+                }
+            }
+            aria-current=move || if is_active() { "true" } else { "false" }
+            href=move || {
+                sort_href(&pathname(), query(), mode, is_active(), dir(), reset_keys)
+            }
+        >
+            <div class="flex items-center gap-2">
+                {label}
+                {move || {
+                    is_active()
+                        .then(|| match dir() {
+                            SortDir::Asc => view! { <Icon icon=i::BiSortUpRegular /> },
+                            SortDir::Desc => view! { <Icon icon=i::BiSortDownRegular /> },
+                        })
+                }}
+            </div>
+        </a>
+    }
+    .into_any()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Stand-in for a route's sort enum: one column that reads best-first
+    /// descending (a profit) and one that reads best-first ascending (a cost),
+    /// which is the combination the four copies disagreed about.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    enum Col {
+        Profit,
+        Cost,
+    }
+
+    impl std::fmt::Display for Col {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(match self {
+                Col::Profit => "profit",
+                Col::Cost => "cost",
+            })
+        }
+    }
+
+    impl SortColumn for Col {
+        fn fallback() -> Self {
+            Col::Profit
+        }
+        fn default_dir(self) -> SortDir {
+            match self {
+                Col::Profit => SortDir::Desc,
+                Col::Cost => SortDir::Asc,
+            }
+        }
+    }
+
+    fn params(pairs: &[(&str, &str)]) -> ParamsMap {
+        let mut q = ParamsMap::new();
+        for (k, v) in pairs {
+            q.insert(k.to_string(), v.to_string());
+        }
+        q
+    }
+
+    #[test]
+    fn clicking_the_active_column_flips_direction() {
+        assert_eq!(next_dir(Col::Profit, true, SortDir::Desc), SortDir::Asc);
+        assert_eq!(next_dir(Col::Profit, true, SortDir::Asc), SortDir::Desc);
+    }
+
+    #[test]
+    fn clicking_a_different_column_starts_at_that_columns_default() {
+        // Not "always descending": a cost column arriving descending shows the
+        // most expensive rows first, which is never why it was clicked.
+        assert_eq!(next_dir(Col::Profit, false, SortDir::Asc), SortDir::Desc);
+        assert_eq!(next_dir(Col::Cost, false, SortDir::Desc), SortDir::Asc);
+    }
+
+    #[test]
+    fn the_default_direction_stays_out_of_the_url() {
+        // Clicking a fresh column writes `?sort=` alone; if `dir` leaked in
+        // here every shared link would carry a redundant param, and flipping
+        // the default later would silently change what old links mean.
+        assert_eq!(
+            sort_href("/t", params(&[]), Col::Cost, false, SortDir::Desc, &[]),
+            "/t?sort=cost"
+        );
+        assert_eq!(
+            sort_href("/t", params(&[]), Col::Profit, false, SortDir::Asc, &[]),
+            "/t?sort=profit"
+        );
+    }
+
+    #[test]
+    fn the_non_default_direction_is_written() {
+        assert_eq!(
+            sort_href("/t", params(&[]), Col::Cost, true, SortDir::Asc, &[]),
+            "/t?sort=cost&dir=desc"
+        );
+        assert_eq!(
+            sort_href("/t", params(&[]), Col::Profit, true, SortDir::Desc, &[]),
+            "/t?sort=profit&dir=asc"
+        );
+    }
+
+    #[test]
+    fn every_other_query_param_survives() {
+        // The part each copy got subtly different. Losing `world` here drops
+        // the visitor onto a different world's data mid-sort.
+        let q = params(&[("world", "Gilgamesh"), ("dir", "asc"), ("sort", "profit")]);
+        let href = sort_href("/t", q, Col::Cost, false, SortDir::Asc, &[]);
+        assert!(href.contains("world=Gilgamesh"), "{href}");
+        assert!(href.contains("sort=cost"), "{href}");
+        assert!(!href.contains("dir="), "stale dir survived: {href}");
+    }
+
+    #[test]
+    fn reset_keys_are_dropped() {
+        // Re-sorting a paginated list has to return to page 1 — page 7 of a
+        // different ordering is a different set of items entirely.
+        let q = params(&[("page", "7"), ("per_page", "50")]);
+        let href = sort_href("/t", q, Col::Cost, false, SortDir::Desc, &["page"]);
+        assert!(!href.contains("page=7"), "{href}");
+        // `per%5Fpage` is `ParamsMap`'s own escaping of the underscore, not a
+        // mangled key — the browser decodes it back to `per_page`.
+        assert!(href.contains("per%5Fpage=50"), "{href}");
+    }
+
+    #[test]
+    fn sort_dir_round_trips_through_string() {
+        assert_eq!("asc".parse::<SortDir>(), Ok(SortDir::Asc));
+        assert_eq!("desc".parse::<SortDir>(), Ok(SortDir::Desc));
+        assert_eq!(SortDir::Asc.to_string(), "asc");
+        assert_eq!(SortDir::Desc.to_string(), "desc");
+        assert!("sideways".parse::<SortDir>().is_err());
+    }
+}

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -24,6 +24,7 @@ use crate::{
         sales_cadence_badge::SalesCadenceBadge,
         saved_views::SavedViewsMenu,
         skeleton::{SingleLineSkeleton, SkeletonCell, SkeletonColumn, TableSkeleton},
+        sort_header::{SortColumn, SortDir, SortHeader},
         sparkline::Sparkline,
         toggle::Toggle,
         tool_help::{ActionableEmptyState, ToolHeader},
@@ -145,7 +146,6 @@ use leptos::{either::Either, prelude::*, reactive::wrappers::write::SignalSetter
 use leptos_router::{
     NavigateOptions,
     hooks::{query_signal, use_location, use_navigate, use_params_map, use_query_map},
-    location::Location,
 };
 use std::{
     cmp::Reverse,
@@ -212,30 +212,11 @@ enum SortMode {
     ProfitPerDay,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
-enum SortDir {
-    Asc,
-    #[default]
-    Desc,
-}
-
-impl FromStr for SortDir {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "asc" => Ok(SortDir::Asc),
-            "desc" => Ok(SortDir::Desc),
-            _ => Err(()),
-        }
-    }
-}
-
-impl std::fmt::Display for SortDir {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            SortDir::Asc => "asc",
-            SortDir::Desc => "desc",
-        })
+/// Every Flip Finder column reads best-first descending, so the shared
+/// default direction applies unchanged.
+impl SortColumn for SortMode {
+    fn fallback() -> Self {
+        SortMode::ProfitPerDay
     }
 }
 
@@ -1135,73 +1116,6 @@ fn classify_market_update(
     }
 }
 
-/// One sortable column header.
-///
-/// Clicking an inactive column sorts by it descending; clicking the column
-/// already in effect flips the direction. The arrow reflects the direction
-/// actually applied — the three call sites this replaces each hardcoded a
-/// down arrow, so `?dir=asc` rendered ascending rows under a descending
-/// glyph, and nothing in the UI could reach `?dir=` at all.
-///
-/// `dir` is omitted from the href when it would be the default, so the
-/// common case stays a clean `?sort=…` and bookmarks don't accumulate a
-/// redundant param.
-#[component]
-fn SortHeader(
-    mode: SortMode,
-    #[prop(into)] label: String,
-    sort_mode: Memo<Option<SortMode>>,
-    sort_dir: Memo<Option<SortDir>>,
-) -> impl IntoView {
-    let Location {
-        pathname, query, ..
-    } = use_location();
-    let is_active = Signal::derive(move || sort_mode().unwrap_or(SortMode::ProfitPerDay) == mode);
-    let dir = Signal::derive(move || sort_dir().unwrap_or_default());
-    view! {
-        <a
-            class=move || {
-                if is_active() {
-                    "!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
-                } else {
-                    "!text-brand-300 hover:text-brand-200"
-                }
-            }
-            aria-current=move || if is_active() { "true" } else { "false" }
-            href=move || {
-                let mut q = query();
-                q.remove("sort");
-                q.remove("dir");
-                q.insert("sort".to_string(), mode.to_string());
-                let next = if is_active() {
-                    match dir() {
-                        SortDir::Desc => SortDir::Asc,
-                        SortDir::Asc => SortDir::Desc,
-                    }
-                } else {
-                    SortDir::Desc
-                };
-                if next != SortDir::default() {
-                    q.insert("dir".to_string(), next.to_string());
-                }
-                format!("{}{}", pathname(), q.to_query_string())
-            }
-        >
-            <div class="flex items-center gap-2">
-                {label}
-                {move || {
-                    is_active()
-                        .then(|| match dir() {
-                            SortDir::Asc => view! { <Icon icon=i::BiSortUpRegular /> },
-                            SortDir::Desc => view! { <Icon icon=i::BiSortDownRegular /> },
-                        })
-                }}
-            </div>
-        </a>
-    }
-    .into_any()
-}
-
 #[component]
 fn AnalyzerTable(
     /// The built profit table, or `None` while the market boards are still
@@ -1761,10 +1675,13 @@ fn AnalyzerTable(
             })
             .collect::<Vec<_>>();
 
+        // Fall back through `SortColumn` rather than a literal, so the rows
+        // are ordered by exactly what the header highlights and arrows.
+        let mode = sort_mode().unwrap_or_else(SortMode::fallback);
         sort_rows(
             &mut sorted_data,
-            sort_mode().unwrap_or(SortMode::ProfitPerDay),
-            sort_dir().unwrap_or_default(),
+            mode,
+            sort_dir().unwrap_or_else(|| mode.default_dir()),
         );
         FilteredRows {
             rows: sorted_data.into_iter().enumerate().collect(),
@@ -4330,49 +4247,16 @@ mod tests {
         }
     }
 
-    /// The header's flip rule, extracted from the href closure so it can be
-    /// pinned without a router. Clicking the column already in effect flips;
-    /// clicking any other column starts descending.
-    fn next_sort_dir(is_active: bool, current: SortDir) -> SortDir {
-        if is_active {
-            match current {
-                SortDir::Desc => SortDir::Asc,
-                SortDir::Asc => SortDir::Desc,
-            }
-        } else {
-            SortDir::Desc
+    #[test]
+    fn every_flip_finder_column_reads_best_first_descending() {
+        // The shared header omits `dir` whenever it matches the column's
+        // default, so every bookmarked `?sort=` on this route means
+        // descending. Giving a column its own default here would silently
+        // flip what those old links resolve to.
+        for mode in [SortMode::Roi, SortMode::Profit, SortMode::ProfitPerDay] {
+            assert_eq!(mode.default_dir(), SortDir::Desc, "{mode}");
         }
-    }
-
-    #[test]
-    fn clicking_the_active_column_flips_direction() {
-        assert_eq!(next_sort_dir(true, SortDir::Desc), SortDir::Asc);
-        assert_eq!(next_sort_dir(true, SortDir::Asc), SortDir::Desc);
-    }
-
-    #[test]
-    fn clicking_a_different_column_starts_descending() {
-        // Arriving at a new column ascending would bury the best rows, which
-        // is the opposite of what every one of these columns is sorted for.
-        assert_eq!(next_sort_dir(false, SortDir::Asc), SortDir::Desc);
-        assert_eq!(next_sort_dir(false, SortDir::Desc), SortDir::Desc);
-    }
-
-    #[test]
-    fn descending_is_the_default_so_it_stays_out_of_the_url() {
-        // The header omits `dir` whenever it equals the default; if that
-        // default ever changed, every bookmarked `?sort=` would silently
-        // flip meaning.
-        assert_eq!(SortDir::default(), SortDir::Desc);
-    }
-
-    #[test]
-    fn sort_dir_round_trips_through_string() {
-        assert_eq!("asc".parse::<SortDir>(), Ok(SortDir::Asc));
-        assert_eq!("desc".parse::<SortDir>(), Ok(SortDir::Desc));
-        assert_eq!(SortDir::Asc.to_string(), "asc");
-        assert_eq!(SortDir::Desc.to_string(), "desc");
-        assert!("sideways".parse::<SortDir>().is_err());
+        assert_eq!(<SortMode as SortColumn>::fallback(), SortMode::ProfitPerDay);
     }
 
     #[test]

--- a/ultros-frontend/ultros-app/src/routes/item_explorer.rs
+++ b/ultros-frontend/ultros-app/src/routes/item_explorer.rs
@@ -10,6 +10,7 @@ use crate::components::job_set_card::JobSetCard;
 use crate::components::job_set_grouping::{GroupableItem, group_into_sets};
 use crate::components::loading::Loading;
 use crate::components::query_button::QueryButton;
+use crate::components::sort_header::{SortColumn, SortDir, SortHeader};
 use crate::components::toggle::Toggle;
 use crate::components::world_name::WorldName;
 use crate::components::{add_to_list::*, cheapest_price::*, item_icon::*, meta::*};
@@ -23,8 +24,7 @@ use leptos::prelude::*;
 use leptos::reactive::wrappers::write::SignalSetter;
 use leptos_router::components::A;
 use leptos_router::components::Outlet;
-use leptos_router::hooks::{query_signal, use_location, use_params_map};
-use leptos_router::location::Location;
+use leptos_router::hooks::{query_signal, use_params_map};
 use paginate::Pages;
 use percent_encoding::percent_decode_str;
 use ultros_api_types::world_helper::AnySelector;
@@ -545,106 +545,42 @@ impl Display for ItemSortOption {
     }
 }
 
-#[derive(PartialEq, PartialOrd, Copy, Clone)]
-enum SortDirection {
-    Asc,
-    Desc,
-}
-
-impl FromStr for SortDirection {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "asc" => SortDirection::Asc,
-            "dsc" => SortDirection::Desc,
-            _ => return Err(()),
-        })
+/// The Item Explorer's list is item-level-descending until the visitor says
+/// otherwise; every column here reads best-first descending, so the shared
+/// default direction applies unchanged.
+impl SortColumn for ItemSortOption {
+    fn fallback() -> Self {
+        ItemSortOption::ItemLevel
     }
 }
 
-impl Display for SortDirection {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let val = match self {
-            SortDirection::Asc => "asc",
-            SortDirection::Desc => "desc",
-        };
-        f.write_str(val)
-    }
-}
+/// Re-sorting has to return to page 1: page 7 of a different ordering is a
+/// different set of items, and an out-of-range page is what
+/// `?page=35&sort=ilvl` deep-links used to hydrate-crash on.
+const RESET_ON_SORT: &[&str] = &["page"];
 
-/// Sortable column header for the results list. Clicking sets `sort` to
-/// `value` and resets the page; clicking the already-active column
-/// toggles between descending (the default — `dir` removed) and
-/// ascending. Href construction mirrors `QueryButton` so all other query
-/// params (`world`, `per_page`, ...) survive.
-#[component]
-fn SortHeader(
-    /// value written to the `sort` query key
-    value: &'static str,
-    /// active when no `sort` param is present
-    #[prop(optional)]
-    default: bool,
-    children: Children,
-) -> impl IntoView {
-    let Location {
-        pathname, query, ..
-    } = use_location();
-    let is_active = Signal::derive(move || {
-        query.with(|q| {
-            let current = q.get_str("sort");
-            current == Some(value) || (default && current.is_none())
-        })
-    });
-    let is_asc = Signal::derive(move || query.with(|q| q.get_str("dir") == Some("asc")));
-    let href = move || {
-        let mut query = query();
-        query.remove("page");
-        query.remove("sort");
-        query.insert("sort".to_string(), value.to_string());
-        let flip_to_asc = is_active.get() && !is_asc.get();
-        query.remove("dir");
-        if flip_to_asc {
-            query.insert("dir".to_string(), "asc".to_string());
-        }
-        format!("{}{}", pathname(), query.to_query_string())
-    };
-    view! {
-        <div
-            role="columnheader"
-            aria-sort=move || {
-                if is_active() {
-                    if is_asc() { "ascending" } else { "descending" }
-                } else {
-                    "none"
-                }
-            }
-        >
-            <a
-                href=href
-                class="flex items-center gap-1 hover:text-brand-300 transition-colors"
-            >
-                {children()}
-                <span class="w-3 inline-block">
-                    {move || {
-                        if is_active() {
-                            if is_asc() { "↑" } else { "↓" }
-                        } else {
-                            ""
-                        }
-                    }}
-                </span>
-            </a>
-        </div>
+/// `aria-sort` for a header cell. The shared [`SortHeader`] renders the link;
+/// the cell around it is what carries `role="columnheader"`, so the ARIA
+/// state has to be computed out here.
+fn column_aria_sort(
+    mode: ItemSortOption,
+    sort: Memo<Option<ItemSortOption>>,
+    dir: Memo<Option<SortDir>>,
+) -> &'static str {
+    if sort.get().unwrap_or_else(ItemSortOption::fallback) != mode {
+        return "none";
     }
-    .into_any()
+    match dir.get().unwrap_or_else(|| mode.default_dir()) {
+        SortDir::Asc => "ascending",
+        SortDir::Desc => "descending",
+    }
 }
 
 #[component]
 fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView {
     let i18n = use_i18n();
     let (page, _set_page) = query_signal::<i32>("page");
-    let (direction, _set_direction) = query_signal::<SortDirection>("dir");
+    let (direction, _set_direction) = query_signal::<SortDir>("dir");
     let (sort, _set_sort) = query_signal::<ItemSortOption>("sort");
 
     let cheapest_prices = use_context::<CheapestPrices>().unwrap();
@@ -688,8 +624,8 @@ fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView
     });
 
     let sorted_items = Memo::new(move |_| {
-        let direction = direction().unwrap_or(SortDirection::Desc);
-        let item_property = sort().unwrap_or(ItemSortOption::ItemLevel);
+        let item_property = sort().unwrap_or_else(ItemSortOption::fallback);
+        let direction = direction().unwrap_or_else(|| item_property.default_dir());
         let price_map = if hydrated.get() {
             listings_resource.get().and_then(|r| r.ok())
         } else {
@@ -710,8 +646,8 @@ fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView
             })
             .sorted_by(|a, b| {
                 let ((_, item_a), (_, item_b)) = match direction {
-                    SortDirection::Asc => (a, b),
-                    SortDirection::Desc => (b, a),
+                    SortDir::Asc => (a, b),
+                    SortDir::Desc => (b, a),
                 };
                 match item_property {
                     ItemSortOption::ItemLevel => item_a.level_item.cmp(&item_b.level_item),
@@ -860,10 +796,45 @@ fn ItemList(items: Memo<Vec<(&'static ItemId, &'static Item)>>) -> impl IntoView
                     }
                 >
                     <div role="columnheader"></div>
-                    <SortHeader value="name">{t!(i18n, item_explorer_name)}</SortHeader>
-                    <SortHeader value="ilvl" default=true>{t!(i18n, item_explorer_ilvl)}</SortHeader>
+                    <div
+                        role="columnheader"
+                        aria-sort=move || column_aria_sort(ItemSortOption::Name, sort, direction)
+                    >
+                        <SortHeader
+                            mode=ItemSortOption::Name
+                            label=t_string!(i18n, item_explorer_name).to_string()
+                            sort_mode=sort
+                            sort_dir=direction
+                            reset_keys=RESET_ON_SORT
+                        />
+                    </div>
+                    <div
+                        role="columnheader"
+                        aria-sort=move || {
+                            column_aria_sort(ItemSortOption::ItemLevel, sort, direction)
+                        }
+                    >
+                        <SortHeader
+                            mode=ItemSortOption::ItemLevel
+                            label=t_string!(i18n, item_explorer_ilvl).to_string()
+                            sort_mode=sort
+                            sort_dir=direction
+                            reset_keys=RESET_ON_SORT
+                        />
+                    </div>
                     <div role="columnheader">{t!(i18n, item_explorer_col_equip_level)}</div>
-                    <SortHeader value="price">{t!(i18n, nq)}</SortHeader>
+                    <div
+                        role="columnheader"
+                        aria-sort=move || column_aria_sort(ItemSortOption::Price, sort, direction)
+                    >
+                        <SortHeader
+                            mode=ItemSortOption::Price
+                            label=t_string!(i18n, nq).to_string()
+                            sort_mode=sort
+                            sort_dir=direction
+                            reset_keys=RESET_ON_SORT
+                        />
+                    </div>
                     <div role="columnheader">{t!(i18n, hq)}</div>
                     <div role="columnheader" class="hidden xl:block">
                         {t!(i18n, item_explorer_vendor)}

--- a/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
+++ b/ultros-frontend/ultros-app/src/routes/scrip_sources.rs
@@ -5,10 +5,10 @@ use crate::{
     api::get_cheapest_listings,
     components::{
         gil::*,
-        icon::Icon,
         item_icon::*,
         realtime_status::RealtimeStatus,
         skeleton::BoxSkeleton,
+        sort_header::{SortColumn, SortDir, SortHeader},
         tool_help::*,
         toolbar::{Toolbar, ToolbarField},
         virtual_scroller::*,
@@ -18,12 +18,10 @@ use crate::{
         LocalWorldData, home_world::use_home_world, region_for_world::use_region_for_world,
     },
 };
-use icondata as i;
 use leptos::prelude::*;
 use leptos_router::{
     NavigateOptions,
-    hooks::{query_signal, use_location, use_navigate, use_query_map},
-    location::Location,
+    hooks::{query_signal, use_navigate, use_query_map},
 };
 use std::{collections::HashSet, sync::Arc};
 use thousands::Separable;
@@ -282,43 +280,18 @@ impl std::fmt::Display for SortMode {
     }
 }
 
-impl SortMode {
-    /// The direction each column sorts in when first clicked (and when no
-    /// `?dir=` is present). Costs read best-first ascending; the scrip payout
-    /// reads best-first descending.
+impl SortColumn for SortMode {
+    fn fallback() -> Self {
+        SortMode::CostPerScrip
+    }
+
+    /// Costs read best-first ascending; the scrip payout reads best-first
+    /// descending.
     fn default_dir(self) -> SortDir {
         match self {
             SortMode::CostPerScrip | SortMode::Cost => SortDir::Asc,
             SortMode::ScripAmount => SortDir::Desc,
         }
-    }
-}
-
-/// `?dir=` — sort direction override. Absent means the active mode's
-/// [`SortMode::default_dir`].
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum SortDir {
-    Asc,
-    Desc,
-}
-
-impl std::str::FromStr for SortDir {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "asc" => Ok(SortDir::Asc),
-            "desc" => Ok(SortDir::Desc),
-            _ => Err(()),
-        }
-    }
-}
-
-impl std::fmt::Display for SortDir {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            SortDir::Asc => "asc",
-            SortDir::Desc => "desc",
-        })
     }
 }
 
@@ -379,71 +352,6 @@ fn rank_scrip_sources(
 
     results.truncate(limit);
     results
-}
-
-/// One sortable column header, after the analyzer's pattern.
-///
-/// Clicking an inactive column sorts by it in that column's default
-/// direction; clicking the active column flips the direction. The arrow
-/// reflects the direction actually applied. `dir` is omitted from the href
-/// when it matches the mode's default so the common case stays a clean
-/// `?sort=…`.
-#[component]
-fn SortHeader(
-    mode: SortMode,
-    #[prop(into)] label: String,
-    sort_mode: Memo<Option<SortMode>>,
-    sort_dir: Memo<Option<SortDir>>,
-) -> impl IntoView {
-    let Location {
-        pathname, query, ..
-    } = use_location();
-    let is_active = Signal::derive(move || sort_mode().unwrap_or(SortMode::CostPerScrip) == mode);
-    let dir = Signal::derive(move || {
-        sort_dir().unwrap_or_else(|| sort_mode().unwrap_or(SortMode::CostPerScrip).default_dir())
-    });
-    view! {
-        <a
-            class=move || {
-                if is_active() {
-                    "!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
-                } else {
-                    "!text-brand-300 hover:text-brand-200"
-                }
-            }
-            aria-current=move || if is_active() { "true" } else { "false" }
-            href=move || {
-                let mut q = query();
-                q.remove("sort");
-                q.remove("dir");
-                q.insert("sort".to_string(), mode.to_string());
-                let next = if is_active() {
-                    match dir() {
-                        SortDir::Desc => SortDir::Asc,
-                        SortDir::Asc => SortDir::Desc,
-                    }
-                } else {
-                    mode.default_dir()
-                };
-                if next != mode.default_dir() {
-                    q.insert("dir".to_string(), next.to_string());
-                }
-                format!("{}{}", pathname(), q.to_query_string())
-            }
-        >
-            <div class="flex items-center gap-2">
-                {label}
-                {move || {
-                    is_active()
-                        .then(|| match dir() {
-                            SortDir::Asc => view! { <Icon icon=i::BiSortUpRegular /> },
-                            SortDir::Desc => view! { <Icon icon=i::BiSortDownRegular /> },
-                        })
-                }}
-            </div>
-        </a>
-    }
-    .into_any()
 }
 
 #[component]
@@ -587,7 +495,7 @@ fn ScripSourceTable(
             });
         }
 
-        let mode = sort_mode().unwrap_or(SortMode::CostPerScrip);
+        let mode = sort_mode().unwrap_or_else(SortMode::fallback);
         let dir = sort_dir().unwrap_or_else(|| mode.default_dir());
         // Rank the *full* set so the result count below is exact; the render
         // memo applies `ROW_LIMIT`.

--- a/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
+++ b/ultros-frontend/ultros-app/src/routes/vendor_resale.rs
@@ -9,9 +9,9 @@ use crate::{
         icon::Icon,
         item_icon::*,
         meta::*,
-        query_button::QueryButton,
         realtime_status::RealtimeStatus,
         skeleton::BoxSkeleton,
+        sort_header::{SortColumn, SortDir, SortHeader},
         tool_help::*,
         toolbar::{Toolbar, ToolbarField, ToolbarPills},
         virtual_scroller::*,
@@ -182,6 +182,14 @@ impl std::fmt::Display for SortMode {
     }
 }
 
+/// Both columns read best-first descending — the biggest margin, the biggest
+/// return — so the shared default direction applies unchanged.
+impl SortColumn for SortMode {
+    fn fallback() -> Self {
+        SortMode::Roi
+    }
+}
+
 impl VendorProfitTable {
     fn new(sales: RecentSales, world_cheapest_listings: CheapestListings) -> Self {
         let data = tracked_data();
@@ -269,6 +277,7 @@ fn VendorResaleTable(
 
     let items = &tracked_data().items;
     let (sort_mode, _set_sort_mode) = query_signal::<SortMode>("sort");
+    let (sort_dir, _set_sort_dir) = query_signal::<SortDir>("dir");
     let (minimum_profit, set_minimum_profit) = query_signal::<i32>("profit");
     let (minimum_roi, set_minimum_roi) = query_signal::<i32>("roi");
     // Seeded to 1d by VendorWorldView so a first-time visitor isn't shown items
@@ -367,9 +376,18 @@ fn VendorResaleTable(
             })
             .collect::<Vec<_>>();
 
-        match sort_mode().unwrap_or(SortMode::Roi) {
-            SortMode::Roi => sorted_data.sort_by_key(|data| Reverse(data.return_on_investment)),
-            SortMode::Profit => sorted_data.sort_by_key(|data| Reverse(data.profit)),
+        // `?dir=` used to be ignored here while the header hardcoded a
+        // descending arrow, so the one direction the table could produce was
+        // also the only one it claimed. The shared header can now reach `asc`.
+        let mode = sort_mode().unwrap_or_else(SortMode::fallback);
+        let dir = sort_dir().unwrap_or_else(|| mode.default_dir());
+        let key = |data: &CalculatedVendorProfitData| match mode {
+            SortMode::Roi => data.return_on_investment,
+            SortMode::Profit => data.profit,
+        };
+        match dir {
+            SortDir::Desc => sorted_data.sort_by_key(|data| Reverse(key(data))),
+            SortDir::Asc => sorted_data.sort_by_key(key),
         }
         sorted_data
             .into_iter()
@@ -628,37 +646,20 @@ fn VendorResaleTable(
                                     {t!(i18n, vendor_resale_item)}
                                 </div>
                                 <div role="columnheader" class="w-30 p-4">
-                                    <QueryButton
-                                        class="!text-brand-300 hover:text-brand-200"
-                                        active_classes="!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
-                                        key="sort"
-                                        value="profit"
-                                    >
-                                        <div class="flex items-center gap-2">
-                                            {t!(i18n, vendor_resale_profit)}
-                                            {move || {
-                                                (sort_mode() == Some(SortMode::Profit))
-                                                    .then(|| view! { <Icon icon=i::BiSortDownRegular /> })
-                                            }}
-                                        </div>
-                                    </QueryButton>
+                                    <SortHeader
+                                        mode=SortMode::Profit
+                                        label=t_string!(i18n, vendor_resale_profit).to_string()
+                                        sort_mode
+                                        sort_dir
+                                    />
                                 </div>
                                 <div role="columnheader" class="w-30 p-4">
-                                    <QueryButton
-                                        class="!text-brand-300 hover:text-brand-200"
-                                        active_classes="!text-[color:var(--brand-fg)] hover:!text-[color:var(--brand-fg)]"
-                                        key="sort"
-                                        value="roi"
-                                        default=true
-                                    >
-                                        <div class="flex items-center gap-2">
-                                            {t!(i18n, vendor_resale_roi)}
-                                            {move || {
-                                                (sort_mode() == Some(SortMode::Roi))
-                                                    .then(|| view! { <Icon icon=i::BiSortDownRegular /> })
-                                            }}
-                                        </div>
-                                    </QueryButton>
+                                    <SortHeader
+                                        mode=SortMode::Roi
+                                        label=t_string!(i18n, vendor_resale_roi).to_string()
+                                        sort_mode
+                                        sort_dir
+                                    />
                                 </div>
                                 <div role="columnheader" class="w-30 p-4">
                                     {t!(i18n, vendor_resale_vendor_price)}


### PR DESCRIPTION
Phase 1 of the UI-kit unification umbrella (#1133). Closes #1125.

Four routes had grown their own sortable column header and disagreed on the details that matter: which direction a fresh click applies, whether the arrow reflects the direction actually in effect, and whether `?dir=` is written when it is redundant.

## What's shared now

`components/sort_header.rs` owns the contract, generic over the route's sort enum via a small trait:

```rust
pub trait SortColumn: Copy + PartialEq + Display + Send + Sync + 'static {
    fn fallback() -> Self;                                  // what `?sort=` absent means
    fn default_dir(self) -> SortDir { SortDir::Desc }       // per-column, overridable
}
```

`SortDir` is shared instead of redeclared per route (three copies of the same `asc`/`desc` `FromStr`+`Display` are gone). The flip rule and the href builder are free functions, so the query-string-preserving behaviour — the part every copy got subtly different — is pinned by tests without standing up a router.

## Ports

| route | before |
|---|---|
| flip finder | the reference implementation; moved out verbatim |
| scrip sources | a near-identical fork, per-column defaults preserved (costs read best-first ascending) |
| item explorer | string-keyed variant. Keeps its `role="columnheader"` cell and `aria-sort`; its `page` reset now goes through `reset_keys`. Local `SortDirection` — which parsed `"dsc"` but printed `"desc"` — deleted |
| vendor resale | inline `QueryButton` + hardcoded down arrow |

## Behaviour changes

- **Vendor resale sorting was stuck descending.** The route parsed `?sort=` but never `?dir=`, so the one order it could produce was also the only one the (hardcoded) arrow claimed. It now reads `?dir=` and the header can reach ascending.
- **Item explorer's arrows** become the shared icon set instead of `↑`/`↓` text, and the link picks up the shared active/inactive brand colours — the intended convergence, and the reason its full table conversion is still tracked under #1080.
- Each route's own sort now falls back through `SortColumn::fallback()` rather than a duplicated literal, so rows are ordered by exactly what the header highlights.

## Verification

- `./check_ci.sh` — clean (fmt + clippy `-D warnings`)
- `cargo test -p ultros-app --lib` — 446 passed. Seven new tests in `sort_header` cover the flip rule, per-column defaults, default-dir omission, param preservation and `reset_keys`; the analyzer's copies of those tests (which tested a re-implementation of the rule, not the code that shipped) are replaced by one that pins the flip finder's per-column defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)