### PR TITLE
🐛 Attach panic source location to server-side Glitchtip events

### DIFF
--- a/ultros/src/main.rs
+++ b/ultros/src/main.rs
@@ -215,6 +215,70 @@ fn error_reporting_disabled(environment: Option<&str>) -> bool {
     environment == Some("development")
 }
 
+/// Format a panic's `#[track_caller]` source location as `file:line:column`.
+///
+/// Mirrors the wasm-side reporter in `ultros-client/src/lib.rs`, so a server
+/// panic and a client panic read identically in Glitchtip.
+fn panic_location_string(info: &std::panic::PanicHookInfo<'_>) -> Option<String> {
+    info.location()
+        .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+}
+
+/// Attach the panicking source location to every Sentry panic event.
+///
+/// `sentry-panic` 0.49 builds its event purely from the panic *payload* and a
+/// runtime backtrace — it never reads `PanicHookInfo::location()`
+/// (`sentry_panic::PanicIntegration::event_from_panic_info`). Our release
+/// binary ships without symbols, so every frame Glitchtip receives is an
+/// `<unknown>` at a bare instruction address, and the addresses are ASLR'd,
+/// so they differ between events for the *same* panic. The result is what the
+/// server backlog actually looks like today: `culprit: <unknown>`, no tags,
+/// and a single un-actionable issue per panic *message* — 34k events under
+/// "called `Option::unwrap()` on a `None` value" (Glitchtip #6876) with no way
+/// to tell which of the ~hundreds of `unwrap()`s in the tree produced them.
+///
+/// `location()` needs no symbols at all: `file:line:column` is baked in at
+/// compile time by `#[track_caller]` and is already sitting on the
+/// `PanicHookInfo` we are handed. Wrapping the hook that `sentry::init`
+/// installed (rather than adding a second `PanicIntegration`, which the
+/// upstream docs say is unsupported — extractors are ignored when the
+/// integration is registered twice) records it on:
+///
+/// * tag `panic.location` — searchable/filterable in Glitchtip, and
+/// * context `rust_panic.location` — the exact shape the wasm reporter uses.
+///
+/// It also fingerprints by location, so panics split into one issue per
+/// panic *site* instead of per message. This is the same trick the client-side
+/// reporter uses ("a stable per-location fingerprint, so it collapses to one
+/// issue per panic site" — `ultros-app/src/error_filter.js`). Expect existing
+/// server panic issues to go quiet and be replaced by per-site ones on deploy.
+///
+/// Must be called *after* `sentry::init`, since that is what installs the hook
+/// being wrapped.
+fn attach_panic_location_to_sentry() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let Some(location) = panic_location_string(info) else {
+            previous(info);
+            return;
+        };
+        sentry::with_scope(
+            |scope| {
+                scope.set_tag("panic.location", &location);
+                scope.set_context(
+                    "rust_panic",
+                    sentry::protocol::Context::Other(
+                        std::iter::once(("location".to_string(), location.clone().into()))
+                            .collect(),
+                    ),
+                );
+                scope.set_fingerprint(Some(["panic", location.as_str()].as_slice()));
+            },
+            || previous(info),
+        );
+    }));
+}
+
 // Bolt: Switched to multi-threaded runtime for better performance on multi-core systems
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -276,6 +340,13 @@ async fn main() -> Result<()> {
             options.send_default_pii = false;
             sentry::init((dsn, options))
         });
+
+    // Wrap the panic hook `sentry::init` just installed so panic events carry
+    // their source location. Only meaningful when reporting is on, and the
+    // wrap must happen after init — see `attach_panic_location_to_sentry`.
+    if _sentry_guard.is_some() {
+        attach_panic_location_to_sentry();
+    }
 
     // Create the db before we proceed
     let filter: EnvFilter =
@@ -499,5 +570,49 @@ mod tests {
         assert!(!error_reporting_disabled(Some("production")));
         assert!(!error_reporting_disabled(Some("staging")));
         assert!(!error_reporting_disabled(None));
+    }
+
+    /// `panic_location_string` is what makes a server panic attributable at
+    /// all: the release binary is unsymbolicated, so `file:line:column` from
+    /// `#[track_caller]` is the only source information Glitchtip ever gets.
+    /// The panic hook is a `Box<dyn Fn>` we cannot call directly from a test,
+    /// so exercise the formatter through a real panic.
+    #[test]
+    fn panic_location_is_file_line_column() {
+        use std::sync::{Arc, Mutex};
+
+        let captured: Arc<Mutex<Option<String>>> = Arc::default();
+        let sink = captured.clone();
+
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            *sink.lock().unwrap() = super::panic_location_string(info);
+        }));
+        let _ = std::panic::catch_unwind(|| panic!("boom"));
+        std::panic::set_hook(previous);
+
+        let location = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("panics carry a location");
+        // `main.rs:<line>:<col>` — the shape the wasm reporter already sends as
+        // `contexts.rust_panic.location`.
+        let (file, line_col) = location
+            .rsplit_once(':')
+            .and_then(|(rest, col)| {
+                rest.rsplit_once(':')
+                    .map(|(file, line)| (file, (line, col)))
+            })
+            .expect("location is file:line:column");
+        assert!(file.ends_with("main.rs"), "unexpected file in {location}");
+        assert!(
+            line_col.0.parse::<u32>().is_ok(),
+            "unexpected line in {location}"
+        );
+        assert!(
+            line_col.1.parse::<u32>().is_ok(),
+            "unexpected column in {location}"
+        );
     }
 }


### PR DESCRIPTION
## The problem

Every server-side panic in Glitchtip is currently unattributable.

`sentry-panic` 0.49 builds its event purely from the panic payload and a runtime backtrace — [`PanicIntegration::event_from_panic_info`](https://docs.rs/sentry-panic/0.49.1/src/sentry_panic/lib.rs.html) never reads `PanicHookInfo::location()`. Our release binary ships without symbols, so every frame Glitchtip receives is an `<unknown>` at a bare instruction address, and those addresses are ASLR'd, so they differ between events for the *same* panic.

The result is what the server backlog actually looks like:

| Issue | Events | Title | Attribution |
|---|---:|---|---|
| [#6876](https://glitchtip.ultros.app/ultros/issues/6876) | 34,217 | `called Option::unwrap() on a None value` | `culprit: <unknown>`, no tags |
| [#6886](https://glitchtip.ultros.app/ultros/issues/6886) | 21,915 | `Tried to access a reactive value that has already been disposed.` | same |
| [#6888](https://glitchtip.ultros.app/ultros/issues/6888) | 826 | `I18n context is missing` | same |

Grouping falls back to the panic *message*, so #6876 lumps together every `unwrap()` in the tree into one issue with nothing pointing at a line of code.

## The fix

`location()` needs no symbols at all — `file:line:column` is baked in at compile time by `#[track_caller]` and is already sitting on the `PanicHookInfo` the hook is handed. This wraps the hook that `sentry::init` installs and records it as:

- tag `panic.location` — searchable/filterable in Glitchtip
- context `rust_panic.location` — the exact shape the wasm reporter already sends
- the event **fingerprint**, so panics split into one issue per panic *site* instead of per message

The wasm client has done all three since the fingerprint work in `error_filter.js` ("a stable per-location fingerprint, so it collapses to one issue per panic site"). This just brings the server to parity.

Two deliberate choices:

- **Wrapping the hook, not adding a second `PanicIntegration` with an extractor.** Upstream documents that the panic integration cannot be used more than once and that it *silently ignores extractors* when registered twice. The alternative — `default_integrations = false` plus a hand-maintained integration list — breaks quietly on every sentry upgrade.
- **Installed after `sentry::init`, and only when a DSN produced a guard**, since init is what installs the hook being wrapped.

## Verification

Reproduced and verified against sentry 0.49 out-of-tree using `sentry::test` with `apply_defaults`, panicking at two *distinct* `unwrap()` sites:

**Before** — both sites indistinguishable, which is the bug:
```
value       : Some("called `Option::unwrap()` on a `None` value")
tags        : {}
rust_panic  : None
fingerprint : ["{{ default }}"]          <- identical for both sites
```

**After** — each site carries its own location and its own fingerprint:
```
tags        : {"panic.location": "src/main.rs:30:50"}
rust_panic  : Some(Other({"location": String("src/main.rs:30:50")}))
fingerprint : ["panic", "src/main.rs:30:50"]

tags        : {"panic.location": "src/main.rs:31:50"}
rust_panic  : Some(Other({"location": String("src/main.rs:31:50")}))
fingerprint : ["panic", "src/main.rs:31:50"]
```

A unit test in `ultros/src/main.rs` covers the `file:line:column` formatter through a real panic.

CI gates run locally: `cargo fmt --all -- --check` clean, `cargo clippy -p ultros --all-targets -- -D warnings` exit 0 with zero warnings. (The `ultros` bin's test *binary* does not link on Windows/MSVC — a known repo quirk — so `clippy --all-targets` is the compile gate for the test module here; the behaviour itself was verified out-of-tree as above.)

## What to expect on deploy

Existing server panic issues (#6876, #6886, #6888, #7120, #7119, #6895 …) will go quiet and be replaced by **new, per-site** issues that name a file and line. That is the point of the change, but it is a visible one-time churn in the issue list.

This does not fix any individual panic — it makes the top three server issues diagnosable for the first time.

## Also in this run

Triaged 30 stale single-event issues from the 2026-08-09 07:30 burst (`Error getting listings` / `response failed` / `Returning web error`, all within ~20 seconds of each other) to **ignored**. They are one incident fragmented per-URL by culprit grouping, and the persistent trackers for that class ([#2209](https://glitchtip.ultros.app/ultros/issues/2209), [#2210](https://glitchtip.ultros.app/ultros/issues/2210)) remain open and unresolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
