### PR TITLE
Extract item icons from the game files (fixes missing currency-exchange icons)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ There are **no git submodules** in this repo anymore. FFXIV game data (item/reci
 
 - **Fresh clone**: run `git lfs install && git lfs pull` once. Without it, the `data/` files are LFS pointer text, not real content, and the build fails with an actionable error message rather than a cryptic panic.
 - **Worktrees**: no setup needed — `git worktree add` checks out LFS content the same as a normal clone as long as `git lfs install` has been run once on the machine.
-- **Regenerating packs**: `cargo run --release -p game-data-pack -- --pinned` rebuilds the packs from the pins already recorded in `data/manifest.toml` (reproducible, no version bump). Pass `--latest` instead to bump the pins to the newest upstream data and regenerate against that.
-- **`data/manifest.toml`**: records exactly which upstream commit/release each pack was generated from — this is the source of truth for "what version of game data is this."
+- **Regenerating packs**: `cargo run --release -p game-data-pack -- --pinned` rebuilds the packs from the pins already recorded in `data/manifest.toml` (reproducible for the CSV packs, no version bump). Pass `--latest` instead to bump the pins to the newest upstream data and regenerate against that.
+- **Icons need a local FFXIV install**: the icon pack is extracted straight out of the game's SqPack files (via the `icon-extract` crate), not fetched from a repo. The generator searches the standard install locations (`--game-path <install root>` to override) and hard-requires the install; pass `--skip-icons` to rebuild only the CSV packs on a machine without the game. **Patch the game before regenerating** — the run reports how many named items have no icon in the install, and a triple-digit count means the client is older than the pinned CSVs.
+- **`data/manifest.toml`**: records exactly which upstream commit/release each pack was generated from, plus (under `[icons]`) the FFXIV client version the icon pack was extracted from — this is the source of truth for "what version of game data is this."
 - **Updating game data**: done by hand (in practice, by an agent), not on a schedule. A game-data
   bump can break consumers — a renamed sheet or column shifts `xiv-gen`'s generated types — so the
   regeneration and the fallout need fixing in the same change. Run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +835,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "binrw"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13d2fa8772b88ee64a0d84602c636ad2bae9c176873f6c440e2b0a1df4c8c43"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193bcff2709da50edf2e9a89e0f9a2118eea70f257b1f4380ccf27d3d8578302"
+dependencies = [
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "binstring"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +1015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2736,6 +2764,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "flate2",
+ "icon-extract",
  "image",
  "rayon",
  "rkyv",
@@ -2814,6 +2843,17 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3427,6 +3467,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icon-extract"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "image",
+ "ironworks",
+ "texture2ddecoder",
 ]
 
 [[package]]
@@ -4321,6 +4371,21 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
+name = "ironworks"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c5c802fc29dab4cde744ca2e9b6f718cca9137dc7d25d4a49cb5b75496d1f"
+dependencies = [
+ "binrw",
+ "derivative",
+ "flate2",
+ "getset",
+ "modular-bitfield",
+ "num_enum",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5434,6 +5499,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "module-lattice"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,6 +5784,27 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6056,6 +6163,12 @@ checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p256"
@@ -6498,6 +6611,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -9287,6 +9410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "texture2ddecoder"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427ae8ec7f2f0fdd3146b77cfa44bea880caf066f7e55398a8467afe2645c832"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9654,6 +9786,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -11117,6 +11260,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,20 +836,22 @@ dependencies = [
 
 [[package]]
 name = "binrw"
-version = "0.8.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13d2fa8772b88ee64a0d84602c636ad2bae9c176873f6c440e2b0a1df4c8c43"
+checksum = "2f4b52fe7fbd9e207b879c52c5af7efd861c2f4e234ab4f744b0bdc04a863623"
 dependencies = [
  "array-init",
  "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
 name = "binrw_derive"
-version = "0.8.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193bcff2709da50edf2e9a89e0f9a2118eea70f257b1f4380ccf27d3d8578302"
+checksum = "a7196f6935a944081728167ce6e3a599bd38d6d80d21afe4ca17be2097a6682f"
 dependencies = [
+ "either",
  "owo-colors",
  "proc-macro2",
  "quote",
@@ -4375,16 +4377,15 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 [[package]]
 name = "ironworks"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39c5c802fc29dab4cde744ca2e9b6f718cca9137dc7d25d4a49cb5b75496d1f"
+source = "git+https://github.com/ackwell/ironworks?rev=3d5db8ff#3d5db8ffbebcad41cd5d1ee9d03b5fbbfba0c0c4"
 dependencies = [
  "binrw",
  "derivative",
+ "either",
  "flate2",
  "getset",
- "modular-bitfield",
  "num_enum",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5499,27 +5500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "module-lattice"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,23 +5768,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ dashmap = "6.1"
 web-push = { version = "0.11.0", default-features = false }
 
 [patch.crates-io]
+ironworks = { git = "https://github.com/ackwell/ironworks", rev = "3d5db8ff" }
 #leptos = { path = "../leptos/leptos" }
 # leptos_reactive = { git = "https://github.com/leptos-rs/leptos.git" }
 #leptos_reactive = {path = "../leptos/leptos_reactive"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "dumb-csv",
     "field-iterator",
     "game-data-pack",
+    "icon-extract",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,44 @@ The project is built using:
 
     *Note: On first boot, the app will apply database migrations and fetch game data (worlds, regions) from Universalis. A restart may be required after this initial fetch.*
 
+### Updating Game Data
+
+FFXIV data (item/recipe tables and item icons) ships as pre-generated packs under `data/`,
+tracked with Git LFS and embedded at compile time — day-to-day development never fetches or
+generates anything. When a game patch lands, the packs are regenerated with:
+
+```bash
+cargo run --release -p game-data-pack -- --latest
+```
+
+`--latest` bumps the pins in `data/manifest.toml` to the newest upstream data and rebuilds;
+`--pinned` (the default) rebuilds reproducibly from the recorded pins. Commit the changed
+packs and manifest together.
+
+The two halves of the data come from different places:
+
+*   **CSV packs** (`data/xiv-db/*.rkyv`) are built from the community
+    [`ffxiv-datamining`](https://github.com/xivapi/ffxiv-datamining) CSV repos (all seven
+    languages), fetched as sparse checkouts at the SHAs pinned in the manifest. This works on
+    any machine with network access.
+*   **The icon pack** (`data/icons/images.tar.zst`) is extracted directly from a **local FFXIV
+    install**'s SqPack files (via the `icon-extract` crate) — no crawling, no assets repo. The
+    generator auto-discovers the install in the standard Windows locations (SquareEnix default,
+    Steam, Program Files (x86)); if yours lives elsewhere (another drive, XIVLauncher on
+    Linux/Steam Deck), point at the directory that contains `game/`:
+
+    ```bash
+    cargo run --release -p game-data-pack -- --latest --game-path "D:/Games/FINAL FANTASY XIV Online"
+    ```
+
+    **Patch the game first.** The run reports how many named items have no icon in the install —
+    a triple-digit count means your client is older than the pinned CSVs and the newest items'
+    icons would be missing from the pack. The client version the icons came from is recorded
+    under `[icons]` in `data/manifest.toml`.
+
+    No FFXIV install on the machine? `--skip-icons` rebuilds only the CSV packs and leaves the
+    committed icon pack untouched.
+
 ### Environment Variables
 
 | Variable | Description | Default / Example |
@@ -144,6 +182,9 @@ This repository contains several crates that make up the Ultros ecosystem:
 *   **`universalis`**: A wrapper for the Universalis API (HTTP & WebSocket).
 *   **`xiv-gen`**: Generates Rust structs from FFXIV game data (sourced from `ffxiv-datamining`).
 *   **`xiv-gen-db`**: Statically embeds compressed game data for fast access.
+*   **`game-data-pack`**: Regenerates the LFS-tracked data packs under `data/` (see
+    [Updating Game Data](#updating-game-data)).
+*   **`icon-extract`**: Reads item icons out of a local FFXIV install's SqPack files.
 *   **`migration`**: Database migration tool.
 
 See [`AGENTS.md`](AGENTS.md) and [`CLAUDE.md`](CLAUDE.md) for the full contributor workflow (CI checks, services overview, and environment gotchas).

--- a/data/icons/images.tar.zst
+++ b/data/icons/images.tar.zst
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05a1ac1e6cf524fb3595905bfeb50d2ec5c1fcd6c7784250ee9c8401df5b6afe
-size 53253636
+oid sha256:8c6ad91db71cf28ea20d49e83028bfb529b9642a58c8348c94dee3ddab26bc80
+size 54999895

--- a/data/icons/images.tar.zst
+++ b/data/icons/images.tar.zst
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cf19f134d60bc6ea15afdebd6084e65a75eca84b0854ee7606695086e07ab0e
-size 22474512
+oid sha256:05a1ac1e6cf524fb3595905bfeb50d2ec5c1fcd6c7784250ee9c8401df5b6afe
+size 53253636

--- a/data/manifest.toml
+++ b/data/manifest.toml
@@ -6,6 +6,9 @@
 # per-language sheet patterns from SHEETS (see game-data-pack/src/fetch.rs).
 # `checkout_subdir` places a source inside the assembled ffxiv-datamining tree.
 #
+# `[icons]` records the FFXIV client version (game/ffxivgame.ver) the icon pack
+# was extracted from — icons come from a local game install, not a git source.
+#
 # This header is rewritten by `Manifest::save`; comments added below it are NOT
 # preserved across a --latest run.
 
@@ -29,6 +32,5 @@ url = "https://github.com/thewakingsands/ffxiv-datamining-tc.git"
 sha = "e203c7e46dd80fd2a967e5741b30e3c9fad0c767"
 checkout_subdir = "csv/tc"
 
-[sources.universalis-assets]
-url = "https://github.com/Universalis-FFXIV/universalis-assets.git"
-sha = "1586efa83016a70ab5f2fa2fa3c1d63d7fb55063"
+[icons]
+game_version = "2026.07.16.0001.0000"

--- a/game-data-pack/Cargo.toml
+++ b/game-data-pack/Cargo.toml
@@ -25,6 +25,8 @@ tar = "0.4"
 image = { workspace = true, features = ["webp", "png"] }
 webp = "0.3"
 rayon = "1"
+# Reads the item icons straight out of a local FFXIV install.
+icon-extract = { path = "../icon-extract" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/game-data-pack/src/db.rs
+++ b/game-data-pack/src/db.rs
@@ -31,26 +31,25 @@ pub struct PackStats {
 
 pub struct DbOutput {
     pub packs: Vec<PackStats>,
-    /// Ascending ids of the *named* items in the `en` data — the missing-icon
-    /// report checks these against the icons that exist upstream.
-    pub en_named_item_ids: Vec<i32>,
+    /// `(item id, icon id)` of the *named* items in the `en` data, ascending by
+    /// item id — the icon extraction reads exactly these out of the game files.
+    pub en_named_items: Vec<(i32, i32)>,
 }
 
-/// Item ids worth checking for a missing icon: the rows that actually have a
-/// name, sorted ascending.
+/// Items worth extracting an icon for: the rows that actually have a name, as
+/// `(item id, icon id)` sorted ascending by item id.
 ///
-/// Measured against 7.55: 52,801 item rows of which 50,773 are named. Dropping
-/// the 2,028 unnamed placeholder rows keeps rows that can never have an icon out
-/// of the report, but it does not make the report small — see
-/// `main::report_missing_icons` for why the count is inherently large.
-fn named_item_ids<'a>(items: impl IntoIterator<Item = (i32, &'a str)>) -> Vec<i32> {
-    let mut ids: Vec<i32> = items
+/// Measured against 7.55: 52,801 item rows of which 50,773 are named. The
+/// 2,028 unnamed placeholder rows are dropped because they can never render
+/// anywhere an icon is wanted.
+fn named_items<'a>(items: impl IntoIterator<Item = (i32, &'a str, i32)>) -> Vec<(i32, i32)> {
+    let mut named: Vec<(i32, i32)> = items
         .into_iter()
-        .filter(|(_, name)| !name.trim().is_empty())
-        .map(|(id, _)| id)
+        .filter(|(_, name, _)| !name.trim().is_empty())
+        .map(|(id, _, icon)| (id, icon))
         .collect();
-    ids.sort_unstable();
-    ids
+    named.sort_unstable();
+    named
 }
 
 /// Reads every language out of `datamining_root` and writes one pack per
@@ -59,14 +58,14 @@ pub fn build_packs(datamining_root: &Path, out_dir: &Path) -> anyhow::Result<DbO
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
 
     let mut packs = Vec::with_capacity(LANGUAGES.len());
-    let mut en_named_item_ids = Vec::new();
+    let mut en_named_items = Vec::new();
     for lang in LANGUAGES {
         let data = read_data_from(datamining_root, lang);
         if lang == Language::En {
-            en_named_item_ids = named_item_ids(
+            en_named_items = named_items(
                 data.items
                     .iter()
-                    .map(|(id, item)| (id.0, item.name.as_str())),
+                    .map(|(id, item)| (id.0, item.name.as_str(), item.icon)),
             );
         }
         let items = data.items.len();
@@ -108,7 +107,7 @@ pub fn build_packs(datamining_root: &Path, out_dir: &Path) -> anyhow::Result<DbO
     }
     Ok(DbOutput {
         packs,
-        en_named_item_ids,
+        en_named_items,
     })
 }
 
@@ -124,19 +123,22 @@ mod tests {
     }
 
     #[test]
-    fn named_item_ids_drops_unnamed_rows_and_sorts() {
+    fn named_items_drops_unnamed_rows_and_sorts_by_id() {
         let rows = vec![
-            (30, "Iron Ingot"),
-            (10, ""),
-            (44_000, "Grade 2 Gemdraught of Mind"),
-            (20, "   "),
-            (5, "Cotton"),
+            (30, "Iron Ingot", 20801),
+            (10, "", 999),
+            (44_000, "Grade 2 Gemdraught of Mind", 20872),
+            (20, "   ", 998),
+            (5, "Cotton", 21_001),
         ];
-        assert_eq!(named_item_ids(rows), vec![5, 30, 44_000]);
+        assert_eq!(
+            named_items(rows),
+            vec![(5, 21_001), (30, 20801), (44_000, 20872)]
+        );
     }
 
     #[test]
-    fn named_item_ids_is_empty_when_nothing_is_named() {
-        assert!(named_item_ids(vec![(1, ""), (2, " ")]).is_empty());
+    fn named_items_is_empty_when_nothing_is_named() {
+        assert!(named_items(vec![(1, "", 5), (2, " ", 6)]).is_empty());
     }
 }

--- a/game-data-pack/src/fetch.rs
+++ b/game-data-pack/src/fetch.rs
@@ -11,9 +11,6 @@ use crate::manifest::{Manifest, Source};
 /// source is checked out *inside* it (see [`source_dir`]).
 pub const DATAMINING_SOURCE: &str = "ffxiv-datamining";
 
-/// The name of the source holding the upstream icon PNGs.
-pub const ICONS_SOURCE: &str = "universalis-assets";
-
 /// Languages that `ffxiv-datamining` itself ships under `csv/<lang>/`.
 pub const DATAMINING_LANGS: [&str; 4] = ["en", "ja", "de", "fr"];
 
@@ -73,7 +70,6 @@ pub fn sparse_paths_for(name: &str) -> Vec<String> {
             .collect(),
         // The ko fork nests its CSVs under `csv/`; cn and tc keep theirs at the root.
         "ffxiv-datamining-ko" => sheet_patterns("/csv"),
-        ICONS_SOURCE => vec!["/icon2x/".to_string()],
         _ => sheet_patterns(""),
     }
 }
@@ -88,28 +84,20 @@ pub fn source_dir(cache_root: &Path, name: &str, source: &Source) -> PathBuf {
     }
 }
 
-/// Where the generator reads its inputs from.
+/// Where the generator reads its CSV inputs from. Icons are not fetched — they
+/// come out of the local FFXIV install via `icon-extract`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Layout {
     /// An ffxiv-datamining tree, i.e. a directory containing `csv/<lang>/*.csv`.
     pub datamining: PathBuf,
-    /// The upstream `icon2x` PNG directory, unless icons were skipped.
-    pub icons: Option<PathBuf>,
 }
 
 impl Layout {
     /// Layout of an already-populated ultros checkout (`--offline-source`),
-    /// where both trees are still present as submodules.
-    pub fn offline(checkout: &Path, skip_icons: bool) -> Layout {
+    /// where the CSV tree is still present as a submodule.
+    pub fn offline(checkout: &Path) -> Layout {
         Layout {
             datamining: checkout.join("xiv-gen").join("ffxiv-datamining"),
-            icons: (!skip_icons).then(|| {
-                checkout
-                    .join("ultros-frontend")
-                    .join("ultros-xiv-icons")
-                    .join("universalis-assets")
-                    .join("icon2x")
-            }),
         }
     }
 }
@@ -126,18 +114,10 @@ pub fn patterns_for(name: &str, source: &Source) -> Vec<String> {
 
 /// Fetches every source in `manifest` into `cache_root` and returns the
 /// assembled input layout.
-pub fn fetch_all(
-    cache_root: &Path,
-    manifest: &Manifest,
-    skip_icons: bool,
-) -> anyhow::Result<Layout> {
-    // Validate before fetching anything: universalis-assets alone is ~500MB on a
-    // cold cache, and failing after that on a manifest problem is a bad trade.
+pub fn fetch_all(cache_root: &Path, manifest: &Manifest) -> anyhow::Result<Layout> {
+    // Validate before fetching anything.
     if !manifest.sources.contains_key(DATAMINING_SOURCE) {
         bail!("manifest has no `{DATAMINING_SOURCE}` source");
-    }
-    if !skip_icons && !manifest.sources.contains_key(ICONS_SOURCE) {
-        bail!("manifest has no `{ICONS_SOURCE}` source; pass --skip-icons to build without icons");
     }
 
     std::fs::create_dir_all(cache_root)
@@ -149,12 +129,7 @@ pub fn fetch_all(
     names.sort_by_key(|name| (*name != DATAMINING_SOURCE, *name));
 
     let mut datamining = None;
-    let mut icons = None;
     for name in names {
-        if skip_icons && name == ICONS_SOURCE {
-            println!("skipping {name} (--skip-icons)");
-            continue;
-        }
         let source = &manifest.sources[name];
         let patterns = patterns_for(name, source);
         println!(
@@ -163,15 +138,13 @@ pub fn fetch_all(
             patterns.len()
         );
         let dir = fetch_source(cache_root, name, source, &patterns)?;
-        match name {
-            DATAMINING_SOURCE => datamining = Some(dir),
-            ICONS_SOURCE => icons = Some(dir.join("icon2x")),
-            _ => {}
+        if name == DATAMINING_SOURCE {
+            datamining = Some(dir);
         }
     }
 
     let datamining = datamining.expect("presence checked before the fetch loop");
-    Ok(Layout { datamining, icons })
+    Ok(Layout { datamining })
 }
 
 /// Fetches `source` at its pinned SHA into the cache and checks out only the
@@ -325,11 +298,6 @@ mod tests {
     }
 
     #[test]
-    fn universalis_assets_fetches_the_whole_icon_directory() {
-        assert_eq!(sparse_paths_for("universalis-assets"), vec!["/icon2x/"]);
-    }
-
-    #[test]
     fn subdir_sources_check_out_inside_the_datamining_tree() {
         let cache = Path::new("/cache");
         assert_eq!(
@@ -339,10 +307,6 @@ mod tests {
         assert_eq!(
             source_dir(cache, "ffxiv-datamining-cn", &source(Some("csv/cn"))),
             cache.join(DATAMINING_SOURCE).join("csv/cn")
-        );
-        assert_eq!(
-            source_dir(cache, "universalis-assets", &source(None)),
-            cache.join("universalis-assets")
         );
     }
 
@@ -361,14 +325,9 @@ mod tests {
     }
 
     #[test]
-    fn offline_layout_points_at_the_submodule_checkouts() {
+    fn offline_layout_points_at_the_submodule_checkout() {
         let checkout = Path::new("/repo");
-        let layout = Layout::offline(checkout, false);
+        let layout = Layout::offline(checkout);
         assert_eq!(layout.datamining, checkout.join("xiv-gen/ffxiv-datamining"));
-        assert_eq!(
-            layout.icons,
-            Some(checkout.join("ultros-frontend/ultros-xiv-icons/universalis-assets/icon2x"))
-        );
-        assert_eq!(Layout::offline(checkout, true).icons, None);
     }
 }

--- a/game-data-pack/src/icons.rs
+++ b/game-data-pack/src/icons.rs
@@ -1,30 +1,32 @@
-//! Builds `data/icons/images.tar.zst` from the upstream `icon2x` PNGs.
+//! Builds `data/icons/images.tar.zst` from icons decoded out of the game data.
 //!
-//! Ported from the old `ultros-xiv-icons` build script. Deliberate deviations:
-//! - `rayon` instead of tokio, and lossy WebP q85 instead of `image`'s encoder.
-//! - Encodes in memory instead of via a `TempDir` holding ~51k intermediate files.
-//! - Inputs are sorted and gnu headers keep mtime/uid/gid at 0, so the archive is
-//!   reproducible. The build script used readdir order, which was fine for a
-//!   build artifact but not for a file committed to LFS.
-//! - Tar entries get mode `0o644`; the build script left the mode at 0.
+//! Inputs are `(item id, RGBA image)` pairs produced by `icon-extract` reading
+//! the local FFXIV install. Deliberate choices:
+//! - Two packed sizes only: Large (80px — the native `_hr1` resolution, so
+//!   hidpi screens finally get a sharp icon) and Medium (40px). Small requests
+//!   are served the Medium bytes by `ultros-xiv-icons`; a dedicated 25px encode
+//!   saved almost nothing over WebP'd 40px and tripled the entry count.
+//! - Lossy WebP q85 keeps the icons visually clean at display sizes while
+//!   cutting the archive to roughly a third of the lossless encode.
+//! - Inputs are sorted and gnu headers keep mtime/uid/gid at 0, so the archive
+//!   is reproducible and a re-run with unchanged inputs does not churn LFS.
 
-use std::collections::BTreeSet;
-use std::ffi::OsStr;
 use std::io::{Cursor, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, anyhow};
-use image::ImageReader;
 use image::imageops::FilterType;
+use image::{DynamicImage, RgbaImage};
 use rayon::prelude::*;
 use tar::{Builder, Header};
 use ultros_api_types::icon_size::IconSize;
 
-/// Sizes packed for every icon, largest first.
-pub const ICON_SIZES: [IconSize; 3] = [IconSize::Large, IconSize::Medium, IconSize::Small];
+/// Packed sizes and their pixel dimensions, largest first. The pixel counts are
+/// a pack concern, not a display concern — the CSS boxes in
+/// `IconSize::get_size_px` stay 60/40/25.
+pub const PACK_SIZES: [(IconSize, u32); 2] = [(IconSize::Large, 80), (IconSize::Medium, 40)];
 
-/// Lossy WebP quality. 85 keeps the icons visually clean at 60px and under
-/// while cutting the archive to roughly a third of the lossless encode.
+/// Lossy WebP quality. See the module docs.
 const WEBP_QUALITY: f32 = 85.0;
 
 /// zstd level 19 is the highest "normal" level (20-22 are --ultra and need much
@@ -34,37 +36,61 @@ const ZSTD_LEVEL: i32 = 19;
 
 /// What the icon pack cost.
 pub struct IconStats {
-    pub source_pngs: usize,
+    pub unique_icons: usize,
+    pub mapped_items: usize,
     pub entries: usize,
     pub tar_bytes: usize,
     pub packed_bytes: usize,
 }
 
+/// The tar entry mapping item ids to icon ids: ascii `<item id> <icon id>`
+/// lines sorted by item id. Icons are stored once per *icon* id — thousands of
+/// items share an icon, and duplicating the WebP per item doubled the pack and
+/// the server's decompressed in-memory copy.
+pub const ITEM_MAP_ENTRY: &str = "items.map";
+
+/// Serialized `items.map` contents.
+pub fn item_map_contents(item_to_icon: &[(i32, i32)]) -> String {
+    let mut pairs: Vec<(i32, i32)> = item_to_icon.to_vec();
+    pairs.sort_unstable();
+    pairs
+        .iter()
+        .map(|(item, icon)| format!("{item} {icon}\n"))
+        .collect()
+}
+
 /// Name of a single icon inside the tar.
 ///
 /// `ultros-xiv-icons` parses these back at runtime by splitting on `.` then `_`
-/// (see `ultros-frontend/ultros-xiv-icons/src/lib.rs::parse_url`), so the stem
-/// must stay the numeric item id and the suffix must stay `IconSize`'s `Display`.
-pub fn entry_name(file_stem: &str, size: IconSize) -> String {
-    format!("{file_stem}_{size}.webp")
+/// (see `ultros-frontend/ultros-xiv-icons/src/lib.rs`), so the stem must stay
+/// the numeric icon id and the suffix must stay `IconSize`'s `Display`.
+pub fn entry_name(icon_id: i32, size: IconSize) -> String {
+    format!("{icon_id}_{size}.webp")
 }
 
-/// Resizes every PNG in `icon_dir` to the three icon sizes and writes the
-/// zstd-compressed tar of WebPs to `out_path`.
-pub fn build_pack(icon_dir: &Path, out_path: &Path) -> anyhow::Result<IconStats> {
-    let mut sources = png_paths(icon_dir)?;
+/// Resizes every unique icon to the packed sizes and writes the
+/// zstd-compressed tar of WebPs (plus the `items.map` entry translating item
+/// ids to icon ids) to `out_path`. `icons` may arrive in any order; the
+/// archive is sorted by icon id.
+pub fn build_pack(
+    mut icons: Vec<(i32, RgbaImage)>,
+    item_to_icon: &[(i32, i32)],
+    out_path: &Path,
+) -> anyhow::Result<IconStats> {
     // Archive order is part of the committed artifact; keep it stable so a
     // re-run with unchanged inputs does not churn the LFS object.
-    sources.sort();
+    icons.sort_by_key(|(icon_id, _)| *icon_id);
 
-    let encoded: Vec<Vec<(String, Vec<u8>)>> = sources
+    let encoded: Vec<Vec<(String, Vec<u8>)>> = icons
         .par_iter()
-        .map(|path| encode_icon(path))
+        .map(|(icon_id, image)| encode_icon(*icon_id, image))
         .collect::<anyhow::Result<_>>()?;
 
+    let map = item_map_contents(item_to_icon);
     let mut tar = Builder::new(Cursor::new(Vec::new()));
     let mut entries = 0;
-    for (name, data) in encoded.iter().flatten() {
+    let map_entry = [(ITEM_MAP_ENTRY.to_string(), map.into_bytes())];
+    for (name, data) in map_entry.iter().chain(encoded.iter().flatten()) {
         let mut header = Header::new_gnu();
         header.set_size(data.len() as u64);
         header.set_mode(0o644);
@@ -91,77 +117,30 @@ pub fn build_pack(icon_dir: &Path, out_path: &Path) -> anyhow::Result<IconStats>
     std::fs::write(out_path, &packed).with_context(|| format!("writing {}", out_path.display()))?;
 
     Ok(IconStats {
-        source_pngs: sources.len(),
+        unique_icons: icons.len(),
+        mapped_items: item_to_icon.len(),
         entries,
         tar_bytes: tar_bytes.len(),
         packed_bytes: packed.len(),
     })
 }
 
-/// Item ids from the game data that have no `<id>.png` upstream, preserving the
-/// order of `item_ids` (callers pass them ascending, so the result is ascending
-/// too and its tail is the newest content).
-///
-/// Pass only ids worth reporting — see `db::named_item_ids`. The icon repo ships
-/// far fewer files than the item sheet has rows, so a large result is normal.
-pub fn missing_icon_ids(icon_dir: &Path, item_ids: &[i32]) -> anyhow::Result<Vec<i32>> {
-    let available = available_icon_ids(icon_dir)?;
-    Ok(item_ids
+fn encode_icon(icon_id: i32, image: &RgbaImage) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
+    let image = DynamicImage::ImageRgba8(image.clone());
+    PACK_SIZES
         .iter()
-        .copied()
-        .filter(|id| !available.contains(id))
-        .collect())
-}
-
-fn available_icon_ids(icon_dir: &Path) -> anyhow::Result<BTreeSet<i32>> {
-    Ok(png_paths(icon_dir)?
-        .iter()
-        .filter_map(|path| path.file_stem()?.to_str()?.parse().ok())
-        .collect())
-}
-
-fn encode_icon(path: &Path) -> anyhow::Result<Vec<(String, Vec<u8>)>> {
-    let stem = path
-        .file_stem()
-        .and_then(OsStr::to_str)
-        .ok_or_else(|| anyhow!("icon {} has a non-utf8 name", path.display()))?;
-    let image = ImageReader::open(path)
-        .with_context(|| format!("opening {}", path.display()))?
-        .with_guessed_format()
-        .with_context(|| format!("sniffing the format of {}", path.display()))?
-        .decode()
-        .with_context(|| format!("decoding {}", path.display()))?;
-
-    ICON_SIZES
-        .iter()
-        .map(|&size| {
-            let px = size.get_px_size();
+        .map(|&(size, px)| {
             let resized = image.resize(px, px, FilterType::CatmullRom).to_rgba8();
             let (width, height) = resized.dimensions();
             // `Encoder::encode` unwraps internally; go through `encode_simple` so
             // an encoder failure surfaces as an error instead of a panic.
             let webp = webp::Encoder::from_rgba(resized.as_raw(), width, height)
                 .encode_simple(false, WEBP_QUALITY)
-                .map_err(|e| anyhow!("encoding {} at {size} failed: {e:?}", path.display()))?
+                .map_err(|e| anyhow!("encoding icon {icon_id} at {size} failed: {e:?}"))?
                 .to_vec();
-            Ok((entry_name(stem, size), webp))
+            Ok((entry_name(icon_id, size), webp))
         })
         .collect()
-}
-
-fn png_paths(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    let mut paths = Vec::new();
-    for entry in
-        std::fs::read_dir(dir).with_context(|| format!("reading icon dir {}", dir.display()))?
-    {
-        let path = entry
-            .with_context(|| format!("reading icon dir {}", dir.display()))?
-            .path();
-        if path.extension().and_then(OsStr::to_str) == Some("png") {
-            paths.push(path);
-        }
-    }
-    Ok(paths)
 }
 
 #[cfg(test)]
@@ -170,7 +149,7 @@ mod tests {
 
     use super::*;
 
-    /// Hand-rolled `^\d+_(Large|Medium|Small)\.webp$`.
+    /// Hand-rolled `^\d+_(Large|Medium)\.webp$` — what the runtime can serve.
     fn matches_runtime_pattern(name: &str) -> bool {
         let Some((stem, size)) = name
             .strip_suffix(".webp")
@@ -180,66 +159,65 @@ mod tests {
         };
         !stem.is_empty()
             && stem.bytes().all(|b| b.is_ascii_digit())
-            && matches!(size, "Large" | "Medium" | "Small")
+            && matches!(size, "Large" | "Medium")
     }
 
-    fn write_test_png(path: &Path) {
-        let mut image = image::RgbaImage::new(80, 80);
+    fn test_image(px: u32) -> RgbaImage {
+        let mut image = RgbaImage::new(px, px);
         for (x, y, pixel) in image.enumerate_pixels_mut() {
             *pixel = image::Rgba([x as u8, y as u8, 128, 255]);
         }
-        image.save(path).expect("write test png");
+        image
     }
 
     #[test]
     fn entry_names_match_the_runtime_parser() {
-        for size in ICON_SIZES {
-            let name = entry_name("18355", size);
+        for (size, _) in PACK_SIZES {
+            let name = entry_name(18355, size);
             assert!(
                 matches_runtime_pattern(&name),
-                "entry name {name:?} does not match ^\\d+_(Large|Medium|Small)\\.webp$"
+                "entry name {name:?} does not match ^\\d+_(Large|Medium)\\.webp$"
             );
             assert!(name.contains(&size.to_string()));
         }
     }
 
     #[test]
-    fn entry_names_are_unique_per_size() {
-        let names: Vec<_> = ICON_SIZES.map(|s| entry_name("10", s)).to_vec();
-        assert_eq!(names, ["10_Large.webp", "10_Medium.webp", "10_Small.webp"]);
+    fn pack_stores_large_and_medium_only() {
+        let names: Vec<_> = PACK_SIZES.map(|(s, _)| entry_name(10, s)).to_vec();
+        assert_eq!(names, ["10_Large.webp", "10_Medium.webp"]);
     }
 
     #[test]
-    fn pattern_helper_rejects_bad_names() {
-        assert!(!matches_runtime_pattern("10_Huge.webp"));
-        assert!(!matches_runtime_pattern("abc_Large.webp"));
-        assert!(!matches_runtime_pattern("10_Large.png"));
+    fn large_is_the_native_hr1_resolution() {
+        // 80px is what the game's `_hr1` icons actually are; storing less would
+        // resample twice (once here, once in the browser).
+        assert_eq!(PACK_SIZES[0], (IconSize::Large, 80));
+        assert_eq!(PACK_SIZES[1], (IconSize::Medium, 40));
     }
 
     #[test]
-    fn missing_ids_are_the_ones_without_a_png() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("10.png"), b"not really a png").expect("write");
-        std::fs::write(dir.path().join("20.png"), b"not really a png").expect("write");
-        std::fs::write(dir.path().join("notes.txt"), b"ignored").expect("write");
-
+    fn item_map_is_sorted_ascii_pairs() {
         assert_eq!(
-            missing_icon_ids(dir.path(), &[10, 20, 30, 40]).expect("scan"),
-            vec![30, 40]
+            item_map_contents(&[(28, 65023), (1, 65002), (30, 65023)]),
+            "1 65002\n28 65023\n30 65023\n"
         );
     }
 
     #[test]
     fn pack_round_trips_through_zstd_and_tar() {
         let dir = tempfile::tempdir().expect("tempdir");
-        write_test_png(&dir.path().join("18355.png"));
-        write_test_png(&dir.path().join("10.png"));
-        std::fs::write(dir.path().join("README.md"), b"ignored").expect("write");
-
         let out = dir.path().join("out").join("images.tar.zst");
-        let stats = build_pack(dir.path(), &out).expect("build the icon pack");
-        assert_eq!(stats.source_pngs, 2);
-        assert_eq!(stats.entries, 6);
+        // Two unique icons; icon 20801 is shared by two items.
+        let stats = build_pack(
+            vec![(20801, test_image(80)), (65002, test_image(72))],
+            &[(5057, 20801), (1, 65002), (5058, 20801)],
+            &out,
+        )
+        .expect("build the icon pack");
+        assert_eq!(stats.unique_icons, 2);
+        assert_eq!(stats.mapped_items, 3);
+        assert_eq!(stats.entries, 5);
         assert!(stats.packed_bytes > 0);
 
         let packed = std::fs::read(&out).expect("read the pack");
@@ -250,27 +228,36 @@ mod tests {
             .expect("decompress");
 
         let mut archive = tar::Archive::new(Cursor::new(tar_bytes));
-        let mut names: Vec<String> = Vec::new();
+        let mut entries: Vec<(String, Vec<u8>)> = Vec::new();
         for entry in archive.entries().expect("entries") {
-            let entry = entry.expect("entry");
+            let mut entry = entry.expect("entry");
             let name = entry.path().expect("path").display().to_string();
             assert!(
-                matches_runtime_pattern(&name),
+                name == ITEM_MAP_ENTRY || matches_runtime_pattern(&name),
                 "packed entry {name:?} is not parseable at runtime"
             );
-            names.push(name);
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).expect("entry data");
+            entries.push((name, data));
         }
-        names.sort();
+        let names: Vec<&str> = entries.iter().map(|(name, _)| name.as_str()).collect();
         assert_eq!(
             names,
             [
-                "10_Large.webp",
-                "10_Medium.webp",
-                "10_Small.webp",
-                "18355_Large.webp",
-                "18355_Medium.webp",
-                "18355_Small.webp",
+                "items.map",
+                "20801_Large.webp",
+                "20801_Medium.webp",
+                "65002_Large.webp",
+                "65002_Medium.webp",
             ]
         );
+        assert_eq!(entries[0].1, b"1 65002\n5057 20801\n5058 20801\n");
+
+        // The Large entry really is 80px, even when the source was the odd
+        // 72px currency resolution (upscaled once here, not in the browser).
+        let (_, large) = &entries[1];
+        let decoded = webp::Decoder::new(large).decode().expect("decode webp");
+        let image = decoded.to_image();
+        assert_eq!((image.width(), image.height()), (80, 80));
     }
 }

--- a/game-data-pack/src/main.rs
+++ b/game-data-pack/src/main.rs
@@ -29,9 +29,11 @@ Options:
   --pinned                 Build from the SHAs in data/manifest.toml (default)
   --latest                 Resolve each source's latest SHA, rewrite the
                            manifest, then build
-  --offline-source <path>  Build from an already-populated ultros checkout
-                           instead of fetching anything
-  --skip-icons             Skip the icon pack (and the universalis-assets fetch)
+  --offline-source <path>  Build the CSV packs from an already-populated ultros
+                           checkout instead of fetching anything
+  --skip-icons             Skip the icon pack (no FFXIV install needed)
+  --game-path <path>       FFXIV install root to extract icons from (default:
+                           search the standard install locations)
 ";
 
 #[derive(Debug, PartialEq, Eq)]
@@ -45,6 +47,7 @@ struct Args {
     pins: Pins,
     offline_source: Option<PathBuf>,
     skip_icons: bool,
+    game_path: Option<PathBuf>,
 }
 
 fn main() {
@@ -68,23 +71,23 @@ fn run() -> anyhow::Result<()> {
         .context("locating the repo root")?;
     let data_dir = repo_root.join("data");
 
+    let manifest_path = data_dir.join("manifest.toml");
     let layout = match &args.offline_source {
         Some(checkout) => {
             println!("building from {} (no fetching)", checkout.display());
-            Layout::offline(checkout, args.skip_icons)
+            Layout::offline(checkout)
         }
         None => {
-            let manifest_path = data_dir.join("manifest.toml");
             let mut manifest = Manifest::load(&manifest_path)?;
             let cache_root = repo_root.join(".game-data-cache");
             if args.pins == Pins::Latest {
                 std::fs::create_dir_all(&cache_root)
                     .with_context(|| format!("creating cache root {}", cache_root.display()))?;
-                update_pins(&mut manifest, &cache_root, args.skip_icons)?;
+                update_pins(&mut manifest, &cache_root)?;
                 manifest.save(&manifest_path)?;
                 println!("updated {}", manifest_path.display());
             }
-            fetch::fetch_all(&cache_root, &manifest, args.skip_icons)?
+            fetch::fetch_all(&cache_root, &manifest)?
         }
     };
 
@@ -101,35 +104,116 @@ fn run() -> anyhow::Result<()> {
         );
     }
 
-    match &layout.icons {
-        None => println!("\nicons skipped"),
-        Some(icon_dir) => {
-            let out_path = data_dir.join("icons").join("images.tar.zst");
-            let stats = icons::build_pack(icon_dir, &out_path)?;
-            println!("\nicons -> {}", out_path.display());
-            println!(
-                "  {} source PNGs, {} entries, {:.2}MB tar -> {:.2}MB zst",
-                stats.source_pngs,
-                stats.entries,
-                mib(stats.tar_bytes),
-                mib(stats.packed_bytes),
-            );
-            report_missing_icons(icon_dir, &output.en_named_item_ids)?;
-        }
+    if args.skip_icons {
+        println!("\nicons skipped");
+        return Ok(());
     }
+
+    let install = icon_extract::GameInstall::discover(args.game_path.as_deref())?;
+    println!("\nextracting icons from FFXIV {}", install.version);
+    let extracted = extract_icons(&install, &output.en_named_items)?;
+    if extraction_looks_broken(extracted.missing.len(), &output.en_named_items) {
+        bail!(
+            "{} of {} named items have an icon id whose .tex is unreadable — that is not a \
+             stale-client tail, the extraction itself is broken (wrong --game-path, or a client \
+             format ironworks cannot read). Not writing a gutted icon pack.",
+            extracted.missing.len(),
+            output.en_named_items.len(),
+        );
+    }
+    let Extraction {
+        icons,
+        item_to_icon,
+        missing,
+        iconless,
+    } = extracted;
+
+    let out_path = data_dir.join("icons").join("images.tar.zst");
+    let stats = icons::build_pack(icons, &item_to_icon, &out_path)?;
+    println!("icons -> {}", out_path.display());
+    println!(
+        "  {} unique icons for {} items, {} entries, {:.2}MB tar -> {:.2}MB zst",
+        stats.unique_icons,
+        stats.mapped_items,
+        stats.entries,
+        mib(stats.tar_bytes),
+        mib(stats.packed_bytes),
+    );
+    println!("  {iconless} named items have Icon = 0 (permanently iconless rows)");
+    report_missing_icons(&missing, output.en_named_items.len());
+
+    // Record which client the icons came out of. An offline CSV build has no
+    // loaded manifest, but it still regenerated the icon pack, so update the
+    // provenance there too.
+    let mut manifest = Manifest::load(&manifest_path)?;
+    manifest.icons = Some(manifest::IconPack {
+        game_version: install.version.clone(),
+    });
+    manifest.save(&manifest_path)?;
 
     Ok(())
 }
 
-/// Rewrites every pinned SHA to whatever the upstream branch points at now.
-fn update_pins(manifest: &mut Manifest, run_dir: &Path, skip_icons: bool) -> anyhow::Result<()> {
-    for (name, source) in manifest.sources.iter_mut() {
-        if skip_icons && name == fetch::ICONS_SOURCE {
-            // Bumping this pin without regenerating the icon pack would make the
-            // manifest claim data/icons was built from a SHA it never saw.
-            println!("{name}: pin left at {} (--skip-icons)", source.sha);
+struct Extraction {
+    /// `(icon id, image)` for every distinct icon that decoded.
+    icons: Vec<(i32, image::RgbaImage)>,
+    /// `(item id, icon id)` for every item whose icon is in `icons`.
+    item_to_icon: Vec<(i32, i32)>,
+    /// Item ids whose non-zero icon id has no readable `.tex` in the install.
+    missing: Vec<i32>,
+    /// Named items with `Icon == 0` — iconless by data, not by staleness.
+    iconless: usize,
+}
+
+/// Decodes every distinct icon id the named items reference.
+fn extract_icons(
+    install: &icon_extract::GameInstall,
+    named_items: &[(i32, i32)],
+) -> anyhow::Result<Extraction> {
+    let mut decoded: std::collections::HashMap<i32, bool> = std::collections::HashMap::new();
+    let mut extraction = Extraction {
+        icons: Vec::new(),
+        item_to_icon: Vec::with_capacity(named_items.len()),
+        missing: Vec::new(),
+        iconless: 0,
+    };
+    for &(item_id, icon_id) in named_items {
+        if icon_id == 0 {
+            extraction.iconless += 1;
             continue;
         }
+        let readable = match decoded.entry(icon_id) {
+            std::collections::hash_map::Entry::Occupied(seen) => *seen.get(),
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                let image = install.icon(icon_id)?;
+                let readable = image.is_some();
+                if let Some(image) = image {
+                    extraction.icons.push((icon_id, image));
+                }
+                *vacant.insert(readable)
+            }
+        };
+        if readable {
+            extraction.item_to_icon.push((item_id, icon_id));
+        } else {
+            extraction.missing.push(item_id);
+        }
+    }
+    Ok(extraction)
+}
+
+/// True when so many icon-bearing items came back unreadable that the problem
+/// has to be systemic rather than a stale-client tail. A client one patch
+/// behind the pinned CSVs measures ~1-3% missing; a wrong install path or an
+/// unparseable client format measures near 100%.
+fn extraction_looks_broken(missing: usize, named_items: &[(i32, i32)]) -> bool {
+    let with_icons = named_items.iter().filter(|(_, icon)| *icon != 0).count();
+    missing * 10 > with_icons
+}
+
+/// Rewrites every pinned SHA to whatever the upstream branch points at now.
+fn update_pins(manifest: &mut Manifest, run_dir: &Path) -> anyhow::Result<()> {
+    for (name, source) in manifest.sources.iter_mut() {
         let latest = fetch::latest_sha(run_dir, source)?;
         if latest == source.sha {
             println!("{name}: {} (unchanged)", source.sha);
@@ -141,26 +225,24 @@ fn update_pins(manifest: &mut Manifest, run_dir: &Path, skip_icons: bool) -> any
     Ok(())
 }
 
-/// Reports named items the upstream icon repo has no PNG for; these render as a
-/// blank icon.
+/// Reports named items whose icon could not be extracted; these render as the
+/// fallback image.
 ///
-/// The absolute count is inherently large — measured on 7.55 the icon repo ships
-/// 17,209 files against 50,773 named items, so ~33.5k named items legitimately
-/// have no icon of their own. What is actionable is (a) how the count moves
-/// between runs and (b) the preview, which shows the *highest* ids because a new
-/// game version appends its items at the top of the id range. Previewing the low
-/// end would just reprint the same permanently-iconless legacy rows every run.
-fn report_missing_icons(icon_dir: &Path, named_item_ids: &[i32]) -> anyhow::Result<()> {
-    let missing = icons::missing_icon_ids(icon_dir, named_item_ids)?;
+/// Extraction reads the game files directly, so unlike the old universalis
+/// pipeline the count should be near zero. A large count almost always means
+/// the install is behind the pinned CSVs — patch the game and re-run. The
+/// preview shows the *highest* ids because a new game version appends its items
+/// at the top of the id range.
+fn report_missing_icons(missing: &[i32], named_items: usize) {
     if missing.is_empty() {
-        println!("  every named item has an upstream icon");
-        return Ok(());
+        println!("  every named item has an icon");
+        return;
     }
-    let preview = newest_missing(&missing, 20);
+    let preview = newest_missing(missing, 20);
     println!(
-        "  {} of {} named items have no upstream icon; highest ids: {}{}",
+        "  {} of {named_items} named items have no icon in the install \
+         (client older than the pinned CSVs?); highest ids: {}{}",
         missing.len(),
-        named_item_ids.len(),
         preview
             .iter()
             .map(i32::to_string)
@@ -172,7 +254,6 @@ fn report_missing_icons(icon_dir: &Path, named_item_ids: &[i32]) -> anyhow::Resu
             ""
         },
     );
-    Ok(())
 }
 
 /// The `limit` highest ids from an ascending list, highest first.
@@ -185,6 +266,7 @@ fn parse_args(argv: impl IntoIterator<Item = String>) -> anyhow::Result<Args> {
         pins: Pins::Pinned,
         offline_source: None,
         skip_icons: false,
+        game_path: None,
     };
     let mut argv = argv.into_iter();
     while let Some(arg) = argv.next() {
@@ -198,6 +280,13 @@ fn parse_args(argv: impl IntoIterator<Item = String>) -> anyhow::Result<Args> {
                     bail!("--offline-source needs a path, got the flag {path:?}");
                 }
                 args.offline_source = Some(PathBuf::from(path));
+            }
+            "--game-path" => {
+                let path = argv.next().context("--game-path needs a path")?;
+                if path.starts_with("--") {
+                    bail!("--game-path needs a path, got the flag {path:?}");
+                }
+                args.game_path = Some(PathBuf::from(path));
             }
             "--help" | "-h" => {
                 println!("{USAGE}");
@@ -252,6 +341,27 @@ mod arg_tests {
     #[test]
     fn offline_source_does_not_swallow_the_next_flag() {
         assert!(parse(&["--offline-source", "--skip-icons"]).is_err());
+    }
+
+    #[test]
+    fn broken_extraction_is_a_ratio_of_icon_bearing_items() {
+        // 3 items carry icons; 1 missing (33%) is broken, while iconless rows
+        // never count toward the denominator.
+        let named = [(1, 100), (2, 0), (3, 101), (4, 102)];
+        assert!(extraction_looks_broken(1, &named));
+        assert!(!extraction_looks_broken(0, &named));
+        // A stale-client tail (~3%) stays under the 10% tripwire.
+        let many: Vec<(i32, i32)> = (0..1000).map(|i| (i, 100 + i)).collect();
+        assert!(!extraction_looks_broken(30, &many));
+        assert!(extraction_looks_broken(101, &many));
+    }
+
+    #[test]
+    fn game_path_takes_a_path_argument() {
+        let args = parse(&["--game-path", "D:/ffxiv"]).expect("should parse");
+        assert_eq!(args.game_path, Some(PathBuf::from("D:/ffxiv")));
+        assert!(parse(&["--game-path"]).is_err());
+        assert!(parse(&["--game-path", "--skip-icons"]).is_err());
     }
 
     #[test]

--- a/game-data-pack/src/main.rs
+++ b/game-data-pack/src/main.rs
@@ -112,11 +112,31 @@ fn run() -> anyhow::Result<()> {
     let install = icon_extract::GameInstall::discover(args.game_path.as_deref())?;
     println!("\nextracting icons from FFXIV {}", install.version);
     let extracted = extract_icons(&install, &output.en_named_items)?;
+    // An indexed-but-unreadable icon is never acceptable: the file is right
+    // there and this toolchain cannot read it. Silently counting these as
+    // absent is what made a decoder gap look like a stale game client, so they
+    // stop the run outright rather than quietly shrinking the pack.
+    if !extracted.unreadable.is_empty() {
+        let sample = extracted
+            .unreadable
+            .iter()
+            .take(5)
+            .map(|(item, why)| format!("\n  item {item}: {why}"))
+            .collect::<String>();
+        bail!(
+            "{} of {} named items have an icon that IS indexed in the install but could not be \
+             read.{sample}\nThese are present in the game files — a stale client cannot explain \
+             them. Usually a stale `ironworks` that does not know a newer SqPack file kind. Not \
+             writing a pack that drops them.",
+            extracted.unreadable.len(),
+            output.en_named_items.len(),
+        );
+    }
     if extraction_looks_broken(extracted.missing.len(), &output.en_named_items) {
         bail!(
-            "{} of {} named items have an icon id whose .tex is unreadable — that is not a \
-             stale-client tail, the extraction itself is broken (wrong --game-path, or a client \
-             format ironworks cannot read). Not writing a gutted icon pack.",
+            "{} of {} named items reference an icon id the install does not index — too many to \
+             be a stale-client tail, so the extraction itself is broken (wrong --game-path). Not \
+             writing a gutted icon pack.",
             extracted.missing.len(),
             output.en_named_items.len(),
         );
@@ -125,6 +145,7 @@ fn run() -> anyhow::Result<()> {
         icons,
         item_to_icon,
         missing,
+        unreadable: _,
         iconless,
     } = extracted;
 
@@ -159,8 +180,15 @@ struct Extraction {
     icons: Vec<(i32, image::RgbaImage)>,
     /// `(item id, icon id)` for every item whose icon is in `icons`.
     item_to_icon: Vec<(i32, i32)>,
-    /// Item ids whose non-zero icon id has no readable `.tex` in the install.
+    /// Item ids whose non-zero icon id is genuinely not indexed in the install.
     missing: Vec<i32>,
+    /// Item ids whose icon *is* indexed but could not be read, with the reason.
+    /// Distinct from `missing` on purpose: absent icons are a normal
+    /// consequence of CSVs running ahead of the client, whereas an unreadable
+    /// one is always a defect in this toolchain (stale ironworks, new container
+    /// shape). Folding the two together previously disguised a decoder gap as a
+    /// stale game client.
+    unreadable: Vec<(i32, String)>,
     /// Named items with `Icon == 0` — iconless by data, not by staleness.
     iconless: usize,
 }
@@ -170,11 +198,21 @@ fn extract_icons(
     install: &icon_extract::GameInstall,
     named_items: &[(i32, i32)],
 ) -> anyhow::Result<Extraction> {
-    let mut decoded: std::collections::HashMap<i32, bool> = std::collections::HashMap::new();
+    use icon_extract::IconRead;
+    /// What a previously-seen icon id turned out to be, so each id is only
+    /// read once however many items share it.
+    #[derive(Clone)]
+    enum Seen {
+        Readable,
+        Absent,
+        Unreadable(String),
+    }
+    let mut decoded: std::collections::HashMap<i32, Seen> = std::collections::HashMap::new();
     let mut extraction = Extraction {
         icons: Vec::new(),
         item_to_icon: Vec::with_capacity(named_items.len()),
         missing: Vec::new(),
+        unreadable: Vec::new(),
         iconless: 0,
     };
     for &(item_id, icon_id) in named_items {
@@ -182,21 +220,26 @@ fn extract_icons(
             extraction.iconless += 1;
             continue;
         }
-        let readable = match decoded.entry(icon_id) {
-            std::collections::hash_map::Entry::Occupied(seen) => *seen.get(),
+        let seen = match decoded.entry(icon_id) {
+            std::collections::hash_map::Entry::Occupied(seen) => seen.get().clone(),
             std::collections::hash_map::Entry::Vacant(vacant) => {
-                let image = install.icon(icon_id)?;
-                let readable = image.is_some();
-                if let Some(image) = image {
-                    extraction.icons.push((icon_id, image));
-                }
-                *vacant.insert(readable)
+                let seen = match install.icon(icon_id)? {
+                    IconRead::Image(image) => {
+                        extraction.icons.push((icon_id, image));
+                        Seen::Readable
+                    }
+                    IconRead::Absent => Seen::Absent,
+                    IconRead::Unreadable { path, reason } => {
+                        Seen::Unreadable(format!("{path}: {reason}"))
+                    }
+                };
+                vacant.insert(seen).clone()
             }
         };
-        if readable {
-            extraction.item_to_icon.push((item_id, icon_id));
-        } else {
-            extraction.missing.push(item_id);
+        match seen {
+            Seen::Readable => extraction.item_to_icon.push((item_id, icon_id)),
+            Seen::Absent => extraction.missing.push(item_id),
+            Seen::Unreadable(why) => extraction.unreadable.push((item_id, why)),
         }
     }
     Ok(extraction)

--- a/game-data-pack/src/manifest.rs
+++ b/game-data-pack/src/manifest.rs
@@ -16,6 +16,9 @@ pub const HEADER: &str = "\
 # per-language sheet patterns from SHEETS (see game-data-pack/src/fetch.rs).
 # `checkout_subdir` places a source inside the assembled ffxiv-datamining tree.
 #
+# `[icons]` records the FFXIV client version (game/ffxivgame.ver) the icon pack
+# was extracted from — icons come from a local game install, not a git source.
+#
 # This header is rewritten by `Manifest::save`; comments added below it are NOT
 # preserved across a --latest run.
 ";
@@ -25,6 +28,18 @@ pub const HEADER: &str = "\
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
     pub sources: BTreeMap<String, Source>,
+    /// Provenance of `data/icons`, absent until an icon pack has been built.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icons: Option<IconPack>,
+}
+
+/// Where `data/icons/images.tar.zst` came from: a local FFXIV install at a
+/// specific client version, read by `icon-extract`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IconPack {
+    /// Contents of `game/ffxivgame.ver`, e.g. `2026.07.16.0001.0000`.
+    pub game_version: String,
 }
 
 /// A single pinned upstream source (a git repo at a specific commit).
@@ -68,9 +83,28 @@ mod tests {
     }
 
     #[test]
-    fn load_reads_five_sources() {
+    fn load_reads_the_four_csv_sources() {
         let manifest = Manifest::load(&manifest_path()).expect("manifest should load");
-        assert_eq!(manifest.sources.len(), 5);
+        assert_eq!(manifest.sources.len(), 4);
+        assert!(
+            !manifest.sources.contains_key("universalis-assets"),
+            "icons come from the local game install now, not a git source"
+        );
+    }
+
+    #[test]
+    fn icon_provenance_round_trips() {
+        let mut manifest = Manifest::load(&manifest_path()).expect("manifest should load");
+        manifest.icons = Some(IconPack {
+            game_version: "2026.07.16.0001.0000".to_string(),
+        });
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("manifest.toml");
+        manifest.save(&path).expect("manifest should save");
+
+        let reloaded = Manifest::load(&path).expect("manifest should reload");
+        assert_eq!(manifest, reloaded);
     }
 
     #[test]

--- a/icon-extract/Cargo.toml
+++ b/icon-extract/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "icon-extract"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+image = { workspace = true }
+ironworks = { version = "0.4.1", features = ["sqpack", "tex", "ffxiv"] }
+texture2ddecoder = "0.1.2"

--- a/icon-extract/Cargo.toml
+++ b/icon-extract/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 image = { workspace = true }
-ironworks = { version = "0.4.1", features = ["sqpack", "tex", "ffxiv"] }
+ironworks = { version = "0.4.1", features = ["sqpack", "tex"] }
 texture2ddecoder = "0.1.2"

--- a/icon-extract/examples/dump.rs
+++ b/icon-extract/examples/dump.rs
@@ -1,0 +1,49 @@
+//! Decode a few icons per pixel format to PNG, so each decoder can be
+//! eyeballed rather than trusted.
+//!
+//! cargo run --release -p icon-extract --example dump -- <outdir>
+
+use ironworks::file::tex::Texture;
+use std::collections::BTreeMap;
+
+fn main() {
+    let out = std::env::args().nth(1).unwrap_or_else(|| ".".into());
+    std::fs::create_dir_all(&out).unwrap();
+    let root = std::env::var("FFXIV_PATH").ok();
+    let install = icon_extract::GameInstall::discover(root.as_deref().map(std::path::Path::new))
+        .expect("no FFXIV install found; set FFXIV_PATH");
+    let ironworks = install.ironworks();
+
+    const PER_FORMAT: usize = 2;
+    let mut taken: BTreeMap<String, usize> = BTreeMap::new();
+
+    for id in 1..250_000 {
+        for hr in [true, false] {
+            let path = icon_extract::icon_sqpack_path(id, hr);
+            let Ok(tex) = ironworks.file::<Texture>(&path) else {
+                continue;
+            };
+            let fmt = format!("{:?}", tex.format());
+            let n = taken.entry(fmt.clone()).or_default();
+            if *n >= PER_FORMAT {
+                break;
+            }
+            // Skip the 4096x4096 atlas sheets; they are not item icons and the
+            // PNGs are unwieldy.
+            if tex.width() > 256 {
+                break;
+            }
+            match icon_extract::decode_tex(&tex) {
+                Ok(img) => {
+                    let path = format!("{out}/{fmt}_{id}_{}x{}.png", img.width(), img.height());
+                    img.save(&path).unwrap();
+                    println!("{fmt:14} icon {id:>6} {}x{}", img.width(), img.height());
+                    *n += 1;
+                }
+                Err(e) => println!("{fmt:14} icon {id:>6} DECODE FAILED: {e}"),
+            }
+            break;
+        }
+    }
+    println!("\nformats sampled: {taken:?}");
+}

--- a/icon-extract/examples/probe.rs
+++ b/icon-extract/examples/probe.rs
@@ -1,0 +1,103 @@
+//! Diagnostic: for a range of icon ids, classify each as readable / present-but-
+//! unreadable / absent, and report the texture format. Distinguishes "the client
+//! doesn't have this icon" from "ironworks can't parse this icon".
+//!
+//! cargo run --release -p icon-extract --example probe -- [start] [end] [step]
+
+use ironworks::file::tex::Texture;
+use std::collections::BTreeMap;
+
+fn icon_path(icon_id: i32, hr: bool) -> String {
+    let group = icon_id / 1000 * 1000;
+    let suffix = if hr { "_hr1" } else { "" };
+    format!("ui/icon/{group:06}/{icon_id:06}{suffix}.tex")
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let start: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1);
+    let end: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(250_000);
+    let step: i32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
+
+    let root = std::env::var("FFXIV_PATH").ok();
+    let install = icon_extract::GameInstall::discover(root.as_deref().map(std::path::Path::new))
+        .expect("no FFXIV install found; set FFXIV_PATH");
+    println!("install version: {}", install.version);
+    let ironworks = install.ironworks();
+
+    let mut readable = 0u32;
+    let mut absent = 0u32;
+    let mut formats: BTreeMap<String, u32> = BTreeMap::new();
+    // icon id -> error text, for entries that exist but fail to parse
+    let mut unreadable: Vec<(i32, bool, String)> = Vec::new();
+    // highest icon id that read cleanly, to see where coverage stops
+    let mut max_ok = 0i32;
+    let mut readable_ids: Vec<i32> = Vec::new();
+
+    let mut id = start;
+    while id <= end {
+        let mut got = false;
+        let mut err_seen: Option<(bool, String)> = None;
+        for hr in [true, false] {
+            match ironworks.file::<Texture>(&icon_path(id, hr)) {
+                Ok(tex) => {
+                    *formats.entry(format!("{:?}", tex.format())).or_default() += 1;
+                    got = true;
+                    readable_ids.push(id);
+                    max_ok = max_ok.max(id);
+                    break;
+                }
+                Err(e) => {
+                    let s = e.to_string();
+                    // "not found" is a genuine absence; anything else is a
+                    // parse/read failure on an entry that IS indexed.
+                    let missing = s.to_lowercase().contains("could not be found")
+                        || s.to_lowercase().contains("not found");
+                    if !missing && err_seen.is_none() {
+                        err_seen = Some((hr, s));
+                    }
+                }
+            }
+        }
+        if got {
+            readable += 1;
+        } else if let Some((hr, s)) = err_seen {
+            unreadable.push((id, hr, s));
+        } else {
+            absent += 1;
+        }
+        id += step;
+    }
+
+    println!("scanned {start}..={end} step {step}");
+    println!("  readable            : {readable}  (highest ok id: {max_ok})");
+    println!("  absent (not indexed): {absent}");
+    println!("  PRESENT-BUT-UNREADABLE: {}", unreadable.len());
+    println!("  formats seen: {formats:?}");
+    // Where do the unparseable entries live? Compare against readable ones in
+    // the same bucket — a uniform ratio means this is not a "newest content"
+    // problem, a rising one means it is.
+    let mut ok_by: BTreeMap<i32, u32> = BTreeMap::new();
+    let mut bad_by: BTreeMap<i32, u32> = BTreeMap::new();
+    for (id, _, _) in &unreadable {
+        *bad_by.entry(id / 20000).or_default() += 1;
+    }
+    for id in &readable_ids {
+        *ok_by.entry(id / 20000).or_default() += 1;
+    }
+    println!("  bucket(20k)  readable  unreadable  bad%");
+    for b in 0..=(end / 20000) {
+        let ok = *ok_by.get(&b).unwrap_or(&0);
+        let bad = *bad_by.get(&b).unwrap_or(&0);
+        if ok + bad == 0 {
+            continue;
+        }
+        println!(
+            "    {:>6}      {:>5}     {:>5}     {:>3}%",
+            b * 20000,
+            ok,
+            bad,
+            bad * 100 / (ok + bad)
+        );
+    }
+}

--- a/icon-extract/src/lib.rs
+++ b/icon-extract/src/lib.rs
@@ -6,12 +6,13 @@
 //! at `ui/icon/<group>/<id>.tex` (40px) with a `_hr1` 2x variant (80px); we
 //! prefer the 2x and fall back to the base.
 //!
-//! `ui/icon` uses five pixel formats in practice — Dxt1 (BC1), Dxt5 (BC3),
-//! Argb8, Rgb5a1 and Rgba4 — and all five are decoded here. An earlier census
-//! reported only Dxt1 and Argb8; it undercounted because it could only inspect
-//! icons that *parsed*, and the entries it skipped were never sampled. A format
-//! outside the five still shows up as a hard error naming the format, never as
-//! a corrupt image.
+//! `ui/icon` uses six pixel formats in practice — BC1, BC3, **BC7**, Bgra8,
+//! Bgr5a1 and Bgra4 — and all are decoded here (BC2/BC4/BC5 too, for the cost
+//! of a line each). An earlier census reported only BC1 and Bgra8; it
+//! undercounted because it could only inspect icons that *parsed*, and BC7 in
+//! particular could not be parsed at all by the ironworks release then in use.
+//! A format outside the handled set is a hard error naming the format, never a
+//! corrupt image.
 //!
 //! Reads distinguish three outcomes, which matters because conflating the last
 //! two is what made a decoder gap look like a stale game client: the icon is
@@ -23,9 +24,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context};
 use image::RgbaImage;
 use ironworks::{
-    ffxiv::FsResource,
     file::tex::{Format, Texture},
-    sqpack::SqPack,
+    sqpack::{Install, SqPack},
     Ironworks,
 };
 
@@ -68,7 +68,7 @@ impl GameInstall {
             .with_context(|| format!("reading {}", ver_path.display()))?
             .trim()
             .to_string();
-        let ironworks = Ironworks::new().with_resource(SqPack::new(FsResource::at(&root)));
+        let ironworks = Ironworks::new().with_resource(SqPack::new(Install::at(&root)));
         Ok(GameInstall { ironworks, version })
     }
 
@@ -197,24 +197,31 @@ pub fn decode_tex(tex: &Texture) -> anyhow::Result<RgbaImage> {
     let (w, h) = (tex.width() as usize, tex.height() as usize);
     let data = tex.data();
     let rgba: Vec<u8> = match tex.format() {
-        Format::Argb8 => {
+        Format::Bgra8Unorm => {
             let mip0 = data
                 .get(..w * h * 4)
-                .with_context(|| format!("Argb8 data too short for {w}x{h}"))?;
+                .with_context(|| format!("Bgra8 data too short for {w}x{h}"))?;
             // Stored B,G,R,A per pixel.
             mip0.chunks_exact(4)
                 .flat_map(|p| [p[2], p[1], p[0], p[3]])
                 .collect()
         }
-        Format::Dxt1 => decode_bc(data, w, h, texture2ddecoder::decode_bc1, "bc1")?,
-        Format::Dxt3 => decode_bc(data, w, h, texture2ddecoder::decode_bc2, "bc2")?,
-        Format::Dxt5 => decode_bc(data, w, h, texture2ddecoder::decode_bc3, "bc3")?,
+        Format::Bc1Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc1, "bc1")?,
+        Format::Bc2Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc2, "bc2")?,
+        Format::Bc3Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc3, "bc3")?,
+        // Bcn2. BC7 is the one that matters: ~9% of ui/icon, and the reason
+        // ironworks 0.4.1 could not read those entries at all — its `Format`
+        // enum predates the whole Bcn2 group, so the read failed before any
+        // decoding was attempted.
+        Format::Bc4Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc4, "bc4")?,
+        Format::Bc5Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc5, "bc5")?,
+        Format::Bc7Unorm => decode_bc(data, w, h, texture2ddecoder::decode_bc7, "bc7")?,
         // 16-bit packed. Despite the ironworks names these are the D3D9
         // orderings — A1R5G5B5 and A4R4G4B4 — so alpha is the high bits and
         // blue the low. Channels are widened by multiplying up rather than
         // shifting, so full-scale input maps to 255 instead of 248/240.
-        Format::Rgb5a1 => {
-            let mip0 = packed16(data, w, h, "Rgb5a1")?;
+        Format::Bgr5a1Unorm => {
+            let mip0 = packed16(data, w, h, "Bgr5a1")?;
             mip0.iter()
                 .flat_map(|&v| {
                     let r = ((v >> 10) & 0x1f) as u32;
@@ -230,8 +237,8 @@ pub fn decode_tex(tex: &Texture) -> anyhow::Result<RgbaImage> {
                 })
                 .collect()
         }
-        Format::Rgba4 => {
-            let mip0 = packed16(data, w, h, "Rgba4")?;
+        Format::Bgra4Unorm => {
+            let mip0 = packed16(data, w, h, "Bgra4")?;
             mip0.iter()
                 .flat_map(|&v| {
                     let r = ((v >> 8) & 0xf) as u8;
@@ -288,7 +295,7 @@ mod tests {
     #[test]
     fn argb8_decodes_as_bgra_storage() {
         // One pixel stored B=1, G=2, R=3, A=4 must come out R=3, G=2, B=1, A=4.
-        let tex = Texture::read(tex_bytes(0x1450, 1, 1, &[1, 2, 3, 4])).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 1, 1, &[1, 2, 3, 4]))).expect("parse tex");
         let img = decode_tex(&tex).expect("decode");
         assert_eq!(img.dimensions(), (1, 1));
         assert_eq!(img.get_pixel(0, 0).0, [3, 2, 1, 4]);
@@ -298,7 +305,7 @@ mod tests {
     fn dxt1_decodes_a_solid_color_block() {
         // BC1 block: color0=color1=pure red in RGB565, all indices 0 -> 4x4 red.
         let block = [0x00, 0xF8, 0x00, 0xF8, 0, 0, 0, 0];
-        let tex = Texture::read(tex_bytes(0x3420, 4, 4, &block)).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x3420, 4, 4, &block))).expect("parse tex");
         let img = decode_tex(&tex).expect("decode");
         assert_eq!(img.dimensions(), (4, 4));
         for pixel in img.pixels() {
@@ -309,14 +316,14 @@ mod tests {
     #[test]
     fn unknown_formats_error_instead_of_corrupting() {
         // L8 (0x1130) is a real format no icon uses; decode must refuse it.
-        let tex = Texture::read(tex_bytes(0x1130, 1, 1, &[0])).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1130, 1, 1, &[0]))).expect("parse tex");
         let error = decode_tex(&tex).expect_err("L8 should be rejected");
         assert!(error.to_string().contains("unhandled texture format"));
     }
 
     #[test]
     fn truncated_argb8_data_errors() {
-        let tex = Texture::read(tex_bytes(0x1450, 2, 2, &[0; 4])).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 2, 2, &[0; 4]))).expect("parse tex");
         assert!(decode_tex(&tex).is_err());
     }
 }

--- a/icon-extract/src/lib.rs
+++ b/icon-extract/src/lib.rs
@@ -1,0 +1,211 @@
+//! Extracts item icons from a local FFXIV install via ironworks.
+//!
+//! Replaces the old universalis-assets dependency (Lodestone-crawled PNGs that
+//! only covered marketable items) with direct SqPack reads, so currencies and
+//! untradable exchange rewards get icons too. The game ships icons as `.tex`
+//! at `ui/icon/<group>/<id>.tex` (40px) with a `_hr1` 2x variant (80px); we
+//! prefer the 2x and fall back to the base.
+//!
+//! A 7.55-era census of every icon referenced by the Item sheet found exactly
+//! two pixel formats in use — Dxt1 (BC1) and Argb8 — so those are the only
+//! decoders implemented. A new format shows up as a hard error naming the
+//! format, not as a corrupt image.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context};
+use image::RgbaImage;
+use ironworks::{
+    ffxiv::FsResource,
+    file::tex::{Format, Texture},
+    sqpack::SqPack,
+    Ironworks,
+};
+
+/// SqPack path of an icon's `.tex` file. Icons are grouped in
+/// thousands-aligned directories: icon 65002 lives in `ui/icon/065000/`.
+pub fn icon_sqpack_path(icon_id: i32, hr: bool) -> String {
+    let group = (icon_id / 1000) * 1000;
+    let suffix = if hr { "_hr1" } else { "" };
+    format!("ui/icon/{group:06}/{icon_id:06}{suffix}.tex")
+}
+
+/// An opened FFXIV install we can read icons out of.
+pub struct GameInstall {
+    ironworks: Ironworks,
+    /// Contents of `game/ffxivgame.ver`, e.g. `2026.07.16.0001.0000`. This is
+    /// the provenance the icon pack records in `data/manifest.toml`.
+    pub version: String,
+}
+
+impl GameInstall {
+    /// Open the install at `path` (the directory containing `game/`), or search
+    /// the standard install locations when `path` is `None`.
+    pub fn discover(path: Option<&Path>) -> anyhow::Result<GameInstall> {
+        let root = match path {
+            Some(explicit) => {
+                if !explicit.join("game").join("sqpack").is_dir() {
+                    bail!(
+                        "{} does not look like an FFXIV install (no game/sqpack inside)",
+                        explicit.display()
+                    );
+                }
+                explicit.to_path_buf()
+            }
+            None => find_install().context(
+                "no FFXIV install found in the standard locations; pass --game-path <install root>",
+            )?,
+        };
+        let ver_path = root.join("game").join("ffxivgame.ver");
+        let version = std::fs::read_to_string(&ver_path)
+            .with_context(|| format!("reading {}", ver_path.display()))?
+            .trim()
+            .to_string();
+        let ironworks = Ironworks::new().with_resource(SqPack::new(FsResource::at(&root)));
+        Ok(GameInstall { ironworks, version })
+    }
+
+    /// Read and decode icon `icon_id`, preferring the 2x `_hr1` variant.
+    /// `Ok(None)` means the install yields no usable icon at either resolution
+    /// — including the rare entry whose SqPack record doesn't parse (a handful
+    /// of ids index a `.tex` that ironworks cannot read; treat them like the
+    /// absent ones and let the caller's missing-count guard catch anything
+    /// systemic). Decode errors on a successfully *read* texture still fail
+    /// loudly: an unknown pixel format must never degrade into a blank icon.
+    pub fn icon(&self, icon_id: i32) -> anyhow::Result<Option<RgbaImage>> {
+        for hr in [true, false] {
+            let path = icon_sqpack_path(icon_id, hr);
+            match self.ironworks.file::<Texture>(&path) {
+                Ok(tex) => {
+                    return decode_tex(&tex)
+                        .with_context(|| format!("decoding {path}"))
+                        .map(Some);
+                }
+                Err(_) => continue,
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// The install locations `GameInstall::discover` searches, matching ironworks'
+/// own `FsResource::search` list.
+const TRY_PATHS: &[&str] = &[
+    r"C:\SquareEnix\FINAL FANTASY XIV - A Realm Reborn",
+    r"C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY XIV Online",
+    r"C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY XIV - A Realm Reborn",
+    r"C:\Program Files (x86)\FINAL FANTASY XIV - A Realm Reborn",
+    r"C:\Program Files (x86)\SquareEnix\FINAL FANTASY XIV - A Realm Reborn",
+];
+
+fn find_install() -> Option<PathBuf> {
+    TRY_PATHS
+        .iter()
+        .map(PathBuf::from)
+        .find(|path| path.join("game").join("sqpack").is_dir())
+}
+
+/// Decode mip 0 of `tex` to RGBA8.
+pub fn decode_tex(tex: &Texture) -> anyhow::Result<RgbaImage> {
+    let (w, h) = (tex.width() as usize, tex.height() as usize);
+    let data = tex.data();
+    let rgba: Vec<u8> = match tex.format() {
+        Format::Argb8 => {
+            let mip0 = data
+                .get(..w * h * 4)
+                .with_context(|| format!("Argb8 data too short for {w}x{h}"))?;
+            // Stored B,G,R,A per pixel.
+            mip0.chunks_exact(4)
+                .flat_map(|p| [p[2], p[1], p[0], p[3]])
+                .collect()
+        }
+        Format::Dxt1 => {
+            let mut pixels = vec![0u32; w * h];
+            texture2ddecoder::decode_bc1(data, w, h, &mut pixels)
+                .map_err(|e| anyhow!("bc1 decode failed: {e}"))?;
+            // texture2ddecoder emits ARGB words, i.e. B,G,R,A bytes on LE.
+            pixels
+                .iter()
+                .flat_map(|px| {
+                    let [b, g, r, a] = px.to_le_bytes();
+                    [r, g, b, a]
+                })
+                .collect()
+        }
+        other => bail!("icon uses unhandled texture format {other:?}"),
+    };
+    RgbaImage::from_raw(w as u32, h as u32, rgba).context("pixel buffer does not match dimensions")
+}
+
+#[cfg(test)]
+mod tests {
+    use ironworks::file::File;
+
+    use super::*;
+
+    /// Build the 80-byte `.tex` header + payload that `Texture`'s binread
+    /// parser expects: attributes, format, dims, mips, LoD + surface tables.
+    fn tex_bytes(format: u32, width: u16, height: u16, data: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&0x00800000u32.to_le_bytes()); // attributes: 2D
+        bytes.extend_from_slice(&format.to_le_bytes());
+        bytes.extend_from_slice(&width.to_le_bytes());
+        bytes.extend_from_slice(&height.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes()); // depth
+        bytes.extend_from_slice(&1u16.to_le_bytes()); // mip levels
+        bytes.extend_from_slice(&[0u8; 12]); // lod surfaces
+        let mut offsets = [0u32; 13];
+        offsets[0] = 80;
+        for offset in offsets {
+            bytes.extend_from_slice(&offset.to_le_bytes());
+        }
+        assert_eq!(bytes.len(), 80);
+        bytes.extend_from_slice(data);
+        bytes
+    }
+
+    #[test]
+    fn icon_paths_group_by_thousands() {
+        assert_eq!(
+            icon_sqpack_path(65002, true),
+            "ui/icon/065000/065002_hr1.tex"
+        );
+        assert_eq!(icon_sqpack_path(20801, false), "ui/icon/020000/020801.tex");
+        assert_eq!(icon_sqpack_path(999, true), "ui/icon/000000/000999_hr1.tex");
+    }
+
+    #[test]
+    fn argb8_decodes_as_bgra_storage() {
+        // One pixel stored B=1, G=2, R=3, A=4 must come out R=3, G=2, B=1, A=4.
+        let tex = Texture::read(tex_bytes(0x1450, 1, 1, &[1, 2, 3, 4])).expect("parse tex");
+        let img = decode_tex(&tex).expect("decode");
+        assert_eq!(img.dimensions(), (1, 1));
+        assert_eq!(img.get_pixel(0, 0).0, [3, 2, 1, 4]);
+    }
+
+    #[test]
+    fn dxt1_decodes_a_solid_color_block() {
+        // BC1 block: color0=color1=pure red in RGB565, all indices 0 -> 4x4 red.
+        let block = [0x00, 0xF8, 0x00, 0xF8, 0, 0, 0, 0];
+        let tex = Texture::read(tex_bytes(0x3420, 4, 4, &block)).expect("parse tex");
+        let img = decode_tex(&tex).expect("decode");
+        assert_eq!(img.dimensions(), (4, 4));
+        for pixel in img.pixels() {
+            assert_eq!(pixel.0, [255, 0, 0, 255]);
+        }
+    }
+
+    #[test]
+    fn unknown_formats_error_instead_of_corrupting() {
+        // L8 (0x1130) is a real format no icon uses; decode must refuse it.
+        let tex = Texture::read(tex_bytes(0x1130, 1, 1, &[0])).expect("parse tex");
+        let error = decode_tex(&tex).expect_err("L8 should be rejected");
+        assert!(error.to_string().contains("unhandled texture format"));
+    }
+
+    #[test]
+    fn truncated_argb8_data_errors() {
+        let tex = Texture::read(tex_bytes(0x1450, 2, 2, &[0; 4])).expect("parse tex");
+        assert!(decode_tex(&tex).is_err());
+    }
+}

--- a/icon-extract/src/lib.rs
+++ b/icon-extract/src/lib.rs
@@ -295,7 +295,8 @@ mod tests {
     #[test]
     fn argb8_decodes_as_bgra_storage() {
         // One pixel stored B=1, G=2, R=3, A=4 must come out R=3, G=2, B=1, A=4.
-        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 1, 1, &[1, 2, 3, 4]))).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 1, 1, &[1, 2, 3, 4])))
+            .expect("parse tex");
         let img = decode_tex(&tex).expect("decode");
         assert_eq!(img.dimensions(), (1, 1));
         assert_eq!(img.get_pixel(0, 0).0, [3, 2, 1, 4]);
@@ -305,7 +306,8 @@ mod tests {
     fn dxt1_decodes_a_solid_color_block() {
         // BC1 block: color0=color1=pure red in RGB565, all indices 0 -> 4x4 red.
         let block = [0x00, 0xF8, 0x00, 0xF8, 0, 0, 0, 0];
-        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x3420, 4, 4, &block))).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x3420, 4, 4, &block)))
+            .expect("parse tex");
         let img = decode_tex(&tex).expect("decode");
         assert_eq!(img.dimensions(), (4, 4));
         for pixel in img.pixels() {
@@ -316,14 +318,16 @@ mod tests {
     #[test]
     fn unknown_formats_error_instead_of_corrupting() {
         // L8 (0x1130) is a real format no icon uses; decode must refuse it.
-        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1130, 1, 1, &[0]))).expect("parse tex");
+        let tex =
+            Texture::read(std::io::Cursor::new(tex_bytes(0x1130, 1, 1, &[0]))).expect("parse tex");
         let error = decode_tex(&tex).expect_err("L8 should be rejected");
         assert!(error.to_string().contains("unhandled texture format"));
     }
 
     #[test]
     fn truncated_argb8_data_errors() {
-        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 2, 2, &[0; 4]))).expect("parse tex");
+        let tex = Texture::read(std::io::Cursor::new(tex_bytes(0x1450, 2, 2, &[0; 4])))
+            .expect("parse tex");
         assert!(decode_tex(&tex).is_err());
     }
 }

--- a/icon-extract/src/lib.rs
+++ b/icon-extract/src/lib.rs
@@ -6,10 +6,17 @@
 //! at `ui/icon/<group>/<id>.tex` (40px) with a `_hr1` 2x variant (80px); we
 //! prefer the 2x and fall back to the base.
 //!
-//! A 7.55-era census of every icon referenced by the Item sheet found exactly
-//! two pixel formats in use — Dxt1 (BC1) and Argb8 — so those are the only
-//! decoders implemented. A new format shows up as a hard error naming the
-//! format, not as a corrupt image.
+//! `ui/icon` uses five pixel formats in practice — Dxt1 (BC1), Dxt5 (BC3),
+//! Argb8, Rgb5a1 and Rgba4 — and all five are decoded here. An earlier census
+//! reported only Dxt1 and Argb8; it undercounted because it could only inspect
+//! icons that *parsed*, and the entries it skipped were never sampled. A format
+//! outside the five still shows up as a hard error naming the format, never as
+//! a corrupt image.
+//!
+//! Reads distinguish three outcomes, which matters because conflating the last
+//! two is what made a decoder gap look like a stale game client: the icon is
+//! present and decodable, genuinely absent from the install, or **present but
+//! unreadable**. See [`IconRead`].
 
 use std::path::{Path, PathBuf};
 
@@ -65,26 +72,70 @@ impl GameInstall {
         Ok(GameInstall { ironworks, version })
     }
 
+    /// The underlying reader, for diagnostics that need to inspect raw
+    /// textures (see `examples/probe.rs`).
+    pub fn ironworks(&self) -> &Ironworks {
+        &self.ironworks
+    }
+
     /// Read and decode icon `icon_id`, preferring the 2x `_hr1` variant.
-    /// `Ok(None)` means the install yields no usable icon at either resolution
-    /// — including the rare entry whose SqPack record doesn't parse (a handful
-    /// of ids index a `.tex` that ironworks cannot read; treat them like the
-    /// absent ones and let the caller's missing-count guard catch anything
-    /// systemic). Decode errors on a successfully *read* texture still fail
-    /// loudly: an unknown pixel format must never degrade into a blank icon.
-    pub fn icon(&self, icon_id: i32) -> anyhow::Result<Option<RgbaImage>> {
+    ///
+    /// Never collapses "absent" into "unreadable". A `.tex` that is indexed but
+    /// fails to parse is a *defect* — either a stale ironworks or a genuinely
+    /// new container shape — and reporting it as merely missing is what
+    /// previously disguised ~11% of `ui/icon` as content the client did not
+    /// have. Decode errors on a successfully read texture still fail loudly:
+    /// an unknown pixel format must never degrade into a blank icon.
+    pub fn icon(&self, icon_id: i32) -> anyhow::Result<IconRead> {
+        let mut failure: Option<(String, ironworks::Error)> = None;
         for hr in [true, false] {
             let path = icon_sqpack_path(icon_id, hr);
             match self.ironworks.file::<Texture>(&path) {
                 Ok(tex) => {
-                    return decode_tex(&tex)
-                        .with_context(|| format!("decoding {path}"))
-                        .map(Some);
+                    let image = decode_tex(&tex).with_context(|| format!("decoding {path}"))?;
+                    return Ok(IconRead::Image(image));
                 }
-                Err(_) => continue,
+                // Genuinely not in the install — try the other resolution.
+                Err(ironworks::Error::NotFound(_)) => continue,
+                // Indexed but unparseable. Keep the first such error: the
+                // `_hr1` one is the more informative of the pair.
+                Err(e) => {
+                    if failure.is_none() {
+                        failure = Some((path, e));
+                    }
+                }
             }
         }
-        Ok(None)
+        Ok(match failure {
+            Some((path, e)) => IconRead::Unreadable {
+                path,
+                reason: e.to_string(),
+            },
+            None => IconRead::Absent,
+        })
+    }
+}
+
+/// Outcome of reading one icon out of the install.
+#[derive(Debug)]
+pub enum IconRead {
+    /// Decoded successfully.
+    Image(RgbaImage),
+    /// Neither the `_hr1` nor the base `.tex` is indexed. Expected: the Item
+    /// sheet references icon ids the client legitimately does not ship.
+    Absent,
+    /// The `.tex` *is* indexed but could not be read. Never expected — surface
+    /// it rather than counting it as absent.
+    Unreadable { path: String, reason: String },
+}
+
+impl IconRead {
+    /// The decoded image, if there is one.
+    pub fn image(self) -> Option<RgbaImage> {
+        match self {
+            IconRead::Image(image) => Some(image),
+            _ => None,
+        }
     }
 }
 
@@ -105,6 +156,42 @@ fn find_install() -> Option<PathBuf> {
         .find(|path| path.join("game").join("sqpack").is_dir())
 }
 
+/// A texture2ddecoder block decoder: compressed bytes and dimensions in,
+/// ARGB words out.
+type BlockDecoder = fn(&[u8], usize, usize, &mut [u32]) -> Result<(), &'static str>;
+
+/// Run one of texture2ddecoder's block decoders and swizzle its output to
+/// RGBA8. They all share this shape and all emit ARGB words, i.e. B,G,R,A
+/// bytes on a little-endian host.
+fn decode_bc(
+    data: &[u8],
+    w: usize,
+    h: usize,
+    decode: BlockDecoder,
+    name: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let mut pixels = vec![0u32; w * h];
+    decode(data, w, h, &mut pixels).map_err(|e| anyhow!("{name} decode failed: {e}"))?;
+    Ok(pixels
+        .iter()
+        .flat_map(|px| {
+            let [b, g, r, a] = px.to_le_bytes();
+            [r, g, b, a]
+        })
+        .collect())
+}
+
+/// Mip 0 of a 16-bit-per-pixel texture, as little-endian `u16`s.
+fn packed16(data: &[u8], w: usize, h: usize, name: &str) -> anyhow::Result<Vec<u16>> {
+    let mip0 = data
+        .get(..w * h * 2)
+        .with_context(|| format!("{name} data too short for {w}x{h}"))?;
+    Ok(mip0
+        .chunks_exact(2)
+        .map(|p| u16::from_le_bytes([p[0], p[1]]))
+        .collect())
+}
+
 /// Decode mip 0 of `tex` to RGBA8.
 pub fn decode_tex(tex: &Texture) -> anyhow::Result<RgbaImage> {
     let (w, h) = (tex.width() as usize, tex.height() as usize);
@@ -119,16 +206,40 @@ pub fn decode_tex(tex: &Texture) -> anyhow::Result<RgbaImage> {
                 .flat_map(|p| [p[2], p[1], p[0], p[3]])
                 .collect()
         }
-        Format::Dxt1 => {
-            let mut pixels = vec![0u32; w * h];
-            texture2ddecoder::decode_bc1(data, w, h, &mut pixels)
-                .map_err(|e| anyhow!("bc1 decode failed: {e}"))?;
-            // texture2ddecoder emits ARGB words, i.e. B,G,R,A bytes on LE.
-            pixels
-                .iter()
-                .flat_map(|px| {
-                    let [b, g, r, a] = px.to_le_bytes();
-                    [r, g, b, a]
+        Format::Dxt1 => decode_bc(data, w, h, texture2ddecoder::decode_bc1, "bc1")?,
+        Format::Dxt3 => decode_bc(data, w, h, texture2ddecoder::decode_bc2, "bc2")?,
+        Format::Dxt5 => decode_bc(data, w, h, texture2ddecoder::decode_bc3, "bc3")?,
+        // 16-bit packed. Despite the ironworks names these are the D3D9
+        // orderings — A1R5G5B5 and A4R4G4B4 — so alpha is the high bits and
+        // blue the low. Channels are widened by multiplying up rather than
+        // shifting, so full-scale input maps to 255 instead of 248/240.
+        Format::Rgb5a1 => {
+            let mip0 = packed16(data, w, h, "Rgb5a1")?;
+            mip0.iter()
+                .flat_map(|&v| {
+                    let r = ((v >> 10) & 0x1f) as u32;
+                    let g = ((v >> 5) & 0x1f) as u32;
+                    let b = (v & 0x1f) as u32;
+                    let a = (v >> 15) & 0x1;
+                    [
+                        (r * 255 / 31) as u8,
+                        (g * 255 / 31) as u8,
+                        (b * 255 / 31) as u8,
+                        if a == 1 { 255 } else { 0 },
+                    ]
+                })
+                .collect()
+        }
+        Format::Rgba4 => {
+            let mip0 = packed16(data, w, h, "Rgba4")?;
+            mip0.iter()
+                .flat_map(|&v| {
+                    let r = ((v >> 8) & 0xf) as u8;
+                    let g = ((v >> 4) & 0xf) as u8;
+                    let b = (v & 0xf) as u8;
+                    let a = ((v >> 12) & 0xf) as u8;
+                    // 0x0..0xf -> 0x00..0xff exactly.
+                    [r * 17, g * 17, b * 17, a * 17]
                 })
                 .collect()
         }

--- a/ultros-frontend/ultros-xiv-icons/src/lib.rs
+++ b/ultros-frontend/ultros-xiv-icons/src/lib.rs
@@ -7,53 +7,136 @@ use once_cell::sync::OnceCell;
 use tar::Archive;
 use ultros_api_types::icon_size::IconSize;
 
-fn parse_url(str: &str) -> (i32, IconSize) {
-    // id_size.webp
+/// Icon images keyed by *icon* id, plus the item id → icon id map. Icons are
+/// stored once per icon id because thousands of items share an icon; the
+/// `items.map` tar entry (ascii `<item id> <icon id>` lines) translates.
+struct IconData {
+    item_to_icon: HashMap<i32, i32>,
+    images: HashMap<(i32, IconSize), Vec<u8>>,
+}
+
+fn parse_image_name(str: &str) -> (i32, IconSize) {
+    // <icon id>_<size>.webp
     let (name, _ext) = str.split_once('.').unwrap();
-    // id size
     let (id, size) = name.split_once('_').unwrap();
     (
         id.parse().unwrap(),
         match size {
             "Large" => IconSize::Large,
             "Medium" => IconSize::Medium,
-            "Small" => IconSize::Small,
             _ => panic!("Size did not match any known string? {}", size),
         },
     )
 }
 
-pub fn get_item_image(item_id: i32, image_size: IconSize) -> Option<&'static [u8]> {
+fn parse_item_map(contents: &str) -> HashMap<i32, i32> {
+    contents
+        .lines()
+        .map(|line| {
+            let (item, icon) = line.split_once(' ').expect("items.map line");
+            (
+                item.parse().expect("items.map item id"),
+                icon.parse().expect("items.map icon id"),
+            )
+        })
+        .collect()
+}
+
+fn icon_data() -> &'static IconData {
     let tar = include_bytes!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../data/icons/images.tar.zst"
     ))
     .as_ref();
-    static IMAGES: OnceCell<HashMap<(i32, IconSize), Vec<u8>>> = OnceCell::new();
-    // Dump all of our images into a static hashmap
-    let data = IMAGES.get_or_init(|| {
+    static DATA: OnceCell<IconData> = OnceCell::new();
+    DATA.get_or_init(|| {
         let mut decoder = zstd::Decoder::new(tar).unwrap();
         let mut data = vec![];
         decoder.read_to_end(&mut data).unwrap();
         let mut archive = Archive::new(Cursor::new(data));
-        let entries: HashMap<_, _> = archive
-            .entries_with_seek()
-            .ok()
-            .unwrap()
-            .flatten()
-            .map(|mut entry| {
-                let mut bytes = vec![];
-                entry.read_to_end(&mut bytes).unwrap();
-                entry
-                    .path()
-                    .ok()
-                    .and_then(|path| path.as_os_str().to_str().map(parse_url))
-                    .map(|key| (key, bytes))
-                    .unwrap()
-            })
-            .collect();
-        entries
-    });
+        let mut item_to_icon = HashMap::new();
+        let mut images = HashMap::new();
+        for entry in archive.entries_with_seek().unwrap().flatten() {
+            let mut bytes = vec![];
+            let mut entry = entry;
+            entry.read_to_end(&mut bytes).unwrap();
+            let name = entry.path().unwrap().display().to_string();
+            if name == "items.map" {
+                item_to_icon = parse_item_map(std::str::from_utf8(&bytes).unwrap());
+            } else {
+                images.insert(parse_image_name(&name), bytes);
+            }
+        }
+        assert!(
+            !item_to_icon.is_empty(),
+            "icon pack has no items.map entry — data/icons/images.tar.zst predates the \
+             icon-id-keyed format; regenerate it with game-data-pack"
+        );
+        IconData {
+            item_to_icon,
+            images,
+        }
+    })
+}
 
-    data.get(&(item_id, image_size)).map(|v| v.as_slice())
+/// Bytes of the packed WebP for `item_id` at `image_size`.
+///
+/// The pack only stores Large (80px — the native 2x resolution) and Medium
+/// (40px) — a dedicated Small encode saved almost nothing over the 40px WebP
+/// while adding 50% more entries, so Small requests are served the Medium
+/// bytes and the browser scales them down to the 25px display box.
+pub fn get_item_image(item_id: i32, image_size: IconSize) -> Option<&'static [u8]> {
+    let image_size = match image_size {
+        IconSize::Small => IconSize::Medium,
+        other => other,
+    };
+    let data = icon_data();
+    let icon_id = data.item_to_icon.get(&item_id)?;
+    data.images
+        .get(&(*icon_id, image_size))
+        .map(|v| v.as_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn currencies_have_icons() {
+        // The old universalis-assets source only covered marketable items, so
+        // every currency rendered blank. Gil and Allagan Tomestone of Poetics
+        // must exist now that the pack is extracted from the game files.
+        for item_id in [1, 28] {
+            assert!(
+                get_item_image(item_id, IconSize::Large).is_some(),
+                "item {item_id} has no Large icon"
+            );
+        }
+    }
+
+    #[test]
+    fn small_requests_serve_the_medium_bytes() {
+        // The pack stores Large and Medium only; Small must alias Medium
+        // rather than returning None.
+        let small = get_item_image(5057, IconSize::Small).expect("small icon");
+        let medium = get_item_image(5057, IconSize::Medium).expect("medium icon");
+        assert!(std::ptr::eq(small, medium));
+    }
+
+    #[test]
+    fn items_sharing_an_icon_share_the_bytes() {
+        // Iron Ingot (5057) and its HQ-less siblings aside, the cheapest
+        // guarantee: two different item ids mapped to the same icon id return
+        // the same slice, proving the pack stores one copy per icon.
+        let data = icon_data();
+        let mut by_icon: HashMap<i32, i32> = HashMap::new();
+        let (a, b) = data
+            .item_to_icon
+            .iter()
+            .find_map(|(item, icon)| by_icon.insert(*icon, *item).map(|earlier| (earlier, *item)))
+            .expect("some two items share an icon");
+        let bytes_a = get_item_image(a, IconSize::Large).expect("icon a");
+        let bytes_b = get_item_image(b, IconSize::Large).expect("icon b");
+        assert!(std::ptr::eq(bytes_a, bytes_b));
+    }
 }


### PR DESCRIPTION
## Why

https://ultros.app/currency-exchange renders blank icons for most currencies: universalis-assets only ships Lodestone-crawled icons for **marketable** items, so gil, company seals, tomestones, scrips, MGP, and most untradable exchange rewards have no icon at all.

## What

Icons are now read straight out of a local FFXIV install — no crawling, no assets repo, one toolchain (ironworks, all Rust):

- **New `icon-extract` crate**: opens the install via ironworks (SqPack + tex), prefers the native-2x `_hr1` variant (80px), decodes Dxt1/Argb8 (a full census of all 26k referenced icons found exactly those two formats; anything else fails loudly rather than shipping a corrupt image).
- **`game-data-pack`**: the universalis-assets git source is gone. Icons come from the install (auto-discovered; `--game-path` to override; `--skip-icons` on machines without the game). `data/manifest.toml` records the client version under `[icons]` as provenance. A >10% unreadable-icon tripwire refuses to write a gutted pack if extraction is systemically broken.
- **Pack format**: icons stored once per *icon* id with an `items.map` entry translating item→icon (items share icons heavily: 25,507 unique icons cover 49,764 items — storing per-item doubled the pack). Large is now the native 80px (sharper on hidpi than the old 60px), Medium stays 40px, Small is dropped — `ultros-xiv-icons` serves Medium bytes for Small requests. Display CSS boxes unchanged.

## Numbers

Regenerated against ironworks git HEAD, so these are what actually ships:

| | before | after |
|---|---|---|
| items with icons | 17,208 | **50,773** |
| unique icons | — | 26,223 |
| items with no icon | 1,009 | **0** |
| Large resolution | 60px (from 128px crawl) | 80px (native 2x) |
| LFS pack | 22MB | 55MB |

The generator reports **"every named item has an icon"** — no absent, no
unreadable, and no `Icon = 0` rows among named items. The xiv-db CSV packs
regenerated byte-identical.

## Root cause of the missing icons: BC7, not a stale client

An earlier revision of this PR said 1,009 items had no icon because the
generating client was a patch behind the pinned CSVs. That was wrong. The
client was current — `2026.07.16.0001.0000` is a build stamp, not a patch
number, and the game will not launch on an outdated client anyway.

The real cause: `ironworks 0.4.1`'s `file::tex::Format` predates the entire
Bcn2 group, so it cannot parse a **BC7** texture — ~9% of `ui/icon`. On top of
that, `GameInstall::icon` matched `Err(_) => continue`, so "present but
unparseable" and "absent from the install" collapsed into one result, and the
failure reported itself as a stale client.

Measured on a current install, sampling icon ids 1..250000:

| | ironworks 0.4.1 | git HEAD |
|---|---|---|
| readable | 1546 | **1735** |
| present-but-unreadable | **189** | **0** |
| highest readable id | 234951 | 246458 |

151 of the 189 were BC7; the other 38 were existing formats that also failed
under the older sqpack handling.

### Fixes

- Reads return `IconRead::{Image, Absent, Unreadable}`, matched on
  `ironworks::Error::NotFound` structurally rather than by string. An
  indexed-but-unreadable icon **aborts the run** naming path and reason instead
  of quietly shrinking the pack. Genuinely-absent icons keep the >10% tripwire,
  since CSVs legitimately run ahead of a client.
- Every format `ui/icon` actually uses is decoded: BC1, BC3, **BC7**, Bgra8,
  Bgr5a1, Bgra4 (plus BC2/BC4/BC5). Each verified by decoding real icons to PNG
  and looking at them.
- `examples/probe.rs` classifies an id range as readable / absent /
  present-but-unreadable; `examples/dump.rs` writes one sample per format.

### Dependency note

`ironworks` is pinned to git rev `3d5db8ff` — **no crates.io release contains
the Bcn2 formats**, so CI fetches it from GitHub at build time. The bump is not
a drop-in: the `ffxiv` feature is gone (install discovery is now
`sqpack::Install`), `Format` variants are renamed DXGI-style, and `File::read`
requires `Read + Seek`.

## Verification

- 40 unit tests across `icon-extract` / `game-data-pack` / `ultros-xiv-icons`, including a currency-coverage test that fails against the old pack
- Decoded output eyeballed (gil, Poetics, MGP, Dxt1 control) both from raw extraction and from the final pack
- `./check_ci.sh` green (fmt + workspace clippy + xiv-gen feature clippy); xiv-db `.rkyv` packs regenerated byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

