### PR TITLE
fix(observability): give ClickHouse failures a groupable error title

### DIFF
--- a/ultros-clickhouse/src/lib.rs
+++ b/ultros-clickhouse/src/lib.rs
@@ -36,6 +36,149 @@ pub enum ClickHouseError {
     Backfill(String),
 }
 
+/// A stable, low-cardinality label for *why* a ClickHouse call failed.
+///
+/// Error reporting groups events by their message, so the message has to name
+/// the failure class and nothing else. ClickHouse's own text can't do that job:
+/// it embeds live figures that differ on every occurrence —
+///
+/// ```text
+/// Code: 241 ... would use 5.40 GiB ... current RSS: 3.96 GiB, maximum: 5.40 GiB
+/// Code: 241 ... would use 5.44 GiB ... current RSS: 4.06 GiB, maximum: 5.40 GiB
+/// ```
+///
+/// Interpolating that into the message would make one incident look like
+/// hundreds of unrelated one-off issues, so nothing ever crosses an alert
+/// threshold. Report the *kind* and keep the raw text in a structured field,
+/// where it stays readable without splintering the group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClickHouseErrorKind {
+    /// Server-side `Code: 241`: the query wanted more memory than the server's
+    /// ceiling allows. Usually a capacity problem (container limit, thread
+    /// count, missing spill-to-disk) rather than a bug in the query.
+    MemoryLimitExceeded,
+    /// The request did not complete in time.
+    Timeout,
+    /// The server could not be reached at all.
+    Unavailable,
+    /// Anything else — including decode failures, which are the shape a schema
+    /// drift between a row struct and the live table takes.
+    Other,
+}
+
+impl ClickHouseErrorKind {
+    /// Snake-case label, stable across releases: it ends up in issue titles and
+    /// alert rules, so renaming one silently re-groups every historical issue
+    /// that used it.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MemoryLimitExceeded => "memory_limit_exceeded",
+            Self::Timeout => "timeout",
+            Self::Unavailable => "unavailable",
+            Self::Other => "other",
+        }
+    }
+}
+
+impl std::fmt::Display for ClickHouseErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl ClickHouseError {
+    /// Classify this error for reporting. See [`ClickHouseErrorKind`].
+    pub fn kind(&self) -> ClickHouseErrorKind {
+        match self {
+            // Backfill failures wrap a Postgres-side message; there is no
+            // ClickHouse status code to read.
+            ClickHouseError::Backfill(_) => ClickHouseErrorKind::Other,
+            ClickHouseError::Client(e) => classify_client_error(&e.to_string()),
+        }
+    }
+}
+
+/// Match on the rendered text rather than `clickhouse::error::Error`'s variants:
+/// the condition most worth distinguishing (`Code: 241`) arrives as an opaque
+/// `BadResponse(String)`, so the variant alone cannot tell a capacity problem
+/// from a malformed query. Deliberately conservative — an unrecognised error
+/// falls through to `Other` rather than being mislabelled, because a wrong label
+/// is worse than a vague one when it points an operator at a subsystem.
+fn classify_client_error(text: &str) -> ClickHouseErrorKind {
+    if text.contains("Code: 241") || text.contains("MEMORY_LIMIT_EXCEEDED") {
+        ClickHouseErrorKind::MemoryLimitExceeded
+    } else if text.contains("timed out") || text.contains("TimedOut") {
+        ClickHouseErrorKind::Timeout
+    } else if text.contains("Connection refused")
+        || text.contains("tcp connect error")
+        || text.contains("dns error")
+    {
+        ClickHouseErrorKind::Unavailable
+    } else {
+        ClickHouseErrorKind::Other
+    }
+}
+
+#[cfg(test)]
+mod error_kind_tests {
+    use super::*;
+
+    /// Verbatim from the 2026-08-02 outage, when a 6 GB container cap had
+    /// ClickHouse killing roughly half of all row-returning queries. The two
+    /// samples differ only in their memory figures — which is precisely why the
+    /// message must not carry them, and why both have to land on one kind.
+    #[test]
+    fn code_241_is_a_memory_limit_whatever_the_figures_say() {
+        let a = "bad response: Code: 241. DB::Exception: (total) memory limit exceeded: \
+                 would use 5.40 GiB (attempt to allocate chunk of 0.00 B bytes), current RSS: \
+                 3.96 GiB, maximum: 5.40 GiB. (MEMORY_LIMIT_EXCEEDED)";
+        let b = "bad response: Code: 241. DB::Exception: (total) memory limit exceeded: \
+                 would use 5.44 GiB (attempt to allocate chunk of 0.00 B bytes), current RSS: \
+                 4.06 GiB, maximum: 5.40 GiB. (MEMORY_LIMIT_EXCEEDED)";
+        assert_eq!(
+            classify_client_error(a),
+            ClickHouseErrorKind::MemoryLimitExceeded
+        );
+        assert_eq!(
+            classify_client_error(a),
+            classify_client_error(b),
+            "two occurrences of one incident must group together"
+        );
+    }
+
+    #[test]
+    fn transport_failures_are_distinguishable() {
+        assert_eq!(
+            classify_client_error("error sending request: tcp connect error: Connection refused"),
+            ClickHouseErrorKind::Unavailable
+        );
+        assert_eq!(
+            classify_client_error("operation timed out"),
+            ClickHouseErrorKind::Timeout
+        );
+    }
+
+    /// An unrecognised error must degrade to `Other`, never borrow a label that
+    /// would send an operator after the wrong subsystem.
+    #[test]
+    fn unknown_errors_do_not_borrow_a_label() {
+        assert_eq!(
+            classify_client_error("bad response: Code: 62. DB::Exception: Syntax error"),
+            ClickHouseErrorKind::Other
+        );
+    }
+
+    /// These labels reach alert rules, so they are API.
+    #[test]
+    fn labels_are_stable() {
+        assert_eq!(
+            ClickHouseErrorKind::MemoryLimitExceeded.as_str(),
+            "memory_limit_exceeded"
+        );
+        assert_eq!(ClickHouseErrorKind::Other.as_str(), "other");
+    }
+}
+
 /// Cheaply-cloneable handle to a configured ClickHouse client.
 ///
 /// The inner `Client` is wrapped in `Arc` so cloning is just a refcount bump —

--- a/ultros/src/web.rs
+++ b/ultros/src/web.rs
@@ -561,7 +561,7 @@ pub(crate) async fn build_price_series(
             .await
             .map_err(|e| {
                 tracing::warn!(error = ?e, item_id, "price_series CH query failed");
-                anyhow::anyhow!("ClickHouse price_series query failed: {e}")
+                crate::web::error::ClickHouseQueryError::new("price_series", e)
             })?;
 
             if rows.len() <= MAX_BUCKETS {
@@ -618,7 +618,7 @@ pub(crate) async fn build_price_series(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, item_id, "price_series raw_sales CH query failed");
-            anyhow::anyhow!("ClickHouse raw_sales query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("raw_sales", e)
         })?;
         Some(
             sales
@@ -900,7 +900,7 @@ async fn price_density(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, item_id, "price_density min_max CH query failed");
-            anyhow::anyhow!("ClickHouse price_min_max query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("price_min_max", e)
         })?;
 
     let payload = match extent {
@@ -930,7 +930,7 @@ async fn price_density(
             .await
             .map_err(|e| {
                 tracing::warn!(error = ?e, item_id, "price_density CH query failed");
-                anyhow::anyhow!("ClickHouse price_density query failed: {e}")
+                crate::web::error::ClickHouseQueryError::new("price_density", e)
             })?;
             ultros_api_types::price_density::PriceDensity {
                 bucket_seconds,

--- a/ultros/src/web/api/item_stats.rs
+++ b/ultros/src/web/api/item_stats.rs
@@ -58,7 +58,7 @@ pub(crate) async fn get_item_stats(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, item_id, world_name, "item_stats CH query failed");
-            anyhow::anyhow!("ClickHouse item_stats query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("item_stats", e)
         })?;
 
     let variants = ultros_clickhouse::queries::aggregate_item_stats_variants(&scans);

--- a/ultros/src/web/api/market_heat.rs
+++ b/ultros/src/web/api/market_heat.rs
@@ -34,7 +34,7 @@ pub(crate) async fn get_market_heat(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, world_id, "market_heat CH query failed");
-            anyhow::anyhow!("ClickHouse market_heat query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("market_heat", e)
         })?;
 
     // The query returns only categories that had activity. We pad to the

--- a/ultros/src/web/api/movers.rs
+++ b/ultros/src/web/api/movers.rs
@@ -65,7 +65,7 @@ pub(crate) async fn get_movers(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, world_id, "top_movers CH query failed");
-            anyhow::anyhow!("ClickHouse top_movers query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("top_movers", e)
         })?;
 
     // For each mover, fetch the 24h sparkline so the response is one
@@ -148,7 +148,7 @@ pub(crate) async fn post_sparklines(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, world_id, "sparklines_batch CH query failed");
-            anyhow::anyhow!("ClickHouse sparklines query failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("sparklines", e)
         })?;
 
     let series: Vec<SparklineSeries> = rows

--- a/ultros/src/web/api/resale_quality.rs
+++ b/ultros/src/web/api/resale_quality.rs
@@ -70,7 +70,7 @@ pub(crate) async fn post_resale_quality(
         .await
         .map_err(|e| {
             tracing::warn!(error = ?e, world_id, "resale_quality deep_scan_batch failed");
-            anyhow::anyhow!("ClickHouse deep_scan failed: {e}")
+            crate::web::error::ClickHouseQueryError::new("deep_scan", e)
         })?;
 
     let window_f32 = (window_days as f32).max(1.0);

--- a/ultros/src/web/error.rs
+++ b/ultros/src/web/error.rs
@@ -27,6 +27,49 @@ use crate::{analyzer_service::AnalyzerError, event};
 
 use crate::character_claim::ClaimError;
 
+/// A ClickHouse call that failed, tagged with which query it was and why it
+/// failed.
+///
+/// Exists so ClickHouse failures stop falling into [`AnyhowError`]'s
+/// `"Generic error {0}"` catch-all. Two things were wrong with going through
+/// `anyhow`: the typed error was flattened to a string at the call site, and the
+/// string it was flattened into carried ClickHouse's live memory figures, which
+/// differ on every occurrence.
+///
+/// `query` is a `&'static str` and `kind` is a small enum precisely so
+/// [`Display`](std::fmt::Display) stays low-cardinality: `query × kind` is a
+/// handful of possible messages, each one alertable. Per-occurrence detail lives
+/// on `source`, which callers log as a structured field.
+///
+/// Note the `Display` here *does* include `source`, volatile figures and all —
+/// deliberately. It renders into the `error` **field**, which is not part of the
+/// grouping key, so an operator still sees "would use 5.44 GiB, maximum: 5.40
+/// GiB" on the issue. Only [`report_title`], which builds the grouping key,
+/// leaves it out.
+///
+/// [`AnyhowError`]: WebError::AnyhowError
+#[derive(Debug, Error)]
+#[error("ClickHouse {query} query failed ({kind}): {source}")]
+pub struct ClickHouseQueryError {
+    /// Which query failed — the function name in `ultros_clickhouse::queries`.
+    pub query: &'static str,
+    pub kind: ultros_clickhouse::ClickHouseErrorKind,
+    #[source]
+    pub source: ultros_clickhouse::ClickHouseError,
+}
+
+impl ClickHouseQueryError {
+    /// Classify `source` and tag it with the query that produced it.
+    pub fn new(query: &'static str, source: ultros_clickhouse::ClickHouseError) -> Self {
+        let kind = source.kind();
+        Self {
+            query,
+            kind,
+            source,
+        }
+    }
+}
+
 /// Generates an `Error`-deriving enum with the variants shared between `ApiError` and `WebError`.
 /// The shared variants and their `#[from]` / `#[error]` attributes are kept in one place so the
 /// two enums can't drift. Caller passes in any enum-specific variants between braces.
@@ -46,6 +89,11 @@ macro_rules! define_error_enum {
             ),
             #[error("Generic error {0}")]
             AnyhowError(#[from] anyhow::Error),
+            // Kept ahead of the `anyhow` catch-all on purpose: a ClickHouse
+            // failure that reaches `AnyhowError` loses its type and, with it,
+            // any hope of being alerted on specifically.
+            #[error(transparent)]
+            ClickHouse(#[from] ClickHouseQueryError),
             #[error("Parse int failed {0}")]
             ParseIntError(#[from] ParseIntError),
             #[error("{0}")]
@@ -185,6 +233,19 @@ impl RetainerStatus for StatusCode {
     }
 }
 
+/// [`report_title`]'s counterpart for [`ApiError`]. Kept as two small functions
+/// rather than a trait: the enums are macro-generated and only share variants,
+/// not a common type, and two three-line matches read better than the generic
+/// machinery needed to unify them.
+fn api_report_title(error: &ApiError) -> std::borrow::Cow<'static, str> {
+    match error {
+        ApiError::ClickHouse(e) => {
+            std::borrow::Cow::Owned(format!("ClickHouse {} query failed ({})", e.query, e.kind))
+        }
+        _ => std::borrow::Cow::Borrowed("Generic API error"),
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         if let ApiError::DiscordTokenInvalid(mut cookies) = self {
@@ -205,7 +266,13 @@ impl IntoResponse for ApiError {
         }
         let status = self.as_status_code();
         if status.is_server_error() {
-            error!(error = ?self, "Generic API error");
+            // Same grouping rule as `WebError` — see `report_title`. The API
+            // routes are where the ClickHouse-backed endpoints live
+            // (item_stats, movers, resale_quality, market_heat), so collapsing
+            // them all under "Generic API error" is what made a ClickHouse
+            // outage indistinguishable from any other 500.
+            let title = api_report_title(&self);
+            error!(error = ?self, "{title}");
         }
         (
             status,
@@ -227,6 +294,26 @@ define_error_enum!(WebError {
     #[error("Bad request")]
     BadRequest,
 });
+
+/// The title error reporting groups this error under.
+///
+/// `tracing`'s *message* is the grouping key — structured fields are not — so a
+/// constant message collapses every 5xx into a single undifferentiated issue.
+/// That is what `"Returning web error"` did: a ClickHouse outage and an OAuth
+/// failure landed in the same bucket, so neither could be alerted on. Naming the
+/// failure class here splits them, while `query × kind` keeps the number of
+/// distinct titles small enough that each accumulates a count instead of
+/// splintering.
+///
+/// Everything else keeps the original title so existing issues stay continuous.
+fn report_title(error: &WebError) -> std::borrow::Cow<'static, str> {
+    match error {
+        WebError::ClickHouse(e) => {
+            std::borrow::Cow::Owned(format!("ClickHouse {} query failed ({})", e.query, e.kind))
+        }
+        _ => std::borrow::Cow::Borrowed("Returning web error"),
+    }
+}
 
 impl WebError {
     fn as_status_code(&self) -> StatusCode {
@@ -264,10 +351,15 @@ impl IntoResponse for WebError {
             format!("{self}")
         };
 
+        // `error = %self` is a *field*, not the message, so it never affects
+        // grouping — which is why the per-occurrence detail (ClickHouse's live
+        // memory figures, the failing item id) can safely ride along here while
+        // the title stays stable.
+        let title = report_title(&self);
         if status.is_server_error() && !is_transient_warmup {
-            tracing::error!(error = %self, %status, "Returning web error");
+            tracing::error!(error = %self, %status, "{title}");
         } else {
-            tracing::debug!(error = %self, %status, "Returning web error");
+            tracing::debug!(error = %self, %status, "{title}");
         }
         (status, message).into_response()
     }


### PR DESCRIPTION
## What

Adds `ClickHouseErrorKind` and `ClickHouseQueryError`, and converts the nine ClickHouse call sites off `anyhow!("...{e}")` so a ClickHouse failure produces a distinct, alertable error title instead of collapsing into a generic 500.

## Why

Every 5xx logged through `WebError`/`ApiError` used a **constant** tracing message — `"Returning web error"` / `"Generic API error"`. That message is the grouping key for error reporting; `error = %self` is a structured field and does not affect grouping. A ClickHouse outage, an OAuth failure and a sitemap error therefore all landed in one undifferentiated issue, and none could be alerted on individually.

This was measured, not hypothetical. On 2026-08-02 a 6 GB ClickHouse container cap produced `Code: 241 MEMORY_LIMIT_EXCEEDED` on roughly half of all row-returning queries — **647 killed queries and 428 failed `price_series` calls in two hours**, plus the rollup refreshers — and nothing in the error signal distinguished it from any other 500.

## How

| before | after |
|---|---|
| `Returning web error` | `ClickHouse price_series query failed (memory_limit_exceeded)` |
| `Generic API error` | `ClickHouse item_stats query failed (unavailable)` |

`query × kind` is a small bounded set, so each title accumulates a count rather than splintering. Non-ClickHouse errors keep their original titles so existing issues stay continuous.

The volatile figures are **not** lost: `ClickHouseQueryError`'s `Display` deliberately includes `source`, because it renders into the `error` field, which is not part of the grouping key. An operator still sees `would use 5.44 GiB, maximum: 5.40 GiB` on the issue.

## Reviewer notes

- **Classification matches on rendered text, not `clickhouse::error::Error` variants.** `Code: 241` arrives as an opaque `BadResponse(String)`, so the variant alone cannot separate a capacity problem from a malformed query. It is deliberately conservative — an unrecognised error degrades to `other` rather than borrowing a label that would point at the wrong subsystem.
- **The call-site `warn!`s are intentionally left as `warn!`.** They already carry `item_id`/`world_id` and the raw error, and they surface as breadcrumbs on the event. Promoting them to `error!` would emit a *second* event per failure, since `into_response` already fires one for every 5xx.
- **The `ClickHouse` variant sits ahead of the `anyhow` catch-all** in the shared macro so the type survives to the reporting layer.
- The snake_case labels (`memory_limit_exceeded`, …) are treated as API, since they reach issue titles and alert rules — renaming one silently re-groups historical issues.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ultros -p ultros-clickhouse --all-targets -- -D warnings` — clean, exit 0
- `cargo test -p ultros-clickhouse --lib` — 37 passed, including 4 new

New tests pin the behaviour that motivated the change: the two **verbatim** `Code: 241` strings from the outage differ only in their memory figures and must classify identically; unknown errors must not borrow a label; the labels are stable.

## Not in scope

Production had no server-side error reporting at all until 2026-08-05 — `main.rs` gates `sentry::init` on `GLITCHTIP_DSN`, and prod only ever set `ULTROS_ERROR_REPORTING_DSN` (the frontend/WASM reporter). That has been fixed separately on the host; this PR is the refinement that makes the now-flowing events specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)