### PR TITLE
fix(ssr): stop the server fetching its own API through Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The two halves of the data come from different places:
 | `DISCORD_CLIENT_ID` | Discord Application ID | Required |
 | `DISCORD_CLIENT_SECRET` | Discord Client Secret | Required |
 | `HOSTNAME` | Public URL of the app (for OAuth redirects) | `http://localhost:8080` |
+| `ULTROS_INTERNAL_API_ORIGIN` | Origin the SSR renderer calls its own API on. Defaults to the loopback form of `LEPTOS_SITE_ADDR`, so the server never leaves the box to fetch its own data; only set this if the API lives somewhere else. | derived from `LEPTOS_SITE_ADDR` |
 | `KEY` | Secret key for cookie encryption | Random string |
 | `DATABASE_URL` | Postgres connection string | `postgres://user:pass@host/db` |
 | `PORT` | HTTP server port | `8080` |

--- a/ultros-frontend/ultros-app/src/api.rs
+++ b/ultros-frontend/ultros-app/src/api.rs
@@ -814,9 +814,11 @@ where
 /// Headers that must not be copied from the inbound browser request onto the
 /// outbound internal API request.
 ///
-/// The SSR path re-issues each API call against `HOSTNAME`, which in production
-/// is the *public* origin, so the request travels back out through the CDN.
-/// Copying the inbound `host` header onto a request aimed at a different URL
+/// The SSR path re-issues each API call against [`internal_api_origin`], which
+/// is no longer the public origin — but it still must not carry the inbound
+/// `host`, and the reason it originally mattered is worth keeping: when the
+/// outbound call did travel back out through the CDN,
+/// copying the inbound `host` header onto a request aimed at a different URL
 /// makes the CDN reject it: a `Host` that does not match the edge certificate
 /// answers `403 Forbidden`, and on a pooled TLS connection (the client below
 /// sets a 60s keepalive, so connections are reused) a `Host` that disagrees
@@ -865,6 +867,105 @@ const NON_FORWARDABLE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "x-real-ip",
 ];
+
+/// Turn the address the server is bound to into an origin it can call itself
+/// on, or `None` if it does not look like an `addr:port` pair.
+///
+/// `0.0.0.0` and `[::]` are the *unspecified* address — "listen on every
+/// interface". They are a valid bind target and not a valid destination, so
+/// they map to the matching loopback address. Anything else is already a
+/// concrete address the process answers on and is used verbatim.
+#[cfg(feature = "ssr")]
+fn loopback_origin_from_site_addr(site_addr: &str) -> Option<String> {
+    let (host, port) = site_addr.trim().rsplit_once(':')?;
+    if port.is_empty() || !port.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    // IPv6 literals arrive bracketed (`[::]:8080`) and stay bracketed in a URL.
+    let host = match host.strip_prefix('[').and_then(|h| h.strip_suffix(']')) {
+        Some("::" | "::0" | "0:0:0:0:0:0:0:0") => "[::1]",
+        Some(_) => host,
+        None if host.is_empty() || host == "0.0.0.0" => "127.0.0.1",
+        None => host,
+    };
+    Some(format!("http://{host}:{port}"))
+}
+
+/// Pick the origin the SSR renderer issues its own API calls against.
+///
+/// Precedence: an explicit override, then the address the server is bound to,
+/// then the public `HOSTNAME`, then a development default.
+///
+/// This used to be `HOSTNAME` alone, and `HOSTNAME` is the app's *public* URL
+/// (`https://ultros.app` in production) — it has to stay that way, OAuth
+/// redirects are built from it. Using it here too meant every server-rendered
+/// page re-fetched its own API by leaving the box: DNS to Cloudflare, a fresh
+/// TLS handshake, back in through the edge, into the very same process.
+///
+/// Measured on the production host: `/api/v1/cheapest/Europe` answers in 8-20ms
+/// over loopback versus ~60ms through the edge when the edge is healthy — and
+/// the edge is not always healthy. A single 4h26m container log window
+/// (2026-08-10 08:53→13:19) held **429** `source: TimedOut` failures against
+/// this module's 10s client budget, concentrated in two minutes (10:53-10:54)
+/// where the edge stalled: 88 for `cheapest/Europe`, 53 for
+/// `cheapest/North-America`, 52 for `retainer/listings/{id}`, and a long tail of
+/// `listings/{world}/{id}` — CN and JP worlds especially. Those are GlitchTip
+/// issues 2209 ("Error doing leptos fetch") and 2210 ("Error getting value").
+///
+/// A failed SSR fetch does not error the page; the resource still renders, just
+/// empty. So the visible symptom is a page that silently loses a section, which
+/// is why this survived so long. Going over loopback removes the entire class:
+/// no DNS, no TLS handshake, no CDN, no WAF, no edge rate limit between the
+/// process and its own API.
+///
+/// It is *not* a fix for the SSR panic flood (GlitchTip 6876/6886/6888/6895) —
+/// those run at a steady ~120/min across the whole window and do not correlate
+/// with the timeout bursts.
+///
+/// `HOSTNAME` is kept as a fallback so an unusual deployment still works, and
+/// its trailing slash is trimmed — `fly.toml` sets `https://ultros.app/`, which
+/// concatenated with a leading-slash path produced a double-slash URL.
+#[cfg(feature = "ssr")]
+fn resolve_internal_api_origin(
+    explicit: Option<&str>,
+    site_addr: Option<&str>,
+    hostname: Option<&str>,
+) -> String {
+    fn set(value: Option<&str>) -> Option<&str> {
+        value.map(str::trim).filter(|value| !value.is_empty())
+    }
+
+    if let Some(explicit) = set(explicit) {
+        return explicit.trim_end_matches('/').to_owned();
+    }
+    if let Some(origin) = set(site_addr).and_then(loopback_origin_from_site_addr) {
+        return origin;
+    }
+    if let Some(hostname) = set(hostname) {
+        return hostname.trim_end_matches('/').to_owned();
+    }
+    "http://localhost:8080".to_owned()
+}
+
+/// The origin every SSR-side API call is issued against, resolved once.
+///
+/// See [`resolve_internal_api_origin`] for why this is not simply `HOSTNAME`.
+#[cfg(feature = "ssr")]
+fn internal_api_origin() -> &'static str {
+    static ORIGIN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    ORIGIN.get_or_init(|| {
+        let explicit = std::env::var("ULTROS_INTERNAL_API_ORIGIN").ok();
+        let site_addr = std::env::var("LEPTOS_SITE_ADDR").ok();
+        let hostname = std::env::var("HOSTNAME").ok();
+        let origin = resolve_internal_api_origin(
+            explicit.as_deref(),
+            site_addr.as_deref(),
+            hostname.as_deref(),
+        );
+        tracing::info!(%origin, "resolved SSR internal API origin");
+        origin
+    })
+}
 
 /// Copy the inbound request's headers into a header map suitable for the
 /// outbound internal API call, dropping everything in [`NON_FORWARDABLE_HEADERS`].
@@ -915,9 +1016,7 @@ where
     });
     let req_parts = use_context::<Parts>().ok_or(AppError::ParamMissing)?;
     let headers = req_parts.headers;
-    let hostname =
-        std::env::var("HOSTNAME").unwrap_or_else(|_| "http://localhost:8080".to_string());
-    let path = format!("{hostname}{path}");
+    let path = format!("{}{path}", internal_api_origin());
     let request = client
         .delete(&path)
         .headers(forwardable_headers(headers))
@@ -993,9 +1092,7 @@ where
     });
     let req_parts = use_context::<Parts>().ok_or(AppError::ParamMissing)?;
     let headers = req_parts.headers;
-    let hostname =
-        std::env::var("HOSTNAME").unwrap_or_else(|_| "http://localhost:8080".to_string());
-    let path = format!("{hostname}{path}");
+    let path = format!("{}{path}", internal_api_origin());
     let request = client
         .get(&path)
         .headers(forwardable_headers(headers))
@@ -1226,6 +1323,114 @@ mod ssr_response_tests {
             "changing the status must not change what callers observe"
         );
         assert_eq!(fixed_401, AppError::ApiError(ApiError::NotAuthenticated));
+    }
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod ssr_origin_tests {
+    use super::{loopback_origin_from_site_addr, resolve_internal_api_origin};
+
+    /// The production configuration, and the whole point of the change.
+    ///
+    /// The container runs with `HOSTNAME=https://ultros.app` and
+    /// `LEPTOS_SITE_ADDR=0.0.0.0:8080`. Before this, every SSR fetch went to the
+    /// public origin: out to Cloudflare and back into the same process, 10s
+    /// budget, hundreds of `TimedOut` errors per log window. It must stay on the
+    /// box.
+    #[test]
+    fn production_env_resolves_to_loopback_not_the_public_origin() {
+        let origin =
+            resolve_internal_api_origin(None, Some("0.0.0.0:8080"), Some("https://ultros.app"));
+        assert_eq!(origin, "http://127.0.0.1:8080");
+        assert!(
+            !origin.contains("ultros.app"),
+            "the SSR loopback must not leave the machine: {origin}"
+        );
+    }
+
+    /// `LEPTOS_SITE_ADDR` is what the server actually binds, so it wins over the
+    /// public `HOSTNAME` — but an operator can still pin the origin by hand.
+    #[test]
+    fn explicit_override_wins_over_everything() {
+        assert_eq!(
+            resolve_internal_api_origin(
+                Some("http://api.internal:9000"),
+                Some("0.0.0.0:8080"),
+                Some("https://ultros.app"),
+            ),
+            "http://api.internal:9000"
+        );
+    }
+
+    /// Unset in development (`cargo leptos serve` may not export it), in which
+    /// case behaviour is exactly what it was before: `HOSTNAME`, then the
+    /// localhost default. Blank strings count as unset — an env var set to the
+    /// empty string would otherwise resolve to an origin-less URL.
+    #[test]
+    fn falls_back_through_hostname_then_the_dev_default() {
+        assert_eq!(
+            resolve_internal_api_origin(None, None, Some("http://localhost:3000")),
+            "http://localhost:3000"
+        );
+        assert_eq!(
+            resolve_internal_api_origin(Some(""), Some("  "), Some("")),
+            "http://localhost:8080"
+        );
+        assert_eq!(
+            resolve_internal_api_origin(None, None, None),
+            "http://localhost:8080"
+        );
+    }
+
+    /// `fly.toml` sets `HOSTNAME = "https://ultros.app/"`. Concatenated with a
+    /// leading-slash path that produced `https://ultros.app//api/v1/...`.
+    #[test]
+    fn a_trailing_slash_on_the_origin_is_trimmed() {
+        assert_eq!(
+            resolve_internal_api_origin(None, None, Some("https://ultros.app/")),
+            "https://ultros.app"
+        );
+        assert_eq!(
+            format!("{}{}", "https://ultros.app", "/api/v1/cheapest/Europe"),
+            "https://ultros.app/api/v1/cheapest/Europe"
+        );
+    }
+
+    /// The unspecified address is a valid thing to *bind* and not a valid thing
+    /// to *connect to*, so it has to become the matching loopback address. A
+    /// concrete bind address is already reachable and is used as-is.
+    #[test]
+    fn the_unspecified_address_becomes_loopback() {
+        for (addr, expected) in [
+            ("0.0.0.0:8080", "http://127.0.0.1:8080"),
+            ("[::]:8080", "http://[::1]:8080"),
+            ("[::0]:3000", "http://[::1]:3000"),
+            (":8080", "http://127.0.0.1:8080"),
+            ("127.0.0.1:8080", "http://127.0.0.1:8080"),
+            ("localhost:3000", "http://localhost:3000"),
+            ("[::1]:3000", "http://[::1]:3000"),
+            ("192.168.1.5:8080", "http://192.168.1.5:8080"),
+            (" 0.0.0.0:8080 ", "http://127.0.0.1:8080"),
+        ] {
+            assert_eq!(
+                loopback_origin_from_site_addr(addr).as_deref(),
+                Some(expected),
+                "{addr}"
+            );
+        }
+    }
+
+    /// Anything that is not an `addr:port` pair must fall through to the next
+    /// source rather than produce a URL that cannot be connected to.
+    #[test]
+    fn a_malformed_site_addr_falls_through() {
+        for addr in ["0.0.0.0", "", "http://0.0.0.0:8080/", "0.0.0.0:", "8080"] {
+            assert_eq!(loopback_origin_from_site_addr(addr), None, "{addr}");
+        }
+        assert_eq!(
+            resolve_internal_api_origin(None, Some("0.0.0.0"), Some("https://ultros.app")),
+            "https://ultros.app"
+        );
     }
 }
 


### PR DESCRIPTION
## The bug

Every server-rendered page re-issues its API calls against `HOSTNAME`, which in production is the **public** origin (`https://ultros.app`). So the container leaves the box to talk to itself: DNS → TLS handshake → Cloudflare → back in through the edge → into the very same process.

Measured on the prod host (`ssh chew@boxbox`):

| path | loopback | public edge (healthy) |
| :--- | ---: | ---: |
| `/api/v1/cheapest/Europe` | 20ms | 63ms |
| `/api/v1/listings/陸行鳥/12997` | 8ms | 58ms |

And the edge is not always healthy. One 4h26m container log window (2026-08-10 08:53→13:19) held **429 `source: TimedOut`** failures against this module's 10s client budget, concentrated in two minutes (10:53–10:54) where the edge stalled:

- 88 × `/api/v1/cheapest/Europe`
- 53 × `/api/v1/cheapest/North-America`
- 52 × `/api/v1/retainer/listings/{id}`
- long tail of `/api/v1/listings/{world}/{id}` — CN and JP worlds especially

Those are GlitchTip [2209](https://glitchtip.ultros.app/ultros/issues/2209) ("Error doing leptos fetch", 3365 events) and [2210](https://glitchtip.ultros.app/ultros/issues/2210) ("Error getting value", 2191 events).

**A failed SSR fetch does not error the page** — the resource still renders, just empty. So the visible symptom is a page that silently loses a section, which is why this survived so long. I confirmed the shape on a sampled event: issue 7074's culprit is `http://ultros.app/api/v1/listings/North-America/3147` with `sqlx::pool::acquire` slow-threshold breadcrumbs around it.

## The fix

Resolve the internal origin from `LEPTOS_SITE_ADDR` — the address the server actually binds, already `0.0.0.0:8080` in the prod container — mapping the *unspecified* address (`0.0.0.0`, `[::]`) to its loopback form. Precedence:

1. `ULTROS_INTERNAL_API_ORIGIN` (new, explicit escape hatch for a split deployment)
2. loopback form of `LEPTOS_SITE_ADDR`
3. `HOSTNAME` (previous behaviour — preserved for anything unusual)
4. `http://localhost:8080`

**`HOSTNAME` itself is untouched.** It is the app's public URL and OAuth redirects are built from it; this only changes what the SSR renderer dials.

This removes the whole failure class between the process and its own API: no DNS, no TLS, no CDN, no WAF, no edge rate limit. It also supersedes the situation #1154 worked around — with no CDN in the path there is no `Host`/SNI mismatch to produce 403/421. The `host` denylist entry and its tests stay, since forwarding the inbound host is still wrong.

Incidental: the fallback path now trims a trailing slash. `fly.toml` sets `HOSTNAME = "https://ultros.app/"`, which concatenated with a leading-slash path produced `https://ultros.app//api/v1/...`.

## What this is *not*

**It does not fix the SSR panic flood** — GlitchTip [6876](https://glitchtip.ultros.app/ultros/issues/6876) (15,763), [6886](https://glitchtip.ultros.app/ultros/issues/6886) (2,505), [6888](https://glitchtip.ultros.app/ultros/issues/6888), [6895](https://glitchtip.ultros.app/ultros/issues/6895), [7119](https://glitchtip.ultros.app/ultros/issues/7119). I initially believed the timeouts caused them and had to drop that: the panics run at a steady 100–240/min across the entire log window, while the timeouts are confined to two minutes. No correlation.

Two negative results worth recording so nobody re-walks them:

- **`/analyzer/{world}` is not a repro.** Curling it from the box appeared to add +1/+2 panics every time — but a no-request control over the same 5s window gave +0, +9, +2. Prod's background panic rate swamps any single-request delta. Any future attempt at this needs a quiet-traffic window or a per-request correlation id, not a log-count delta.
- **`/itemcard/{world}/{id}` is confirmed innocent.** The `usvg` "No fonts with a 阳/U+9633 character" warnings that sit next to every panic come from that route, which is a plain axum handler with no reactive graph.

The panic locations from the prod log, for whoever picks this up next (`docker logs ultros | grep -o "panicked at [^ ]*:" | sort | uniq -c | sort -rn`):

```
2462 reactive_graph-0.2.14/src/traits.rs:394:39      <- Get::get() on a disposed signal
1220 reactive_graph-0.2.14/src/computed/arc_memo.rs:334:24
  46 ultros-app/src/components/skeleton.rs:224:16    <- use_i18n()
  29 ultros-app/src/components/item_tooltip.rs:32:16
  25 ultros-app/src/components/clipboard.rs:10:66    <- use_context::<GlobalLastCopiedText>().unwrap()
  15 leptos_router-0.8.15/src/link.rs:161:16         <- <A/> outside a <Router/>
```

## Verification

| gate | result |
| :--- | :--- |
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy -p ultros-app --all-targets -- -D warnings` | 0 (5m09s) |
| `cargo check -p ultros-app --no-default-features --features hydrate --target wasm32-unknown-unknown` | 0 (1m51s) |
| `cargo test -p ultros-app --lib` | **538 passed** (base 532 + 6) |

Genuine red→green **by mutation**: restoring the pre-fix body (`HOSTNAME` verbatim, else the dev default) fails **4 of 6** new tests at exit **101** —

```
a_trailing_slash_on_the_origin_is_trimmed ... FAILED
production_env_resolves_to_loopback_not_the_public_origin ... FAILED
falls_back_through_hostname_then_the_dev_default ... FAILED
explicit_override_wins_over_everything ... FAILED
```

The other two exercise `loopback_origin_from_site_addr` directly, which the mutation does not touch — they pass either way **by design** (address-parsing guards), not because they are weak.

## GlitchTip triage this run — 34 ignored

- **9 Discord alert-delivery issues** (#6877–6879, #6881–6885): prod serves `/pkg/077c9ed/`, so #1159's permanent-failure fix **is** deployed, and they have been silent since 2026-08-09 18:17.
- **25 count-1 fragments** (#7051–7075) of one 2026-08-09 07:31 incident — duplicates of #2209/#2210 by another name. Both aggregate issues stay **open** as the tracking issues for this fix; leaving them is how we will tell whether the deploy worked.

## Deploy note

No config change required — `LEPTOS_SITE_ADDR=0.0.0.0:8080` is already set on the container. After deploying, `#2209`/`#2210` should stop accruing; the log line `resolved SSR internal API origin` reports the chosen origin at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
