### PR TITLE
fix(analyzer): stop the Flip Finder's region memo panicking on failed world data

### DIFF
--- a/ultros-frontend/ultros-app/src/error.rs
+++ b/ultros-frontend/ultros-app/src/error.rs
@@ -24,6 +24,13 @@ pub enum AppError {
     ApiError(#[from] ApiError),
     #[error("Homeworld not set")]
     NoHomeWorld,
+    /// The world list never loaded, so no world/datacenter/region name can be resolved.
+    ///
+    /// Produced when `LocalWorldData` is absent or holds an `Err` — on the client that is a
+    /// failed `/api/v1/world_data` fetch (see `ultros-client`'s bootstrap, which stores the
+    /// failure via `LocalWorldData::failed`).
+    #[error("World data is unavailable")]
+    WorldDataUnavailable,
 }
 
 /// This error type implements From's for the non serializable error types and shoves them into a string

--- a/ultros-frontend/ultros-app/src/global_state/region_for_world.rs
+++ b/ultros-frontend/ultros-app/src/global_state/region_for_world.rs
@@ -9,9 +9,41 @@
 use leptos::prelude::*;
 use ultros_api_types::world_helper::AnyResult;
 
+use crate::error::AppError;
 use crate::global_state::{LocalWorldData, home_world::use_home_world};
 
 const DEFAULT_REGION: &str = "North-America";
+
+/// Resolves the region owning `world_name`, reporting failure instead of falling back.
+///
+/// The counterpart to [`use_region_for_world`], for callers that must not silently
+/// substitute another region's prices — the Flip Finder keys its region-wide board off the
+/// `:world` route param, so guessing would show one region's numbers under another's name.
+/// Those callers want the page's existing error state instead.
+///
+/// Takes its inputs by value rather than reading context itself, so the resolution is a
+/// plain function: no reactive runtime needed to test it, and every failure mode is a
+/// return value. That matters because the only caller runs this inside a `Memo`, where a
+/// panic is unusually destructive — `reactive_graph` *takes* a memo's cached value before
+/// running the body, so an unwind leaves the memo permanently `None` and every subsequent
+/// read panics in `try_read_untracked` (`arc_memo.rs:334`) rather than at the original
+/// fault. One bad unwrap here takes down the whole page, repeatedly.
+pub fn region_for_world_name(
+    world_data: Option<LocalWorldData>,
+    world_name: Option<String>,
+) -> Result<String, AppError> {
+    let worlds = world_data
+        .and_then(|data| data.0.ok())
+        .ok_or(AppError::WorldDataUnavailable)?;
+    let world_name = world_name.ok_or(AppError::ParamMissing)?;
+    worlds
+        .lookup_world_by_name(&world_name)
+        .map(|world| {
+            let region = worlds.get_region(world);
+            AnyResult::Region(region).get_name().to_string()
+        })
+        .ok_or(AppError::ParamMissing)
+}
 
 /// Returns a reactive `Memo<String>` of the region name for `world_name_source`.
 ///
@@ -42,4 +74,81 @@ where
             })
             .unwrap_or_else(|| DEFAULT_REGION.to_string())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use ultros_api_types::world::{Datacenter, Region, World, WorldData};
+    use ultros_api_types::world_helper::WorldHelper;
+
+    fn worlds() -> LocalWorldData {
+        LocalWorldData(Ok(Arc::new(WorldHelper::new(WorldData {
+            regions: vec![Region {
+                id: 1,
+                name: "North-America".to_string(),
+                datacenters: vec![Datacenter {
+                    id: 10,
+                    name: "Aether".to_string(),
+                    region_id: 1,
+                    worlds: vec![World {
+                        id: 100,
+                        name: "Gilgamesh".to_string(),
+                        datacenter_id: 10,
+                    }],
+                }],
+            }],
+        }))))
+    }
+
+    #[test]
+    fn resolves_the_region_owning_a_known_world() {
+        assert_eq!(
+            region_for_world_name(Some(worlds()), Some("Gilgamesh".to_string())),
+            Ok("North-America".to_string())
+        );
+    }
+
+    /// A failed `/api/v1/world_data` fetch stores `LocalWorldData(Err(_))`. This used to be
+    /// `.0.unwrap()` inside the Flip Finder's `region` memo, so the fetch failing took the
+    /// page's wasm bundle down instead of showing its error state.
+    #[test]
+    fn failed_world_data_is_an_error_not_a_panic() {
+        assert_eq!(
+            region_for_world_name(
+                Some(LocalWorldData::failed("world data fetch failed")),
+                Some("Gilgamesh".to_string())
+            ),
+            Err(AppError::WorldDataUnavailable)
+        );
+    }
+
+    /// Likewise `use_context::<LocalWorldData>()` returning `None` — previously an
+    /// `.expect("Worlds should always be populated here")`.
+    #[test]
+    fn missing_world_data_context_is_an_error_not_a_panic() {
+        assert_eq!(
+            region_for_world_name(None, Some("Gilgamesh".to_string())),
+            Err(AppError::WorldDataUnavailable)
+        );
+    }
+
+    #[test]
+    fn a_missing_world_param_is_reported() {
+        assert_eq!(
+            region_for_world_name(Some(worlds()), None),
+            Err(AppError::ParamMissing)
+        );
+    }
+
+    /// An unknown world name stays an error rather than falling back to a default region:
+    /// showing another region's prices under this one's name would be worse than an error.
+    #[test]
+    fn an_unknown_world_is_reported_rather_than_defaulted() {
+        assert_eq!(
+            region_for_world_name(Some(worlds()), Some("Nonexistent".to_string())),
+            Err(AppError::ParamMissing)
+        );
+    }
 }

--- a/ultros-frontend/ultros-app/src/routes/analyzer.rs
+++ b/ultros-frontend/ultros-app/src/routes/analyzer.rs
@@ -36,7 +36,7 @@ use crate::{
         world_picker::*,
     },
     error::AppError,
-    global_state::LocalWorldData,
+    global_state::{LocalWorldData, region_for_world::region_for_world_name},
     math::filter_outliers_iqr_in_place,
     query_defaults::{
         DEFAULT_MAX_SALE_TIME, filter_query_signal, seed_flip_finder_default_view,
@@ -3014,20 +3014,10 @@ pub fn AnalyzerWorldView() -> impl IntoView {
     );
 
     let region = Memo::new(move |_| {
-        let worlds = use_context::<LocalWorldData>()
-            .expect("Worlds should always be populated here")
-            .0
-            .unwrap();
-        let world = params.with(|p| p.get("world").clone());
-        let world = world.ok_or(AppError::ParamMissing)?;
-        let region = worlds
-            .lookup_world_by_name(&world)
-            .map(|world| {
-                let region = worlds.get_region(world);
-                AnyResult::Region(region).get_name().to_string()
-            })
-            .ok_or(AppError::ParamMissing)?;
-        Result::<_, AppError>::Ok(region)
+        region_for_world_name(
+            use_context::<LocalWorldData>(),
+            params.with(|p| p.get("world").clone()),
+        )
     });
 
     let global_cheapest_listings = ArcResource::new(


### PR DESCRIPTION
## What

`AnalyzerWorldView`'s `region` memo resolved its region like this:

```rust
let worlds = use_context::<LocalWorldData>()
    .expect("Worlds should always be populated here")
    .0
    .unwrap();
```

Both accessors can fail on the client. `ultros-client/src/lib.rs:422` stores `LocalWorldData::failed(..)` whenever the `/api/v1/world_data` fetch errors, so `.0` is genuinely an `Err` in that case — and the Flip Finder panicked instead of rendering the error state it already has.

This was the **only** `Memo::new` body in `ultros-app` containing a panicking accessor; every sibling analyzer page already routes through the shared `use_region_for_world` helper.

## Why a panic *there* is worse than a panic anywhere else

It's inside a `Memo`. From `reactive_graph-0.2.14/src/computed/inner.rs::update_if_necessary`:

```rust
let value = self.value.write().or_poisoned().take();   // value -> None, BEFORE the body runs
let (new_value, changed) = self.owner.with_cleanup(|| { (self.fun)(...) });
// ...only now: *value_lock = Some(new_value);
```

Any unwind out of the body leaves the memo permanently `None`. Every later read then panics at `arc_memo.rs:334:24` (`t.as_ref().unwrap()`, commented *"safe to unwrap here because update_if_necessary guarantees the value is Some"*) — at the library, with the real fault nowhere in the stack. **`try_get`/`try_read` do not help**: the unwrap is inside `try_read_untracked`.

So one failed `world_data` fetch doesn't produce one error — it kills the page's wasm bundle repeatedly, reported at a line that says nothing about the cause.

## The change

Behaviour-preserving. The resolution moves into `region_for_world_name`, a plain function beside the existing `use_region_for_world` in `global_state/region_for_world.rs`. Taking its inputs by value makes every failure mode a return value and makes it testable with no reactive runtime.

The two panics become `AppError::WorldDataUnavailable` (new variant), which flows into exactly the same resource error path the page already renders. Every case that works today still works.

The deliberate difference from `use_region_for_world` — **no** fallback to `"North-America"` — is preserved and now documented: the Flip Finder keys its region-wide board off the `:world` route param, so quietly substituting another region's prices would be worse than an error.

## Verification

Genuine red→green **by mutation**: restoring the original `.expect(..).0.unwrap()` fails at exit **101**, with the two panic-targeting tests panicking at the restored accessors (`region_for_world.rs:36` and `:38`). Restored → green.

The other three tests pass both ways *by design* — they guard the behaviour this refactor must not change (known world resolves, missing param and unknown world stay errors rather than silently defaulting), so they are regression guards, not part of the red count.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo test -p ultros-app --lib` | **529 passed**, 0 failed (524 baseline + 5 new) |
| `cargo clippy -p ultros-app --all-targets -- -D warnings` | 0 |
| `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown` | 0 |

The hydrate/wasm check is included because CI never lints that cfg, and it's the build that actually ships to browsers.

## Found while triaging, and NOT fixed here

**GlitchTip #6876 (`panic: called Option::unwrap() on a None value`, 3922 events, ~1340/day) is the `arc_memo.rs:334` cascade above** — I pulled the exact site from `docker logs ultros | grep "panicked at"` on the prod box, since release binaries are stripped and every GlitchTip frame comes back `<unknown>`. In 24h: 1338 hits at that one line, versus 4 disposed-signal and 3 `I18n context is missing`. **This PR is not a fix for #6876** — no `analyzer.rs` panic message appears in prod logs, so that memo is not the one currently poisoned. Two things worth flagging separately:

1. **Most of #6876 should disappear on the next deploy.** Prod serves `/pkg/09bc771/` = `09bc7715`; **#1154 (`a0b63ab9`, the SSR Host-header fix) is merged but not deployed.** The trigger is the container's own healthcheck — `docker inspect` shows `GET / HTTP/1.0` with `Host: localhost` every **30 s**, which the pre-#1154 SSR forwards to `https://ultros.app/api/v1/...`, so Cloudflare answers `421 Misdirected Request` / `403 Forbidden`. That 30 s cadence matches the panic cadence in the logs exactly.
2. **The residue is an upstream race, not fixable here.** `needs_update`'s `Check` arm is `sources.any(|s| s.update_if_necessary())`. Thread A takes the value and runs the body; thread B reads concurrently, finds the sources already marked clean, gets `needs_update == false`, and hits the `else` branch — which sets `state = Clean` **without restoring the value** — then unwraps `None`. `0.2.14` is the newest stable `reactive_graph`; `0.3.0-beta*` needs leptos 0.9, and leptos is pinned at 0.8.20 by `leptos_i18n`.

Also still open, unchanged by this PR: **Discord alert delivery retries permanent failures forever** (`ultros/src/alerts/delivery.rs`) — `Unknown Channel` / `Missing Access` for alerts 5–14 (#6877–#6885, #6889), ~150 events/day, and those users silently never receive alerts. Needs a product call (auto-disable vs. surface in the UI). And **#6888 `I18n context is missing`** at `components/realtime_status.rs:46` (`use_i18n()`), 5 events on the current release — real but undiagnosed.

## Triage this run

Ignored **19** May-12 flood fragments (**#1223 → #1205**), contiguous. Spot-checked #1223 first: dead release `c88703d8`, Chrome 112, UTC, `HTMLDocument.c` — the known scraper-flood fingerprint. The flood tail continues below #1205.

Left alone per convention: the `Bahamut`/development issues, #6831, #6887/#6890 (count-1 on current releases, so live signal rather than stale noise), and the Discord-delivery cluster above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
