### PR TITLE
chore(jules): collapse .Jules/.jules palette.md case duplicate

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2023-10-27 - Confirm Action Aria-Live
-**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
-**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,6 @@
 ## 2024-07-23 - Add explicit input associations
 **Learning:** In Leptos, when defining `for` and `id` attributes that need dynamic values within `move ||` closures, ensure you do not inadvertently move an entire struct (like `group`) multiple times, which causes E0382. Instead, extract the required value (e.g. `let group_id = group.id;`) beforehand so it can be copied into the closures.
 **Action:** Always extract and copy small values before using them inside Leptos closures to avoid ownership issues.
+## 2026-08-12 - Confirm Action Aria-Live
+**Learning:** Adding `aria-live="polite"` to a button that changes text to confirm an action (e.g. from "Clear All" to "Confirm Clear") is an easy accessibility win to notify screen reader users of the new state. However, putting `aria-live` directly on the button can sometimes be flaky across different screen readers, but it's an acceptable micro-UX improvement for an inline confirmation pattern.
+**Action:** Use `aria-live` regions or visually hidden elements for more complex state changes, but inline `aria-live="polite"` on a changing button is a quick enhancement for simple confirm interactions.


### PR DESCRIPTION
Follow-up to #1166.

## What

The repo tracks the same agent-memory file under **two paths differing only by case**: `.Jules/palette.md` and `.jules/palette.md`. On a case-insensitive filesystem (Windows, macOS default) these are one file on disk, so a checkout leaves whichever git wrote last and `git status` reports the other as permanently modified.

This is the long-standing "case-phantom `palette.md` dirties the tree after merge" annoyance, already flagged for cleanup in:
- `docs/superpowers/specs/2026-05-10-price-alerts-design.md`
- `docs/superpowers/specs/2026-07-26-first-load-boot-messaging-design.md`

## Why now

It caused real content loss in #1166. That PR rewrote `.Jules/palette.md` down to a single entry, dropping five prior accessibility learnings (icon-only buttons, accessible textareas, image-only menu buttons, resend-button context, explicit input associations). They survived only by accident in the lowercase copy.

I pushed a fix to the #1166 branch, but the Jules bot pushed `209ef3a` on top of it ~16 min later, moving the lines back to `.Jules/` and undoing the consolidation. GitHub then squash-merged that head, so `main` currently has the two files **out of sync**:

| path | state on `main` |
|---|---|
| `.jules/palette.md` | the 5 original entries, missing the new one |
| `.Jules/palette.md` | only the new entry, 5 originals gone |

## This PR

Consolidates onto the lowercase path — matching `bolt.md` / `sentry.md` / `sentinel.md` — with all six entries present, and untracks the uppercase duplicate.

Docs-only; no code touched.
