### PR TITLE
perf(db): drop the 59 GB SaleHistoryFullIndex, which no query can use

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -36,6 +36,7 @@ mod m20260804_000001_active_listing_cheapest_index;
 mod m20260805_000001_group_invite;
 mod m20260808_000001_active_listing_identity_columns;
 mod m20260809_000001_notification_endpoint_health;
+mod m20260811_000001_drop_unused_sale_history_full_index;
 
 pub struct Migrator;
 
@@ -81,6 +82,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260805_000001_group_invite::Migration),
             Box::new(m20260808_000001_active_listing_identity_columns::Migration),
             Box::new(m20260809_000001_notification_endpoint_health::Migration),
+            Box::new(m20260811_000001_drop_unused_sale_history_full_index::Migration),
         ]
     }
 }

--- a/migration/src/m20260811_000001_drop_unused_sale_history_full_index.rs
+++ b/migration/src/m20260811_000001_drop_unused_sale_history_full_index.rs
@@ -1,0 +1,130 @@
+use sea_orm_migration::prelude::*;
+
+/// Drop `SaleHistoryFullIndex` — a 59 GB index on `sale_history` that no query
+/// can use.
+///
+/// `m20220911_200503_add_sale_index` created it as
+///
+/// ```sql
+/// CREATE INDEX "SaleHistoryFullIndex" ON sale_history
+///     (price_per_item, quantity, hq, buying_character_id, sold_item_id, world_id)
+/// ```
+///
+/// Its leading column is `price_per_item`, and nothing in `ultros-db` ever
+/// filters or orders on that column — it is only ever projected. A btree whose
+/// leading column is never a predicate is only reachable by a full index scan,
+/// which the planner will never prefer over `sale_history_lookup_index`
+/// (`sold_item_id, world_id, sold_date DESC`), the index purpose-built for the
+/// one hot query on this table:
+///
+/// ```sql
+/// SELECT ... FROM sale_history
+/// WHERE sold_item_id = $1 AND world_id = $2
+/// ORDER BY sold_date DESC LIMIT $3
+/// ```
+///
+/// Measured on production before this migration:
+///
+/// | index                       | size  | `idx_scan` |
+/// |-----------------------------|-------|------------|
+/// | `SaleHistoryFullIndex`      | 59 GB | 0          |
+/// | `sale_history_lookup_index` | 53 GB | 3,629,728  |
+///
+/// over a window carrying 1.18 M inserts into a 122 GB table. So it is pure
+/// cost: six columns of index maintenance on every ingested sale, and 59 GB of
+/// page cache competing with the index that actually serves reads. That
+/// competition is visible — `EXPLAIN (ANALYZE, BUFFERS)` on the hot query shows
+/// 100 of 109 buffers coming from disk (42 ms of `shared read` out of a 44 ms
+/// execution), and under load those reads stretch to the 1.1–1.5 s
+/// `slow statement` warnings that precede the pool-acquire timeouts behind
+/// GlitchTip #2209 / #2210 and the catch-up ingest failures (#6868 / #6869).
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// `sale_history` is written continuously by ingest, and a plain `DROP INDEX`
+/// takes an `ACCESS EXCLUSIVE` lock on the table while it unlinks 59 GB of
+/// segment files. `CONCURRENTLY` keeps writers running, at the cost of not
+/// being allowed inside a transaction block — hence `use_transaction` below,
+/// matching `m20260804_000001_active_listing_cheapest_index`.
+///
+/// The identifier **must stay double-quoted**. It was created mixed-case, so an
+/// unquoted `DROP INDEX ... IF EXISTS SaleHistoryFullIndex` folds to
+/// `salehistoryfullindex`, matches nothing, and — because of `IF EXISTS` —
+/// succeeds while dropping nothing at all.
+const DROP_SQL: &str = r#"DROP INDEX CONCURRENTLY IF EXISTS "SaleHistoryFullIndex""#;
+
+const RECREATE_SQL: &str = r#"CREATE INDEX CONCURRENTLY IF NOT EXISTS "SaleHistoryFullIndex"
+                   ON sale_history (price_per_item, quantity, hq, buying_character_id, sold_item_id, world_id)"#;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    fn use_transaction(&self) -> Option<bool> {
+        Some(false)
+    }
+
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(DROP_SQL)
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(RECREATE_SQL)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The index was created mixed-case, so Postgres only resolves it when the
+    /// identifier is double-quoted. Unquoted, it folds to lowercase, matches
+    /// nothing, and `IF EXISTS` turns the whole migration into a silent no-op
+    /// that leaves 59 GB in place while reporting success.
+    #[test]
+    fn drop_quotes_the_mixed_case_identifier() {
+        assert!(
+            DROP_SQL.contains(r#""SaleHistoryFullIndex""#),
+            "identifier must be double-quoted, got: {DROP_SQL}"
+        );
+        assert!(
+            !DROP_SQL.contains(" SaleHistoryFullIndex"),
+            "identifier must never appear unquoted, got: {DROP_SQL}"
+        );
+    }
+
+    #[test]
+    fn recreate_quotes_the_mixed_case_identifier() {
+        assert!(
+            RECREATE_SQL.contains(r#""SaleHistoryFullIndex""#),
+            "identifier must be double-quoted, got: {RECREATE_SQL}"
+        );
+    }
+
+    /// `CONCURRENTLY` is what keeps ingest writing while the drop runs; it is
+    /// also what forces `use_transaction() == Some(false)`. If either half is
+    /// removed without the other, the migration fails at runtime — Postgres
+    /// rejects `CONCURRENTLY` inside a transaction block.
+    #[test]
+    fn concurrent_ddl_runs_outside_a_transaction() {
+        assert!(DROP_SQL.contains("CONCURRENTLY"));
+        assert!(RECREATE_SQL.contains("CONCURRENTLY"));
+        assert_eq!(Migration.use_transaction(), Some(false));
+    }
+
+    /// `down` must restore exactly the column list
+    /// `m20220911_200503_add_sale_index` created, in order — a reversal that
+    /// silently changes the index is not a reversal.
+    #[test]
+    fn down_restores_the_original_column_list() {
+        assert!(RECREATE_SQL.contains(
+            "(price_per_item, quantity, hq, buying_character_id, sold_item_id, world_id)"
+        ));
+    }
+}


### PR DESCRIPTION
## What

Adds one migration: `DROP INDEX CONCURRENTLY IF EXISTS "SaleHistoryFullIndex"`.

## Why

`m20220911_200503_add_sale_index` created it as:

```sql
CREATE INDEX "SaleHistoryFullIndex" ON sale_history
    (price_per_item, quantity, hq, buying_character_id, sold_item_id, world_id)
```

The leading column is `price_per_item`, and **nothing in `ultros-db` ever filters or orders on that column** — it is only ever projected (`sales.rs:104`, `common_type_conversions.rs:160/172`). A btree whose leading column is never a predicate is reachable only by a full index scan, which the planner will never prefer over `sale_history_lookup_index` on `(sold_item_id, world_id, sold_date DESC)` — the index purpose-built for the one hot query on this table.

### Measured on production

| index | size | `idx_scan` |
|---|---|---|
| `SaleHistoryFullIndex` | **59 GB** | **0** |
| `sale_history_lookup_index` | 53 GB | 3,629,728 |
| `sale_history` (heap) | 122 GB | — |

…over a stats window carrying 1,181,653 inserts into `sale_history`. So the index is pure cost: six columns of index maintenance on every ingested sale, plus 59 GB of page cache competing with the index that actually serves reads.

That competition is visible. `EXPLAIN (ANALYZE, BUFFERS)` on the hot item-page query:

```
Limit  (actual time=0.132..44.666 rows=200 loops=1)
  Buffers: shared hit=9 read=100
  I/O Timings: shared read=42.654
  ->  Index Scan using sale_history_lookup_index on sale_history
        Index Cond: ((sold_item_id = 12907) AND (world_id = 40))
Execution Time: 44.716 ms
```

100 of 109 buffers come **from disk** — 42 ms of the 44 ms is `shared read`. Under load those reads stretch into the sqlx warnings that dominate the prod log:

```
WARN sqlx::query: slow statement: execution time exceeded alert threshold,
  summary: "SELECT ... FROM sale_history WHERE sold_item_id = $1 AND world_id = $2
            ORDER BY sold_date DESC LIMIT $3",
  rows_returned: 200, elapsed: 1.332471098s, slow_threshold: 1s
```

which are exactly the breadcrumbs preceding the pool-acquire timeouts (`acquired_after_secs: 24.9`, threshold 2s) behind:

- **#2209 / #2210** — "Error doing leptos fetch" / "Error getting value", 6,075 events. All 16 remaining loopback timeouts in the last 14h are `/api/v1/listings/{world}/{item}`, i.e. this query.
- **#6868 / #6869** — "catch-up sale/listing update failed", 5,049 events. Confirmed **production** (`server_name: 5d8bbbd78b6d`), `error: Failed to acquire connection from pool: Connection pool timed out` at `item_update_service.rs:244`.

## Safety

- `CONCURRENTLY` outside a transaction (`use_transaction() -> Some(false)`), matching the existing `m20260804_000001_active_listing_cheapest_index`. `sale_history` is written continuously by ingest, and a plain `DROP INDEX` would hold `ACCESS EXCLUSIVE` while unlinking 59 GB of segment files.
- `down` recreates the index with the original column list, in order.

## Verification

- `cargo fmt --all -- --check` → 0
- `cargo clippy -p migration --all-targets -- -D warnings` → 0
- `cargo test -p migration` → **4 passed** (crate had 0 tests before)

**Genuine red→green by mutation.** The real hazard here is quoting: the index was created mixed-case, so an *unquoted* `DROP INDEX ... IF EXISTS SaleHistoryFullIndex` folds to `salehistoryfullindex`, matches nothing, and — because of `IF EXISTS` — **succeeds while dropping nothing at all**. Verified against the live database:

```
select to_regclass('SaleHistoryFullIndex'), to_regclass('"SaleHistoryFullIndex"');
 → NULL | "SaleHistoryFullIndex"
```

Removing the quotes fails `drop_quotes_the_mixed_case_identifier` at exit 101. The other 3 tests pass either way **by design** — they are behaviour-preservation guards (CONCURRENTLY ↔ `use_transaction` pairing, and the `down` column list), not part of the red count.

Note that CI does not run migrations, so this is not executed against a database in CI.

## Follow-up, not in this PR

`UltrosDb::get_sale_history_from_multiple_worlds` (`ultros-db/src/sales.rs:118`) fans out one query **per world** via `try_join_all` — up to ~30 concurrent copies of the query above for a single region item page. That is the other half of the pool pressure and wants its own change (a single `world_id = ANY($2)` scan), measured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
