### PR TITLE
fix(item-view): 404 /item/<world>/0 instead of flooding GlitchTip

### DIFF
--- a/ultros-frontend/ultros-app/src/global_state/xiv_data.rs
+++ b/ultros-frontend/ultros-app/src/global_state/xiv_data.rs
@@ -47,9 +47,18 @@ pub fn item_exists(id: i32) -> bool {
 /// Parses a route path param as an item id, returning `None` if it doesn't
 /// parse as an integer or doesn't name a real item — the two ways a garbage
 /// `/item/<id>` URL currently falls through to a fake "item 0" page.
+///
+/// Id 0 is rejected explicitly. Row 0 of the game's Item sheet is a real row
+/// (the unnamed "nothing here" placeholder), so `item_exists(0)` is `true` and
+/// the page used to mount for `/item/<world>/0`. Every fetch in `crate::api`
+/// short-circuits id 0 to `AppError::NoItem` without touching the network, and
+/// the item page logs that failure with `tracing::error!` — which on the server
+/// is reported to GlitchTip once per render of such a URL. Crawlers hit these
+/// URLs steadily, so this produced a continuous stream of "Error getting value"
+/// error events for what is really just a 404.
 pub fn resolve_item_id(raw: Option<&str>) -> Option<i32> {
     let id: i32 = raw?.parse().ok()?;
-    item_exists(id).then_some(id)
+    (id > 0 && item_exists(id)).then_some(id)
 }
 
 #[cfg(test)]
@@ -75,5 +84,26 @@ mod tests {
     #[test]
     fn resolve_item_id_rejects_missing_param() {
         assert_eq!(resolve_item_id(None), None);
+    }
+
+    #[test]
+    fn item_zero_is_the_blank_placeholder_row() {
+        // Row 0 of the game's Item sheet is a real row with an empty name — the
+        // "nothing equipped" placeholder. It is present in the pack, so a bare
+        // `contains_key` check treats /item/<world>/0 as a valid item.
+        let blank = tracked_data().items.get(&xiv_gen::ItemId(0));
+        assert!(blank.is_some(), "item 0 should be present in the pack");
+        assert!(
+            blank.unwrap().name.is_empty(),
+            "item 0 should be the unnamed placeholder row"
+        );
+    }
+
+    #[test]
+    fn resolve_item_id_rejects_the_blank_item_zero() {
+        // `/item/<world>/0` must render NotFound, not the item page: every
+        // fetch in `crate::api` short-circuits id 0 to `AppError::NoItem`, and
+        // the resulting `error!` is reported to GlitchTip once per SSR render.
+        assert_eq!(resolve_item_id(Some("0")), None);
     }
 }


### PR DESCRIPTION
## The bug

`resolve_item_id` gates the item page on `item_exists(id)`. But **row 0 of the game's Item sheet is a real row** — the unnamed "nothing here" placeholder — so `item_exists(0)` is `true` and `/item/<world>/0` sailed through the guard and mounted the full item page.

From there:

1. Every fetch in `crate::api` short-circuits id 0 to `AppError::NoItem` without touching the network.
2. `ListingsContent` logs that failure with `tracing::error!` ([`item_view.rs:1708`](../blob/main/ultros-frontend/ultros-app/src/routes/item_view.rs#L1708)). On the server that becomes a **GlitchTip error event per render**.
3. The mounted page renders the world scope picker, which emits `/item/<world>/<item_id>` for **every world** (`item_view_scope.rs`) — so one `/item/X/0` hit publishes ~100 more `/item/<world>/0` links for crawlers to follow.

GlitchTip groups server events by culprit URL, so each crawled world spawned its own `count=1` "Error getting value" issue. That is the run of issues #7125–#7142 and friends — e.g. `/item/Behemoth/0` (Chrome) and `/item/%E5%B9%BB%E5%BD%B1%E7%BE%A4%E5%B2%9B/0` (ClaudeBot), both with `Rust Tracing Fields: { error: "NoItem" }` at `item_view.rs:1708`.

It is a self-perpetuating crawl trap: SEO junk (200-status empty item pages), wasted crawl budget, and a steady stream of unactionable error events.

## The fix

Reject id 0 explicitly in `resolve_item_id`, so the route falls to `NotFound` (which sets the 404 status). The same guard backs `ExchangeItem`, so `/currency-exchange/0` is fixed too.

## Verification

Two tests added:

- `item_zero_is_the_blank_placeholder_row` — asserts item 0 really is present in the pack with an empty name, documenting *why* the old `contains_key` guard let it through. Passes before and after.
- `resolve_item_id_rejects_the_blank_item_zero` — the regression test. **Fails before this change** with `left: Some(0) / right: None`; passes after.

```
running 6 tests
test global_state::xiv_data::tests::resolve_item_id_rejects_the_blank_item_zero ... FAILED
  assertion `left == right` failed
    left: Some(0)
   right: None
```

After:

```
test result: ok. 540 passed; 0 failed   (cargo test -p ultros-app --lib)
```

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p ultros-app --all-targets -j 2 -- -D warnings` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)