### PR TITLE
fix(flip-finder): show that the filter strip has more filters off-screen

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -2346,8 +2346,33 @@ a:not(.nav-link):not(.side-nav-item):not(.menu-item):not(
     flex: 1;
     /* The bar is height-locked, so a reserved scrollbar gutter would eat
        into the chips themselves. Scrolling still works via trackpad,
-       shift+wheel and focus. */
+       shift+wheel, touch and focus. */
     scrollbar-width: none;
+
+    /* ...which leaves nothing on screen to say the strip scrolls at all. At
+       375px with eight filters set, the chips run 1002px inside a 237px
+       viewport and the five past the fold are simply invisible (#1057). These
+       two variables drive an edge fade; analyzer.rs sets them from the row's
+       own scroll geometry, so the fade appears on the side that has more
+       chips and nowhere else. Both default to 0, which collapses each
+       gradient stop pair onto the same position — a zero-width fade, i.e. no
+       visual change at all when everything fits. */
+    --chip-fade-start: 0px;
+    --chip-fade-end: 0px;
+    -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--chip-fade-start),
+        #000 calc(100% - var(--chip-fade-end)),
+        transparent 100%
+    );
+    mask-image: linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--chip-fade-start),
+        #000 calc(100% - var(--chip-fade-end)),
+        transparent 100%
+    );
 }
 .filter-chip-row::-webkit-scrollbar {
     display: none;

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1347,6 +1347,96 @@ fn AnalyzerTable(
         });
     }
 
+    // --- Filter chip strip: edge fades ---------------------------------------
+    // The strip scrolls but shows no scrollbar (the bar is height-locked, so a
+    // gutter would eat the chips), which left nothing on screen to say there
+    // were more filters off to the right — at 375px with eight filters set the
+    // chips run ~1000px inside a ~240px viewport. `--chip-fade-{start,end}`
+    // drive a mask declared in the stylesheet; both are 0 unless there is
+    // actually something to scroll to on that side.
+    let chip_row = NodeRef::<leptos::html::Div>::new();
+    #[cfg(feature = "hydrate")]
+    {
+        let chip_listeners = StoredValue::new_local(
+            None::<(
+                web_sys::HtmlDivElement,
+                Closure<dyn FnMut()>,
+                Closure<dyn FnMut()>,
+            )>,
+        );
+        on_cleanup(move || {
+            chip_listeners.update_value(|slot| {
+                if let Some((el, scroll_cb, resize_cb)) = slot.take() {
+                    let _ = el.remove_event_listener_with_callback(
+                        "scroll",
+                        scroll_cb.as_ref().unchecked_ref(),
+                    );
+                    if let Some(win) = web_sys::window() {
+                        let _ = win.remove_event_listener_with_callback(
+                            "resize",
+                            resize_cb.as_ref().unchecked_ref(),
+                        );
+                    }
+                }
+            });
+        });
+        // Widest fade we ever draw. Enough to read as "this continues" without
+        // dimming a whole chip.
+        const CHIP_FADE_PX: f64 = 24.0;
+        let apply_fades = |el: &web_sys::HtmlDivElement| {
+            let left = el.scroll_left() as f64;
+            // `scroll_width` is an i32 of a value the browser rounds, so the
+            // remaining distance can land a fraction off zero at the far end.
+            // A 1px deadband keeps the trailing fade from lingering once the
+            // strip is scrolled all the way over.
+            let right = (el.scroll_width() as f64 - el.client_width() as f64 - left).max(0.0);
+            let px = |amount: f64| format!("{}px", amount.clamp(0.0, CHIP_FADE_PX).round());
+            // Fully qualified: tachys' `ElementExt::style` is in scope via the
+            // leptos prelude and matches `HtmlDivElement` directly, so it wins
+            // method resolution over the inherent `HtmlElement::style` that
+            // needs a deref step. Bare `el.style()` picks the wrong one.
+            let style = web_sys::HtmlElement::style(el);
+            let _ = style.set_property(
+                "--chip-fade-start",
+                &px(if left > 1.0 { CHIP_FADE_PX } else { 0.0 }),
+            );
+            let _ = style.set_property(
+                "--chip-fade-end",
+                &px(if right > 1.0 { CHIP_FADE_PX } else { 0.0 }),
+            );
+        };
+        Effect::new(move |_| {
+            // Tracked so the fades are re-derived when a chip is added or
+            // removed: that changes `scrollWidth` without firing either
+            // listener below.
+            let _ = active_filters();
+            let Some(el) = chip_row.get() else {
+                return;
+            };
+            let el: web_sys::HtmlDivElement = el.into();
+            if chip_listeners.with_value(|slot| slot.is_none()) {
+                let on_scroll = {
+                    let el = el.clone();
+                    Closure::wrap(Box::new(move || apply_fades(&el)) as Box<dyn FnMut()>)
+                };
+                let on_resize = {
+                    let el = el.clone();
+                    Closure::wrap(Box::new(move || apply_fades(&el)) as Box<dyn FnMut()>)
+                };
+                let _ = el
+                    .add_event_listener_with_callback("scroll", on_scroll.as_ref().unchecked_ref());
+                if let Some(win) = web_sys::window() {
+                    let _ = win.add_event_listener_with_callback(
+                        "resize",
+                        on_resize.as_ref().unchecked_ref(),
+                    );
+                }
+                chip_listeners.set_value(Some((el.clone(), on_scroll, on_resize)));
+            }
+            apply_fades(&el);
+        });
+    }
+
     let clear_all_filters = move || {
         set_minimum_profit(None);
         set_minimum_profit_per_day(None);
@@ -1872,7 +1962,7 @@ fn AnalyzerTable(
                 // Row 2 — the filters themselves. One chip per active filter,
                 // and nothing at all for the ones that are not in use.
                 <div class="h-8 flex items-center gap-2 min-w-0">
-                    <div class="filter-chip-row">
+                    <div class="filter-chip-row" node_ref=chip_row>
                         {move || {
                             active_filters()
                                 .is_empty()

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -1384,7 +1384,7 @@ fn AnalyzerTable(
         // dimming a whole chip.
         const CHIP_FADE_PX: f64 = 24.0;
         let apply_fades = |el: &web_sys::HtmlDivElement| {
-            let left = el.scroll_left() as f64;
+            let left = el.scroll_left();
             // `scroll_width` is an i32 of a value the browser rounds, so the
             // remaining distance can land a fraction off zero at the far end.
             // A 1px deadband keeps the trailing fade from lingering once the
@@ -1413,7 +1413,6 @@ fn AnalyzerTable(
             let Some(el) = chip_row.get() else {
                 return;
             };
-            let el: web_sys::HtmlDivElement = el.into();
             if chip_listeners.with_value(|slot| slot.is_none()) {
                 let on_scroll = {
                     let el = el.clone();


### PR DESCRIPTION
Closes #1057.

## The title says sticky header; the sticky header is fine

I checked that first. At 375px on prod, across six scroll positions, the table header pins exactly where it should:

| scrollY | control bar | table header |
|---|---|---|
| 4000 | top 0, h 76 | **top 76** |
| 3000 | top 0, h 76 | **top 76** |
| 1500 | top 0, h 76 | **top 76** |
| 600 | top 0, h 76 | **top 76** |
| 200 | top 30 | top 123 |
| 0 | top 230 | top 323 |

No clipping, no drift. The sticky-bar work that landed after this issue was filed (#1082/#1083/#1105) appears to have taken care of whatever the screenshot caught.

## What is actually broken is "the full filter list"

`.filter-chip-row` scrolls horizontally but deliberately draws no scrollbar — the control bar is height-locked at 76px (the table header sticks directly beneath it at that offset), so a scrollbar gutter would eat into the 32px row the chips sit in. The consequence was never handled: nothing on screen says the strip scrolls.

Measured on prod at 375px with eight filters set (`?profit=1000&roi=50&confidence=medium&drift=5&min-volume=10&min-buy=500&max-price=900000&quality=hq`):

```
.filter-chip-row  scrollWidth 1002   clientWidth 237
chips at x = 32, 156, 254, 360, 508, 620, 715, 895
```

Everything past `Budget ≤ 900000` — Quality, Drift, Confidence, 30d volume — is off-screen with no scrollbar, no fade and no arrow. The strip *is* swipeable, so the filters are reachable; you just have no way to know they exist.

## The fix

Fade the strip at whichever edge has chips behind it. Two custom properties, `--chip-fade-start` and `--chip-fade-end`, feed a `mask-image` declared beside the strip's own rules; `analyzer.rs` sets them from the row's scroll geometry.

Both default to `0px`, which collapses each gradient stop pair onto the same position — a zero-width fade. **A strip whose chips all fit is byte-for-byte unchanged.**

Re-derived on three triggers: `scroll`, window `resize`, and whenever `active_filters()` changes — that last one matters because adding or removing a chip moves `scrollWidth` without firing either listener.

Verified the logic against prod by driving the real element:

| scrollLeft | remaining right | `--chip-fade-start` | `--chip-fade-end` |
|---|---|---|---|
| 0 | 765 | `0px` | **`24px`** |
| 300 | 465 | **`24px`** | **`24px`** |
| 765 | 0 | **`24px`** | `0px` |
| back to 0 | 765 | `0px` | **`24px`** |

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros-app --all-targets -- -D warnings` — clean
- `cargo check -p ultros-client --target wasm32-unknown-unknown` — clean
- Stylesheet built with cargo-leptos' own `tailwindcss v4.1.10`; mask rule emitted intact

That wasm check is not optional here. The new block is `#[cfg(feature = "hydrate")]`, and CI's clippy compiles `ssr` (the default feature) — so **CI cannot see this code at all**. It caught two real errors on the first run: `el.style()` resolved to tachys' `ElementExt::style` (in scope via the leptos prelude, matching `HtmlDivElement` directly) instead of the inherent `web_sys::HtmlElement::style`, which needs a deref step and therefore loses method resolution. Fully qualified now, with a comment saying why.

Listeners are parked in a `StoredValue` and removed in `on_cleanup`, matching the horizontal scroll-sync block directly above it — a forgotten listener would keep firing after the component is disposed.

## Related

#1139 (mobile edge-to-edge padding) widens this strip from 237px to 284px on a phone, which reduces how often the fade is needed but does not remove the need for it — 284px still holds about two chips.
