### PR TITLE
🛡️ Sentry: [test coverage improvement] Extract GilOrDash presentation logic into pure functions

### DIFF
--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -127,32 +127,35 @@ pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
 /// shape removes that class of mismatch entirely — the icon is just hidden
 /// via CSS when the value is unknown, so the SSR and CSR view trees agree on
 /// element types/positions regardless of resource state.
+pub fn get_gil_or_dash_icon_class(has_amount: bool) -> &'static str {
+    if has_amount { "inline-flex" } else { "hidden" }
+}
+
+pub fn get_gil_or_dash_value_class(has_amount: bool) -> &'static str {
+    if has_amount {
+        ""
+    } else {
+        "text-[color:var(--color-text-muted)]"
+    }
+}
+
+pub fn format_gil_or_dash(amount: Option<i32>) -> String {
+    amount
+        .map(|t| t.separate_with_commas())
+        .unwrap_or_else(|| "—".to_string())
+}
+
 #[component]
 pub fn GilOrDash(#[prop(into)] amount: Signal<Option<i32>>) -> impl IntoView {
-    let icon_class = move || {
-        if amount().is_some() {
-            "inline-flex"
-        } else {
-            "hidden"
-        }
-    };
-    let value_class = move || {
-        if amount().is_some() {
-            ""
-        } else {
-            "text-[color:var(--color-text-muted)]"
-        }
-    };
+    let icon_class = move || get_gil_or_dash_icon_class(amount().is_some());
+    let value_class = move || get_gil_or_dash_value_class(amount().is_some());
     view! {
         <div class="flex flex-row items-center">
             <span class=icon_class>
                 <GilIcon />
             </span>
             <div class=value_class>
-                {move || amount()
-                    .map(|t| t.separate_with_commas())
-                    .unwrap_or_else(|| "—".to_string())
-                }
+                {move || format_gil_or_dash(amount())}
             </div>
         </div>
     }
@@ -170,4 +173,32 @@ where
         </div>
     }
     .into_any()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_gil_or_dash_icon_class() {
+        assert_eq!(get_gil_or_dash_icon_class(true), "inline-flex");
+        assert_eq!(get_gil_or_dash_icon_class(false), "hidden");
+    }
+
+    #[test]
+    fn test_get_gil_or_dash_value_class() {
+        assert_eq!(get_gil_or_dash_value_class(true), "");
+        assert_eq!(
+            get_gil_or_dash_value_class(false),
+            "text-[color:var(--color-text-muted)]"
+        );
+    }
+
+    #[test]
+    fn test_format_gil_or_dash() {
+        assert_eq!(format_gil_or_dash(Some(1234)), "1,234");
+        assert_eq!(format_gil_or_dash(None), "—");
+        assert_eq!(format_gil_or_dash(Some(0)), "0");
+        assert_eq!(format_gil_or_dash(Some(-50)), "-50");
+    }
 }

--- a/ultros-frontend/ultros-app/src/components/gil.rs
+++ b/ultros-frontend/ultros-app/src/components/gil.rs
@@ -114,6 +114,28 @@ pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
     }
 }
 
+/// Visibility class for the gil icon. The icon is hidden rather than
+/// removed so the element shape stays constant - see [`GilOrDash`].
+fn get_gil_or_dash_icon_class(has_amount: bool) -> &'static str {
+    if has_amount { "inline-flex" } else { "hidden" }
+}
+
+/// Class for the value slot - muted while the amount is unknown.
+fn get_gil_or_dash_value_class(has_amount: bool) -> &'static str {
+    if has_amount {
+        ""
+    } else {
+        "text-[color:var(--color-text-muted)]"
+    }
+}
+
+/// The gil amount with thousands separators, or the placeholder.
+fn format_gil_or_dash(amount: Option<i32>) -> String {
+    amount
+        .map(|t| t.separate_with_commas())
+        .unwrap_or_else(|| "—".to_string())
+}
+
 /// Render a gil amount when present, falling back to an em-dash placeholder
 /// when `amount` is `None` — without changing the element shape.
 ///
@@ -127,24 +149,6 @@ pub fn Gil(#[prop(into)] amount: Signal<i32>) -> impl IntoView {
 /// shape removes that class of mismatch entirely — the icon is just hidden
 /// via CSS when the value is unknown, so the SSR and CSR view trees agree on
 /// element types/positions regardless of resource state.
-pub fn get_gil_or_dash_icon_class(has_amount: bool) -> &'static str {
-    if has_amount { "inline-flex" } else { "hidden" }
-}
-
-pub fn get_gil_or_dash_value_class(has_amount: bool) -> &'static str {
-    if has_amount {
-        ""
-    } else {
-        "text-[color:var(--color-text-muted)]"
-    }
-}
-
-pub fn format_gil_or_dash(amount: Option<i32>) -> String {
-    amount
-        .map(|t| t.separate_with_commas())
-        .unwrap_or_else(|| "—".to_string())
-}
-
 #[component]
 pub fn GilOrDash(#[prop(into)] amount: Signal<Option<i32>>) -> impl IntoView {
     let icon_class = move || get_gil_or_dash_icon_class(amount().is_some());


### PR DESCRIPTION
💡 What: Extracted `get_gil_or_dash_icon_class`, `get_gil_or_dash_value_class`, and `format_gil_or_dash` from the `GilOrDash` component in `components/gil.rs` and provided comprehensive tests covering both Some and None states for presentation mapping.
🎯 Why: Extracting pure styling and text mapping functions from Leptos component macros improves unit testability and guarantees deterministic resolution of UI state without needing complex `leptos::mount_to_html` mocks.
📊 Impact: `ultros-frontend/ultros-app/src/components/gil.rs` UI fallback branches are fully tested.
🔬 Verification: Run `cargo test -p ultros-app components::gil::tests`

---
*PR created automatically by Jules for task [9868664638201161533](https://jules.google.com/task/9868664638201161533) started by @akarras*