### PR TITLE
⚡ Bolt: Avoid allocating new Vectors when limiting arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -66,3 +66,6 @@ When returning the top N items from a collection, first use `select_nth_unstable
 In `ultros-db/src/sales.rs` and `ultros/src/discord/ffxiv/analyze.rs`, taking the top N elements of a slice using a full sort (`sort_by_key`/`sort_unstable_by_key` followed by `.truncate()` or `.take()`) takes $O(M \log M)$ time. When returning the top N items from a potentially large collection, avoid full sorts.
 **Action:**
 Use `select_nth_unstable_by_key(N)` followed by `.truncate(N)` and sorting only the remaining $N$ elements to partition the array in $O(M)$ time and do the $O(N \log N)$ sort only on the truncated array. Guard it with `if slice.len() > limit`.
+## 2026-08-07 - Avoid into_iter().take().collect() when limiting arrays
+**Learning:** Using `v.into_iter().take(limit).collect::<Vec<_>>` requires iterating and allocating a new Vec. Rust Vectors have an O(1) in-place `truncate(limit)` method that achieves the exact same result without allocating new memory or requiring a `collect`.
+**Action:** Always prefer `v.truncate(limit)` over `.into_iter().take(limit).collect()` to take the first N elements from an existing `Vec`.

--- a/ultros-frontend/ultros-app/src/components/related_items.rs
+++ b/ultros-frontend/ultros-app/src/components/related_items.rs
@@ -1041,7 +1041,11 @@ pub fn RelatedItems(#[prop(into)] item_id: Signal<i32>) -> impl IntoView {
                 <ActiveListBanner />
                 <div class="grid grid-cols-1 2xl:grid-cols-2 gap-4 max-w-6xl">
                     <For
-                        each=Signal::derive(move || recipes().into_iter().take(5).collect::<Vec<_>>())
+                        each=Signal::derive(move || {
+                            let mut r = recipes();
+                            r.truncate(5);
+                            r
+                        })
                         key=|recipe| recipe.key_id
                         children=move |recipe: &'static Recipe| {
                             view! { <Recipe recipe item_id=ItemId(item_id()) /> }

--- a/ultros-frontend/ultros-app/src/components/top_opportunity.rs
+++ b/ultros-frontend/ultros-app/src/components/top_opportunity.rs
@@ -118,7 +118,8 @@ pub fn TopOpportunities(world: Signal<Option<String>>) -> impl IntoView {
                 v.retain(|d| {
                     d.return_on_investment > 0.0 && d.profit > 0 && d.launder_suspicion <= 0.7
                 });
-                v.into_iter().take(VISIBLE_DEALS).collect::<Vec<_>>()
+                v.truncate(VISIBLE_DEALS);
+                v
             }))
         }
     });


### PR DESCRIPTION
💡 What: Replaced `.into_iter().take(limit).collect::<Vec<_>>()` with in-place `.truncate(limit)`.
🎯 Why: Iterating over an existing vector just to take the first N elements requires allocating a brand new vector and moving the elements.
📊 Impact: Eliminates unnecessary O(n) heap allocations in hot reactive Signal::derive loops for `TopOpportunities` and `RelatedItems` components, lowering memory fragmentation.
🔬 Measurement: Verify zero new allocations are happening by profiling with memory tracking tools during view rerenders.

---
*PR created automatically by Jules for task [18000991221497798364](https://jules.google.com/task/18000991221497798364) started by @akarras*