### PR TITLE
🎨 Palette: Add `aria-live` to recently viewed clear button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,17 +1,3 @@
-## 2023-11-20 - Accessible Icon-Only Buttons
-**Learning:** Found that some icon-only interactive elements like 'Delete Group' and 'Add Member' in the groups component lacked `aria-label`s, making them invisible to screen readers.
-**Action:** Always add reactive `aria-label` properties to icon-only buttons to ensure they are fully accessible, especially when their function might change based on state (e.g. asking for confirmation).
-
-## 2026-07-07 - Accessible textareas
-**Learning:** In the MakePlaceImporter, the textarea was missing an ID and the associated label lacked a `for` attribute, which breaks form field accessibility for screen readers.
-**Action:** Ensure all form controls, such as `<textarea>` and `<input>`, have unique IDs and are properly associated with their corresponding `<label>` elements using the `for` attribute.
-
-## 2026-07-28 - Explicit aria-label for Image-only Menu Buttons
-**Learning:** Found that interactive elements containing only images with alt text might still need an explicit `aria-label` if the image's alt text doesn't adequately describe the element's action (e.g. 'username' vs 'Account menu button').
-**Action:** Always add an explicit `aria-label` to avatar dropdown buttons to standardize the action's description across login states.
-## 2025-02-12 - Added ARIA label to resend button
-**Learning:** Screen readers will struggle to identify multiple identical buttons (like "Resend") across rows in a data table unless they have unique labels with context.
-**Action:** Always include row-specific context (like the item name) in the `aria-label` for buttons inside list/table rows to ensure accessibility.
-## 2024-07-23 - Add explicit input associations
-**Learning:** In Leptos, when defining `for` and `id` attributes that need dynamic values within `move ||` closures, ensure you do not inadvertently move an entire struct (like `group`) multiple times, which causes E0382. Instead, extract the required value (e.g. `let group_id = group.id;`) beforehand so it can be copied into the closures.
-**Action:** Always extract and copy small values before using them inside Leptos closures to avoid ownership issues.
+## 2023-10-27 - Confirm Action Aria-Live
+**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
+**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2023-10-27 - Confirm Action Aria-Live
-**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
-**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Confirm Action Aria-Live
+**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
+**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-07-23 - Add explicit input associations
 **Learning:** In Leptos, when defining `for` and `id` attributes that need dynamic values within `move ||` closures, ensure you do not inadvertently move an entire struct (like `group`) multiple times, which causes E0382. Instead, extract the required value (e.g. `let group_id = group.id;`) beforehand so it can be copied into the closures.
 **Action:** Always extract and copy small values before using them inside Leptos closures to avoid ownership issues.
+## 2026-08-12 - Confirm Action Aria-Live
+**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
+**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,6 +15,3 @@
 ## 2024-07-23 - Add explicit input associations
 **Learning:** In Leptos, when defining `for` and `id` attributes that need dynamic values within `move ||` closures, ensure you do not inadvertently move an entire struct (like `group`) multiple times, which causes E0382. Instead, extract the required value (e.g. `let group_id = group.id;`) beforehand so it can be copied into the closures.
 **Action:** Always extract and copy small values before using them inside Leptos closures to avoid ownership issues.
-## 2026-08-12 - Confirm Action Aria-Live
-**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
-**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,7 +4611,6 @@ dependencies = [
  "wasm-bindgen",
 ]
 
-
 [[package]]
 name = "json5"
 version = "1.3.1"
@@ -10777,7 +10776,6 @@ dependencies = [
  "wasm-bindgen-shared",
 ]
 
-
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.76"
@@ -10788,7 +10786,6 @@ dependencies = [
  "wasm-bindgen",
 ]
 
-
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
@@ -10798,7 +10795,6 @@ dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
 ]
-
 
 [[package]]
 name = "wasm-bindgen-macro-support"
@@ -10813,7 +10809,6 @@ dependencies = [
  "wasm-bindgen-shared",
 ]
 
-
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.126"
@@ -10822,7 +10817,6 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
-
 
 [[package]]
 name = "wasm-encoder"
@@ -10995,7 +10989,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
 
 [[package]]
 name = "web-time"

--- a/ultros-frontend/ultros-app/src/components/recently_viewed.rs
+++ b/ultros-frontend/ultros-app/src/components/recently_viewed.rs
@@ -195,6 +195,7 @@ pub fn RecentlyViewed() -> impl IntoView {
                         <h4 class="dashboard-section-title">{t!(i18n, recently_viewed_title)}</h4>
                         <button
                             class="text-xs text-[color:var(--color-text-muted)] hover:text-[color:var(--color-text)] transition-colors focus:outline-none focus:ring-2 focus:ring-[color:var(--accent)] rounded px-1"
+                            aria-live="polite"
                             on:click=move |_| {
                                 if confirm_clear.get_untracked() {
                                     item_data.clear_items();


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` to the clear button in the recently viewed panel.
🎯 Why: The button uses an inline confirmation pattern where the text changes from "Clear All" to "Confirm Clear". Without `aria-live`, screen reader users might not be aware that the button's action and text have changed.
♿ Accessibility: Improves screen reader experience by announcing the text change on the inline confirmation button.

---
*PR created automatically by Jules for task [9901247805120882797](https://jules.google.com/task/9901247805120882797) started by @akarras*