### PR TITLE
feat(ingest): store Universalis listingID and make listing writes idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10480,6 +10480,7 @@ dependencies = [
  "futures",
  "metrics",
  "reqwest 0.11.27",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "serde_with",

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -34,6 +34,7 @@ mod m20260802_000001_authless_character_claims;
 mod m20260802_000002_user_group_discord_guild;
 mod m20260804_000001_active_listing_cheapest_index;
 mod m20260805_000001_group_invite;
+mod m20260808_000001_active_listing_identity_columns;
 
 pub struct Migrator;
 
@@ -77,6 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260802_000002_user_group_discord_guild::Migration),
             Box::new(m20260804_000001_active_listing_cheapest_index::Migration),
             Box::new(m20260805_000001_group_invite::Migration),
+            Box::new(m20260808_000001_active_listing_identity_columns::Migration),
         ]
     }
 }

--- a/migration/src/m20260808_000001_active_listing_identity_columns.rs
+++ b/migration/src/m20260808_000001_active_listing_identity_columns.rs
@@ -1,0 +1,79 @@
+use sea_orm_migration::prelude::*;
+
+/// Gives `active_listing` a real identity and the payload fields we previously
+/// discarded.
+///
+/// `listing_id` is Universalis' stable id for a listing (their `listingID`, a
+/// decimal string). Until now every write path deduplicated by an advisory
+/// read-diff-insert on (retainer, price, quantity, hq) with **no uniqueness at
+/// the database level**, so any two writers racing on the same (world, item) —
+/// our own task-per-websocket-message ingest, the catch-up sweep's
+/// `buffer_unordered(50)`, the manual refresh route, or Universalis' own
+/// duplicate event emission — could and did insert the same board several
+/// times over (item 44119 on Coeurl reached 306 rows for a 30-listing board).
+/// The partial unique index makes concurrent duplicate writes collapse into
+/// one row via `ON CONFLICT` instead of relying on every caller to have read a
+/// current snapshot.
+///
+/// Partial (`WHERE listing_id IS NOT NULL`) because every pre-migration row —
+/// and any future payload that genuinely lacks a `listingID` — has no identity
+/// to be unique on; those continue through the legacy multiset-diff paths.
+///
+/// `materia`/`stain_id`/`creator_name`/`is_crafted`/`on_mannequin` were always
+/// in the payload and never stored. Universalis' change diff compares only
+/// (listingID, price, quantity), so mutations of these fields emit no
+/// websocket events — they are populated/refreshed exclusively by REST board
+/// fetches (catch-up, manual refresh, sweeps).
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    /// Out of the migration transaction so the unique index can be built
+    /// `CONCURRENTLY` — `active_listing` is written continuously by ingest and
+    /// a plain `CREATE UNIQUE INDEX` would block writes for the whole build.
+    /// The column adds are metadata-only on Postgres 11+ and each statement is
+    /// individually atomic; everything is `IF NOT EXISTS` so a partial failure
+    /// reruns cleanly.
+    fn use_transaction(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(
+            r#"ALTER TABLE active_listing
+               ADD COLUMN IF NOT EXISTS listing_id text,
+               ADD COLUMN IF NOT EXISTS materia jsonb,
+               ADD COLUMN IF NOT EXISTS stain_id integer,
+               ADD COLUMN IF NOT EXISTS creator_name text,
+               ADD COLUMN IF NOT EXISTS is_crafted boolean NOT NULL DEFAULT false,
+               ADD COLUMN IF NOT EXISTS on_mannequin boolean NOT NULL DEFAULT false"#,
+        )
+        .await?;
+        conn.execute_unprepared(
+            r#"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_active_listing_identity
+               ON active_listing (world_id, item_id, listing_id)
+               WHERE listing_id IS NOT NULL"#,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(r#"DROP INDEX CONCURRENTLY IF EXISTS idx_active_listing_identity"#)
+            .await?;
+        conn.execute_unprepared(
+            r#"ALTER TABLE active_listing
+               DROP COLUMN IF EXISTS listing_id,
+               DROP COLUMN IF EXISTS materia,
+               DROP COLUMN IF EXISTS stain_id,
+               DROP COLUMN IF EXISTS creator_name,
+               DROP COLUMN IF EXISTS is_crafted,
+               DROP COLUMN IF EXISTS on_mannequin"#,
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/ultros-db/src/common_type_conversions.rs
+++ b/ultros-db/src/common_type_conversions.rs
@@ -36,6 +36,9 @@ impl From<entity::active_listing::Model> for ActiveListing {
             quantity,
             hq,
             timestamp,
+            // identity/cosmetic columns (listing_id, materia, …) are not part
+            // of the public ActiveListing type yet
+            ..
         } = value;
         Self {
             id,

--- a/ultros-db/src/entity/active_listing.rs
+++ b/ultros-db/src/entity/active_listing.rs
@@ -3,7 +3,22 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+/// One materia slotted into a listed item, as reported by Universalis.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Materia {
+    pub slot_id: Option<i32>,
+    pub materia_id: i32,
+}
+
+/// The full materia loadout of a listing, stored as a jsonb column.
+///
+/// Universalis' change diff compares only (listingID, price, quantity), so
+/// materia mutations emit no websocket events — this field is only as fresh as
+/// the last REST board fetch for the item.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, FromJsonQueryResult, Default)]
+pub struct MateriaList(pub Vec<Materia>);
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, Default)]
 #[sea_orm(table_name = "active_listing")]
 pub struct Model {
     #[sea_orm(primary_key, unique)]
@@ -15,6 +30,16 @@ pub struct Model {
     pub quantity: i32,
     pub hq: bool,
     pub timestamp: DateTime,
+    /// Universalis' stable listing identity (`listingID`). Null on rows
+    /// ingested before the identity migration and on payloads lacking the id;
+    /// unique per (world_id, item_id) when present.
+    pub listing_id: Option<String>,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub materia: Option<MateriaList>,
+    pub stain_id: Option<i32>,
+    pub creator_name: Option<String>,
+    pub is_crafted: bool,
+    pub on_mannequin: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/ultros-db/src/lib.rs
+++ b/ultros-db/src/lib.rs
@@ -323,6 +323,20 @@ impl UltrosDb {
                 .await?;
             retainer.id
         };
+        use active_listing::{Column, Entity};
+        use sea_orm::ExprTrait;
+        let materia = (!listing.materia.is_empty()).then(|| {
+            active_listing::MateriaList(
+                listing
+                    .materia
+                    .iter()
+                    .map(|m| active_listing::Materia {
+                        slot_id: m.slot_id.map(|s| s as i32),
+                        materia_id: m.materia_id as i32,
+                    })
+                    .collect(),
+            )
+        });
         let m = active_listing::ActiveModel {
             world_id: Set(world_id.0),
             item_id: Set(item_id.0),
@@ -331,10 +345,46 @@ impl UltrosDb {
             quantity: Set(quantity),
             hq: Set(listing.hq),
             timestamp: Set(listing.last_review_time.naive_utc()),
+            listing_id: Set(listing.listing_id.clone()),
+            materia: Set(materia),
+            stain_id: Set(listing.stain_id.map(|s| s as i32)),
+            creator_name: Set(listing.creator_name.clone().filter(|n| !n.is_empty())),
+            is_crafted: Set(listing.is_crafted),
+            on_mannequin: Set(listing.on_mannequin),
             ..Default::default()
-        }
-        .insert(&self.db)
-        .await?;
+        };
+        // Upsert on the listing's Universalis identity. This is what makes
+        // concurrent writers safe: any two tasks racing to store the same
+        // listing — duplicate websocket events, catch-up vs. socket, the manual
+        // refresh route — collapse into one row at the database instead of each
+        // trusting its own pre-insert read. The `WHERE` mirrors the partial
+        // unique index `idx_active_listing_identity`; a listing with no
+        // `listing_id` can't conflict and inserts plainly (legacy diff paths
+        // are responsible for not calling us with duplicates of those).
+        let m = Entity::insert(m)
+            .on_conflict(
+                sea_query::OnConflict::columns([
+                    Column::WorldId,
+                    Column::ItemId,
+                    Column::ListingId,
+                ])
+                .target_and_where(sea_query::Expr::col(Column::ListingId).is_not_null())
+                .update_columns([
+                    Column::RetainerId,
+                    Column::PricePerUnit,
+                    Column::Quantity,
+                    Column::Hq,
+                    Column::Timestamp,
+                    Column::Materia,
+                    Column::StainId,
+                    Column::CreatorName,
+                    Column::IsCrafted,
+                    Column::OnMannequin,
+                ])
+                .to_owned(),
+            )
+            .exec_with_returning(&self.db)
+            .await?;
         Ok(m)
     }
 

--- a/ultros-db/src/listings.rs
+++ b/ultros-db/src/listings.rs
@@ -160,9 +160,9 @@ struct ListingsDiff {
 /// including its multiset handling: a retainer legitimately holding three
 /// identical listings when we already store two yields exactly one insert.
 ///
-/// Universalis' `listingID` would be an exact identity, but `active_listing` has
-/// no column for it, so the key is the same (hq, quantity, price, retainer name)
-/// tuple used everywhere else in this module.
+/// This is the *legacy* content-keyed path: since the identity migration,
+/// id-carrying listings are routed through [`listings_to_upsert`] and only
+/// id-less views (and id-less DB rows) still go through this diff.
 fn listings_to_add(
     listings: Vec<ListingView>,
     existing_items: Vec<(active_listing::Model, Option<retainer::Model>)>,
@@ -245,6 +245,147 @@ fn diff_update_listings(
     ListingsDiff { added, removed }
 }
 
+/// Whether a DB row and an incoming view describe the same listing *state*,
+/// for rows already matched by `listing_id`.
+///
+/// Mirrors Universalis' own change detector, which compares exactly
+/// (listingID, pricePerUnit, quantity) — a reprice keeps its listingID and
+/// arrives as remove(old state) + add(new state). `hq` is immutable per
+/// listing id and included only as a safety net. Cosmetic fields (materia,
+/// dye, creator) are deliberately excluded: Universalis emits no events for
+/// them, so requiring them to match would turn every REST-refreshed cosmetic
+/// difference into spurious churn.
+fn view_state_matches_model(view: &ListingView, model: &active_listing::Model) -> bool {
+    model.price_per_unit == view.price_per_unit.unwrap_or(view.total) as i32
+        && model.quantity == view.quantity.unwrap_or(1) as i32
+        && model.hq == view.hq
+}
+
+/// Splits DB rows into (identity-carrying, legacy) by `listing_id` presence.
+type RowsWithRetainers = Vec<(active_listing::Model, Option<retainer::Model>)>;
+fn split_rows_by_identity(rows: RowsWithRetainers) -> (RowsWithRetainers, RowsWithRetainers) {
+    rows.into_iter().partition(|(m, _)| m.listing_id.is_some())
+}
+
+/// Selects the listings from a `listings/add` delta that need writing, keyed on
+/// `listing_id` where available.
+///
+/// Per incoming view:
+/// - id matches a stored row with identical state → already have it, skip;
+/// - id matches a stored row with different state → a reprice; the upsert in
+///   `create_listing` updates the row in place;
+/// - id matches nothing → fall back to the legacy content diff against rows
+///   that have **no** stored id. This is the pre-migration bridge: a re-sent
+///   listing we stored before ids existed must not be inserted a second time
+///   just because the old row can't be matched by id. Genuinely new listings
+///   fall through the content diff and insert (with their id).
+fn listings_to_upsert(listings: Vec<ListingView>, existing: RowsWithRetainers) -> Vec<ListingView> {
+    let (id_rows, legacy_rows) = split_rows_by_identity(existing);
+    let by_id: HashMap<&str, &active_listing::Model> = id_rows
+        .iter()
+        .filter_map(|(m, _)| m.listing_id.as_deref().map(|id| (id, m)))
+        .collect();
+
+    let mut upserts = Vec::new();
+    let mut fallback = Vec::new();
+    for view in listings {
+        match view.listing_id.as_deref().and_then(|id| by_id.get(id)) {
+            Some(model) if view_state_matches_model(&view, model) => {}
+            Some(_) => upserts.push(view),
+            None => fallback.push(view),
+        }
+    }
+    upserts.extend(listings_to_add(fallback, legacy_rows));
+    upserts
+}
+
+/// Selects the DB rows a `listings/remove` payload should delete, keyed on
+/// `listing_id` where available.
+///
+/// An id match alone is NOT enough to delete: a reprice is published as
+/// remove(old state) + add(new state) with the same listingID, and neither
+/// Universalis' bus nor our task-per-message ingest guarantees their order. If
+/// the add lands first (upserting the row to the new price), the late remove —
+/// which still describes the old price — must not kill the live row. So an
+/// id-matched row is deleted only when its state also matches the remove view;
+/// a state mismatch means "this removal was superseded" and keeps the row.
+///
+/// Views whose id matches no stored row fall back to the legacy content diff
+/// against id-less rows, so removes still land on pre-migration data.
+fn listings_to_remove_with_identity(
+    db_listings: Vec<(active_listing::Model, retainer::Model)>,
+    views: Vec<ListingView>,
+) -> Vec<active_listing::Model> {
+    let (id_rows, legacy_rows): (Vec<_>, Vec<_>) = db_listings
+        .into_iter()
+        .partition(|(m, _)| m.listing_id.is_some());
+    let mut by_id: HashMap<String, active_listing::Model> = id_rows
+        .into_iter()
+        .filter_map(|(m, _)| m.listing_id.clone().map(|id| (id, m)))
+        .collect();
+
+    let mut removed = Vec::new();
+    let mut fallback_views = Vec::new();
+    for view in views {
+        match view.listing_id.as_deref() {
+            Some(id) => match by_id.remove(id) {
+                Some(model) if view_state_matches_model(&view, &model) => removed.push(model),
+                // state mismatch: superseded removal, put the row back and keep it
+                Some(model) => {
+                    by_id.insert(id.to_string(), model);
+                }
+                None => fallback_views.push(view),
+            },
+            None => fallback_views.push(view),
+        }
+    }
+    removed.extend(listings_to_remove(legacy_rows, fallback_views));
+    removed
+}
+
+/// Diffs a full REST board against the DB, keyed on `listing_id` where
+/// available.
+///
+/// Identity-carrying rows are kept when the board re-sends the same state,
+/// upserted when the state changed, and removed when their id is absent from
+/// the board. Legacy (id-less) rows go through the old content diff against
+/// whatever id-less views the board carries — in practice REST boards always
+/// carry ids, so the legacy diff's job is to delete every pre-migration row
+/// while the id side re-inserts the same listings with their identity. That
+/// makes any full-board pass (catch-up, manual refresh, sweep) a one-shot
+/// id-backfill for the item.
+fn diff_board_with_identity(
+    listings: Vec<ListingView>,
+    existing: RowsWithRetainers,
+) -> ListingsDiff {
+    let (id_rows, legacy_rows) = split_rows_by_identity(existing);
+    let (id_views, legacy_views): (Vec<_>, Vec<_>) =
+        listings.into_iter().partition(|v| v.listing_id.is_some());
+
+    let mut by_id: HashMap<String, (active_listing::Model, Option<retainer::Model>)> = id_rows
+        .into_iter()
+        .filter_map(|(m, r)| m.listing_id.clone().map(|id| (id, (m, r))))
+        .collect();
+
+    let mut added = Vec::new();
+    for view in id_views {
+        let id = view.listing_id.as_deref().expect("partitioned on is_some");
+        match by_id.remove(id) {
+            // board re-sends the same state: entry consumed = row kept as-is
+            Some((model, _)) if view_state_matches_model(&view, &model) => {}
+            // state changed (or, guard-fallthrough, id row differs): upsert
+            Some(_) | None => added.push(view),
+        }
+    }
+    // ids the board no longer carries
+    let mut removed: Vec<_> = by_id.into_values().collect();
+
+    let legacy = diff_update_listings(legacy_views, legacy_rows);
+    added.extend(legacy.added);
+    removed.extend(legacy.removed);
+    ListingsDiff { added, removed }
+}
+
 impl UltrosDb {
     /// Resolves every retainer named in `listings` to a stored row, creating any
     /// we haven't seen before.
@@ -323,7 +464,7 @@ impl UltrosDb {
             .all(&self.db)
             .await?;
 
-        let to_add = listings_to_add(listings, existing_items);
+        let to_add = listings_to_upsert(listings, existing_items);
         let added = futures::future::join_all(to_add.iter().map(|m| {
             let retainer_id = retainers
                 .get(&m.retainer_name)
@@ -375,7 +516,7 @@ impl UltrosDb {
             .collect();
 
         let items = try_join_all(
-            listings_to_remove(db_listings, remove_listings)
+            listings_to_remove_with_identity(db_listings, remove_listings)
                 .into_iter()
                 .map(|listing| async move {
                     active_listing::Entity::delete_by_id(listing.id)
@@ -577,7 +718,7 @@ impl UltrosDb {
             .find_also_related(retainer::Entity)
             .all(&self.db)
             .await?;
-        let ListingsDiff { added, removed } = diff_update_listings(listings, existing_items);
+        let ListingsDiff { added, removed } = diff_board_with_identity(listings, existing_items);
         let remove_iter = removed.iter();
         let added = added.iter().map(|m| {
             let retainer_id = retainers
@@ -794,6 +935,7 @@ mod diff_tests {
             quantity,
             hq,
             timestamp: naive_ts(),
+            ..Default::default()
         }
     }
 
@@ -1237,6 +1379,272 @@ mod diff_tests {
     /// Every other test in this module builds views with `world_id: Some(..)`,
     /// which production never does, so they all passed straight through the bug.
     /// This one uses `None` on purpose.
+    /// `listing_view` plus a listing id, matching what production payloads carry
+    /// since the `listingID` deserialization fix.
+    fn listing_view_with_id(
+        world_id: i32,
+        retainer_name: &str,
+        price: u32,
+        quantity: u32,
+        hq: bool,
+        listing_id: &str,
+    ) -> ListingView {
+        let mut view = listing_view(world_id, retainer_name, price, quantity, hq);
+        view.listing_id = Some(listing_id.to_string());
+        view
+    }
+
+    fn db_listing_with_id(
+        id: i32,
+        world_id: i32,
+        retainer_id: i32,
+        price: i32,
+        quantity: i32,
+        hq: bool,
+        listing_id: &str,
+    ) -> active_listing::Model {
+        let mut model = db_listing(id, world_id, retainer_id, price, quantity, hq);
+        model.listing_id = Some(listing_id.to_string());
+        model
+    }
+
+    // ---- identity-keyed add path ----
+
+    #[test]
+    fn upsert_skips_a_resent_listing_with_matching_id_and_state() {
+        let world_id = 54;
+        let retainer = retainer_model(1, world_id, "Idmus");
+        let existing = vec![(
+            db_listing_with_id(1, world_id, retainer.id, 500, 1, false, "abc"),
+            Some(retainer.clone()),
+        )];
+        let delta = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        assert!(listings_to_upsert(delta, existing).is_empty());
+    }
+
+    #[test]
+    fn upsert_applies_a_reprice_on_the_same_listing_id() {
+        let world_id = 54;
+        let retainer = retainer_model(1, world_id, "Idmus");
+        let existing = vec![(
+            db_listing_with_id(1, world_id, retainer.id, 500, 1, false, "abc"),
+            Some(retainer.clone()),
+        )];
+        // same id, new price: must be written (create_listing upserts in place)
+        let delta = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            450,
+            1,
+            false,
+            "abc",
+        )];
+        let upserts = listings_to_upsert(delta, existing);
+        assert_eq!(upserts.len(), 1);
+        assert_eq!(upserts[0].price_per_unit, Some(450));
+    }
+
+    /// The pre-migration bridge: a re-sent listing whose row predates the id
+    /// column must not insert a second row just because the id lookup misses.
+    #[test]
+    fn upsert_does_not_duplicate_a_legacy_row_matching_by_content() {
+        let world_id = 54;
+        let retainer = retainer_model(1, world_id, "Legacymus");
+        // stored before the migration: no listing_id
+        let existing = vec![(
+            db_listing(1, world_id, retainer.id, 500, 1, false),
+            Some(retainer.clone()),
+        )];
+        let delta = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        assert!(
+            listings_to_upsert(delta, existing).is_empty(),
+            "the id-less row already holds this listing"
+        );
+    }
+
+    #[test]
+    fn upsert_inserts_a_genuinely_new_listing_with_its_id() {
+        let world_id = 54;
+        let retainer = retainer_model(1, world_id, "Newmus");
+        let existing = vec![(
+            db_listing(1, world_id, retainer.id, 999, 1, false),
+            Some(retainer.clone()),
+        )];
+        let delta = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        let upserts = listings_to_upsert(delta, existing);
+        assert_eq!(upserts.len(), 1);
+        assert_eq!(upserts[0].listing_id.as_deref(), Some("abc"));
+    }
+
+    // ---- identity-keyed remove path ----
+
+    #[test]
+    fn remove_by_id_deletes_the_matching_row() {
+        let world_id = 63;
+        let retainer = retainer_model(1, world_id, "Idmus");
+        let target = db_listing_with_id(1, world_id, retainer.id, 500, 1, false, "abc");
+        let keeper = db_listing_with_id(2, world_id, retainer.id, 600, 1, false, "def");
+        let db_rows = vec![
+            (target.clone(), retainer.clone()),
+            (keeper.clone(), retainer.clone()),
+        ];
+        let views = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        let removed = listings_to_remove_with_identity(db_rows, views);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].id, target.id);
+    }
+
+    /// The reorder hazard the state guard exists for: a reprice is published as
+    /// remove(old state) + add(new state) with the SAME listingID, and neither
+    /// Universalis' bus nor our task-per-message ingest guarantees order. When
+    /// the add lands first (upserting the row to the new price), the late
+    /// remove still describes the old price — deleting on id alone would kill
+    /// the live listing.
+    #[test]
+    fn remove_by_id_keeps_a_row_the_add_already_repriced() {
+        let world_id = 63;
+        let retainer = retainer_model(1, world_id, "Racemus");
+        // row already upserted to the NEW price by the reordered add
+        let repriced = db_listing_with_id(1, world_id, retainer.id, 450, 1, false, "abc");
+        let db_rows = vec![(repriced.clone(), retainer.clone())];
+        // the late remove still carries the OLD price
+        let views = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        assert!(
+            listings_to_remove_with_identity(db_rows, views).is_empty(),
+            "a superseded removal must not delete the repriced row"
+        );
+    }
+
+    /// Pre-migration bridge on the remove side: an id-carrying remove must
+    /// still delete a row stored before the id column existed.
+    #[test]
+    fn remove_by_id_falls_back_to_content_for_legacy_rows() {
+        let world_id = 63;
+        let retainer = retainer_model(1, world_id, "Legacymus");
+        let legacy = db_listing(1, world_id, retainer.id, 500, 1, false);
+        let keeper = db_listing(2, world_id, retainer.id, 600, 1, false);
+        let db_rows = vec![
+            (legacy.clone(), retainer.clone()),
+            (keeper.clone(), retainer.clone()),
+        ];
+        let views = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        let removed = listings_to_remove_with_identity(db_rows, views);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].id, legacy.id);
+    }
+
+    // ---- identity-keyed full-board diff ----
+
+    #[test]
+    fn board_diff_keeps_unchanged_upserts_changed_and_removes_missing_ids() {
+        let world_id = 74;
+        let retainer = retainer_model(1, world_id, "Boardmus");
+        let unchanged = db_listing_with_id(1, world_id, retainer.id, 500, 1, false, "keep");
+        let repriced = db_listing_with_id(2, world_id, retainer.id, 600, 1, false, "reprice");
+        let gone = db_listing_with_id(3, world_id, retainer.id, 700, 1, false, "gone");
+        let existing = vec![
+            (unchanged.clone(), Some(retainer.clone())),
+            (repriced.clone(), Some(retainer.clone())),
+            (gone.clone(), Some(retainer.clone())),
+        ];
+        let board = vec![
+            listing_view_with_id(world_id, &retainer.name, 500, 1, false, "keep"),
+            listing_view_with_id(world_id, &retainer.name, 550, 1, false, "reprice"),
+            listing_view_with_id(world_id, &retainer.name, 800, 1, false, "new"),
+        ];
+        let diff = diff_board_with_identity(board, existing);
+        let mut added_ids: Vec<_> = diff
+            .added
+            .iter()
+            .map(|v| v.listing_id.as_deref().unwrap())
+            .collect();
+        added_ids.sort();
+        assert_eq!(added_ids, ["new", "reprice"]);
+        assert_eq!(diff.removed.len(), 1);
+        assert_eq!(diff.removed[0].0.id, gone.id);
+    }
+
+    /// A full board of id-carrying views deletes every legacy row while the id
+    /// side re-inserts the same listings with their identity — any full-board
+    /// pass is a one-shot id backfill for the item. The 306-rows-for-a-
+    /// 30-listing-board duplicate pile on Coeurl/44119 is exactly what this
+    /// pass cleans up.
+    #[test]
+    fn board_diff_replaces_legacy_rows_with_identity_rows() {
+        let world_id = 74;
+        let retainer = retainer_model(1, world_id, "Backfillmus");
+        // three duplicate legacy rows for one real listing
+        let existing: Vec<_> = (1..=3)
+            .map(|i| {
+                (
+                    db_listing(i, world_id, retainer.id, 500, 1, false),
+                    Some(retainer.clone()),
+                )
+            })
+            .collect();
+        let board = vec![listing_view_with_id(
+            world_id,
+            &retainer.name,
+            500,
+            1,
+            false,
+            "abc",
+        )];
+        let diff = diff_board_with_identity(board, existing);
+        assert_eq!(
+            diff.added.len(),
+            1,
+            "the listing re-inserts carrying its id"
+        );
+        assert_eq!(
+            diff.removed.len(),
+            3,
+            "every legacy row is condemned, including the duplicate pile"
+        );
+    }
+
     #[test]
     fn remove_listings_matches_views_with_no_world_id_like_the_websocket_sends() {
         let world_id = 63;

--- a/ultros/src/discord/ffxiv/helpers.rs
+++ b/ultros/src/discord/ffxiv/helpers.rs
@@ -273,6 +273,7 @@ mod tests {
             quantity: 1,
             hq,
             timestamp: NaiveDateTime::default(),
+            ..Default::default()
         }
     }
 

--- a/ultros/src/stats/listings_stats.rs
+++ b/ultros/src/stats/listings_stats.rs
@@ -38,6 +38,7 @@ mod test {
                 quantity: 50,
                 hq: true,
                 timestamp: NaiveDateTime::default(),
+                ..Default::default()
             },
             active_listing::Model {
                 id: 1,
@@ -48,6 +49,7 @@ mod test {
                 quantity: 50,
                 hq: true,
                 timestamp: NaiveDateTime::default(),
+                ..Default::default()
             },
             active_listing::Model {
                 id: 1,
@@ -58,6 +60,7 @@ mod test {
                 quantity: 50,
                 hq: true,
                 timestamp: NaiveDateTime::default(),
+                ..Default::default()
             },
             active_listing::Model {
                 id: 1,
@@ -68,6 +71,7 @@ mod test {
                 quantity: 50,
                 hq: true,
                 timestamp: NaiveDateTime::default(),
+                ..Default::default()
             },
         ];
         let mut list : Vec<_> = listings.iter().collect();

--- a/universalis/Cargo.toml
+++ b/universalis/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
 clap = {version = "4.0.18", features = ["derive"]}
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 
 [features]
 default = ["websocket"]

--- a/universalis/examples/websocket.rs
+++ b/universalis/examples/websocket.rs
@@ -15,6 +15,9 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
+    // The workspace enables both rustls backends, so no provider is picked
+    // automatically; without this the first TLS connection panics.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     // subscribe to several items
     tracing_subscriber::fmt::init();
     let universalis_client = UniversalisClient::new("ultros-universalis-examples");

--- a/universalis/src/lib.rs
+++ b/universalis/src/lib.rs
@@ -129,7 +129,12 @@ pub struct ListingView {
     pub creator_id: Option<String>,
     pub hq: bool,
     pub is_crafted: bool,
-    pub listing_id: Option<u32>,
+    /// Universalis' stable identity for a listing (a decimal string too large
+    /// for u32). Sent as `listingID` — the previous `listing_id: Option<u32>`
+    /// under `rename_all = "camelCase"` looked for `listingId` and silently
+    /// deserialized to `None` on every REST and websocket payload.
+    #[serde(rename = "listingID")]
+    pub listing_id: Option<String>,
     pub materia: Vec<MateriaView>,
     pub on_mannequin: bool,
     pub retainer_city: u32,
@@ -669,6 +674,38 @@ mod pure_tests {
             total: 100,
             tax: 0,
         }
+    }
+
+    /// The exact field shape Universalis sends on both REST and websocket:
+    /// `listingID` (capital D) carrying a decimal string too large for u32.
+    /// Regression: the old `Option<u32>` field under `rename_all = "camelCase"`
+    /// looked for `listingId`, so every payload deserialized to `None` and the
+    /// listing's stable identity was silently discarded.
+    #[test]
+    fn listing_view_parses_listing_id_from_the_wire_shape() {
+        let json = r#"{
+            "lastReviewTime": 1786225863,
+            "pricePerUnit": 1499999,
+            "quantity": 1,
+            "stainID": 0,
+            "creatorName": "",
+            "creatorID": null,
+            "hq": false,
+            "isCrafted": false,
+            "listingID": "21392098345024855",
+            "materia": [{"slotID": 0, "materiaID": 41}],
+            "onMannequin": false,
+            "retainerCity": 1,
+            "retainerID": "33777097243838095",
+            "retainerName": "Stinky'ra",
+            "sellerID": null,
+            "total": 1499999,
+            "tax": 74999
+        }"#;
+        let listing: ListingView = serde_json::from_str(json).unwrap();
+        assert_eq!(listing.listing_id.as_deref(), Some("21392098345024855"));
+        assert_eq!(listing.materia[0].materia_id, 41);
+        assert_eq!(listing.stain_id, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## The data issue (Coeurl/44119)

Ultros held **306 rows for a 30-listing board** — the same listings duplicated up to 12×, inserted in one moment by ~10 concurrent full-board writers all racing read-diff-insert. Nothing at the database level has ever prevented this: `active_listing` never had a unique constraint, and dedup was always an advisory diff against a snapshot that's stale as soon as a second writer exists. Post-#1122 nothing cleans duplicates either (removes are multiset-bounded, and every websocket add stamps `listing_last_updated` so the catch-up sweep never revisits).

## Root-cause fixes

1. **`listingID` was silently discarded — forever.** `ListingView.listing_id` was `Option<u32>` under `camelCase` rename, so it looked for `"listingId"` while the wire sends `"listingID"` as a big decimal string. Measured live: 891/891 captured listings parsed `None`. Now `Option<String>` + explicit rename, with a regression test pinning the real wire shape.
2. **Partial unique index** on `(world_id, item_id, listing_id) WHERE listing_id IS NOT NULL` (built `CONCURRENTLY` — online-safe), and `create_listing` upserts on it. Concurrent duplicate writes — ours or Universalis' own duplicate event emission — now collapse into one row.
3. **Identity-keyed diffs** with legacy fallbacks:
   - removes delete only on **id + state** match: a reprice is remove(old)+add(new) on the same `listingID` with no ordering guarantee, so a late remove must not kill a row the add already repriced (tested);
   - any full-board pass condemns id-less legacy rows while re-inserting the same listings with ids — catch-up/refresh/sweeps double as a gradual id backfill and flatten existing duplicate piles (tested on the 3-dup-rows case).
4. **New columns we always threw away**: `materia` (typed jsonb), `stain_id`, `creator_name`, `is_crafted`, `on_mannequin`. Universalis emits no events for cosmetic changes (their diff is exactly `(listingID, price, quantity)`), so these refresh only via REST fetches — state equality deliberately excludes them to avoid churn.

## Verification

- `cargo test -p universalis --lib`: 25 passed (new wire-shape regression test)
- `cargo test -p ultros-db --lib`: 45 passed (9 new identity-diff tests: reorder race, legacy bridge both directions, duplicate-pile backfill)
- `./check_ci.sh` green (REAL_EXIT=0)
- Live websocket capture on Coeurl: `listing_id` now parses on every listing (was 0/891 before, 5/5 after)

Follow-ups (separate PRs): one-shot cleanup sweep + aggregated-endpoint deep catch-up when the 200-item recency window saturates; rotating drift reconciler on a request budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)