### PR TITLE
fix(universalis): surface HTTP status instead of a bogus schema error

### DIFF
--- a/ultros/src/item_update_service.rs
+++ b/ultros/src/item_update_service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -38,6 +38,17 @@ pub(crate) struct UpdateService {
     pub(crate) sales: EventProducer<SaleEventData>,
     /// Per-world timestamp of the last saturation-triggered full sweep.
     pub(crate) full_sweep_cooldowns: Mutex<HashMap<i32, Instant>>,
+    /// Worlds Universalis 404s on. Purely a log de-duplicator — see
+    /// [`UpdateService::note_world_uncovered`].
+    pub(crate) uncovered_worlds: Mutex<HashSet<i32>>,
+}
+
+/// True when `error` is a Universalis `404`, i.e. it does not know the entity
+/// we asked about. [`anyhow::Error`] erases the type, so match on the downcast.
+fn universalis_not_found(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<universalis::Error>()
+        .is_some_and(|e| e.is_not_found())
 }
 
 struct CmpListing(Model);
@@ -100,6 +111,15 @@ impl UpdateService {
         Ok(())
     }
 
+    /// Records that Universalis does not cover `world_id`. Returns `true` the
+    /// first time, so the caller logs once instead of on every sweep.
+    fn note_world_uncovered(&self, world_id: i32) -> bool {
+        self.uncovered_worlds
+            .lock()
+            .expect("uncovered_worlds poisoned")
+            .insert(world_id)
+    }
+
     /// Claims the full-sweep slot for a world if its cooldown has elapsed.
     fn claim_full_sweep_slot(&self, world_id: i32) -> bool {
         let mut cooldowns = self
@@ -121,7 +141,25 @@ impl UpdateService {
         &self,
         world: &world::Model,
     ) -> Result<(), anyhow::Error> {
-        let updates = self.get_missing_updates(world).await?;
+        let updates = match self.get_missing_updates(world).await {
+            Ok(updates) => updates,
+            // Universalis 404s the recency endpoint for worlds it no longer
+            // carries (our `world` table keeps rows for worlds it has since
+            // dropped — `Innocence`, `Pixie`, `Titania`, `Tycoon`, `月牙湾`,
+            // `雪松原`, `黄金谷` as of this writing). There is nothing to catch
+            // up on and never will be, so log it once per process rather than
+            // reporting an error every five minutes forever.
+            Err(e) if universalis_not_found(&e) => {
+                if self.note_world_uncovered(world.id) {
+                    warn!(
+                        world = %world.name,
+                        "universalis has no data for this world; skipping catch-up sweeps"
+                    );
+                }
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
         let item_ids: Box<[i32]> = updates.into_iter().map(|i| i.item_id).collect();
         metrics::counter!("ultros_catchup_items_recovered", "world" => world.name.clone())
             .increment(item_ids.len() as u64);

--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -368,6 +368,7 @@ async fn main() -> Result<()> {
         listings: senders.listings.clone(),
         sales: senders.history.clone(),
         full_sweep_cooldowns: Default::default(),
+        uncovered_worlds: Default::default(),
     });
     UpdateService::start_service(update_service.clone(), token.clone());
     // Exports `ultros_world_ingest_staleness_seconds`. Every silent ingest

--- a/universalis/src/lib.rs
+++ b/universalis/src/lib.rs
@@ -33,6 +33,26 @@ pub enum Error {
     BadId(u32),
     #[error("No items were suggested")]
     NoItems,
+    /// Universalis answered with a non-success status. See [`check_status`] for why
+    /// this exists rather than letting the body fall through to the deserializer.
+    #[error("universalis returned HTTP {status} for {url}: {body}")]
+    Status {
+        status: u16,
+        url: String,
+        body: String,
+    },
+}
+
+impl Error {
+    /// True when Universalis answered `404 Not Found`.
+    ///
+    /// Every REST path in this client names an entity (a world, a datacenter, an
+    /// item list), so a 404 means "Universalis does not know that entity" — a
+    /// permanent condition callers should stop retrying, as opposed to the
+    /// transient 429/5xx failures that are worth another pass.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Error::Status { status: 404, .. })
+    }
 }
 
 impl From<async_tungstenite::tungstenite::Error> for Error {
@@ -320,6 +340,52 @@ pub enum WorldOrDatacenter<'a> {
     Datacenter(&'a str),
 }
 
+/// How much of an error body to keep in [`Error::Status`]. Universalis' problem
+/// documents are ~160 bytes; the cap only matters if it ever returns an HTML
+/// error page from a proxy.
+const ERROR_BODY_SNIPPET_LEN: usize = 300;
+
+/// Reject non-success responses before anything tries to deserialize the body.
+///
+/// Universalis answers errors with an RFC 9457 problem document
+/// (`{"type":…,"title":"Not Found","status":404,"traceId":…}`), which has none of
+/// the fields of the success payloads. Calling `Response::json()` straight off the
+/// response therefore reports `missing field \`items\`` — a message that reads like
+/// upstream schema drift and completely hides the status. That is exactly what
+/// ultros' catch-up sweep logged for every world Universalis has since dropped.
+fn check_status(status: u16, url: &str, body: &[u8]) -> Result<(), Error> {
+    if (200..300).contains(&status) {
+        return Ok(());
+    }
+    let body = String::from_utf8_lossy(body);
+    let snippet = match body.char_indices().nth(ERROR_BODY_SNIPPET_LEN) {
+        Some((idx, _)) => format!("{}…", &body[..idx]),
+        None => body.into_owned(),
+    };
+    Err(Error::Status {
+        status,
+        url: url.to_string(),
+        body: snippet,
+    })
+}
+
+/// Read a response body, mapping a non-success status to [`Error::Status`].
+async fn checked_body(url: &str, response: reqwest::Response) -> Result<Vec<u8>, Error> {
+    let status = response.status().as_u16();
+    let body = response.bytes().await?.to_vec();
+    check_status(status, url, &body)?;
+    Ok(body)
+}
+
+/// [`checked_body`] plus deserialization, for the endpoints with a single response shape.
+async fn checked_json<T: serde::de::DeserializeOwned>(
+    url: &str,
+    response: reqwest::Response,
+) -> Result<T, Error> {
+    let body = checked_body(url, response).await?;
+    Ok(serde_json::from_slice(&body)?)
+}
+
 impl UniversalisClient {
     const UNIVERSALIS_BASE_URL: &'static str = "https://universalis.app/api/v2";
 
@@ -333,19 +399,17 @@ impl UniversalisClient {
     }
 
     pub async fn get_data_centers(&self) -> Result<DataCentersView, Error> {
-        let data_centers = Request::new(
-            Method::GET,
-            Url::parse(&format!("{}/data-centers", Self::UNIVERSALIS_BASE_URL))?,
-        );
-        Ok(self.client.execute(data_centers).await?.json().await?)
+        let url = format!("{}/data-centers", Self::UNIVERSALIS_BASE_URL);
+        let data_centers = Request::new(Method::GET, Url::parse(&url)?);
+        let response = self.client.execute(data_centers).await?;
+        checked_json(&url, response).await
     }
 
     pub async fn get_worlds(&self) -> Result<WorldsView, Error> {
-        let data_centers = Request::new(
-            Method::GET,
-            Url::parse(&format!("{}/worlds", Self::UNIVERSALIS_BASE_URL))?,
-        );
-        Ok(self.client.execute(data_centers).await?.json().await?)
+        let url = format!("{}/worlds", Self::UNIVERSALIS_BASE_URL);
+        let worlds = Request::new(Method::GET, Url::parse(&url)?);
+        let response = self.client.execute(worlds).await?;
+        checked_json(&url, response).await
     }
 
     pub async fn marketboard_current_data(
@@ -357,20 +421,19 @@ impl UniversalisClient {
             return Err(Error::NoItems);
         }
         let id_str = Self::ids_to_string(item_ids);
-        let request = Request::new(
-            Method::GET,
-            Url::parse(&format!(
-                "{}/{world_or_datacenter}/{id_str}",
-                Self::UNIVERSALIS_BASE_URL
-            ))?,
+        let url = format!(
+            "{}/{world_or_datacenter}/{id_str}",
+            Self::UNIVERSALIS_BASE_URL
         );
+        let request = Request::new(Method::GET, Url::parse(&url)?);
         info!("Getting current marketboard data: {}", request.url());
         let response = self.client.execute(request).await?;
+        let body = checked_body(&url, response).await?;
         // serde struggles with this untagged enum so I just manually decide for it :)
         Ok(if item_ids.len() == 1 {
-            SingleView(response.json().await?)
+            SingleView(serde_json::from_slice(&body)?)
         } else {
-            MultiView(response.json().await?)
+            MultiView(serde_json::from_slice(&body)?)
         })
     }
 
@@ -386,11 +449,12 @@ impl UniversalisClient {
             id_str
         );
         info!("getting historical marketboard data: {}", url);
-        let response = self.client.get(url).send().await?;
+        let response = self.client.get(&url).send().await?;
+        let body = checked_body(&url, response).await?;
         Ok(if item_ids.len() == 1 {
-            HistoryView::SingleView(response.json().await?)
+            HistoryView::SingleView(serde_json::from_slice(&body)?)
         } else {
-            HistoryView::MultiView(response.json().await?)
+            HistoryView::MultiView(serde_json::from_slice(&body)?)
         })
     }
 
@@ -408,12 +472,90 @@ impl UniversalisClient {
             Self::UNIVERSALIS_BASE_URL
         );
         info!("getting recently updated items {}", url);
-        Ok(self.client.get(url).send().await?.json().await?)
+        let response = self.client.get(&url).send().await?;
+        checked_json(&url, response).await
     }
 
     fn ids_to_string(item_ids: &[i32]) -> String {
         let id_strs: Vec<_> = item_ids.iter().map(|m| m.to_string()).collect();
         id_strs.join(",")
+    }
+}
+
+#[cfg(test)]
+mod status_test {
+    use crate::{Error, MostRecentlyUpdatedItemsView, check_status};
+
+    /// Verbatim body Universalis returns for a world it does not know, e.g.
+    /// `/extra/stats/most-recently-updated?entries=200&world=Innocence`.
+    const NOT_FOUND_BODY: &[u8] = br#"{"type":"https://tools.ietf.org/html/rfc9110#section-15.5.5","title":"Not Found","status":404,"traceId":"00-1046d7d509da111cf20beb46d99f08dc-5aaf766c058a47f2-01"}"#;
+
+    const URL: &str = "https://universalis.app/api/v2/extra/stats/most-recently-updated?entries=200&world=Innocence";
+
+    #[test]
+    fn not_found_is_reported_as_a_status_error_not_a_schema_error() {
+        let err = check_status(404, URL, NOT_FOUND_BODY).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("404"), "{rendered}");
+        assert!(rendered.contains("world=Innocence"), "{rendered}");
+        // The old code deserialized this body as the success type and reported
+        // the resulting serde complaint instead of the status.
+        assert!(!rendered.contains("missing field"), "{rendered}");
+    }
+
+    #[test]
+    fn not_found_is_distinguishable_from_transient_failures() {
+        assert!(
+            check_status(404, URL, NOT_FOUND_BODY)
+                .unwrap_err()
+                .is_not_found()
+        );
+        assert!(
+            !check_status(429, URL, b"slow down")
+                .unwrap_err()
+                .is_not_found()
+        );
+        assert!(
+            !check_status(503, URL, b"upstream down")
+                .unwrap_err()
+                .is_not_found()
+        );
+    }
+
+    #[test]
+    fn success_statuses_pass_through() {
+        assert!(check_status(200, URL, b"{}").is_ok());
+        assert!(check_status(204, URL, b"").is_ok());
+    }
+
+    #[test]
+    fn error_bodies_are_truncated_but_still_identify_the_status() {
+        let huge = vec![b'x'; 10_000];
+        let err = check_status(500, URL, &huge).unwrap_err();
+        match &err {
+            Error::Status { body, status, .. } => {
+                assert_eq!(*status, 500);
+                assert!(body.ends_with('…'), "{body}");
+                assert!(body.len() < 400, "body was {} bytes", body.len());
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn truncation_does_not_split_a_utf8_character() {
+        // A multi-byte body longer than the cap must not panic on a byte slice.
+        let body = "é".repeat(1_000).into_bytes();
+        let err = check_status(500, URL, &body).unwrap_err();
+        assert!(err.to_string().contains("500"));
+    }
+
+    #[test]
+    fn a_success_body_still_parses_after_the_status_check() {
+        let body = br#"{"items":[{"itemID":5,"lastUploadTime":1786194855389,"worldID":63,"worldName":"Gilgamesh"}]}"#;
+        check_status(200, URL, body).unwrap();
+        let parsed: MostRecentlyUpdatedItemsView = serde_json::from_slice(body).unwrap();
+        assert_eq!(parsed.items.len(), 1);
     }
 }
 


### PR DESCRIPTION
## The bug

Every REST method in the `universalis` client called `Response::json()` directly, without ever checking the status. Universalis answers errors with an RFC 9457 problem document:

```json
{"type":"https://tools.ietf.org/html/rfc9110#section-15.5.5","title":"Not Found","status":404,"traceId":"…"}
```

which shares no fields with the success payloads. So a 404 surfaced as:

```
check_for_missed_items_on_world failed, error: HTTP Error: error decoding response body: missing field `items` at line 1 column 162
```

That reads like upstream schema drift and completely hides the status. It also means a 429 (rate limit) or a 5xx would be reported the same way, indistinguishable from a real parse failure.

## Why it's firing now

Prod (`a0d1430`) logs it **101 times per 50 minutes**. The cause is stale world rows: our `world` table carries seven worlds Universalis has since dropped, and the catch-up sweep asks about each every five minutes.

Measured by diffing `https://ultros.app/api/v1/world_data` against `https://universalis.app/api/v2/worlds` (133 vs 128 worlds):

```
IN ULTROS NOT UNIVERSALIS: Innocence, Pixie, Titania, Tycoon, 月牙湾, 雪松原, 黄金谷
```

All 128 worlds Universalis *does* list answer the recency endpoint fine — so this is purely our stale rows, not an upstream outage.

## The fix

- `check_status` rejects non-2xx **before** deserialization and reports the status, URL and a truncated body as a new `Error::Status` variant. Applied to all five REST methods.
- `Error::is_not_found()` distinguishes "Universalis doesn't know this entity" (permanent) from 429/5xx (worth retrying).
- The catch-up sweep skips a world on 404 and warns **once per process** instead of erroring on every pass forever.

After the change, the exact prod case reports:

```
universalis returned HTTP 404 for https://universalis.app/api/v2/extra/stats/most-recently-updated?entries=200&world=Innocence: {"type":…,"title":"Not Found","status":404,…}
```

(verified live against the real API, then the throwaway test removed).

## Verification

| gate | result |
|---|---|
| `cargo test -p universalis --lib` | **24 passed** (base 18 + 6 new), includes the live-network tests, which now run through the status check |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p universalis --all-targets -D warnings` | 0 |
| `cargo clippy -p ultros --all-targets -D warnings` | 0 (8m33s) |

**Red→green by mutation:** making `check_status` a no-op (literally the pre-fix behaviour) fails **4 of the 6** new tests. The other 2 are the success-path guards and pass either way *by design* — they exist to prove the check doesn't reject good responses, not to pad the red count.

## Not addressed here

The seven stale `world` rows themselves. Removing or hiding them is a separate call — they still appear in world pickers, and dropping rows touches user data (retainers, alerts, lists keyed on world id). This PR just stops them generating a misleading error every five minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
