### PR TITLE
fix(ssr): stop forwarding the inbound Host header to the internal API

### DIFF
--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -811,6 +811,88 @@ where
     deserialize(&json)
 }
 
+/// Headers that must not be copied from the inbound browser request onto the
+/// outbound internal API request.
+///
+/// The SSR path re-issues each API call against `HOSTNAME`, which in production
+/// is the *public* origin, so the request travels back out through the CDN.
+/// Copying the inbound `host` header onto a request aimed at a different URL
+/// makes the CDN reject it: a `Host` that does not match the edge certificate
+/// answers `403 Forbidden`, and on a pooled TLS connection (the client below
+/// sets a 60s keepalive, so connections are reused) a `Host` that disagrees
+/// with the connection's SNI answers `421 Misdirected Request`. Both statuses
+/// were live in production against `/api/v1/cheapest/North-America` — the
+/// failure is silent to the visitor, because a failed resource still renders,
+/// just with no data in it, so it only ever showed up as GlitchTip issue 2209
+/// ("Error doing leptos fetch") and as breadcrumbs on unrelated events.
+///
+/// The rest fall into three groups:
+/// - hop-by-hop headers, which are per-connection and must never be forwarded
+///   (RFC 9110 §7.6.1);
+/// - body-framing headers, which would describe a body we are not resending;
+/// - CDN/proxy trust headers, which the edge re-derives for the new request and
+///   must not receive secondhand from a client.
+///
+/// This is deliberately a denylist: the inbound `cookie` carries the visitor's
+/// session and `accept-language` carries their locale, and an allowlist would
+/// silently break auth or i18n the first time a new header started mattering.
+#[cfg(feature = "ssr")]
+const NON_FORWARDABLE_HEADERS: &[&str] = &[
+    // Routing: the whole reason this function exists.
+    "host",
+    // Hop-by-hop (RFC 9110 §7.6.1).
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    // Body framing — these requests carry no body.
+    "content-length",
+    "content-type",
+    // reqwest negotiates (and decodes) its own encodings; forwarding the
+    // browser's list can hand back a body reqwest will not decode.
+    "accept-encoding",
+    // Re-derived by the edge for the outbound request.
+    "cf-connecting-ip",
+    "cf-ipcountry",
+    "cf-ray",
+    "cf-visitor",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+];
+
+/// Copy the inbound request's headers into a header map suitable for the
+/// outbound internal API call, dropping everything in [`NON_FORWARDABLE_HEADERS`].
+///
+/// `HeaderMap`'s iterator yields `None` for the name of a repeated header's
+/// second and subsequent values, so the name is carried forward and the value
+/// appended — otherwise every multi-valued header would be truncated to its
+/// first value.
+#[cfg(feature = "ssr")]
+fn forwardable_headers(headers: axum::http::HeaderMap) -> reqwest::header::HeaderMap {
+    let mut new_map = reqwest::header::HeaderMap::new();
+    let mut current: Option<reqwest::header::HeaderName> = None;
+    for (name, value) in headers.into_iter() {
+        if let Some(name) = name {
+            current = reqwest::header::HeaderName::from_lowercase(name.as_str().as_bytes())
+                .ok()
+                .filter(|name| !NON_FORWARDABLE_HEADERS.contains(&name.as_str()));
+        }
+        let Some(name) = current.clone() else {
+            continue;
+        };
+        if let Ok(value) = reqwest::header::HeaderValue::from_bytes(value.as_bytes()) {
+            new_map.append(name, value);
+        }
+    }
+    new_map
+}
+
 #[cfg(feature = "ssr")]
 #[instrument(skip())]
 pub(crate) async fn delete_api<T>(path: &str) -> AppResult<T>
@@ -836,18 +918,10 @@ where
     let hostname =
         std::env::var("HOSTNAME").unwrap_or_else(|_| "http://localhost:8080".to_string());
     let path = format!("{hostname}{path}");
-    // headers.remove("Accept-Encoding");
-    // this is only necessary because reqwest isn't updated to http 1.0- and I'm being lazy
-    let mut new_map = reqwest::header::HeaderMap::new();
-    for (name, value) in headers.into_iter().filter_map(|(name, value)| {
-        Some((
-            reqwest::header::HeaderName::from_lowercase(name?.as_str().as_bytes()).ok()?,
-            reqwest::header::HeaderValue::from_bytes(value.as_bytes()).ok()?,
-        ))
-    }) {
-        new_map.insert(name, value);
-    }
-    let request = client.delete(&path).headers(new_map).build()?;
+    let request = client
+        .delete(&path)
+        .headers(forwardable_headers(headers))
+        .build()?;
     let response = client
         .execute(request)
         .await
@@ -922,17 +996,10 @@ where
     let hostname =
         std::env::var("HOSTNAME").unwrap_or_else(|_| "http://localhost:8080".to_string());
     let path = format!("{hostname}{path}");
-    // this is only necessary because reqwest isn't updated to http 1.0- and I'm being lazy
-    let mut new_map = reqwest::header::HeaderMap::new();
-    for (name, value) in headers.into_iter().filter_map(|(name, value)| {
-        Some((
-            reqwest::header::HeaderName::from_lowercase(name?.as_str().as_bytes()).ok()?,
-            reqwest::header::HeaderValue::from_bytes(value.as_bytes()).ok()?,
-        ))
-    }) {
-        new_map.insert(name, value);
-    }
-    let request = client.get(&path).headers(new_map).build()?;
+    let request = client
+        .get(&path)
+        .headers(forwardable_headers(headers))
+        .build()?;
     let response = client
         .execute(request)
         .await
@@ -1159,5 +1226,145 @@ mod ssr_response_tests {
             "changing the status must not change what callers observe"
         );
         assert_eq!(fixed_401, AppError::ApiError(ApiError::NotAuthenticated));
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod ssr_header_tests {
+    use super::forwardable_headers;
+    use axum::http::HeaderMap;
+    use axum::http::header::{HeaderName, HeaderValue};
+
+    fn inbound(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.append(
+                HeaderName::from_lowercase(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    /// The bug this module exists for. The SSR path re-issues every API call
+    /// against `HOSTNAME` (the public origin in production), so copying the
+    /// inbound `host` verbatim aims a request at one URL while telling the CDN
+    /// it is for another. Reproduced against production: a request to
+    /// `https://ultros.app/api/v1/cheapest/North-America` carrying
+    /// `Host: boxbox` answers `403 Forbidden` from the edge, byte-for-byte the
+    /// body seen in the GlitchTip breadcrumbs; on a reused TLS connection the
+    /// same mismatch answers `421 Misdirected Request`.
+    #[test]
+    fn host_is_never_forwarded() {
+        let out = forwardable_headers(inbound(&[("host", "boxbox"), ("cookie", "session=abc123")]));
+        assert!(
+            !out.contains_key("host"),
+            "the inbound host would misroute the outbound call: {out:?}"
+        );
+    }
+
+    /// The session cookie is the entire reason the inbound headers are
+    /// forwarded at all — dropping it would log every SSR render out.
+    #[test]
+    fn auth_and_locale_headers_survive() {
+        let out = forwardable_headers(inbound(&[
+            ("host", "boxbox"),
+            ("cookie", "session=abc123"),
+            ("accept-language", "de-DE,de;q=0.9"),
+            ("user-agent", "Mozilla/5.0"),
+        ]));
+        assert_eq!(out.get("cookie").unwrap(), "session=abc123");
+        assert_eq!(out.get("accept-language").unwrap(), "de-DE,de;q=0.9");
+        assert_eq!(out.get("user-agent").unwrap(), "Mozilla/5.0");
+    }
+
+    /// Hop-by-hop headers are per-connection (RFC 9110 §7.6.1) and describe the
+    /// browser's connection to the edge, not ours to the API. `accept-encoding`
+    /// is dropped so reqwest negotiates an encoding it can actually decode —
+    /// there was a commented-out `headers.remove("Accept-Encoding")` sitting in
+    /// this file, which is the same problem noticed and never finished.
+    #[test]
+    fn hop_by_hop_and_framing_headers_are_dropped() {
+        let out = forwardable_headers(inbound(&[
+            ("connection", "keep-alive"),
+            ("keep-alive", "timeout=5"),
+            ("transfer-encoding", "chunked"),
+            ("upgrade", "websocket"),
+            ("te", "trailers"),
+            ("content-length", "42"),
+            ("accept-encoding", "gzip, br, zstd"),
+            ("cookie", "session=abc123"),
+        ]));
+        for dropped in [
+            "connection",
+            "keep-alive",
+            "transfer-encoding",
+            "upgrade",
+            "te",
+            "content-length",
+            "accept-encoding",
+        ] {
+            assert!(
+                !out.contains_key(dropped),
+                "{dropped} must not be forwarded"
+            );
+        }
+        assert_eq!(out.get("cookie").unwrap(), "session=abc123");
+    }
+
+    /// A client must not be able to hand the edge its own provenance headers on
+    /// a request the edge is meant to attribute to us.
+    #[test]
+    fn proxy_trust_headers_are_dropped() {
+        let out = forwardable_headers(inbound(&[
+            ("cf-connecting-ip", "1.2.3.4"),
+            ("x-forwarded-for", "1.2.3.4"),
+            ("x-forwarded-host", "evil.example"),
+            ("x-real-ip", "1.2.3.4"),
+            ("accept", "application/json"),
+        ]));
+        for dropped in [
+            "cf-connecting-ip",
+            "x-forwarded-for",
+            "x-forwarded-host",
+            "x-real-ip",
+        ] {
+            assert!(
+                !out.contains_key(dropped),
+                "{dropped} must not be forwarded"
+            );
+        }
+        assert_eq!(out.get("accept").unwrap(), "application/json");
+    }
+
+    /// `HeaderMap`'s iterator reports `None` for the name of a repeated header's
+    /// second and later values. The previous loop used `name?` inside a
+    /// `filter_map`, so it silently discarded them and kept only the first.
+    #[test]
+    fn repeated_header_values_are_all_forwarded() {
+        let out = forwardable_headers(inbound(&[
+            ("accept-language", "de-DE"),
+            ("accept-language", "en-US"),
+        ]));
+        let values: Vec<_> = out.get_all("accept-language").iter().collect();
+        assert_eq!(values, vec!["de-DE", "en-US"]);
+    }
+
+    /// The continuation values of a *dropped* repeated header must be dropped
+    /// too, rather than latching onto whichever name was forwarded last.
+    #[test]
+    fn continuation_values_of_a_dropped_header_are_also_dropped() {
+        let out = forwardable_headers(inbound(&[
+            ("cookie", "session=abc123"),
+            ("x-forwarded-for", "1.2.3.4"),
+            ("x-forwarded-for", "5.6.7.8"),
+        ]));
+        assert!(!out.contains_key("x-forwarded-for"));
+        let cookies: Vec<_> = out.get_all("cookie").iter().collect();
+        assert_eq!(
+            cookies,
+            vec!["session=abc123"],
+            "leaked into cookie: {out:?}"
+        );
     }
 }


### PR DESCRIPTION
## The bug

The SSR path re-issues every internal API call against `HOSTNAME`, which in production is the **public** origin — so the request goes back out through Cloudflare. Both SSR helpers (`fetch_api`, `delete_api`) then copied the **entire inbound header map** onto that outbound request, including `host`.

That aims a request at one URL while telling the edge it is for another. Cloudflare's answer depends on how the connection was set up:

- a `Host` that doesn't match the edge certificate → **`403 Forbidden`**
- on a **pooled** TLS connection (this client sets `tcp_keepalive(60s)`, so connections are reused) a `Host` that disagrees with the connection's SNI → **`421 Misdirected Request`**

Both statuses are live in production right now against `/api/v1/cheapest/North-America`.

The failure is **silent to the visitor**: a failed resource still renders, just with no data in it. So it never surfaced as a page error — only as GlitchTip issue [2209](https://glitchtip.ultros.app/ultros/issues/2209) ("Error doing leptos fetch", 372 events and still climbing) and as `403`/`421` breadcrumbs riding along on unrelated events.

## Reproduction

Against production, varying only the `Host` header:

```
Host[ultros.app]      -> 200
Host[www.ultros.app]  -> 200
Host[boxbox]          -> 403
Host[5d8bbbd78b6d]    -> 403
```

The 403 body is byte-for-byte the one in the GlitchTip breadcrumbs:

```
<html>\r\n<head><title>403 Forbidden</title></head>\r\n<body>\r\n<center><h1>403 Forbidden</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>
```

I also ruled out user-agent as a cause — Googlebot, SemrushBot, `python-requests` and an empty UA all return 200. It is the `Host` header specifically.

## The fix

A single `forwardable_headers()` helper, used by both SSR helpers, that drops:

- **`host`** — the actual bug;
- **hop-by-hop headers** (`connection`, `keep-alive`, `te`, `trailer`, `transfer-encoding`, `upgrade`, `proxy-*`) — per-connection by definition, RFC 9110 §7.6.1;
- **body-framing headers** (`content-length`, `content-type`) — these requests carry no body;
- **`accept-encoding`** — so reqwest negotiates an encoding it can actually decode. There was a commented-out `headers.remove("Accept-Encoding")` sitting in this file; this is that same problem, noticed and never finished;
- **CDN/proxy trust headers** (`cf-*`, `x-forwarded-*`, `x-real-ip`) — the edge re-derives these, and a client shouldn't be able to hand them to it secondhand.

It is deliberately a **denylist**, not an allowlist: the inbound `cookie` carries the session and `accept-language` carries the locale, and an allowlist would silently break auth or i18n the first time a new header started mattering. There's a test asserting those three survive.

### Secondary fix in the same lines

`HeaderMap`'s iterator yields `None` for the name of a repeated header's second and later values. The old loop used `name?` inside a `filter_map`, so it **silently discarded them** and kept only the first value of every multi-valued header. The new loop carries the name forward and appends — and correctly drops continuation values belonging to a *dropped* header rather than letting them latch onto whichever name was forwarded last (there's a test for that specific trap).

## Verification

Genuine red→green, by reverting `forwardable_headers` to the original loop body:

- **RED**: 5 of the 6 new tests fail at exit **101** (`the inbound host would misroute the outbound call`, `connection must not be forwarded`, `cf-connecting-ip must not be forwarded`, …). The 6th (`auth_and_locale_headers_survive`) passes both ways by design — it's the guard proving the denylist doesn't over-strip.
- **GREEN**: `cargo test -p ultros-app --lib` → **524 passed, 0 failed** (base 518 + 6).

Gates, all exit 0:

- `cargo fmt --all -- --check`
- `cargo clippy -p ultros-app --all-targets -- -D warnings`
- `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown` — CI never lints the hydrate path, and that's what ships to the browser. (The change is entirely inside `#[cfg(feature = "ssr")]` blocks, so this is belt-and-braces.)

## Note for deploy

This fixes the *symptom* correctly — the outbound request now carries no misleading `Host` — but the SSR renderer still makes a full public round-trip through the CDN for every internal API call. Pointing `HOSTNAME` at an internal address (or adding a separate internal base URL for the SSR fetch path) would cut that round-trip out entirely and is worth doing separately. Not changed here because it's a deployment-config decision.

## Triage done in this run

- **Ignored 21** stale May-12 crawler-flood fragments, **#1244 → #1224**. Spot-checked #1244 first: release `c88703d8` (ancient), Chrome 112, UTC, `HTMLDocument.c` — the known flood fingerprint whose root cause is long since fixed. **The flood tail continues below #1224.**
- **Ignored #6778** — count-1 `closure invoked recursively or after being dropped` on dead release `b76d4e6`, dormant since June 24.
- **Left #6887 unresolved on purpose** — same error class but on the **current** release (`9edbc93`), count 1. That's live signal I haven't diagnosed, not noise.

### Found but not fixed here

**Discord alert delivery retries permanent failures forever.** Issues [6879](https://glitchtip.ultros.app/ultros/issues/6879) (71), [6877](https://glitchtip.ultros.app/ultros/issues/6877)/[6878](https://glitchtip.ultros.app/ultros/issues/6878) (28 each), [6885](https://glitchtip.ultros.app/ultros/issues/6885) (18), [6884](https://glitchtip.ultros.app/ultros/issues/6884)/[6881](https://glitchtip.ultros.app/ultros/issues/6881)/[6882](https://glitchtip.ultros.app/ultros/issues/6882)/[6883](https://glitchtip.ultros.app/ultros/issues/6883).

`Unknown Channel` means the channel was deleted; `Missing Access` means the bot was removed. Both are **permanent**, but `ultros/src/alerts/delivery.rs:180` just logs and retries on the next cycle — forever. Six alerts (ids 6, 7, 8, 12, 13, 14) are generating ~150 error events/day between them, and those users are silently never receiving alerts. The fix is to disable (or flag) a destination on a permanent Discord error, but whether that means auto-disable vs. surfacing it in the UI is a product call, so I left it.

**Also still open:** [#6876](https://glitchtip.ultros.app/ultros/issues/6876) (`Option::unwrap()` on `None`, **2014 events**) and [#6886](https://glitchtip.ultros.app/ultros/issues/6886) (disposed reactive value) are production **SSR** panics. Note their `firstSeen` is 2026-08-05 ~18:15, which is when the prod GlitchTip DSN was first set — so these are long-standing, not a new regression. I could not pin either to a source line this run: the release binary is stripped, so every frame comes back unsymbolized. Ruled out by direct measurement against prod world data: the `lookup_world_by_name("North-America").unwrap()` fallback in `item_view.rs` (that region exists), and the `get_region`/`get_datacenters` id unwraps in `world_helper.rs` (all 133 worlds / 18 DCs / 7 regions resolve, zero dangling ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
