### PR TITLE
fix(alerts): stop retrying permanently-dead Discord destinations forever

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -34,6 +34,7 @@ mod m20260802_000001_authless_character_claims;
 mod m20260802_000002_user_group_discord_guild;
 mod m20260804_000001_active_listing_cheapest_index;
 mod m20260805_000001_group_invite;
+mod m20260809_000001_notification_endpoint_health;
 
 pub struct Migrator;
 
@@ -77,6 +78,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260802_000002_user_group_discord_guild::Migration),
             Box::new(m20260804_000001_active_listing_cheapest_index::Migration),
             Box::new(m20260805_000001_group_invite::Migration),
+            Box::new(m20260809_000001_notification_endpoint_health::Migration),
         ]
     }
 }

--- a/migration/src/m20260809_000001_notification_endpoint_health.rs
+++ b/migration/src/m20260809_000001_notification_endpoint_health.rs
@@ -1,0 +1,42 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        // Delivery health for a notification endpoint.
+        //
+        // `disabled_at` being non-NULL means delivery hit a *permanent* failure
+        // (Discord `Unknown Channel` / `Missing Access` — the channel is gone or
+        // the bot was removed) and we stopped retrying it. Before this, every
+        // alert fire re-tried the dead destination forever: six alerts were
+        // generating ~150 error events a day while their owners silently
+        // received nothing.
+        //
+        // `last_error` keeps the reason so the endpoints UI can explain *why* it
+        // stopped, rather than the endpoint just appearing to do nothing.
+        db.execute_unprepared(
+            r#"ALTER TABLE notification_endpoint
+                ADD COLUMN IF NOT EXISTS disabled_at timestamp with time zone,
+                ADD COLUMN IF NOT EXISTS last_error text"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        db.execute_unprepared(
+            r#"ALTER TABLE notification_endpoint
+                DROP COLUMN IF EXISTS disabled_at,
+                DROP COLUMN IF EXISTS last_error"#,
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/ultros-api-types/src/alert.rs
+++ b/ultros-api-types/src/alert.rs
@@ -140,6 +140,15 @@ pub struct Endpoint {
     pub name: String,
     #[serde(flatten)]
     pub method: EndpointMethod,
+    /// Set when delivery hit a permanent failure (Discord channel deleted, bot
+    /// removed) and alerts have stopped being sent here. Carries the reason
+    /// Discord gave so the UI can explain it. `None` means the endpoint is
+    /// healthy.
+    ///
+    /// Defaults on deserialize so an older client/server pair doesn't break on
+    /// the added field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -194,6 +203,32 @@ mod endpoint_tests {
     use serde_json::json;
 
     #[test]
+    fn endpoint_carries_disabled_reason_when_broken() {
+        let e = Endpoint {
+            id: 7,
+            name: "Test".to_string(),
+            method: EndpointMethod::DiscordChannel {
+                channel_id: 5,
+                channel_name: None,
+                guild_id: None,
+                guild_name: None,
+            },
+            disabled_reason: Some("Unknown Channel".to_string()),
+        };
+        let v = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["disabled_reason"], json!("Unknown Channel"));
+    }
+
+    #[test]
+    fn endpoint_accepts_payload_without_disabled_reason() {
+        // A server that predates the field must still deserialize here.
+        let v =
+            json!({"id": 7, "name": "Test", "method": "Webhook", "url": "https://example.invalid"});
+        let e: Endpoint = serde_json::from_value(v).unwrap();
+        assert_eq!(e.disabled_reason, None);
+    }
+
+    #[test]
     fn endpoint_method_serializes_with_method_tag() {
         let m = EndpointMethod::DiscordDm { user_id: 42 };
         let v = serde_json::to_value(&m).unwrap();
@@ -208,6 +243,7 @@ mod endpoint_tests {
             method: EndpointMethod::Webhook {
                 url: "https://example.invalid".into(),
             },
+            disabled_reason: None,
         };
         let v = serde_json::to_value(&e).unwrap();
         assert_eq!(

--- a/ultros-db/src/alerts.rs
+++ b/ultros-db/src/alerts.rs
@@ -182,6 +182,8 @@ impl UltrosDb {
                     config: Set(notification_config),
                     // created_at is DateTimeUtc = DateTime<Utc>
                     created_at: Set(chrono::Utc::now()),
+                    disabled_at: Set(None),
+                    last_error: Set(None),
                 })
                 .exec_with_returning(&txn)
                 .await?
@@ -316,7 +318,13 @@ impl UltrosDb {
         Ok(())
     }
 
-    /// Return all notification endpoints linked to an alert via alert_notification_rule.
+    /// Return the *deliverable* notification endpoints linked to an alert via
+    /// alert_notification_rule.
+    ///
+    /// Endpoints that hit a permanent delivery failure (`disabled_at` set — the
+    /// Discord channel was deleted or the bot was removed) are excluded. They
+    /// stay linked to the alert so the endpoints UI can show why they stopped
+    /// and the user can repair them; they just aren't retried every fire.
     pub async fn get_notification_endpoints_for_alert(
         &self,
         alert_id: i32,
@@ -333,8 +341,58 @@ impl UltrosDb {
 
         Ok(notification_endpoint::Entity::find()
             .filter(notification_endpoint::Column::Id.is_in(endpoint_ids))
+            .filter(notification_endpoint::Column::DisabledAt.is_null())
             .all(&self.db)
             .await?)
+    }
+
+    /// Mark an endpoint as permanently broken so delivery stops retrying it.
+    ///
+    /// Called from the alert delivery path when Discord reports an
+    /// unrecoverable condition (`Unknown Channel`, `Missing Access`). Idempotent
+    /// on `disabled_at` — re-disabling an already-disabled endpoint keeps the
+    /// original timestamp so "broken since" stays truthful — but always
+    /// refreshes `last_error`.
+    pub async fn disable_endpoint_for_delivery_failure(
+        &self,
+        endpoint_id: i32,
+        reason: &str,
+    ) -> Result<()> {
+        let Some(existing) = notification_endpoint::Entity::find_by_id(endpoint_id)
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(());
+        };
+        let already_disabled = existing.disabled_at;
+        let mut active: notification_endpoint::ActiveModel = existing.into();
+        active.disabled_at = Set(Some(already_disabled.unwrap_or_else(chrono::Utc::now)));
+        active.last_error = Set(Some(reason.to_string()));
+        active.update(&self.db).await?;
+        Ok(())
+    }
+
+    /// Clear an endpoint's failure state after a delivery (or an explicit
+    /// "test") succeeds. This is how a repaired endpoint comes back: the user
+    /// fixes the channel, hits Test, and the endpoint re-enters the rotation.
+    ///
+    /// Skips the write when the endpoint is already healthy so the common
+    /// success path doesn't issue an UPDATE per alert fire.
+    pub async fn clear_endpoint_delivery_failure(&self, endpoint_id: i32) -> Result<()> {
+        let Some(existing) = notification_endpoint::Entity::find_by_id(endpoint_id)
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(());
+        };
+        if existing.disabled_at.is_none() && existing.last_error.is_none() {
+            return Ok(());
+        }
+        let mut active: notification_endpoint::ActiveModel = existing.into();
+        active.disabled_at = Set(None);
+        active.last_error = Set(None);
+        active.update(&self.db).await?;
+        Ok(())
     }
 
     pub async fn get_first_endpoint_for_alert(
@@ -423,6 +481,8 @@ impl UltrosDb {
             method: Set(method.to_string()),
             config: Set(config),
             created_at: Set(chrono::Utc::now()),
+            disabled_at: Set(None),
+            last_error: Set(None),
         })
         .exec_with_returning(&self.db)
         .await?;
@@ -448,6 +508,11 @@ impl UltrosDb {
         if let Some((m, c)) = method_and_config {
             active.method = Set(m);
             active.config = Set(c);
+            // Repointing an endpoint at a different destination invalidates any
+            // previous permanent failure — give the new target a fresh chance
+            // instead of leaving it silently disabled.
+            active.disabled_at = Set(None);
+            active.last_error = Set(None);
         }
         active.update(&self.db).await?;
         Ok(())

--- a/ultros-db/src/entity/notification_endpoint.rs
+++ b/ultros-db/src/entity/notification_endpoint.rs
@@ -13,6 +13,13 @@ pub struct Model {
     pub method: String,
     pub config: Json,
     pub created_at: DateTimeUtc,
+    /// Set when delivery hit a *permanent* failure (channel deleted, bot
+    /// removed) and we stopped retrying. `None` means healthy.
+    pub disabled_at: Option<DateTimeUtc>,
+    /// Human-readable reason for the most recent delivery failure. Kept even
+    /// after a successful retry clears `disabled_at`, so the UI can explain a
+    /// past outage.
+    pub last_error: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/ultros-db/src/entity/notification_endpoint.rs
+++ b/ultros-db/src/entity/notification_endpoint.rs
@@ -16,9 +16,9 @@ pub struct Model {
     /// Set when delivery hit a *permanent* failure (channel deleted, bot
     /// removed) and we stopped retrying. `None` means healthy.
     pub disabled_at: Option<DateTimeUtc>,
-    /// Human-readable reason for the most recent delivery failure. Kept even
-    /// after a successful retry clears `disabled_at`, so the UI can explain a
-    /// past outage.
+    /// Human-readable reason the endpoint was disabled, surfaced by the
+    /// endpoints UI. Cleared alongside `disabled_at` when a delivery or an
+    /// explicit Test succeeds, so it only ever describes a *current* outage.
     pub last_error: Option<String>,
 }
 

--- a/ultros-frontend/ultros-app/locales/cn.json
+++ b/ultros-frontend/ultros-app/locales/cn.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "Discord 频道 {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "浏览器推送",
+    "endpoints_disabled_notice": "警报已停止：无法再送达此目标。修复后请点击“测试”以重新启用。",
     "endpoints_test_button": "测试",
     "endpoints_delete_aria": "删除通知端点",
     "endpoints_err_name_required": "名称必填",

--- a/ultros-frontend/ultros-app/locales/de.json
+++ b/ultros-frontend/ultros-app/locales/de.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "Discord-Kanal {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "Browser-Push",
+    "endpoints_disabled_notice": "Benachrichtigungen gestoppt: Dieses Ziel ist nicht mehr erreichbar. Behebe das Problem und drücke dann Testen, um es wieder zu aktivieren.",
     "endpoints_test_button": "Testen",
     "endpoints_delete_aria": "Endpunkt löschen",
     "endpoints_err_name_required": "Name ist erforderlich",

--- a/ultros-frontend/ultros-app/locales/en.json
+++ b/ultros-frontend/ultros-app/locales/en.json
@@ -1167,6 +1167,7 @@
     "endpoints_method_discord_channel_id": "Discord channel {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "Browser push",
+    "endpoints_disabled_notice": "Alerts stopped: this destination is no longer reachable. Fix it, then press Test to re-enable.",
     "endpoints_test_button": "Test",
     "endpoints_delete_aria": "Delete endpoint",
     "endpoints_err_name_required": "Name is required",

--- a/ultros-frontend/ultros-app/locales/fr.json
+++ b/ultros-frontend/ultros-app/locales/fr.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "Salon Discord {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "Push navigateur",
+    "endpoints_disabled_notice": "Alertes interrompues : cette destination n'est plus accessible. Corrigez le problème, puis appuyez sur Tester pour la réactiver.",
     "endpoints_test_button": "Tester",
     "endpoints_delete_aria": "Supprimer le point de distribution",
     "endpoints_err_name_required": "Le nom est requis",

--- a/ultros-frontend/ultros-app/locales/ja.json
+++ b/ultros-frontend/ultros-app/locales/ja.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "Discordチャンネル {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "ブラウザプッシュ",
+    "endpoints_disabled_notice": "通知を停止しました: この送信先には届かなくなっています。問題を解決してから「テスト」を押すと再開できます。",
     "endpoints_test_button": "テスト",
     "endpoints_delete_aria": "配信先を削除",
     "endpoints_err_name_required": "名前は必須です",

--- a/ultros-frontend/ultros-app/locales/ko.json
+++ b/ultros-frontend/ultros-app/locales/ko.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "디스코드 채널 {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "브라우저 푸시",
+    "endpoints_disabled_notice": "알림이 중지되었습니다: 이 대상에 더 이상 전송할 수 없습니다. 문제를 해결한 뒤 '테스트'를 눌러 다시 활성화하세요.",
     "endpoints_test_button": "테스트",
     "endpoints_delete_aria": "엔드포인트 삭제",
     "endpoints_err_name_required": "이름은 필수입니다",

--- a/ultros-frontend/ultros-app/locales/tc.json
+++ b/ultros-frontend/ultros-app/locales/tc.json
@@ -1164,6 +1164,7 @@
     "endpoints_method_discord_channel_id": "Discord 頻道 {{channel_id}}",
     "endpoints_method_webhook": "Webhook",
     "endpoints_method_web_push": "瀏覽器推送",
+    "endpoints_disabled_notice": "警報已停止：無法再送達此目標。修復後請點擊「測試」以重新啟用。",
     "endpoints_test_button": "測試",
     "endpoints_delete_aria": "刪除通知端點",
     "endpoints_err_name_required": "名稱必填",

--- a/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
+++ b/ultros-frontend/ultros-app/src/components/endpoints_panel.rs
@@ -172,11 +172,24 @@ pub fn EndpointsPanel() -> impl IntoView {
                                         }
                                     };
                                     let id = e.id;
+                                    // Delivery disabled this endpoint after Discord
+                                    // rejected it permanently (channel deleted, bot
+                                    // removed). Without this the endpoint just looks
+                                    // fine while silently sending nothing — say why,
+                                    // and point at Test as the way back.
+                                    let disabled_reason = e.disabled_reason.clone();
                                     view! {
                                         <li class="flex items-center justify-between py-2">
                                             <div>
                                                 <div class="font-medium">{e.name.clone()}</div>
                                                 <div class="text-xs opacity-70">{label}</div>
+                                                {disabled_reason.map(|reason| view! {
+                                                    <div class="text-xs text-amber-400 mt-1">
+                                                        {t!(i18n, endpoints_disabled_notice)}
+                                                        " "
+                                                        <span class="opacity-80">{reason}</span>
+                                                    </div>
+                                                })}
                                             </div>
                                             <div class="flex gap-1">
                                                 <button class="btn-ghost" on:click=move |_| on_test(id)>

--- a/ultros/src/alerts/delivery.rs
+++ b/ultros/src/alerts/delivery.rs
@@ -154,6 +154,158 @@ pub(crate) async fn deliver_non_discord_endpoint(
     }
 }
 
+/// Whether a Discord API rejection can ever succeed on a later retry.
+///
+/// Discord answers a failed REST call with an HTTP status plus a numeric JSON
+/// error code. A handful of those codes describe a destination that is simply
+/// *gone* — retrying them every time an alert fires produces nothing but error
+/// spam while the owner silently receives no alerts at all.
+///
+/// Codes (<https://discord.com/developers/docs/topics/opcodes-and-status-codes>):
+/// - `10003` Unknown Channel — the channel was deleted.
+/// - `10013` Unknown User — the DM target no longer exists.
+/// - `50001` Missing Access — the bot was removed from the guild/channel.
+/// - `50007` Cannot send messages to this user — DMs closed.
+/// - `50013` Missing Permissions — send permission revoked on the channel.
+///
+/// Everything else (rate limits, 5xx, transport errors) is treated as transient
+/// so a Discord outage never disables a working endpoint. `-1` is serenity's
+/// placeholder when the error body failed to decode, which tells us nothing —
+/// also transient.
+fn is_permanent_discord_failure(status: u16, discord_code: isize) -> bool {
+    // A 5xx is Discord's problem, never the destination's — regardless of the
+    // code it happens to carry.
+    if status >= 500 {
+        return false;
+    }
+    matches!(discord_code, 10003 | 10013 | 50001 | 50007 | 50013)
+}
+
+/// Pull a permanent-failure reason out of an error returned by
+/// [`deliver_to_endpoint`], if the underlying cause was Discord rejecting the
+/// destination for good.
+///
+/// The delivery helpers surface serenity errors through `anyhow`, so walk the
+/// source chain rather than matching only the top-level error.
+pub(crate) fn permanent_failure_reason(err: &anyhow::Error) -> Option<String> {
+    use poise::serenity_prelude::HttpError;
+
+    for cause in err.chain() {
+        let Some(serenity_prelude::Error::Http(HttpError::UnsuccessfulRequest(resp))) =
+            cause.downcast_ref::<serenity_prelude::Error>()
+        else {
+            continue;
+        };
+        if is_permanent_discord_failure(resp.status_code.as_u16(), resp.error.code) {
+            return Some(resp.error.message.clone());
+        }
+    }
+    None
+}
+
+/// Outcome of fanning an alert out across its notification endpoints.
+pub(crate) enum DispatchOutcome {
+    /// At least one endpoint accepted the message.
+    Delivered,
+    /// Nothing delivered, but the failures look transient — the caller should
+    /// still try any legacy fallback destinations.
+    TransientFailure(anyhow::Error),
+    /// Nothing delivered and every failure was permanent (or the alert has no
+    /// deliverable endpoints left because they were all disabled). Retrying —
+    /// including via the legacy fallback, which points at the same dead Discord
+    /// channels — is pointless, so the caller should record the reason quietly
+    /// rather than reporting a new error every fire.
+    PermanentFailure(String),
+}
+
+/// Look up all deliverable notification endpoints for an alert and dispatch the
+/// message via each.
+///
+/// Endpoints that Discord rejects permanently are disabled as a side effect, so
+/// the next fire skips them entirely. A successful delivery clears any
+/// previously recorded failure.
+pub(crate) async fn dispatch_alert_detailed(
+    alert_id: i32,
+    title: &str,
+    body: &str,
+    click_url: &str,
+    db: &UltrosDb,
+    ctx: &serenity_prelude::Context,
+) -> DispatchOutcome {
+    let endpoints = match db.get_notification_endpoints_for_alert(alert_id).await {
+        Ok(e) => e,
+        Err(e) => return DispatchOutcome::TransientFailure(e),
+    };
+
+    if endpoints.is_empty() {
+        // Either the alert never had rules, or every endpoint it had has been
+        // disabled for a permanent failure. Both are steady states that a retry
+        // cannot change, so don't keep raising them as errors.
+        return DispatchOutcome::PermanentFailure(format!(
+            "alert {alert_id} has no deliverable notification endpoints"
+        ));
+    }
+
+    let mut last_err: Option<anyhow::Error> = None;
+    let mut permanent_reason: Option<String> = None;
+    let mut any_ok = false;
+    let mut any_transient = false;
+
+    for endpoint in endpoints {
+        match deliver_to_endpoint(&endpoint, title, body, click_url, db, ctx).await {
+            Ok(()) => {
+                any_ok = true;
+                // Only touch the DB when there is actually stale failure state
+                // to clear — the healthy path is the common one and shouldn't
+                // pay a write per alert fire.
+                if (endpoint.disabled_at.is_some() || endpoint.last_error.is_some())
+                    && let Err(e) = db.clear_endpoint_delivery_failure(endpoint.id).await
+                {
+                    error!(
+                        "failed to clear delivery failure for endpoint {}: {e}",
+                        endpoint.id
+                    );
+                }
+            }
+            Err(e) => {
+                match permanent_failure_reason(&e) {
+                    Some(reason) => {
+                        // Log at warn: this is an expected steady state we are
+                        // acting on, not an unhandled error, and it should stop
+                        // paging via the error reporter.
+                        tracing::warn!(
+                            "disabling endpoint {} for alert {alert_id}: {reason}",
+                            endpoint.id
+                        );
+                        if let Err(e) = db
+                            .disable_endpoint_for_delivery_failure(endpoint.id, &reason)
+                            .await
+                        {
+                            error!("failed to disable endpoint {}: {e}", endpoint.id);
+                        }
+                        permanent_reason.get_or_insert(reason);
+                    }
+                    None => {
+                        error!("delivery failed for alert {alert_id}: {e}");
+                        any_transient = true;
+                    }
+                }
+                last_err = Some(e);
+            }
+        }
+    }
+
+    if any_ok {
+        DispatchOutcome::Delivered
+    } else if any_transient || permanent_reason.is_none() {
+        DispatchOutcome::TransientFailure(
+            last_err.unwrap_or_else(|| anyhow!("no deliveries succeeded")),
+        )
+    } else {
+        DispatchOutcome::PermanentFailure(permanent_reason.unwrap_or_default())
+    }
+}
+
 /// Look up all notification endpoints for an alert and dispatch the message via each.
 /// Returns Ok(()) if at least one delivered; Err describing the last failure otherwise.
 pub(crate) async fn dispatch_alert(
@@ -164,29 +316,10 @@ pub(crate) async fn dispatch_alert(
     db: &UltrosDb,
     ctx: &serenity_prelude::Context,
 ) -> Result<()> {
-    let endpoints = db.get_notification_endpoints_for_alert(alert_id).await?;
-
-    if endpoints.is_empty() {
-        return Err(anyhow!("alert {alert_id} has no notification rules"));
-    }
-
-    let mut last_err: Option<anyhow::Error> = None;
-    let mut any_ok = false;
-
-    for endpoint in endpoints {
-        match deliver_to_endpoint(&endpoint, title, body, click_url, db, ctx).await {
-            Ok(()) => any_ok = true,
-            Err(e) => {
-                error!("delivery failed for alert {alert_id}: {e}");
-                last_err = Some(e);
-            }
-        }
-    }
-
-    if any_ok {
-        Ok(())
-    } else {
-        Err(last_err.unwrap_or_else(|| anyhow!("no deliveries succeeded")))
+    match dispatch_alert_detailed(alert_id, title, body, click_url, db, ctx).await {
+        DispatchOutcome::Delivered => Ok(()),
+        DispatchOutcome::TransientFailure(e) => Err(e),
+        DispatchOutcome::PermanentFailure(reason) => Err(anyhow!("{reason}")),
     }
 }
 
@@ -375,6 +508,51 @@ async fn send_webhook(url: &str, title: &str, body: &str) -> Result<()> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn dead_discord_destinations_are_permanent() {
+        // The exact pairs behind GlitchTip issues 6877/6878/6879/6885/6889
+        // ("Unknown Channel") and 6881/6882/6883/6884 ("Missing Access"),
+        // which retried forever and produced ~150 error events a day.
+        assert!(is_permanent_discord_failure(404, 10003)); // Unknown Channel
+        assert!(is_permanent_discord_failure(403, 50001)); // Missing Access
+        assert!(is_permanent_discord_failure(404, 10013)); // Unknown User
+        assert!(is_permanent_discord_failure(403, 50007)); // Cannot DM this user
+        assert!(is_permanent_discord_failure(403, 50013)); // Missing Permissions
+    }
+
+    #[test]
+    fn transient_discord_failures_do_not_disable() {
+        // Rate limiting is the whole point of retrying.
+        assert!(!is_permanent_discord_failure(429, 0));
+        // Discord-side outages must never disable a working destination.
+        assert!(!is_permanent_discord_failure(500, 0));
+        assert!(!is_permanent_discord_failure(503, 0));
+        // serenity uses -1 when it couldn't decode the error body — that tells
+        // us nothing, so it can't justify disabling anything.
+        assert!(!is_permanent_discord_failure(400, -1));
+        // An unrecognised 4xx code stays transient rather than guessing.
+        assert!(!is_permanent_discord_failure(400, 50035));
+    }
+
+    #[test]
+    fn a_5xx_never_counts_as_permanent_even_carrying_a_permanent_code() {
+        // Defensive: a gateway returning 502 with a stale body shouldn't take
+        // out every endpoint at once.
+        assert!(!is_permanent_discord_failure(502, 10003));
+        assert!(!is_permanent_discord_failure(500, 50001));
+    }
+
+    #[test]
+    fn non_discord_errors_are_never_permanent() {
+        // Webhook/WebPush failures surface as plain anyhow errors with no
+        // serenity cause in the chain, so they must not disable the endpoint.
+        let err = anyhow!("webhook returned 500: upstream exploded");
+        assert!(permanent_failure_reason(&err).is_none());
+
+        let nested = err.context("delivering to endpoint 3");
+        assert!(permanent_failure_reason(&nested).is_none());
+    }
 
     #[test]
     fn push_payload_carries_the_callers_click_url() {

--- a/ultros/src/alerts/undercut_alert.rs
+++ b/ultros/src/alerts/undercut_alert.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use futures::future::{self, Either};
 use poise::serenity_prelude::{self, Color, UserId};
 use serde::Serialize;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, warn};
 use ultros_api_types::{user::OwnedRetainer, websocket::ListingEventData};
 use ultros_db::UltrosDb;
 
 use crate::{
-    alerts::delivery::dispatch_alert,
+    alerts::delivery::{DispatchOutcome, dispatch_alert_detailed, permanent_failure_reason},
     event::{EventBus, EventType},
 };
 
@@ -73,6 +73,18 @@ async fn get_user_unique_retainer_ids_and_listing_ids_by_price(
     Ok((user_retainer_ids, user_lowest_listings))
 }
 
+/// Result of the legacy `alert_discord_destination` fallback.
+enum LegacyOutcome {
+    /// At least one legacy channel accepted the message.
+    Delivered,
+    /// This alert has no legacy destinations at all. Distinct from success:
+    /// sending to nothing used to report `Ok(())`, which marked the alert
+    /// event as delivered even though nobody was notified.
+    NoDestinations,
+    /// Every legacy destination failed.
+    Failed(anyhow::Error),
+}
+
 #[instrument(skip(ultros_db, ctx))]
 async fn send_discord_alerts(
     alert_id: i32,
@@ -80,11 +92,18 @@ async fn send_discord_alerts(
     ultros_db: &UltrosDb,
     ctx: &serenity_prelude::Context,
     undercut_msg: &str,
-) -> Result<()> {
+) -> Result<LegacyOutcome> {
     let destinations = ultros_db.get_alert_discord_destinations(alert_id).await?;
+    if destinations.is_empty() {
+        return Ok(LegacyOutcome::NoDestinations);
+    }
+    let mut last_err = None;
+    let mut any_ok = false;
     for destination in &destinations {
         let channel_id = serenity_prelude::ChannelId::new(destination.channel_id as u64);
-        let _ = channel_id
+        // Keep going after a failure. One deleted channel used to abort the
+        // whole loop, so every destination after it silently went unnotified.
+        match channel_id
             .send_message(
                 ctx,
                 serenity_prelude::CreateMessage::new()
@@ -100,9 +119,16 @@ async fn send_discord_alerts(
                     )
                     .content(format!("<@{discord_user_id}>")),
             )
-            .await?;
+            .await
+        {
+            Ok(_) => any_ok = true,
+            Err(e) => last_err = Some(e),
+        }
     }
-    Ok(())
+    Ok(match last_err {
+        Some(e) if !any_ok => LegacyOutcome::Failed(e.into()),
+        _ => LegacyOutcome::Delivered,
+    })
 }
 
 pub(crate) enum RetainerAlertTx {
@@ -350,7 +376,13 @@ impl RetainerAlertListener {
                                         let title = "Undercut Alert";
                                         let mut delivered = false;
                                         let mut delivery_error = None;
-                                        match dispatch_alert(
+                                        // Tracks whether every destination failed
+                                        // for a reason a retry can't change (the
+                                        // channel is gone, the bot was removed).
+                                        // Those are recorded on the event but not
+                                        // re-reported as a new error every fire.
+                                        let mut permanent = false;
+                                        let endpoint_failure = match dispatch_alert_detailed(
                                             alert_id,
                                             title,
                                             &undercut_msg,
@@ -360,23 +392,58 @@ impl RetainerAlertListener {
                                         )
                                         .await
                                         {
-                                            Ok(()) => delivered = true,
-                                            Err(endpoint_error) => {
-                                                match send_discord_alerts(
-                                                    alert_id,
-                                                    discord_user,
-                                                    &ultros_db,
-                                                    &ctx,
-                                                    &undercut_msg,
-                                                )
-                                                .await
-                                                {
-                                                    Ok(()) => delivered = true,
-                                                    Err(legacy_error) => {
-                                                        delivery_error = Some(format!(
-                                                            "{endpoint_error}; legacy Discord destinations failed: {legacy_error}"
-                                                        ));
-                                                    }
+                                            DispatchOutcome::Delivered => {
+                                                delivered = true;
+                                                None
+                                            }
+                                            DispatchOutcome::PermanentFailure(reason) => {
+                                                permanent = true;
+                                                Some(reason)
+                                            }
+                                            DispatchOutcome::TransientFailure(e) => {
+                                                Some(format!("{e}"))
+                                            }
+                                        };
+                                        // Always give the legacy destinations a
+                                        // turn — they're a separate set of
+                                        // channels, and some pre-endpoint alerts
+                                        // still have nothing else.
+                                        if let Some(endpoint_failure) = endpoint_failure {
+                                            match send_discord_alerts(
+                                                alert_id,
+                                                discord_user,
+                                                &ultros_db,
+                                                &ctx,
+                                                &undercut_msg,
+                                            )
+                                            .await
+                                            {
+                                                Ok(LegacyOutcome::Delivered) => {
+                                                    delivered = true;
+                                                    permanent = false;
+                                                }
+                                                Ok(LegacyOutcome::NoDestinations) => {
+                                                    // Nothing else to try, so the
+                                                    // endpoint verdict stands.
+                                                    delivery_error = Some(endpoint_failure);
+                                                }
+                                                Ok(LegacyOutcome::Failed(legacy_error)) => {
+                                                    // Only stays "permanent" if
+                                                    // the fallback is dead too.
+                                                    permanent = permanent
+                                                        && permanent_failure_reason(&legacy_error)
+                                                            .is_some();
+                                                    delivery_error = Some(format!(
+                                                        "{endpoint_failure}; legacy Discord destinations failed: {legacy_error}"
+                                                    ));
+                                                }
+                                                Err(lookup_error) => {
+                                                    // Couldn't even read the
+                                                    // destinations — transient.
+                                                    permanent = false;
+                                                    delivery_error = Some(format!(
+                                                        "{endpoint_failure}; legacy Discord destinations failed: {lookup_error}"
+                                                    ));
                                                 }
                                             }
                                         }
@@ -402,7 +469,18 @@ impl RetainerAlertListener {
                                                 );
                                             }
                                         } else if let Some(error) = delivery_error {
-                                            error!("Error sending undercut alerts {error}");
+                                            if permanent {
+                                                // Steady state we've already
+                                                // acted on (endpoint disabled).
+                                                // Keep it out of the error
+                                                // reporter — it fired ~150
+                                                // times a day for six alerts.
+                                                warn!(
+                                                    "undercut alert {alert_id} has no working destinations: {error}"
+                                                );
+                                            } else {
+                                                error!("Error sending undercut alerts {error}");
+                                            }
                                         }
                                     }
                                 }

--- a/ultros/src/web/api/endpoints.rs
+++ b/ultros/src/web/api/endpoints.rs
@@ -127,10 +127,15 @@ pub(crate) async fn list_endpoints(
     let mut out = Vec::with_capacity(rows.len());
     for r in rows {
         let method = db_to_method(&r.method, &r.config).map_err(ApiError::from)?;
+        // Only surface the reason while the endpoint is actually disabled;
+        // `last_error` outlives a recovery so the row doesn't keep shouting
+        // about an outage that a later delivery already cleared.
+        let disabled_reason = r.disabled_at.and(r.last_error);
         out.push(Endpoint {
             id: r.id,
             name: r.name,
             method,
+            disabled_reason,
         });
     }
     Ok(Json(out))
@@ -205,7 +210,12 @@ pub(crate) async fn create_endpoint(
         .create_endpoint(user.id as i64, &name, method_str, config)
         .await
         .map_err(ApiError::from)?;
-    Ok(Json(Endpoint { id, name, method }))
+    Ok(Json(Endpoint {
+        id,
+        name,
+        method,
+        disabled_reason: None,
+    }))
 }
 
 pub(crate) async fn update_endpoint(
@@ -333,10 +343,18 @@ pub(crate) async fn test_endpoint(
     };
 
     match result {
-        Ok(()) => Ok(Json(ResendResult {
-            delivered: true,
-            error: None,
-        })),
+        Ok(()) => {
+            // Testing successfully is how a user un-breaks an endpoint that the
+            // delivery path disabled: fix the channel (or re-invite the bot),
+            // hit Test, and it re-enters the alert rotation.
+            if let Err(e) = db.clear_endpoint_delivery_failure(id).await {
+                tracing::error!("failed to clear delivery failure for endpoint {id}: {e}");
+            }
+            Ok(Json(ResendResult {
+                delivered: true,
+                error: None,
+            }))
+        }
         Err(e) => Ok(Json(ResendResult {
             delivered: false,
             error: Some(format!("{e}")),

--- a/ultros/src/web/api/endpoints.rs
+++ b/ultros/src/web/api/endpoints.rs
@@ -127,9 +127,9 @@ pub(crate) async fn list_endpoints(
     let mut out = Vec::with_capacity(rows.len());
     for r in rows {
         let method = db_to_method(&r.method, &r.config).map_err(ApiError::from)?;
-        // Only surface the reason while the endpoint is actually disabled;
-        // `last_error` outlives a recovery so the row doesn't keep shouting
-        // about an outage that a later delivery already cleared.
+        // Only surface the reason while the endpoint is actually disabled.
+        // Recovery clears both columns together, so this is belt-and-braces: a
+        // stray `last_error` can never make a working endpoint look broken.
         let disabled_reason = r.disabled_at.and(r.last_error);
         out.push(Endpoint {
             id: r.id,

--- a/ultros/src/web/api/push.rs
+++ b/ultros/src/web/api/push.rs
@@ -83,6 +83,7 @@ pub(crate) async fn create_push_subscription(
         id,
         name,
         method: EndpointMethod::WebPush { subscription_id },
+        disabled_reason: None,
     }))
 }
 


### PR DESCRIPTION
Alert delivery retried permanently-dead Discord destinations on every fire, forever.

`Unknown Channel` (the channel was deleted) and `Missing Access` (the bot was
removed from the guild) can never succeed on a retry, but `dispatch_alert` just
logged `error!` and tried again next cycle. Six alerts (ids 5, 6, 7, 8, 12, 13,
14) were producing **~1,050 GlitchTip events over four days** — and, more
importantly, their owners had silently received nothing since the channel broke,
with no indication anywhere in the UI that their endpoint was dead.

GlitchTip issues this closes:
[6879](https://glitchtip.ultros.app/ultros/issues/6879) (418),
[6877](https://glitchtip.ultros.app/ultros/issues/6877) (151),
[6878](https://glitchtip.ultros.app/ultros/issues/6878) (151),
[6885](https://glitchtip.ultros.app/ultros/issues/6885) (112),
[6884](https://glitchtip.ultros.app/ultros/issues/6884) (40),
[6881](https://glitchtip.ultros.app/ultros/issues/6881)/[6882](https://glitchtip.ultros.app/ultros/issues/6882)/[6883](https://glitchtip.ultros.app/ultros/issues/6883) (14 each),
[6889](https://glitchtip.ultros.app/ultros/issues/6889) (9).

## What changed

**Classify the failure.** `is_permanent_discord_failure(status, code)` reads the
numeric JSON error code Discord returns (`10003` Unknown Channel, `10013`
Unknown User, `50001` Missing Access, `50007` Cannot DM, `50013` Missing
Permissions). Everything else — rate limits, transport errors, and *any* 5xx
regardless of the code it carries — stays transient, so a Discord outage can
never mass-disable working endpoints. serenity's `-1` "couldn't decode the error
body" placeholder is transient too.

**Stop retrying it.** `notification_endpoint` gains `disabled_at` + `last_error`
(migration `m20260809_000001`). A permanent failure disables the endpoint;
`get_notification_endpoints_for_alert` skips disabled rows, so the next fire
doesn't touch the dead channel at all. Logging for that path drops to `warn!` —
it's a steady state we've acted on, not an unhandled error, and `warn` doesn't
reach GlitchTip.

**Tell the user, and give them a way back.** `GET /api/v1/endpoints` exposes
`disabled_reason`, and the endpoints panel renders it inline: *"Alerts stopped:
this destination is no longer reachable. Fix it, then press Test to re-enable."*
A successful **Test** — or any successful delivery, or repointing the endpoint
via PATCH — clears the flag and puts it back in rotation. No new UI controls, no
manual DB surgery.

## Two related bugs found in the same path

- `send_discord_alerts` (the legacy `alert_discord_destination` fallback) used
  `?` inside its loop, so **the first dead channel aborted the whole loop** and
  every destination after it was silently skipped. Now it tries all of them and
  only reports failure if none succeeded.
- That same function returned `Ok(())` when the alert had **zero** legacy
  destinations, which marked the `alert_event` as `delivered` even though nobody
  was notified. It now returns a distinct `LegacyOutcome::NoDestinations`.

The legacy fallback is still attempted whenever the endpoint path fails — an
alert that predates notification endpoints has nothing else — and the failure is
only treated as permanent when the fallback is dead too.

## Testing

`is_permanent_discord_failure` is covered directly, including the exact
status/code pairs behind the issues above, the 5xx-carrying-a-permanent-code
case, and serenity's `-1`. `permanent_failure_reason` is covered for non-serenity
errors (webhook/web-push failures must never disable an endpoint), including
through an `anyhow` context layer. `Endpoint`'s new field is covered for both
serialization and back-compat deserialization of a payload that lacks it.

`./check_ci.sh` passes clean. `cargo test -p ultros-api-types`: 155 passed.

`cargo test -p ultros` cannot link on Windows/MSVC — `libultros_app-*.rlib :
warning LNK4003: invalid library format; library ignored`, then 1120 unresolved
externals — so the `ultros` crate's tests were type-checked via
`cargo clippy -p ultros --all-targets` and the decision table was additionally
**executed** by extracting `is_permanent_discord_failure` verbatim into a
standalone `rustc --test` binary: 3 passed. Reverting just the `matches!` arm to
the old always-transient behaviour fails
`dead_discord_destinations_are_permanent` on `(404, 10003)` and leaves the two
"don't over-disable" guardrail tests green — i.e. the new test is actually
pinned to the production failure, not to the implementation. Someone on Linux
should confirm with a plain `cargo test -p ultros`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
